### PR TITLE
Fix vega dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@
 
 ## Table of Contents
 
--   [React Spectrum Charts](#react-spectrum-charts)
-    -   [Table of Contents](#table-of-contents)
-    -   [Overview](#overview)
-        -   [Key Features:](#key-features)
-    -   [Installation](#installation)
-        -   [npm](#npm)
-        -   [yarn](#yarn)
-    -   [Usage](#usage)
-        -   [Example](#example)
-    -   [Spectrum (Adobe Design System) Integration](#spectrum-adobe-design-system-integration)
-    -   [API](#api)
-    -   [Storybook](#storybook)
-    -   [Support](#support)
-    -   [Contributing](#contributing)
-    -   [License](#license)
-        -   [Apache License 2.0 Summary](#apache-license-20-summary)
-    -   [Roadmap](#roadmap)
+- [React Spectrum Charts](#react-spectrum-charts)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Key Features:](#key-features)
+  - [Installation](#installation)
+      - [npm](#npm)
+      - [yarn](#yarn)
+  - [Usage](#usage)
+    - [Example](#example)
+  - [Spectrum (Adobe Design System) Integration](#spectrum-adobe-design-system-integration)
+  - [API](#api)
+  - [Storybook](#storybook)
+  - [Support](#support)
+  - [Contributing](#contributing)
+  - [License](#license)
+    - [Apache License 2.0 Summary](#apache-license-20-summary)
+  - [Roadmap](#roadmap)
 
 ## Overview
 
@@ -72,13 +72,13 @@
 #### npm
 
 ```
-npm install @adobe/react-spectrum-charts
+npm install @adobe/react-spectrum-charts vega vega-lite
 ```
 
 #### yarn
 
 ```
-yarn add @adobe/react-spectrum-charts
+yarn add @adobe/react-spectrum-charts vega vega-lite
 ```
 
 ## Usage

--- a/__mocks__/useElementSize.ts
+++ b/__mocks__/useElementSize.ts
@@ -1,3 +1,0 @@
-const useElementSizeMock = () => [500, 500];
-
-export default useElementSizeMock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,6 @@ module.exports = {
 	},
 	moduleDirectories: ['src', 'node_modules'],
 	moduleNameMapper: {
-		'@hooks/useElementSize': '<rootDir>/__mocks__/useElementSize.ts',
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/__mocks__/fileMock.ts',
 		'\\.(css)$': 'identity-obj-proxy',

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
 		"ts-loader": "^9.4.2",
 		"tsconfig-paths-webpack-plugin": "^4.0.0",
 		"typescript": "^4.9.3",
+		"vega": "5.26.0",
+		"vega-lite": "^5.16.2",
 		"webpack": "^5.75.0",
 		"webpack-cli": "^5.0.1",
 		"webpack-dev-server": "^4.11.1",
@@ -103,14 +105,14 @@
 		"react": "17.0.2 - latest",
 		"react-dom": "17.0.2 - latest",
 		"uuid": "9.0.0 - latest",
-		"vega": "5.22.1 - latest",
-		"vega-embed": "6.21.0 - latest",
-		"vega-lite": "5.6.0 - latest"
+		"vega-embed": "6.23.0 - latest"
 	},
 	"peerDependencies": {
 		"@adobe/react-spectrum": "^3.23.0 - latest",
 		"react": "17.0.2 - latest",
-		"react-dom": "17.0.2 - latest"
+		"react-dom": "17.0.2 - latest",
+		"vega": "5.20.2 - latest",
+		"vega-lite": "5.0.0 - latest"
 	},
 	"resolutions": {
 		"@types/react": "17.0.50",

--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -262,7 +262,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 						<PlaceholderContent loading={loading} data={data} height={height} />
 					) : (
 						<VegaChart
-							chartId={chartId.current}
 							spec={spec}
 							config={chartConfig}
 							data={data}

--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -10,7 +10,6 @@ import embed from 'vega-embed';
 import { Options as TooltipOptions } from 'vega-tooltip';
 
 export interface VegaChartProps {
-	chartId: string;
 	config: Config;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	data: ChartData[];
@@ -26,7 +25,6 @@ export interface VegaChartProps {
 }
 
 export const VegaChart: FC<VegaChartProps> = ({
-	chartId,
 	config,
 	data,
 	debug,
@@ -39,6 +37,7 @@ export const VegaChart: FC<VegaChartProps> = ({
 	tooltip,
 	width,
 }) => {
+	const containerRef = useRef<HTMLDivElement>(null);
 	const chartView = useRef<View>();
 
 	// Need to de a deep copy of the data because vega tries to transform the data
@@ -57,7 +56,7 @@ export const VegaChart: FC<VegaChartProps> = ({
 	useDebugSpec(debug, spec, chartData, width, height, config);
 
 	useEffect(() => {
-		if (width && height) {
+		if (width && height && containerRef.current) {
 			const specCopy = JSON.parse(JSON.stringify(spec)) as Spec;
 			const tableData = specCopy.data?.find((d) => d.name === TABLE);
 			if (tableData && 'values' in tableData) {
@@ -71,7 +70,7 @@ export const VegaChart: FC<VegaChartProps> = ({
 					return signal;
 				});
 			}
-			embed(`#${chartId}-chart`, specCopy, {
+			embed(containerRef.current, specCopy, {
 				actions: false,
 				expressionFunctions: expressionFunctions,
 				renderer,
@@ -94,7 +93,7 @@ export const VegaChart: FC<VegaChartProps> = ({
 				chartView.current = undefined;
 			}
 		};
-	}, [chartData.table, chartId, config, data, height, onNewView, padding, renderer, signals, spec, tooltip, width]);
+	}, [chartData.table, config, data, height, onNewView, padding, renderer, signals, spec, tooltip, width]);
 
-	return <div id={`${chartId}-chart`} className="rsc"></div>;
+	return <div ref={containerRef} className="rsc"></div>;
 };

--- a/src/expressionFunctions.ts
+++ b/src/expressionFunctions.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { ADOBE_CLEAN_FONT } from '@themes/spectrumTheme';
 
 interface LabelDatum {

--- a/src/hooks/useElementSize.tsx
+++ b/src/hooks/useElementSize.tsx
@@ -17,7 +17,11 @@ export default function useElementSize(ref: RefObject<HTMLElement>) {
 
 	useLayoutEffect(() => {
 		const handleResize = () => {
-			if (!ref.current) return;
+			if (!ref.current) {
+				setWidth(0);
+				setHeight(0);
+				return;
+			}
 			// in jest, offsetWidth and offsetHeight are always 0
 			// default to 500px for testing
 			setWidth(ref.current.offsetWidth || 500);

--- a/src/hooks/useElementSize.tsx
+++ b/src/hooks/useElementSize.tsx
@@ -17,8 +17,11 @@ export default function useElementSize(ref: RefObject<HTMLElement>) {
 
 	useLayoutEffect(() => {
 		const handleResize = () => {
-			setWidth(ref.current?.offsetWidth ?? 0);
-			setHeight(ref.current?.offsetHeight ?? 0);
+			if (!ref.current) return;
+			// in jest, offsetWidth and offsetHeight are always 0
+			// default to 500px for testing
+			setWidth(ref.current.offsetWidth || 500);
+			setHeight(ref.current.offsetHeight || 500);
 		};
 		handleResize();
 		window.addEventListener('resize', handleResize);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,11 +5708,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/clone@~2.1.1":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-2.1.4.tgz#9680f886c935dcf596273f1218abb71efb01531a"
-  integrity sha512-NKRWaEGaVGVLnGLB2GazvDaZnyweW9FJLLFL5LhywGJB3aqGMT9R/EUoJoSRP4nzofYnZysuDmrEJtJdAqUOtQ==
-
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz#6e5e3602d93bda975cebc3449e1a318340af9e20"
@@ -5778,6 +5773,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/fined/-/fined-1.1.3.tgz#83f03e8f0a8d3673dfcafb18fce3571f6250e1bc"
   integrity sha512-CWYnSRnun3CGbt6taXeVo2lCbuaj4mchVJ4UF/BdU5TSuIn3AmS13pGMwCsBUoehGbhZrBrpNJZSZI5EVilXww==
+
+"@types/geojson@7946.0.4":
+  version "7946.0.4"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.4.tgz#4e049756383c3f055dd8f3d24e63fb543e98eb07"
+  integrity sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==
 
 "@types/glob@*":
   version "8.1.0"
@@ -8086,11 +8086,6 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-clone@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
-
 clsx@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
@@ -8641,17 +8636,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.2.tgz#673b5f233bf34d8e602b949429f8171d9121bea3"
   integrity sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@^3.1.1, d3-array@^3.2.2:
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
-  dependencies:
-    internmap "1 - 2"
-
-d3-array@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.2.tgz#f8ac4705c5b06914a7e0025bbf8d5f1513f6a86e"
-  integrity sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==
   dependencies:
     internmap "1 - 2"
 
@@ -8704,7 +8692,7 @@ d3-geo-projection@^4.0.0:
     d3-array "1 - 3"
     d3-geo "1.12.0 - 3"
 
-"d3-geo@1.12.0 - 3", d3-geo@^3.0.1, d3-geo@^3.1.0:
+"d3-geo@1.12.0 - 3", d3-geo@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
   integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
@@ -9995,7 +9983,7 @@ extract-zip@^1.6.6:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -10038,7 +10026,7 @@ fast-json-patch@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
   integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@~2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -16795,15 +16783,10 @@ tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0, tslib@^2.6.1, tslib@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@~2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -17327,7 +17310,7 @@ vega-canvas@^1.2.6, vega-canvas@^1.2.7:
   resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-1.2.7.tgz#cf62169518f5dcd91d24ad352998c2248f8974fb"
   integrity sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==
 
-vega-crossfilter@~4.1.0:
+vega-crossfilter@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz#3ff3ca0574883706f7a399dc6d60f4a0f065ece4"
   integrity sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==
@@ -17336,7 +17319,7 @@ vega-crossfilter@~4.1.0:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
+vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.5:
   version "5.7.5"
   resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-5.7.5.tgz#0d559f3c3a968831f2995e099a2e270993ddfed9"
   integrity sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==
@@ -17345,21 +17328,21 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.4:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-"vega-embed@6.21.0 - latest":
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.21.0.tgz#a6f7d4965c653e40620bfd0a51fb419321cff02c"
-  integrity sha512-Tzo9VAfgNRb6XpxSFd7uphSeK2w5OxDY2wDtmpsQ+rQlPSEEI9TE6Jsb2nHRLD5J4FrmXKLrTcORqidsNQSXEg==
+"vega-embed@6.23.0 - latest":
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/vega-embed/-/vega-embed-6.23.0.tgz#640fe1cefef58a8a061da084ec804a1b4abbd5ef"
+  integrity sha512-8Iava57LdROsatqsOhMLErHYaBpZBB7yZJlSVU3/xOK3l8Ft5WFnj5fm3OOAVML97/0yULE7LRVjXW5hV3fSpg==
   dependencies:
     fast-json-patch "^3.1.1"
     json-stringify-pretty-compact "^3.0.0"
-    semver "^7.3.7"
-    tslib "^2.4.0"
-    vega-interpreter "^1.0.4"
+    semver "^7.5.4"
+    tslib "^2.6.1"
+    vega-interpreter "^1.0.5"
     vega-schema-url-parser "^2.2.0"
-    vega-themes "^2.10.0"
-    vega-tooltip "^0.28.0"
+    vega-themes "^2.14.0"
+    vega-tooltip "^0.33.0"
 
-vega-encode@~4.9.0:
+vega-encode@~4.9.2:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-4.9.2.tgz#2426215fba8e6899cdcdda1800b8df662de4ca1c"
   integrity sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==
@@ -17370,12 +17353,12 @@ vega-encode@~4.9.0:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
-vega-event-selector@^3.0.0, vega-event-selector@~3.0.0:
+vega-event-selector@^3.0.1, vega-event-selector@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-3.0.1.tgz#b99e92147b338158f8079d81b28b2e7199c2e259"
   integrity sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==
 
-vega-expression@^5.0.0, vega-expression@^5.0.1, vega-expression@^5.1.0:
+vega-expression@^5.0.1, vega-expression@^5.1.0, vega-expression@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.1.0.tgz#4ec0e66b56a2faba88361eb717011303bbb1ff61"
   integrity sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==
@@ -17383,24 +17366,16 @@ vega-expression@^5.0.0, vega-expression@^5.0.1, vega-expression@^5.1.0:
     "@types/estree" "^1.0.0"
     vega-util "^1.17.1"
 
-vega-expression@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.0.1.tgz#e6a6eff564d2a93496a9bf34cbc78d8942f236a8"
-  integrity sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    vega-util "^1.17.1"
-
-vega-force@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.1.1.tgz#27bffa96bda293f27d2a2492c2cbf99d49fec77e"
-  integrity sha512-T6fJAUz9zdXf2qj2Hz0VlmdtaY7eZfcKNazhUV8hza4R3F9ug6r/hSrdovfc9ExmbUjL5iyvDUsf63r8K3/wVQ==
+vega-force@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.2.0.tgz#5374d0dbac674c92620a9801e12b650b0966336a"
+  integrity sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==
   dependencies:
     d3-force "^3.0.0"
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-format@^1.1.1, vega-format@~1.1.0:
+vega-format@^1.1.1, vega-format@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vega-format/-/vega-format-1.1.1.tgz#92e4876e18064e7ad54f39045f7b24dede0030b8"
   integrity sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==
@@ -17411,10 +17386,10 @@ vega-format@^1.1.1, vega-format@~1.1.0:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-functions@^5.12.1, vega-functions@^5.13.1, vega-functions@~5.13.0:
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.13.2.tgz#928348b7867955be3fb6a2b116fd15b6a24992ad"
-  integrity sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==
+vega-functions@^5.13.1, vega-functions@^5.14.0, vega-functions@~5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.14.0.tgz#8235157ae35c0e12f9122e3b783d693967de3c40"
+  integrity sha512-Q0rocHmJDfQ0tS91kdN8WcEosq1e3HPK1Yf5z36SPYPmTzKw3uxUGE52tLxC832acAYqPmi8R41wAoI/yFQTPg==
   dependencies:
     d3-array "^3.2.2"
     d3-color "^3.1.0"
@@ -17423,12 +17398,12 @@ vega-functions@^5.12.1, vega-functions@^5.13.1, vega-functions@~5.13.0:
     vega-expression "^5.1.0"
     vega-scale "^7.3.0"
     vega-scenegraph "^4.10.2"
-    vega-selections "^5.4.1"
+    vega-selections "^5.4.2"
     vega-statistics "^1.8.1"
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-geo@~4.4.0:
+vega-geo@~4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-4.4.1.tgz#3850232bf28c98fab5e26c5fb401acb6fb37b5e5"
   integrity sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==
@@ -17442,7 +17417,7 @@ vega-geo@~4.4.0:
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
 
-vega-hierarchy@~4.1.0:
+vega-hierarchy@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz#897974a477dfa70cc0d4efab9465b6cc79a9071f"
   integrity sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==
@@ -17451,12 +17426,12 @@ vega-hierarchy@~4.1.0:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-interpreter@^1.0.4:
+vega-interpreter@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/vega-interpreter/-/vega-interpreter-1.0.5.tgz#19e1d1b5f84a4ea9cb25c4e90a05ce16cd058484"
   integrity sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg==
 
-vega-label@~1.2.0:
+vega-label@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-1.2.1.tgz#ea45fa5a407991c44edfea9c4ca40874d544a3db"
   integrity sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==
@@ -17466,23 +17441,19 @@ vega-label@~1.2.0:
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
 
-"vega-lite@5.6.0 - latest":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.6.0.tgz#0f0adfc8b86f5eea071df186b2877d828c870c11"
-  integrity sha512-aTjQk//SzL9ctHY4ItA8yZSGflHMWPJmCXEs8LeRlixuOaAbamZmeL8xNMbQpS/vAZQeFAqjcJ32Fuztz/oGww==
+vega-lite@^5.16.2:
+  version "5.16.2"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.16.2.tgz#8b328cbea9d5b0838a0c7c4bf18b3a532e45e537"
+  integrity sha512-lC+yx7bD8EyBu4CHNr7kLfPZ8+uU01xJZyOxNB1XSMdW0oNTKewLrA5be3W6mHgNDl60i4uZ5l463jfFGQ290A==
   dependencies:
-    "@types/clone" "~2.1.1"
-    clone "~2.1.2"
-    fast-deep-equal "~3.1.3"
-    fast-json-stable-stringify "~2.1.0"
     json-stringify-pretty-compact "~3.0.0"
-    tslib "~2.4.0"
-    vega-event-selector "~3.0.0"
-    vega-expression "~5.0.0"
-    vega-util "~1.17.0"
-    yargs "~17.6.0"
+    tslib "~2.6.2"
+    vega-event-selector "~3.0.1"
+    vega-expression "~5.1.0"
+    vega-util "~1.17.2"
+    yargs "~17.7.2"
 
-vega-loader@^4.5.1, vega-loader@~4.5.0:
+vega-loader@^4.5.1, vega-loader@~4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-4.5.1.tgz#b85262b3cb8376487db0c014a8a13c3a5e6d52ad"
   integrity sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==
@@ -17493,18 +17464,18 @@ vega-loader@^4.5.1, vega-loader@~4.5.0:
     vega-format "^1.1.1"
     vega-util "^1.17.1"
 
-vega-parser@~6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.1.4.tgz#4868e41af2c9645b6d7daeeb205cfad06b9d465c"
-  integrity sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==
+vega-parser@~6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.2.1.tgz#102299993ef6c9562c6e3388925cb8a2663176ac"
+  integrity sha512-F79bQXt6fMkACR+TfFl7ueehKO26yCR/3iRZxhU7/pgHerx/d8K8pf2onMguu3NAN4eitT+PPuTgkDZtcqo9Qg==
   dependencies:
-    vega-dataflow "^5.7.3"
-    vega-event-selector "^3.0.0"
-    vega-functions "^5.12.1"
-    vega-scale "^7.1.1"
-    vega-util "^1.16.0"
+    vega-dataflow "^5.7.5"
+    vega-event-selector "^3.0.1"
+    vega-functions "^5.14.0"
+    vega-scale "^7.3.1"
+    vega-util "^1.17.2"
 
-vega-projection@^1.6.0:
+vega-projection@^1.6.0, vega-projection@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.6.0.tgz#921acd3220e7d9d04ccd5ce0109433afb3236966"
   integrity sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==
@@ -17513,25 +17484,17 @@ vega-projection@^1.6.0:
     d3-geo-projection "^4.0.0"
     vega-scale "^7.3.0"
 
-vega-projection@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.5.0.tgz#51c5f0455170cd35b3c5f3e653e99c3616520640"
-  integrity sha512-aob7qojh555x3hQWZ/tr8cIJNSWQbm6EoWTJaheZgFOY2x3cDa4Qrg3RJbGw6KwVj/IQk2p40paRzixKZ2kr+A==
-  dependencies:
-    d3-geo "^3.0.1"
-    d3-geo-projection "^4.0.0"
-
-vega-regression@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.1.1.tgz#b53a964152a2fec4847e31571f522bfda23089af"
-  integrity sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==
+vega-regression@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.2.0.tgz#12e9df88cf49994ac1a1799f64fb9c118a77a5e0"
+  integrity sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==
   dependencies:
     d3-array "^3.2.2"
     vega-dataflow "^5.7.3"
-    vega-statistics "^1.7.9"
+    vega-statistics "^1.9.0"
     vega-util "^1.15.2"
 
-vega-runtime@^6.1.4, vega-runtime@~6.1.3:
+vega-runtime@^6.1.4, vega-runtime@~6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-6.1.4.tgz#98b67160cea9554e690bfd44719f9d17f90c4220"
   integrity sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==
@@ -17539,10 +17502,10 @@ vega-runtime@^6.1.4, vega-runtime@~6.1.3:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-scale@^7.1.1, vega-scale@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.3.0.tgz#02b83435a892c6d91a87ee7d3d350fac987f464b"
-  integrity sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==
+vega-scale@^7.3.0, vega-scale@^7.3.1, vega-scale@~7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.3.1.tgz#5cb23d1edcf5d759e25fe40b7608a6132a62da46"
+  integrity sha512-tyTlaaCpHN2Ik/PPKl/j9ThadBDjPtypqW1D7IsUSkzfoZ7RPlI2jwAaoj2C/YW5jFRbEOx3njmjogp48I5CvA==
   dependencies:
     d3-array "^3.2.2"
     d3-interpolate "^3.0.1"
@@ -17550,21 +17513,10 @@ vega-scale@^7.1.1, vega-scale@^7.3.0:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-scale@~7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.2.0.tgz#9e298cc02ad340498cb56847436b19439911f0fc"
-  integrity sha512-QYltO/otrZHLrCGGf06Y99XtPtqWXITr6rw7rO9oL+l3d9o5RFl9sjHrVxiM7v+vGoZVWbBd5IPbFhPsXZ6+TA==
-  dependencies:
-    d3-array "^3.1.1"
-    d3-interpolate "^3.0.1"
-    d3-scale "^4.0.2"
-    vega-time "^2.1.0"
-    vega-util "^1.17.0"
-
-vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2, vega-scenegraph@~4.10.1:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz#3ae9ad8e99bbf75e2a4f3ebf2c1f9dee7562d245"
-  integrity sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==
+vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2, vega-scenegraph@~4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.11.0.tgz#af3d408e908900ec6133176b32f3129f10164238"
+  integrity sha512-NQtxA53/w9whUwZScv+/vxSb68frgLwanpy207vaBew46hnFZI9GUWmLWemOww8pJwBnVmnF4jFhUBbKq13HVw==
   dependencies:
     d3-path "^3.1.0"
     d3-shape "^3.2.0"
@@ -17578,35 +17530,28 @@ vega-schema-url-parser@^2.2.0:
   resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz#a0d1e02915adfbfcb1fd517c8c2ebe2419985c1e"
   integrity sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==
 
-vega-selections@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.4.1.tgz#3233acb920703bfc323df8b960aa52e55ac08c70"
-  integrity sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==
+vega-selections@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.4.2.tgz#cb4f41f5d4c0ee924ebf131b8dbd43e7885bcad4"
+  integrity sha512-99FUhYmg0jOJr2/K4TcEURmJRkuibrCDc8KBUX7qcQEITzrZ5R6a4QE+sarCvbb3hi8aA9GV2oyST6MQeA9mgQ==
   dependencies:
-    d3-array "3.2.2"
+    d3-array "3.2.4"
     vega-expression "^5.0.1"
     vega-util "^1.17.1"
 
-vega-statistics@^1.7.9, vega-statistics@^1.8.1:
+vega-statistics@^1.8.1, vega-statistics@^1.9.0, vega-statistics@~1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-1.9.0.tgz#7d6139cea496b22d60decfa6abd73346f70206f9"
   integrity sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==
   dependencies:
     d3-array "^3.2.2"
 
-vega-statistics@~1.8.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-1.8.1.tgz#596fc3713ac68cc649bf28d0faf7def5ef34fef6"
-  integrity sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==
-  dependencies:
-    d3-array "^3.2.2"
-
-vega-themes@^2.10.0:
+vega-themes@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/vega-themes/-/vega-themes-2.14.0.tgz#0df269396e057123ecf3942e3b704bf125d1eed7"
   integrity sha512-9dLmsUER7gJrDp8SEYKxBFmXmpyzLlToKIjxq3HCvYjz8cnNrRGyAhvIlKWOB3ZnGvfYV+vnv3ZRElSNL31nkA==
 
-vega-time@^2.1.0, vega-time@^2.1.1, vega-time@~2.1.0:
+vega-time@^2.1.1, vega-time@~2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-2.1.1.tgz#0f1fb4e220dd5ed57401b58fb2293241f049ada0"
   integrity sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==
@@ -17615,17 +17560,17 @@ vega-time@^2.1.0, vega-time@^2.1.1, vega-time@~2.1.0:
     d3-time "^3.1.0"
     vega-util "^1.17.1"
 
-vega-tooltip@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.28.0.tgz#8bae2601ffae5e67622de37108f53f284e9a978b"
-  integrity sha512-DbK0V5zzk+p9cphZZXV91ZGeKq0zr6JIS0VndUoGTisldzw4tRgmpGQcTfMjew53o7/voeTM2ELTnJAJRzX4tg==
+vega-tooltip@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.33.0.tgz#32bcaad713171d2ae00b47189e6334a318566739"
+  integrity sha512-jMcvH2lP20UfyvO2KAEdloiwRyasikaiLuNFhzwrrzf2RamGTxP4G7B2OZ2QENfrGUH05Z9ei5tn/eErdzOaZQ==
   dependencies:
-    vega-util "^1.17.0"
+    vega-util "^1.17.2"
 
-vega-transforms@~4.10.0:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.10.2.tgz#3a5ff3e92d8b0ee86868aed88e57b847b459d64e"
-  integrity sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==
+vega-transforms@~4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.11.0.tgz#3b7c2508c6cb1929fe69012e18ce7162223f7b8a"
+  integrity sha512-BeDASz7s9pIFjcSBljJJb8Eg0to2VjU0DvS/UjCQQYtqlfmzz78/mZnHyC+mW06h58ZKN+1QrIfqTZ6uMB4ySw==
   dependencies:
     d3-array "^3.2.2"
     vega-dataflow "^5.7.5"
@@ -17633,21 +17578,22 @@ vega-transforms@~4.10.0:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-typings@~0.22.0:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.22.3.tgz#f6c73b5ffcdb152539cfcc5ad240a413af579ba7"
-  integrity sha512-PREcya3nXT9Tk7xU0IhEpOLVTlqizNtKXV55NhI6ApBjJtqVYbJL7IBh2ckKxGBy3YeUQ37BQZl56UqqiYVWBw==
+vega-typings@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.0.0.tgz#4bdaeac817f01a8332e3a9d6c5172c5cfe232f4e"
+  integrity sha512-ML8MVdNQurPvOQ6mskp+Zxf7Yy4M5G73QI04aIi51hACqa032qOxgzApZUPEoqBDBczm4zPPF0X9SQgaxJXq4A==
   dependencies:
-    vega-event-selector "^3.0.0"
-    vega-expression "^5.0.0"
-    vega-util "^1.15.2"
+    "@types/geojson" "7946.0.4"
+    vega-event-selector "^3.0.1"
+    vega-expression "^5.1.0"
+    vega-util "^1.17.2"
 
-vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.17.0, vega-util@^1.17.1, vega-util@~1.17.0:
+vega-util@^1.15.2, vega-util@^1.17.1, vega-util@^1.17.2, vega-util@~1.17.2:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.2.tgz#f69aa09fd5d6110c19c4a0f0af9e35945b99987d"
   integrity sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==
 
-vega-view-transforms@~4.5.8:
+vega-view-transforms@~4.5.9:
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz#5f109555c08ee9ac23ff9183d578eb9cbac6fe61"
   integrity sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==
@@ -17656,7 +17602,7 @@ vega-view-transforms@~4.5.8:
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
 
-vega-view@~5.11.0:
+vega-view@~5.11.1:
   version "5.11.1"
   resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.11.1.tgz#a703d7d6344489c6a6e9e9d9c7a732519bf4432c"
   integrity sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==
@@ -17670,16 +17616,16 @@ vega-view@~5.11.0:
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
 
-vega-voronoi@~4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.2.1.tgz#521a22d3d4c545fe1d5eea19eac0fd3ac5e58b1b"
-  integrity sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==
+vega-voronoi@~4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.2.2.tgz#f2068ddd01d184047c4f18bceb14dbf5edab2854"
+  integrity sha512-Bq2YOp2MGphhQnUuLwl3dsyBs6MuEU86muTjDbBJg33+HkZtE1kIoQZr+EUHa46NBsY1NzSKddOTu8wcaFrWiQ==
   dependencies:
     d3-delaunay "^6.0.2"
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-wordcloud@~4.1.3:
+vega-wordcloud@~4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz#38584cf47ef52325d6a8dc38908b5d2378cc6e62"
   integrity sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==
@@ -17690,38 +17636,38 @@ vega-wordcloud@~4.1.3:
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
 
-"vega@5.22.1 - latest":
-  version "5.22.1"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.22.1.tgz#e028f3645de18e0070317bc04410282975549e1e"
-  integrity sha512-KJBI7OWSzpfCPbmWl3GQCqBqbf2TIdpWS0mzO6MmWbvdMhWHf74P9IVnx1B1mhg0ZTqWFualx9ZYhWzMMwudaQ==
+vega@5.26.0:
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-5.26.0.tgz#6fe22f4426fa415909c9a55c0f0843553287bd9f"
+  integrity sha512-Gvg4SMv6dHdY7aEbbsr6rbUfsI3hVVrEhGKmb5vV8SEqtJqGoeIKT/QZ9Yjw5uQOaGJJqkPcox3WW0n+qGGP/Q==
   dependencies:
-    vega-crossfilter "~4.1.0"
-    vega-dataflow "~5.7.4"
-    vega-encode "~4.9.0"
-    vega-event-selector "~3.0.0"
-    vega-expression "~5.0.0"
-    vega-force "~4.1.0"
-    vega-format "~1.1.0"
-    vega-functions "~5.13.0"
-    vega-geo "~4.4.0"
-    vega-hierarchy "~4.1.0"
-    vega-label "~1.2.0"
-    vega-loader "~4.5.0"
-    vega-parser "~6.1.4"
-    vega-projection "~1.5.0"
-    vega-regression "~1.1.0"
-    vega-runtime "~6.1.3"
-    vega-scale "~7.2.0"
-    vega-scenegraph "~4.10.1"
-    vega-statistics "~1.8.0"
-    vega-time "~2.1.0"
-    vega-transforms "~4.10.0"
-    vega-typings "~0.22.0"
-    vega-util "~1.17.0"
-    vega-view "~5.11.0"
-    vega-view-transforms "~4.5.8"
-    vega-voronoi "~4.2.0"
-    vega-wordcloud "~4.1.3"
+    vega-crossfilter "~4.1.1"
+    vega-dataflow "~5.7.5"
+    vega-encode "~4.9.2"
+    vega-event-selector "~3.0.1"
+    vega-expression "~5.1.0"
+    vega-force "~4.2.0"
+    vega-format "~1.1.1"
+    vega-functions "~5.14.0"
+    vega-geo "~4.4.1"
+    vega-hierarchy "~4.1.1"
+    vega-label "~1.2.1"
+    vega-loader "~4.5.1"
+    vega-parser "~6.2.1"
+    vega-projection "~1.6.0"
+    vega-regression "~1.2.0"
+    vega-runtime "~6.1.4"
+    vega-scale "~7.3.1"
+    vega-scenegraph "~4.11.0"
+    vega-statistics "~1.9.0"
+    vega-time "~2.1.1"
+    vega-transforms "~4.11.0"
+    vega-typings "~1.0.0"
+    vega-util "~1.17.2"
+    vega-view "~5.11.1"
+    vega-view-transforms "~4.5.9"
+    vega-voronoi "~4.2.2"
+    vega-wordcloud "~4.1.4"
 
 vfile-location@^3.0.0, vfile-location@^3.2.0:
   version "3.2.0"
@@ -18286,15 +18232,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@*, yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
@@ -18324,23 +18270,10 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1, yargs@^17.7.2:
+yargs@^17.3.1, yargs@^17.7.2, yargs@~17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
-yargs@~17.6.0:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

vega and vega-lite were listed as dependencies. The issue with this is it is likely that users of this library will have multiple instances installed of vega/vega-lite and all the associated packages. This is not only bad for size of installed packages, it can cause RSC to fail to render because some of the vega packages are persistent instances. For example, vega-functions us used to register custom expression functions. If the functions is registered to one instance but vega tries to digest the functions from the other instance, the registered function won't exist.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

see description

## How Has This Been Tested?

Ran `yarn pack-test` and installed into APA where the multiple install issue was reported from. Confirmed that it is fixed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
