### PR TITLE
fix: do not use snake case on potentially localized values

### DIFF
--- a/src/Prism.tsx
+++ b/src/Prism.tsx
@@ -135,11 +135,6 @@ export const Prism = forwardRef<PrismHandle, PrismProps>(
 			UNSAFE_vegaSpec,
 		});
 
-		// if the spec has changed, reset the chartView
-		useEffect(() => {
-			chartView.current = undefined;
-		}, [spec]);
-
 		const { controlledHoverSignal, selectedIdSignalName, selectedSeriesSignalName } = useSpecProps(spec);
 		const prismConfig = useMemo(() => getPrismConfig(config, colorScheme), [config, colorScheme]);
 

--- a/src/hooks/usePrismImperativeHandle.tsx
+++ b/src/hooks/usePrismImperativeHandle.tsx
@@ -9,15 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-import { toSnakeCase } from '@utils';
 import { MutableRefObject, Ref, useImperativeHandle } from 'react';
+
 import { PrismHandle } from 'types';
 import { View } from 'vega';
 
 export default function usePrismImperativeHandle(
 	forwardedRef: Ref<PrismHandle>,
-	{ chartView, title }: { chartView: MutableRefObject<View | undefined>; title?: string },
+	{ chartView, title }: { chartView: MutableRefObject<View | undefined>; title?: string }
 ) {
 	return useImperativeHandle(forwardedRef, () => ({
 		copy() {
@@ -30,13 +29,13 @@ export default function usePrismImperativeHandle(
 								const blob = await response.blob();
 								navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]).then(
 									() => resolve('Chart copied to clipboard'),
-									() => reject('Error occurred while writing to clipboard, copy to clipboard failed'),
+									() => reject('Error occurred while writing to clipboard, copy to clipboard failed')
 								);
 							} catch (error) {
 								reject('Error occurred while fetching image, copy to clipboard failed');
 							}
 						},
-						() => reject('Error occurred while converting image to URL, copy to clipboard failed'),
+						() => reject('Error occurred while converting image to URL, copy to clipboard failed')
 					);
 				} else {
 					reject("There isn't a chart to copy, copy to clipboard failed");
@@ -46,7 +45,7 @@ export default function usePrismImperativeHandle(
 		download(customFileName?: string) {
 			return new Promise<string>((resolve, reject) => {
 				if (chartView.current) {
-					const filename = `${toSnakeCase(customFileName || title || 'prism_export')}.png`;
+					const filename = `${customFileName || title || 'chart_export'}.png`;
 					chartView.current.toImageURL('png').then(
 						(url) => {
 							const link = document.createElement('a');
@@ -56,7 +55,7 @@ export default function usePrismImperativeHandle(
 							link.dispatchEvent(new MouseEvent('click'));
 							resolve(`Chart downloaded as ${filename}`);
 						},
-						() => reject('Error occurred while converting image to URL, download failed'),
+						() => reject('Error occurred while converting image to URL, download failed')
 					);
 				} else {
 					reject("There isn't a chart to download, download failed");

--- a/src/stories/Prism.test.tsx
+++ b/src/stories/Prism.test.tsx
@@ -9,12 +9,12 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import React, { createRef } from 'react';
 
 import '@matchMediaMock';
 import { Axis, Bar, ChartTooltip, Line, Prism, PrismHandle } from '@prism';
 import { findPrism, getAllMarksByGroupName, render, screen } from '@test-utils';
 import { getElement } from '@utils';
-import React, { createRef } from 'react';
 
 import { Basic, Config, Width } from './Prism.story';
 import {
@@ -154,7 +154,7 @@ describe('Prism', () => {
 			render(
 				<Prism data={data} ref={ref}>
 					<Line dimension="x" metric="y" />
-				</Prism>,
+				</Prism>
 			);
 			if (ref.current) {
 				// should reject since the chart isn't done rendering
@@ -164,10 +164,26 @@ describe('Prism', () => {
 				expect(prism).toBeInTheDocument();
 				// should reject because fetch isn't mocked
 				await expect(ref.current.copy()).rejects.toBe(
-					'Error occurred while fetching image, copy to clipboard failed',
+					'Error occurred while fetching image, copy to clipboard failed'
 				);
 				// should resolve
-				await expect(ref.current.download()).resolves.toBe('Chart downloaded as prism_export.png');
+				await expect(ref.current.download()).resolves.toBe('Chart downloaded as chart_export.png');
+			}
+		});
+		test('download uses supplied filename', async () => {
+			const ref = createRef<PrismHandle>();
+			render(
+				<Prism data={data} ref={ref}>
+					<Line dimension="x" metric="y" />
+				</Prism>
+			);
+			if (ref.current) {
+				// should reject since the chart isn't done rendering
+				await expect(ref.current.download()).rejects.toBe("There isn't a chart to download, download failed");
+				const prism = await findPrism();
+				expect(prism).toBeInTheDocument();
+				// should resolve
+				await expect(ref.current.download('My filename')).resolves.toBe('Chart downloaded as My filename.png');
 			}
 		});
 	});

--- a/src/utils/utils.test.tsx
+++ b/src/utils/utils.test.tsx
@@ -22,32 +22,11 @@ import {
 	getComponentName,
 	sanitizeAxisAnnotationChildren,
 	toCamelCase,
-	toSnakeCase,
 	toggleStringArrayValue,
 } from '@utils';
 import { Prism } from 'Prism';
 
 describe('utils', () => {
-	describe('toSnakeCase()', () => {
-		test('camelCase should convert to snake_case', () => {
-			expect(toSnakeCase('thisIsATest')).toStrictEqual('this_is_a_test');
-		});
-		test('kebab-case should convert to snake_case', () => {
-			expect(toSnakeCase('test-utils')).toStrictEqual('test_utils');
-		});
-		test('PascalCase should convert to snake_case', () => {
-			expect(toSnakeCase('SnakeTest')).toStrictEqual('snake_test');
-		});
-		test('sentence should convert to snake_case', () => {
-			expect(toSnakeCase('This is a test')).toStrictEqual('this_is_a_test');
-		});
-		test('wild string should convert to snake_case', () => {
-			expect(toSnakeCase('The guickFox_jumped-over 2 DOGS!')).toStrictEqual('the_guick_fox_jumped_over_2_dogs');
-		});
-		test('no alpha numeric characters should return original string', () => {
-			expect(toSnakeCase('&()*')).toStrictEqual('&()*');
-		});
-	});
 	describe('toCamelCase()', () => {
 		test('camelCase should convert to camelCase', () => {
 			expect(toCamelCase('camelTest')).toStrictEqual('camelTest');

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -111,15 +111,6 @@ export function toCamelCase(str: string) {
 	return str;
 }
 
-// converts any string to the snake_case equivalent
-export function toSnakeCase(str: string) {
-	const words = str.match(/[A-Z]{2,}(?=[A-Z][a-z]+\d*|\b)|[A-Z]?[a-z]+\d*|[A-Z]|\d+/g);
-	if (words) {
-		return words.map((x) => x.toLowerCase()).join('_');
-	}
-	return str;
-}
-
 /**
  * IMMUTABLE
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When exporting a PNG and providing a custom filename for the export, Chinese characters get turned in to non-sense.

## Related Issue

[Filename passed in to download function gets messed up in Chinese](https://github.com/adobe/react-spectrum-charts/issues/7)

## Motivation and Context

This is causing internationalization problems.

## How Has This Been Tested?

`yarn pack-test`
Then installed the tarball in product to verify issue was fixed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
