### PR TITLE
Switch to vega embed

### DIFF
--- a/__mocks__/useElementSize.ts
+++ b/__mocks__/useElementSize.ts
@@ -1,0 +1,3 @@
+const useElementSizeMock = () => [500, 500];
+
+export default useElementSizeMock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 	},
 	moduleDirectories: ['src', 'node_modules'],
 	moduleNameMapper: {
-		'@aaui/core': '<rootDir>/__mocks__/core.ts',
+		'@hooks/useElementSize': '<rootDir>/__mocks__/useElementSize.ts',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/__mocks__/fileMock.ts',
 		'\\.(css)$': 'identity-obj-proxy',

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
 		"react-vega": "7.6.0 - latest",
 		"uuid": "9.0.0 - latest",
 		"vega": "5.22.1 - latest",
+		"vega-embed": "^6.23.0",
 		"vega-lite": "5.6.0 - latest"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
 		"react-dom": "17.0.2 - latest",
 		"uuid": "9.0.0 - latest",
 		"vega": "5.22.1 - latest",
-		"vega-embed": "^6.0.0 - latest"
+		"vega-embed": "6.0.0 - latest",
+		"vega-lite": "5.6.0 - latest"
 	},
 	"peerDependencies": {
 		"@adobe/react-spectrum": "^3.23.0 - latest",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"react-dom": "17.0.2 - latest",
 		"uuid": "9.0.0 - latest",
 		"vega": "5.22.1 - latest",
-		"vega-embed": "6.0.0 - latest",
+		"vega-embed": "6.21.0 - latest",
 		"vega-lite": "5.6.0 - latest"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -102,11 +102,9 @@
 		"immer": "9.0.16 - latest",
 		"react": "17.0.2 - latest",
 		"react-dom": "17.0.2 - latest",
-		"react-vega": "7.6.0 - latest",
 		"uuid": "9.0.0 - latest",
 		"vega": "5.22.1 - latest",
-		"vega-embed": "^6.23.0",
-		"vega-lite": "5.6.0 - latest"
+		"vega-embed": "^6.0.0 - latest"
 	},
 	"peerDependencies": {
 		"@adobe/react-spectrum": "^3.23.0 - latest",

--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -141,14 +141,10 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 			tooltipElement.hidden = popoverIsOpen;
 
 			// if the popover is closed, reset the selected data
-			if (!popoverIsOpen && chartView.current) {
+			if (!popoverIsOpen) {
 				selectedData.current = null;
-
-				setTimeout(() => {
-					chartView.current?.runAsync();
-				}, 1000);
 			}
-		}, [popoverIsOpen, chartView]);
+		}, [popoverIsOpen]);
 
 		useChartImperativeHandle(forwardedRef, { chartView, title });
 

--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -1,16 +1,20 @@
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useMemo, useRef } from 'react';
 
 import { TABLE } from '@constants';
+import { useDebugSpec } from '@hooks/useDebugSpec';
+import { extractValues, isVegaData } from '@specBuilder/specUtils';
 import { expressionFunctions } from 'expressionFunctions';
+import { ChartData } from 'types';
 import { Config, Padding, Renderers, Spec, View } from 'vega';
 import embed from 'vega-embed';
 import { Options as TooltipOptions } from 'vega-tooltip';
 
-export interface VegaRendererProps {
+export interface VegaChartProps {
 	chartId: string;
 	config: Config;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	data: { table: object[] };
+	data: ChartData[];
+	debug: boolean;
 	height: number;
 	onNewView: (view: View) => void;
 	padding: Padding;
@@ -21,10 +25,11 @@ export interface VegaRendererProps {
 	width: number;
 }
 
-export const VegaRenderer: FC<VegaRendererProps> = ({
+export const VegaChart: FC<VegaChartProps> = ({
 	chartId,
 	config,
 	data,
+	debug,
 	height,
 	onNewView,
 	padding,
@@ -34,14 +39,29 @@ export const VegaRenderer: FC<VegaRendererProps> = ({
 	tooltip,
 	width,
 }) => {
-	console.log('render VegaRenderer');
+	const chartView = useRef<View>();
+
+	// Need to de a deep copy of the data because vega tries to transform the data
+	const chartData = useMemo(() => {
+		const clonedData = JSON.parse(JSON.stringify(data));
+
+		// We received a full Vega data array with potentially multiple dataset objects
+		if (isVegaData(clonedData)) {
+			return extractValues(clonedData);
+		}
+
+		// We received a simple array of data and we'll set a default key of 'table' to reference internally
+		return { [TABLE]: clonedData };
+	}, [data]);
+
+	useDebugSpec(debug, spec, chartData, width, height, config);
+
 	useEffect(() => {
 		if (width && height) {
-			console.log('reder visualization');
 			const specCopy = JSON.parse(JSON.stringify(spec)) as Spec;
 			const tableData = specCopy.data?.find((d) => d.name === TABLE);
 			if (tableData && 'values' in tableData) {
-				tableData.values = data.table;
+				tableData.values = chartData.table;
 			}
 			if (signals) {
 				specCopy.signals = specCopy.signals?.map((signal) => {
@@ -61,10 +81,20 @@ export const VegaRenderer: FC<VegaRendererProps> = ({
 				padding,
 				tooltip,
 			}).then(({ view }) => {
+				chartView.current = view;
 				onNewView(view);
+				view.resize();
+				view.runAsync();
 			});
 		}
-	}, [chartId, config, data, height, onNewView, padding, renderer, signals, spec, tooltip, width]);
+		return () => {
+			// destroy the chart on unmount
+			if (chartView.current) {
+				chartView.current.finalize();
+				chartView.current = undefined;
+			}
+		};
+	}, [chartData.table, chartId, config, data, height, onNewView, padding, renderer, signals, spec, tooltip, width]);
 
 	return <div id={`${chartId}-chart`} className="rsc"></div>;
 };

--- a/src/VegaRenderer.tsx
+++ b/src/VegaRenderer.tsx
@@ -1,0 +1,70 @@
+import { FC, useEffect } from 'react';
+
+import { TABLE } from '@constants';
+import { expressionFunctions } from 'expressionFunctions';
+import { Config, Padding, Renderers, Spec, View } from 'vega';
+import embed from 'vega-embed';
+import { Options as TooltipOptions } from 'vega-tooltip';
+
+export interface VegaRendererProps {
+	chartId: string;
+	config: Config;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	data: { table: object[] };
+	height: number;
+	onNewView: (view: View) => void;
+	padding: Padding;
+	renderer: Renderers;
+	signals?: Record<string, unknown>;
+	spec: Spec;
+	tooltip: TooltipOptions;
+	width: number;
+}
+
+export const VegaRenderer: FC<VegaRendererProps> = ({
+	chartId,
+	config,
+	data,
+	height,
+	onNewView,
+	padding,
+	renderer = 'svg',
+	signals,
+	spec,
+	tooltip,
+	width,
+}) => {
+	console.log('render VegaRenderer');
+	useEffect(() => {
+		if (width && height) {
+			console.log('reder visualization');
+			const specCopy = JSON.parse(JSON.stringify(spec)) as Spec;
+			const tableData = specCopy.data?.find((d) => d.name === TABLE);
+			if (tableData && 'values' in tableData) {
+				tableData.values = data.table;
+			}
+			if (signals) {
+				specCopy.signals = specCopy.signals?.map((signal) => {
+					if (signal.name in signals && signals[signal.name] !== undefined && 'value' in signal) {
+						signal.value = signals[signal.name];
+					}
+					return signal;
+				});
+			}
+			embed(`#${chartId}-chart`, specCopy, {
+				actions: false,
+				expressionFunctions: expressionFunctions,
+				renderer,
+				width,
+				height,
+				config,
+				padding,
+				tooltip,
+			}).then(({ view }) => {
+				onNewView(view);
+			});
+		}
+	}, [chartId, config, data, height, onNewView, padding, renderer, signals, spec, tooltip, width]);
+
+	return <div id={`${chartId}-chart`} className="rsc"></div>;
+};

--- a/src/hooks/useChartWidth.tsx
+++ b/src/hooks/useChartWidth.tsx
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { useMemo } from 'react';
 
 export default function useChartWidth(
@@ -31,6 +30,6 @@ export default function useChartWidth(
 				`width of ${width} is not a valid width. Please provide a valid number, 'auto' or percentage ex. 75%`
 			);
 		}
-		return Math.min(maxWidth, Math.max(minWidth, targetWidth));
+		return targetWidth === 0 ? 0 : Math.min(maxWidth, Math.max(minWidth, targetWidth));
 	}, [containerWidth, maxWidth, minWidth, width]);
 }

--- a/src/stories/Chart.test.tsx
+++ b/src/stories/Chart.test.tsx
@@ -39,26 +39,33 @@ const PopoverTest = (
 describe('Chart', () => {
 	test('Basic renders properly', async () => {
 		render(<Basic {...Basic.args} />);
-		const view = await screen.findByRole('graphics-document');
-		expect(view).toBeInTheDocument();
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
 	});
 
-	test('Basic renders properly', async () => {
+	test('Config renders properly', async () => {
 		render(<Config {...Config.args} />);
-		const view = await screen.findByRole('graphics-document');
-		expect(view).toBeInTheDocument();
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
 	});
 
-	test('Basic renders properly', async () => {
+	test('Width renders properly', async () => {
 		render(<Width {...Width.args} />);
-		const view = await screen.findByRole('graphics-document');
-		expect(view).toBeInTheDocument();
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
 	});
 
-	test('Basic renders properly with invalid width', async () => {
+	test('Width renders properly with invalid width', async () => {
 		render(<Width {...Width.args} width="50.2%" />);
-		const view = await screen.findByRole('graphics-document');
-		expect(view).toBeInTheDocument();
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+	});
+
+	test('Chart does not render if the width or height are 0', () => {
+		render(<Width {...Width.args} width={0} />);
+		expect(screen.queryByRole('graphics-document')).not.toBeInTheDocument();
+		render(<Width {...Width.args} height={0} />);
+		expect(screen.queryByRole('graphics-document')).not.toBeInTheDocument();
 	});
 
 	test('Existence of children and UNSAFE_vegaSpec throw an error', async () => {

--- a/src/stories/Chart.test.tsx
+++ b/src/stories/Chart.test.tsx
@@ -177,7 +177,7 @@ describe('Chart', () => {
 		test('download uses supplied filename', async () => {
 			const ref = createRef<ChartHandle>();
 			render(
-				<Chart data={data} ref={ref}>
+				<Chart data={data} ref={ref} width={200}>
 					<Line dimension="x" metric="y" />
 				</Chart>
 			);

--- a/src/stories/ChartExamples.story.tsx
+++ b/src/stories/ChartExamples.story.tsx
@@ -614,7 +614,6 @@ StackOverflowTrends.args = {
 	height: 500,
 	minWidth: 840,
 	width: 'auto',
-	debug: true,
 	renderer: 'canvas',
 	title: 'The Fall of Stack Overflow',
 };

--- a/src/stories/ChartUnsafeVega.story.tsx
+++ b/src/stories/ChartUnsafeVega.story.tsx
@@ -36,7 +36,7 @@ export default {
 
 const UnsafeVegaSpecStory: ComponentStory<typeof Chart> = (args): ReactElement => {
 	const chartProps = useChartProps(args);
-	return <Chart {...chartProps} debug />;
+	return <Chart {...chartProps} />;
 };
 
 const BasicBar = bindWithProps(UnsafeVegaSpecStory);

--- a/src/stories/components/Title/Title.test.tsx
+++ b/src/stories/components/Title/Title.test.tsx
@@ -81,7 +81,7 @@ describe('Title', () => {
 
 		const titleGroups = getAllMarksByGroupName(chart, 'role-title', 'g');
 		const positioningGroup = titleGroups[0];
-		expect(positioningGroup).toHaveAttribute('transform', 'translate(194,375)');
+		expect(positioningGroup).toHaveAttribute('transform', 'translate(244,375)');
 	});
 
 	// Title is not a real React component. This is test just provides test coverage for sonarqube

--- a/yarn.lock
+++ b/yarn.lock
@@ -10033,7 +10033,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-patch@^3.0.0-1:
+fast-json-patch@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
   integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
@@ -12654,12 +12654,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-pretty-compact@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz#e77c419f52ff00c45a31f07f4c820c2433143885"
-  integrity sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==
-
-json-stringify-pretty-compact@~3.0.0:
+json-stringify-pretty-compact@^3.0.0, json-stringify-pretty-compact@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
@@ -17350,17 +17345,19 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-"vega-embed@6.0.0 - latest":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.0.0.tgz#f3c5e8f907db2996ebcc62037f1ffec842edc3d1"
-  integrity sha512-CH3/FtiVFek5SmQCLbZVXbpslHIjCH7D0xNbfK6UrtKt4Mr1AmmsCo4rH3L4qqXqDwK6w9Vv4sNrF/6HOH8sDg==
+"vega-embed@6.21.0 - latest":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.21.0.tgz#a6f7d4965c653e40620bfd0a51fb419321cff02c"
+  integrity sha512-Tzo9VAfgNRb6XpxSFd7uphSeK2w5OxDY2wDtmpsQ+rQlPSEEI9TE6Jsb2nHRLD5J4FrmXKLrTcORqidsNQSXEg==
   dependencies:
-    fast-json-patch "^3.0.0-1"
-    json-stringify-pretty-compact "^2.0.0"
-    semver "^6.3.0"
-    vega-schema-url-parser "^1.1.0"
-    vega-themes "^2.5.0"
-    vega-tooltip "^0.19.1"
+    fast-json-patch "^3.1.1"
+    json-stringify-pretty-compact "^3.0.0"
+    semver "^7.3.7"
+    tslib "^2.4.0"
+    vega-interpreter "^1.0.4"
+    vega-schema-url-parser "^2.2.0"
+    vega-themes "^2.10.0"
+    vega-tooltip "^0.28.0"
 
 vega-encode@~4.9.0:
   version "4.9.2"
@@ -17453,6 +17450,11 @@ vega-hierarchy@~4.1.0:
     d3-hierarchy "^3.1.2"
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
+
+vega-interpreter@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/vega-interpreter/-/vega-interpreter-1.0.5.tgz#19e1d1b5f84a4ea9cb25c4e90a05ce16cd058484"
+  integrity sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg==
 
 vega-label@~1.2.0:
   version "1.2.1"
@@ -17571,10 +17573,10 @@ vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2, vega-scenegraph@~4.10.1:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
-vega-schema-url-parser@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-1.1.0.tgz#39168ec04e5468ce278a06c16ec0d126035a85b5"
-  integrity sha512-Tc85J2ofMZZOsxiqDM9sbvfsa+Vdo3GwNLjEEsPOsCDeYqsUHKAlc1IpbbhPLZ6jusyM9Lk0e1izF64GGklFDg==
+vega-schema-url-parser@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz#a0d1e02915adfbfcb1fd517c8c2ebe2419985c1e"
+  integrity sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==
 
 vega-selections@^5.4.1:
   version "5.4.1"
@@ -17599,7 +17601,7 @@ vega-statistics@~1.8.0:
   dependencies:
     d3-array "^3.2.2"
 
-vega-themes@^2.5.0:
+vega-themes@^2.10.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/vega-themes/-/vega-themes-2.14.0.tgz#0df269396e057123ecf3942e3b704bf125d1eed7"
   integrity sha512-9dLmsUER7gJrDp8SEYKxBFmXmpyzLlToKIjxq3HCvYjz8cnNrRGyAhvIlKWOB3ZnGvfYV+vnv3ZRElSNL31nkA==
@@ -17613,12 +17615,12 @@ vega-time@^2.1.0, vega-time@^2.1.1, vega-time@~2.1.0:
     d3-time "^3.1.0"
     vega-util "^1.17.1"
 
-vega-tooltip@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.19.1.tgz#b0534b90a7df21fee9e693bf4e4556312f89296e"
-  integrity sha512-BNZ5T866SLOai+NZyGxg60U6hZhNINHuX313/z1TrUTeCprYLfCR1Ex4qRozY1WPY3HfxQcd5czLJMhoAFDotQ==
+vega-tooltip@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.28.0.tgz#8bae2601ffae5e67622de37108f53f284e9a978b"
+  integrity sha512-DbK0V5zzk+p9cphZZXV91ZGeKq0zr6JIS0VndUoGTisldzw4tRgmpGQcTfMjew53o7/voeTM2ELTnJAJRzX4tg==
   dependencies:
-    vega-util "^1.11.1"
+    vega-util "^1.17.0"
 
 vega-transforms@~4.10.0:
   version "4.10.2"
@@ -17640,7 +17642,7 @@ vega-typings@~0.22.0:
     vega-expression "^5.0.0"
     vega-util "^1.15.2"
 
-vega-util@^1.11.1, vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.17.0, vega-util@^1.17.1, vega-util@~1.17.0:
+vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.17.0, vega-util@^1.17.1, vega-util@~1.17.0:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.2.tgz#f69aa09fd5d6110c19c4a0f0af9e35945b99987d"
   integrity sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==
@@ -18284,15 +18286,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@*, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,11 +5708,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/clone@~2.1.1":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-2.1.2.tgz#94ad2e8909eb214e0eebac3b350a5c88118dc76d"
-  integrity sha512-fKXTsQvII/8K7xSxQF2OEuN6Pt4/PDasws60s/qeqoIOaBX7Aoevy5CmaQ4fANbvOo04MN3kx3xUIc6ZNXsmaQ==
-
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz#6e5e3602d93bda975cebc3449e1a318340af9e20"
@@ -5990,7 +5985,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@17.0.50", "@types/react@^17":
+"@types/react@17.0.50", "@types/react@^17":
   version "17.0.50"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.50.tgz#39abb4f7098f546cfcd6b51207c90c4295ee81fc"
   integrity sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==
@@ -8086,11 +8081,6 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-clone@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
-
 clsx@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
@@ -9995,7 +9985,7 @@ extract-zip@^1.6.6:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -10038,7 +10028,7 @@ fast-json-patch@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
   integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@~2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -12654,7 +12644,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-pretty-compact@^3.0.0, json-stringify-pretty-compact@~3.0.0:
+json-stringify-pretty-compact@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
@@ -14976,16 +14966,6 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react-vega@7.6.0 - latest":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/react-vega/-/react-vega-7.6.0.tgz#b791c944046b20e02d366c7d0f8dcc21bdb4a6bb"
-  integrity sha512-2oMML4wH9qWLnZPRxJm06ozwrVN/K+nkjqdI5/ofWWsrBnnH4iB9rRKrsV8px0nlWgZrwfdCH4g5RUiyyJHWSA==
-  dependencies:
-    "@types/react" "*"
-    fast-deep-equal "^3.1.1"
-    prop-types "^15.8.1"
-    vega-embed "^6.5.1"
-
 "react@17.0.2 - latest":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -16810,11 +16790,6 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@~2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -17355,7 +17330,7 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-vega-embed@^6.23.0, vega-embed@^6.5.1:
+"vega-embed@^6.0.0 - latest":
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.23.0.tgz#640fe1cefef58a8a061da084ec804a1b4abbd5ef"
   integrity sha512-8Iava57LdROsatqsOhMLErHYaBpZBB7yZJlSVU3/xOK3l8Ft5WFnj5fm3OOAVML97/0yULE7LRVjXW5hV3fSpg==
@@ -17368,7 +17343,6 @@ vega-embed@^6.23.0, vega-embed@^6.5.1:
     vega-schema-url-parser "^2.2.0"
     vega-themes "^2.14.0"
     vega-tooltip "^0.33.0"
-    yallist "*"
 
 vega-encode@~4.9.0:
   version "4.9.2"
@@ -17476,22 +17450,6 @@ vega-label@~1.2.0:
     vega-dataflow "^5.7.3"
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
-
-"vega-lite@5.6.0 - latest":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.0.tgz#0f0adfc8b86f5eea071df186b2877d828c870c11"
-  integrity sha512-aTjQk//SzL9ctHY4ItA8yZSGflHMWPJmCXEs8LeRlixuOaAbamZmeL8xNMbQpS/vAZQeFAqjcJ32Fuztz/oGww==
-  dependencies:
-    "@types/clone" "~2.1.1"
-    clone "~2.1.2"
-    fast-deep-equal "~3.1.3"
-    fast-json-stable-stringify "~2.1.0"
-    json-stringify-pretty-compact "~3.0.0"
-    tslib "~2.4.0"
-    vega-event-selector "~3.0.0"
-    vega-expression "~5.0.0"
-    vega-util "~1.17.0"
-    yargs "~17.6.0"
 
 vega-loader@^4.5.1, vega-loader@~4.5.0:
   version "4.5.1"
@@ -18339,19 +18297,6 @@ yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
-yargs@~17.6.0:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17355,7 +17355,7 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-vega-embed@^6.5.1:
+vega-embed@^6.23.0, vega-embed@^6.5.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.23.0.tgz#640fe1cefef58a8a061da084ec804a1b4abbd5ef"
   integrity sha512-8Iava57LdROsatqsOhMLErHYaBpZBB7yZJlSVU3/xOK3l8Ft5WFnj5fm3OOAVML97/0yULE7LRVjXW5hV3fSpg==
@@ -17368,6 +17368,7 @@ vega-embed@^6.5.1:
     vega-schema-url-parser "^2.2.0"
     vega-themes "^2.14.0"
     vega-tooltip "^0.33.0"
+    yallist "*"
 
 vega-encode@~4.9.0:
   version "4.9.2"
@@ -18296,15 +18297,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@*, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,6 +5708,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/clone@~2.1.1":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-2.1.4.tgz#9680f886c935dcf596273f1218abb71efb01531a"
+  integrity sha512-NKRWaEGaVGVLnGLB2GazvDaZnyweW9FJLLFL5LhywGJB3aqGMT9R/EUoJoSRP4nzofYnZysuDmrEJtJdAqUOtQ==
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz#6e5e3602d93bda975cebc3449e1a318340af9e20"
@@ -8081,6 +8086,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+clone@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clsx@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
@@ -9985,7 +9995,7 @@ extract-zip@^1.6.6:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -10023,12 +10033,12 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-patch@^3.1.1:
+fast-json-patch@^3.0.0-1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
   integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -12644,7 +12654,12 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-pretty-compact@^3.0.0:
+json-stringify-pretty-compact@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz#e77c419f52ff00c45a31f07f4c820c2433143885"
+  integrity sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==
+
+json-stringify-pretty-compact@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
@@ -16785,10 +16800,15 @@ tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0, tslib@^2.6.1:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@~2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -17330,19 +17350,17 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-"vega-embed@^6.0.0 - latest":
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.23.0.tgz#640fe1cefef58a8a061da084ec804a1b4abbd5ef"
-  integrity sha512-8Iava57LdROsatqsOhMLErHYaBpZBB7yZJlSVU3/xOK3l8Ft5WFnj5fm3OOAVML97/0yULE7LRVjXW5hV3fSpg==
+"vega-embed@6.0.0 - latest":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.0.0.tgz#f3c5e8f907db2996ebcc62037f1ffec842edc3d1"
+  integrity sha512-CH3/FtiVFek5SmQCLbZVXbpslHIjCH7D0xNbfK6UrtKt4Mr1AmmsCo4rH3L4qqXqDwK6w9Vv4sNrF/6HOH8sDg==
   dependencies:
-    fast-json-patch "^3.1.1"
-    json-stringify-pretty-compact "^3.0.0"
-    semver "^7.5.4"
-    tslib "^2.6.1"
-    vega-interpreter "^1.0.5"
-    vega-schema-url-parser "^2.2.0"
-    vega-themes "^2.14.0"
-    vega-tooltip "^0.33.0"
+    fast-json-patch "^3.0.0-1"
+    json-stringify-pretty-compact "^2.0.0"
+    semver "^6.3.0"
+    vega-schema-url-parser "^1.1.0"
+    vega-themes "^2.5.0"
+    vega-tooltip "^0.19.1"
 
 vega-encode@~4.9.0:
   version "4.9.2"
@@ -17436,11 +17454,6 @@ vega-hierarchy@~4.1.0:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-interpreter@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/vega-interpreter/-/vega-interpreter-1.0.5.tgz#19e1d1b5f84a4ea9cb25c4e90a05ce16cd058484"
-  integrity sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg==
-
 vega-label@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-1.2.1.tgz#ea45fa5a407991c44edfea9c4ca40874d544a3db"
@@ -17450,6 +17463,22 @@ vega-label@~1.2.0:
     vega-dataflow "^5.7.3"
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
+
+"vega-lite@5.6.0 - latest":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.0.tgz#0f0adfc8b86f5eea071df186b2877d828c870c11"
+  integrity sha512-aTjQk//SzL9ctHY4ItA8yZSGflHMWPJmCXEs8LeRlixuOaAbamZmeL8xNMbQpS/vAZQeFAqjcJ32Fuztz/oGww==
+  dependencies:
+    "@types/clone" "~2.1.1"
+    clone "~2.1.2"
+    fast-deep-equal "~3.1.3"
+    fast-json-stable-stringify "~2.1.0"
+    json-stringify-pretty-compact "~3.0.0"
+    tslib "~2.4.0"
+    vega-event-selector "~3.0.0"
+    vega-expression "~5.0.0"
+    vega-util "~1.17.0"
+    yargs "~17.6.0"
 
 vega-loader@^4.5.1, vega-loader@~4.5.0:
   version "4.5.1"
@@ -17542,10 +17571,10 @@ vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2, vega-scenegraph@~4.10.1:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
-vega-schema-url-parser@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz#a0d1e02915adfbfcb1fd517c8c2ebe2419985c1e"
-  integrity sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==
+vega-schema-url-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-1.1.0.tgz#39168ec04e5468ce278a06c16ec0d126035a85b5"
+  integrity sha512-Tc85J2ofMZZOsxiqDM9sbvfsa+Vdo3GwNLjEEsPOsCDeYqsUHKAlc1IpbbhPLZ6jusyM9Lk0e1izF64GGklFDg==
 
 vega-selections@^5.4.1:
   version "5.4.1"
@@ -17570,7 +17599,7 @@ vega-statistics@~1.8.0:
   dependencies:
     d3-array "^3.2.2"
 
-vega-themes@^2.14.0:
+vega-themes@^2.5.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/vega-themes/-/vega-themes-2.14.0.tgz#0df269396e057123ecf3942e3b704bf125d1eed7"
   integrity sha512-9dLmsUER7gJrDp8SEYKxBFmXmpyzLlToKIjxq3HCvYjz8cnNrRGyAhvIlKWOB3ZnGvfYV+vnv3ZRElSNL31nkA==
@@ -17584,12 +17613,12 @@ vega-time@^2.1.0, vega-time@^2.1.1, vega-time@~2.1.0:
     d3-time "^3.1.0"
     vega-util "^1.17.1"
 
-vega-tooltip@^0.33.0:
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.33.0.tgz#32bcaad713171d2ae00b47189e6334a318566739"
-  integrity sha512-jMcvH2lP20UfyvO2KAEdloiwRyasikaiLuNFhzwrrzf2RamGTxP4G7B2OZ2QENfrGUH05Z9ei5tn/eErdzOaZQ==
+vega-tooltip@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.19.1.tgz#b0534b90a7df21fee9e693bf4e4556312f89296e"
+  integrity sha512-BNZ5T866SLOai+NZyGxg60U6hZhNINHuX313/z1TrUTeCprYLfCR1Ex4qRozY1WPY3HfxQcd5czLJMhoAFDotQ==
   dependencies:
-    vega-util "^1.17.2"
+    vega-util "^1.11.1"
 
 vega-transforms@~4.10.0:
   version "4.10.2"
@@ -17611,7 +17640,7 @@ vega-typings@~0.22.0:
     vega-expression "^5.0.0"
     vega-util "^1.15.2"
 
-vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.17.0, vega-util@^1.17.1, vega-util@^1.17.2, vega-util@~1.17.0:
+vega-util@^1.11.1, vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.17.0, vega-util@^1.17.1, vega-util@~1.17.0:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.2.tgz#f69aa09fd5d6110c19c4a0f0af9e35945b99987d"
   integrity sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==
@@ -18255,15 +18284,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@*, yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
@@ -18297,6 +18326,19 @@ yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@~17.6.0:
+  version "17.6.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
+  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently the library uses a tool called react-vega to render the vega charts. The issue with react-vega is we get some weird behavior like resize flicker and a lot of console.errors and console.warns.

Going one level lower to vega-embed and controlling the lifecycle ourselves solves these issues.

## How Has This Been Tested?

All tests are passing which confirms that the new vega renderer was swapped out successfully.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
