### PR TITLE
feat: lines get highlighted with hover and select interactions

### DIFF
--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_METRIC,
 	FILTERED_TABLE,
 	MARK_ID,
+	SERIES_ID,
 	TABLE,
 } from '@constants';
 import { AreaSpecProps } from 'types';
@@ -151,7 +152,7 @@ const defaultSignals = [
 	{
 		name: 'area0_hoveredSeries',
 		on: [
-			{ events: '@area0:mouseover', update: `datum.${DEFAULT_COLOR}` },
+			{ events: '@area0:mouseover', update: `datum.${SERIES_ID}` },
 			{ events: '@area0:mouseout', update: 'null' },
 		],
 		value: null,

--- a/src/specBuilder/area/areaSpecBuilder.ts
+++ b/src/specBuilder/area/areaSpecBuilder.ts
@@ -140,13 +140,13 @@ export const addData = produce<Data[], [AreaSpecProps]>(
 	}
 );
 
-export const addSignals = produce<Signal[], [AreaSpecProps]>((signals, { children, name, color }) => {
+export const addSignals = produce<Signal[], [AreaSpecProps]>((signals, { children, name }) => {
 	if (!children.length) return;
 	if (!hasSignalByName(signals, `${name}_controlledHoveredId`)) {
 		signals.push(getControlledHoverSignal(name));
 	}
 	if (!hasSignalByName(signals, `${name}_hoveredSeries`)) {
-		signals.push(getSeriesHoveredSignal(name, color));
+		signals.push(getSeriesHoveredSignal(name));
 	}
 	if (!hasSignalByName(signals, `${name}_selectedId`)) {
 		signals.push(getGenericSignal(`${name}_selectedId`));

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -25,7 +25,6 @@ import {
 	PADDING_RATIO,
 	STACK_ID,
 } from '@constants';
-import { getOpacityProductionRule } from '@specBuilder/marks/markUtils';
 import { BarSpecProps } from 'types';
 import { RectEncodeEntry } from 'vega';
 
@@ -57,7 +56,6 @@ import {
 	getDodgedDimensionEncodings,
 	getDodgedGroupMark,
 	getFillStrokeOpacity,
-	getHighlightOpacityValue,
 	getMetricEncodings,
 	getOrientationProperties,
 	getStackedCornerRadiusEncodings,
@@ -359,19 +357,6 @@ describe('barUtils', () => {
 			expect(strokeRule[0]).toStrictEqual({
 				test: `bar0_selectedId && bar0_selectedId === datum.${MARK_ID}`,
 				value: 2,
-			});
-		});
-	});
-
-	describe('getHighlightOpacityValue()', () => {
-		test('should divide a signal ref by the highlight contract ratio', () => {
-			expect(getHighlightOpacityValue(getOpacityProductionRule(DEFAULT_COLOR))).toStrictEqual({
-				signal: `scale('opacity', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
-			});
-		});
-		test('shold divide a value ref by the highlight contrast ratio', () => {
-			expect(getHighlightOpacityValue(getOpacityProductionRule({ value: 0.5 }))).toStrictEqual({
-				value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
 			});
 		});
 	});

--- a/src/specBuilder/bar/barUtils.ts
+++ b/src/specBuilder/bar/barUtils.ts
@@ -16,13 +16,13 @@ import {
 	CORNER_RADIUS,
 	DISCRETE_PADDING,
 	FILTERED_TABLE,
-	HIGHLIGHT_CONTRAST_RATIO,
 	MARK_ID,
 	STACK_ID,
 } from '@constants';
 import {
 	getColorProductionRule,
 	getCursor,
+	getHighlightOpacityValue,
 	getOpacityProductionRule,
 	getStrokeDashProductionRule,
 	getTooltip,
@@ -442,15 +442,6 @@ export const getStrokeWidth = ({ children, lineWidth, name }: BarSpecProps): Pro
 		{ test: `${selectSignal} && ${selectSignal} === datum.${MARK_ID}`, value: Math.max(lineWidthValue, 2) },
 		defaultProductionRule,
 	];
-};
-
-export const getHighlightOpacityValue = (
-	opacityValue: { signal: string } | { value: number }
-): ProductionRule<NumericValueRef> => {
-	if ('signal' in opacityValue) {
-		return { signal: `${opacityValue.signal} / ${HIGHLIGHT_CONTRAST_RATIO}` };
-	}
-	return { value: opacityValue.value / HIGHLIGHT_CONTRAST_RATIO };
 };
 
 export const getBarPadding = (paddingRatio: number, paddingOuter?: number) => {

--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -93,7 +93,10 @@ describe('setHoverOpacityForMarks()', () => {
 		test('fillOpacity encoding already exists, rules should be added in the correct spot', () => {
 			const marks = JSON.parse(
 				JSON.stringify([
-					{ ...defaultMark, encode: { ...defaultMark.encode, update: { fillOpacity: [{ value: 1 }] } } },
+					{
+						...defaultMark,
+						encode: { ...defaultMark.encode, update: { strokeOpacity: [], fillOpacity: [{ value: 1 }] } },
+					},
 				])
 			);
 			setHoverOpacityForMarks(marks);

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -30,29 +30,32 @@ export const setHoverOpacityForMarks = (marks: Mark[]) => {
 		const { update } = mark.encode;
 		const { fillOpacity, strokeOpacity } = update;
 
-		// the production rule that sets the fill opacity for this mark
-		const fillOpacityRule = getOpacityRule(fillOpacity);
-		// the new production rule for highlighting
-		const highlightFillOpacityRule = getHighlightOpacityRule(fillOpacityRule);
+		if ('fillOpacity' in update) {
+			// the production rule that sets the fill opacity for this mark
+			const fillOpacityRule = getOpacityRule(fillOpacity);
+			// the new production rule for highlighting
+			const highlightFillOpacityRule = getHighlightOpacityRule(fillOpacityRule);
 
-		if (!Array.isArray(update.fillOpacity)) {
-			update.fillOpacity = [];
+			if (!Array.isArray(update.fillOpacity)) {
+				update.fillOpacity = [];
+			}
+			// // need to insert the new test in the second to last slot
+			const fillRuleInsertIndex = Math.max(update.fillOpacity.length - 1, 0);
+			update.fillOpacity.splice(fillRuleInsertIndex, 0, highlightFillOpacityRule);
 		}
-		// // need to insert the new test in the second to last slot
-		const fillRuleInsertIndex = Math.max(update.fillOpacity.length - 1, 0);
-		update.fillOpacity.splice(fillRuleInsertIndex, 0, highlightFillOpacityRule);
 
-		// the production rule that sets the stroke opacity for this mark
-		const strokeOpacityRule = getOpacityRule(strokeOpacity);
-		// the new production rule for highlighting
-		const highlightStrokeOpacityRule = getHighlightOpacityRule(strokeOpacityRule);
-
-		if (!Array.isArray(update.strokeOpacity)) {
-			update.strokeOpacity = [];
+		if ('strokeOpacity' in update) {
+			// the production rule that sets the stroke opacity for this mark
+			const strokeOpacityRule = getOpacityRule(strokeOpacity);
+			// the new production rule for highlighting
+			const highlightStrokeOpacityRule = getHighlightOpacityRule(strokeOpacityRule);
+			if (!Array.isArray(update.strokeOpacity)) {
+				update.strokeOpacity = [];
+			}
+			// // need to insert the new test in the second to last slot
+			const strokeRuleInsertIndex = Math.max(update.strokeOpacity.length - 1, 0);
+			update.strokeOpacity.splice(strokeRuleInsertIndex, 0, highlightStrokeOpacityRule);
 		}
-		// // need to insert the new test in the second to last slot
-		const strokeRuleInsertIndex = Math.max(update.strokeOpacity.length - 1, 0);
-		update.strokeOpacity.splice(strokeRuleInsertIndex, 0, highlightStrokeOpacityRule);
 	});
 };
 

--- a/src/specBuilder/legend/legendTestUtils.ts
+++ b/src/specBuilder/legend/legendTestUtils.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import {
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
@@ -36,6 +35,10 @@ export const defaultMark: LineMark = {
 			x: { scale: 'x', field: DEFAULT_CATEGORICAL_DIMENSION },
 			y: { scale: 'y', field: DEFAULT_METRIC },
 			stroke: { scale: 'color', field: DEFAULT_COLOR },
+		},
+		update: {
+			strokeOpacity: [],
+			fillOpacity: [],
 		},
 	},
 };

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -43,6 +43,8 @@ const defaultLineProps: LineSpecProps = {
 	lineType: { value: 'solid' },
 	opacity: { value: 1 },
 	colorScheme: DEFAULT_COLOR_SCHEME,
+	interactiveMarkName: undefined,
+	popoverMarkName: undefined,
 };
 
 const getMetricRangeElement = (props?: Partial<MetricRangeProps>): MetricRangeElement =>
@@ -566,7 +568,7 @@ describe('lineSpecBuilder', () => {
 					],
 				},
 				{
-					name: 'line0_voronoiHoveredId',
+					name: 'line0_hoveredId',
 					value: null,
 					on: [
 						{
@@ -617,7 +619,7 @@ describe('lineSpecBuilder', () => {
 					],
 				},
 				{
-					name: 'line0_voronoiHoveredId',
+					name: 'line0_hoveredId',
 					value: null,
 					on: [
 						{

--- a/src/specBuilder/line/lineUtils.ts
+++ b/src/specBuilder/line/lineUtils.ts
@@ -127,7 +127,6 @@ export const getLineStrokeOpacity = ({
 	const baseRule = getOpacityProductionRule(displayOnHover ? { value: 0 } : opacity);
 	if (!interactiveMarkName) return [baseRule];
 	const strokeOpacityRules: ProductionRule<NumericValueRef> = [];
-	// const targetMarkName = interactiveMarkName ?? name;
 
 	// add a rule that will lower the opacity of the line if there is a hovered series, but this line is not the one hovered
 	const hoverSignal = `${interactiveMarkName}_hoveredSeries`;

--- a/src/specBuilder/line/lineUtils.ts
+++ b/src/specBuilder/line/lineUtils.ts
@@ -9,15 +9,20 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Trendline } from '@components/Trendline';
 import { DEFAULT_SYMBOL_SIZE, DEFAULT_SYMBOL_STROKE_WIDTH, MARK_ID, SERIES_ID } from '@constants';
 import {
 	getColorProductionRule,
 	getCursor,
+	getHighlightOpacityValue,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
 	getStrokeDashProductionRule,
 	getTooltip,
+	hasInteractiveChildren,
+	hasPopover,
 } from '@specBuilder/marks/markUtils';
+import { sanitizeMarkChildren } from '@utils';
 import {
 	ColorFacet,
 	ColorScheme,
@@ -39,19 +44,47 @@ import {
 	SymbolMark,
 } from 'vega';
 
+export const getInteractiveMarkName = (children: MarkChildElement[], name: string): string | undefined => {
+	// if the line has an interactive component, this line is the target for the interactive component
+	if (hasInteractiveChildren(children)) {
+		return name;
+	}
+	// if there is a trendline with an interactive component on the line, then the trendline is the target for the interactive component
+	if (
+		children.some(
+			(child) => child.type === Trendline && hasInteractiveChildren(sanitizeMarkChildren(child.props.children))
+		)
+	) {
+		return `${name}Trendline`;
+	}
+};
+
+export const getPopoverMarkName = (children: MarkChildElement[], name: string): string | undefined => {
+	// if the line has a popover, this line is the target for the popover
+	if (hasPopover(children)) {
+		return name;
+	}
+	// if there is a trendline with a popover on this line, then the trendline is the target for the popover
+	if (children.some((child) => child.type === Trendline && hasPopover(sanitizeMarkChildren(child.props.children)))) {
+		return `${name}Trendline`;
+	}
+};
+
 export interface LineMarkProps {
-	name: string;
+	children?: MarkChildElement[];
 	color: ColorFacet;
-	metric: string;
+	colorScheme: ColorScheme;
 	dimension: string;
-	scaleType: ScaleType;
+	displayOnHover?: boolean;
+	interactiveMarkName?: string; // optional name of the mark that is used for hover and click interactions
 	lineType: LineTypeFacet;
 	lineWidth?: LineWidthFacet;
+	metric: string;
+	name: string;
 	opacity: OpacityFacet;
-	colorScheme: ColorScheme;
-	displayOnHover?: boolean;
+	popoverMarkName?: string;
+	scaleType: ScaleType;
 	staticPoint?: string;
-	parentName?: string;
 }
 
 /**
@@ -60,27 +93,8 @@ export interface LineMarkProps {
  * @param dataSource
  * @returns LineMark
  */
-export const getLineMark = (
-	{
-		name,
-		color,
-		metric,
-		dimension,
-		scaleType,
-		lineType,
-		lineWidth,
-		opacity,
-		colorScheme,
-		displayOnHover,
-		parentName,
-	}: LineMarkProps,
-	dataSource: string
-): LineMark => {
-	// This allows us to only show the metric range when hovering over the parent line component.
-	const baseOpacityRule = getOpacityProductionRule(displayOnHover ? { value: 0 } : opacity);
-	const opacityRules = displayOnHover
-		? [...getHoverRules(parentName ?? name, opacity), baseOpacityRule]
-		: [baseOpacityRule];
+export const getLineMark = (lineMarkProps: LineMarkProps, dataSource: string): LineMark => {
+	const { name, color, metric, dimension, scaleType, lineType, lineWidth, colorScheme } = lineMarkProps;
 
 	return {
 		name,
@@ -98,13 +112,48 @@ export const getLineMark = (
 				// this has to be in update because when you resize the window that doesn't rebuild the spec
 				// but it may change the x position if it causes the chart to resize
 				x: getXProductionRule(scaleType, dimension),
-				strokeOpacity: opacityRules,
+				strokeOpacity: getLineStrokeOpacity(lineMarkProps),
 			},
 		},
 	};
 };
 
-const getHoverRules = (name: string, opacity: OpacityFacet) => {
+export const getLineStrokeOpacity = ({
+	displayOnHover,
+	interactiveMarkName,
+	opacity,
+	popoverMarkName,
+}: LineMarkProps): ProductionRule<NumericValueRef> => {
+	const baseRule = getOpacityProductionRule(displayOnHover ? { value: 0 } : opacity);
+	if (!interactiveMarkName) return [baseRule];
+	const strokeOpacityRules: ProductionRule<NumericValueRef> = [];
+	// const targetMarkName = interactiveMarkName ?? name;
+
+	// add a rule that will lower the opacity of the line if there is a hovered series, but this line is not the one hovered
+	const hoverSignal = `${interactiveMarkName}_hoveredSeries`;
+	strokeOpacityRules.push({
+		test: `${hoverSignal} && ${hoverSignal} !== datum.${SERIES_ID}`,
+		...getHighlightOpacityValue(baseRule),
+	});
+
+	if (popoverMarkName) {
+		const selectSignal = `${interactiveMarkName}_selectedSeries`;
+		strokeOpacityRules.push({
+			test: `${selectSignal} && ${selectSignal} !== datum.${SERIES_ID}`,
+			...getHighlightOpacityValue(baseRule),
+		});
+	}
+
+	if (displayOnHover) {
+		strokeOpacityRules.push(...getDisplayOnHoverRules(interactiveMarkName, opacity));
+	}
+	// This allows us to only show the metric range when hovering over the parent line component.
+	strokeOpacityRules.push(baseRule);
+
+	return strokeOpacityRules;
+};
+
+const getDisplayOnHoverRules = (name: string, opacity: OpacityFacet) => {
 	const opacityRule = getOpacityProductionRule(opacity);
 	const hoverRule = {
 		test: `${name}_hoveredSeries && ${name}_hoveredSeries === datum.${SERIES_ID}`,
@@ -375,7 +424,7 @@ const getHighlightPointStyle = (
 	colorScheme: ColorScheme
 ) => {
 	const displayPointMarkTest = `datum.${displayPointMark} && datum.${displayPointMark} === true`;
-	const hoveredTest = `${name}_voronoiHoveredId && ${name}_voronoiHoveredId === datum.${MARK_ID}`;
+	const hoveredTest = `${name}_hoveredId && ${name}_hoveredId === datum.${MARK_ID}`;
 	const selectedTest = `${name}_selectedId && ${name}_selectedId === datum.${MARK_ID}`;
 	const hoverStrokeRule = `(${hoveredTest} || ${selectedTest}) && datum.${displayPointMark}`;
 
@@ -441,7 +490,7 @@ export const getLinePointMark = ({
  */
 export const getLineHighlightedData = (name: string, source: string, hasPopover: boolean): SourceData => {
 	const selectSignal = `${name}_selectedId`;
-	const hoverSignal = `${name}_voronoiHoveredId`;
+	const hoverSignal = `${name}_hoveredId`;
 	const expr = hasPopover
 		? `${selectSignal} && ${selectSignal} === datum.${MARK_ID} || !${selectSignal} && ${hoverSignal} && ${hoverSignal} === datum.${MARK_ID}`
 		: `${hoverSignal} && ${hoverSignal} === datum.${MARK_ID}`;

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -15,10 +15,11 @@ import { Annotation } from '@components/Annotation';
 import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { MetricRange } from '@components/MetricRange';
-import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR } from '@constants';
+import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR, HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 
 import {
 	getColorProductionRule,
+	getHighlightOpacityValue,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
 	getStrokeDashProductionRule,
@@ -126,5 +127,18 @@ describe('getTooltip()', () => {
 	test('should reference a nested datum if nestedDatum is true', () => {
 		const rule = getTooltip([createElement(ChartTooltip)], 'line0', true);
 		expect(rule?.signal).toContain('datum.datum');
+	});
+});
+
+describe('getHighlightOpacityValue()', () => {
+	test('should divide a signal ref by the highlight contract ratio', () => {
+		expect(getHighlightOpacityValue(getOpacityProductionRule(DEFAULT_COLOR))).toStrictEqual({
+			signal: `scale('opacity', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
+		});
+	});
+	test('shold divide a value ref by the highlight contrast ratio', () => {
+		expect(getHighlightOpacityValue(getOpacityProductionRule({ value: 0.5 }))).toStrictEqual({
+			value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
+		});
 	});
 });

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -15,6 +15,7 @@ import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { MetricRange } from '@components/MetricRange';
 import { Trendline } from '@components/Trendline';
+import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import { getColorValue, getLineWidthPixelsFromLineWidth, getStrokeDashFromLineType } from '@specBuilder/specUtils';
 import {
 	ColorFacet,
@@ -31,6 +32,7 @@ import {
 	ColorValueRef,
 	Cursor,
 	NumericValueRef,
+	ProductionRule,
 	ScaledValueRef,
 	SignalRef,
 } from 'vega';
@@ -94,6 +96,8 @@ export const hasMetricRange = (children: ReactElement[]): boolean =>
 	children.some((child) => child.type === MetricRange);
 export const hasPopover = (children: ReactElement[]): boolean => children.some((child) => child.type === ChartPopover);
 export const hasTooltip = (children: ReactElement[]): boolean => children.some((child) => child.type === ChartTooltip);
+export const childHasTooltip = (children: ReactElement[]): boolean =>
+	children.some((child) => hasTooltip(child.props.children));
 
 export const getColorProductionRule = (color: ColorFacet | DualFacet, colorScheme: ColorScheme): ColorValueRef => {
 	if (Array.isArray(color)) {
@@ -144,4 +148,13 @@ export const getOpacityProductionRule = (opacity: OpacityFacet | DualFacet): { s
 		return { signal: `scale('opacity', datum.${opacity})` };
 	}
 	return { value: opacity.value };
+};
+
+export const getHighlightOpacityValue = (
+	opacityValue: { signal: string } | { value: number }
+): ProductionRule<NumericValueRef> => {
+	if ('signal' in opacityValue) {
+		return { signal: `${opacityValue.signal} / ${HIGHLIGHT_CONTRAST_RATIO}` };
+	}
+	return { value: opacityValue.value / HIGHLIGHT_CONTRAST_RATIO };
 };

--- a/src/specBuilder/metricRange/metricRangeUtils.test.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.test.ts
@@ -9,7 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { createElement } from 'react';
 
+import { MetricRange } from '@components/MetricRange';
 import {
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
@@ -17,15 +19,14 @@ import {
 	DEFAULT_METRIC,
 	FILTERED_TABLE,
 } from '@constants';
+import { LineSpecProps, MetricRangeProps, MetricRangeSpecProps } from 'types';
+
 import {
 	applyMetricRangePropDefaults,
 	getMetricRangeData,
-	getMetricRangeMark,
 	getMetricRangeGroupMarks,
+	getMetricRangeMark,
 } from './metricRangeUtils';
-import { LineSpecProps, MetricRangeProps, MetricRangeSpecProps } from 'types';
-import { createElement } from 'react';
-import { MetricRange } from '@components/MetricRange';
 
 const defaultMetricRangeProps: MetricRangeProps = {
 	children: [],
@@ -59,6 +60,8 @@ const defaultLineProps: LineSpecProps = {
 	lineType: { value: 'solid' },
 	opacity: { value: 1 },
 	colorScheme: DEFAULT_COLOR_SCHEME,
+	interactiveMarkName: undefined,
+	popoverMarkName: undefined,
 };
 
 const basicMetricRangeMarks = [
@@ -141,7 +144,7 @@ const basicMetricRangeMarks = [
 describe('applyMetricRangePropDefaults', () => {
 	test('applies defaults', () => {
 		expect(
-			applyMetricRangePropDefaults({ metricEnd: 'metricStart', metricStart: 'metricEnd' }, 'line0', 0),
+			applyMetricRangePropDefaults({ metricEnd: 'metricStart', metricStart: 'metricEnd' }, 'line0', 0)
 		).toEqual({
 			children: {},
 			displayOnHover: false,
@@ -167,8 +170,8 @@ describe('applyMetricRangePropDefaults', () => {
 					displayOnHover: true,
 				},
 				'line0',
-				0,
-			),
+				0
+			)
 		).toEqual({
 			children: {},
 			displayOnHover: true,

--- a/src/specBuilder/metricRange/metricRangeUtils.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { MetricRange } from '@components/MetricRange';
-import { DEFAULT_METRIC, FILTERED_TABLE, SERIES_ID } from '@constants';
+import { DEFAULT_METRIC, FILTERED_TABLE } from '@constants';
 import { AreaMarkProps, getAreaMark } from '@specBuilder/area/areaUtils';
 import { LineMarkProps, getLineMark } from '@specBuilder/line/lineUtils';
 import { getSeriesHoveredSignal } from '@specBuilder/signal/signalSpecBuilder';
@@ -102,17 +102,12 @@ export const getMetricRangeMark = (
 		displayOnHover: metricRangeProps.displayOnHover,
 	};
 	const lineProps: LineMarkProps = {
-		name: lineMarkProps.name,
+		...lineMarkProps,
 		color: metricRangeProps.color ? { value: metricRangeProps.color } : lineMarkProps.color,
 		metric: metricRangeProps.metric,
-		dimension: lineMarkProps.dimension,
-		scaleType: lineMarkProps.scaleType,
 		lineType: { value: metricRangeProps.lineType },
 		lineWidth: { value: metricRangeProps.lineWidth },
-		opacity: lineMarkProps.opacity,
-		colorScheme: lineMarkProps.colorScheme,
 		displayOnHover: metricRangeProps.displayOnHover,
-		staticPoint: lineMarkProps.staticPoint,
 	};
 
 	const lineMark = getLineMark(lineProps, `${metricRangeProps.name}_facet`);
@@ -151,7 +146,7 @@ export const getMetricRangeSignals = (markProps: LineSpecProps): Signal[] => {
 	const metricRanges = getMetricRanges(children, markName);
 
 	if (metricRanges.length) {
-		signals.push(getSeriesHoveredSignal(markName, `datum.${SERIES_ID}`, `${markName}_voronoi`));
+		signals.push(getSeriesHoveredSignal(markName, true, `${markName}_voronoi`));
 	}
 
 	return signals;

--- a/src/specBuilder/signal/signalSpecBuilder.test.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.test.ts
@@ -49,11 +49,22 @@ describe('Signal spec builder', () => {
 				value: null,
 			});
 		});
+
+		test('should use eventName if provided', () => {
+			expect(getUncontrolledHoverSignal('line0', false, 'line0_voronoi')).toStrictEqual({
+				name: 'line0_hoveredId',
+				on: [
+					{ events: '@line0_voronoi:mouseover', update: `datum.${MARK_ID}` },
+					{ events: '@line0_voronoi:mouseout', update: 'null' },
+				],
+				value: null,
+			});
+		});
 	});
 
 	describe('getSeriesHoveredSignal()', () => {
 		test('uses name for eventName if eventName provided', () => {
-			expect(getSeriesHoveredSignal('bar0', `datum.${SERIES_ID}`)).toStrictEqual({
+			expect(getSeriesHoveredSignal('bar0', true)).toStrictEqual({
 				name: 'bar0_hoveredSeries',
 				on: [
 					{ events: '@bar0:mouseover', update: `datum.datum.${SERIES_ID}` },
@@ -64,10 +75,21 @@ describe('Signal spec builder', () => {
 		});
 
 		test('uses eventName if provided', () => {
-			expect(getSeriesHoveredSignal('bar0', `datum.${SERIES_ID}`, 'bar0_voronoi')).toStrictEqual({
+			expect(getSeriesHoveredSignal('bar0', true, 'bar0_voronoi')).toStrictEqual({
 				name: 'bar0_hoveredSeries',
 				on: [
 					{ events: '@bar0_voronoi:mouseover', update: `datum.datum.${SERIES_ID}` },
+					{ events: '@bar0_voronoi:mouseout', update: 'null' },
+				],
+				value: null,
+			});
+		});
+
+		test('should not nest datum if nestedDatum is false', () => {
+			expect(getSeriesHoveredSignal('bar0', false, 'bar0_voronoi')).toStrictEqual({
+				name: 'bar0_hoveredSeries',
+				on: [
+					{ events: '@bar0_voronoi:mouseover', update: `datum.${SERIES_ID}` },
 					{ events: '@bar0_voronoi:mouseout', update: 'null' },
 				],
 				value: null,

--- a/src/specBuilder/signal/signalSpecBuilder.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { MARK_ID } from '@constants';
+import { MARK_ID, SERIES_ID } from '@constants';
 import { Signal } from 'vega';
 
 /**
@@ -22,18 +22,13 @@ export const hasSignalByName = (signals: Signal[], name: string) => {
 /**
  *  Returns the hover signal for points
  */
-export const getUncontrolledHoverSignal = (name: string, nestedDatum?: boolean): Signal => {
-	// if there is already an '_' in the name then add 'HoveredId'
-	// ex: 'line0_voroni' => 'line0_voroniHoveredId'
-	// if there is not an '_' in the name then add '_hoveredId'
-	// ex: 'bar0' => 'bar0_hoveredId'
-	const signalName = name.includes('_') ? `${name}HoveredId` : `${name}_hoveredId`;
+export const getUncontrolledHoverSignal = (name: string, nestedDatum?: boolean, eventName: string = name): Signal => {
 	return {
-		name: signalName,
+		name: `${name}_hoveredId`,
 		value: null,
 		on: [
-			{ events: `@${name}:mouseover`, update: `${nestedDatum ? 'datum.' : ''}datum.${MARK_ID}` },
-			{ events: `@${name}:mouseout`, update: 'null' },
+			{ events: `@${eventName}:mouseover`, update: `${nestedDatum ? 'datum.' : ''}datum.${MARK_ID}` },
+			{ events: `@${eventName}:mouseout`, update: 'null' },
 		],
 	};
 };
@@ -54,12 +49,12 @@ export const getControlledHoverSignal = (name: string): Signal => {
  *  Returns the hover signal for series
  *  Useful when you want to highlight the whole series on hover (area)
  */
-export const getSeriesHoveredSignal = (name: string, series: string, eventName = name): Signal => {
+export const getSeriesHoveredSignal = (name: string, nestedDatum?: boolean, eventName: string = name): Signal => {
 	return {
 		name: `${name}_hoveredSeries`,
 		value: null,
 		on: [
-			{ events: `@${eventName}:mouseover`, update: `datum.${series}` },
+			{ events: `@${eventName}:mouseover`, update: `${nestedDatum ? 'datum.' : ''}datum.${SERIES_ID}` },
 			{ events: `@${eventName}:mouseout`, update: 'null' },
 		],
 	};

--- a/src/specBuilder/trendline/trendlineUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineUtils.test.ts
@@ -50,6 +50,8 @@ const defaultLineProps: LineSpecProps = {
 	name: 'line0',
 	opacity: { value: 1 },
 	scaleType: 'time',
+	interactiveMarkName: undefined,
+	popoverMarkName: undefined,
 };
 
 describe('getTrendlines()', () => {
@@ -318,8 +320,9 @@ describe('getTrendlineSignals()', () => {
 			...defaultLineProps,
 			children: [createElement(Trendline, {}, createElement(ChartTooltip))],
 		});
-		expect(signals).toHaveLength(1);
-		expect(signals[0]).toHaveProperty('name', 'line0Trendline_voronoiHoveredId');
+		expect(signals).toHaveLength(2);
+		expect(signals[0]).toHaveProperty('name', 'line0Trendline_hoveredId');
+		expect(signals[1]).toHaveProperty('name', 'line0Trendline_hoveredSeries');
 	});
 
 	test('should not return any signals if there is not a ChartTooltip', () => {
@@ -335,8 +338,9 @@ describe('getTrendlineSignals()', () => {
 				createElement(Trendline, {}, createElement(ChartPopover)),
 			],
 		});
-		expect(signals).toHaveLength(2);
-		expect(signals[1]).toHaveProperty('name', 'line0Trendline_selectedId');
+		expect(signals).toHaveLength(4);
+		expect(signals[2]).toHaveProperty('name', 'line0Trendline_selectedId');
+		expect(signals[3]).toHaveProperty('name', 'line0Trendline_selectedSeries');
 	});
 
 	test('should not return selected signal if there is not a ChartPopover', () => {
@@ -344,7 +348,7 @@ describe('getTrendlineSignals()', () => {
 			...defaultLineProps,
 			children: [createElement(Trendline, {}, createElement(ChartTooltip))],
 		});
-		expect(signals).toHaveLength(1);
+		expect(signals).toHaveLength(2);
 		expect(signals[0].name).not.toContain('selected');
 	});
 });

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -133,6 +133,29 @@ describe('ChartPopover', () => {
 		expect(highlightPoint).not.toBeInTheDocument();
 	});
 
+	test('should highlight the selected line by fading other lines', async () => {
+		render(<LineChart {...LineChart.args} />);
+		// validate that the line drew
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		// lines should have full opacity
+		const lines = await findAllMarksByGroupName(chart, 'line0');
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+		expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
+		expect(lines[2]).toHaveAttribute('stroke-opacity', '1');
+
+		// click on the first line
+		const points = await findAllMarksByGroupName(chart, 'line0_voronoi');
+		await clickNthElement(points, 0);
+
+		// validate the first line is still full opacity, but the other lines are faded
+		expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+		expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(lines[2]).toHaveAttribute('stroke-opacity', '0.2');
+	});
+
 	test('Dodged bar popover opens on mark click and closes when clicking outside', async () => {
 		render(<DodgedBarChart {...DodgedBarChart.args} />);
 

--- a/src/stories/components/Line/Line.test.tsx
+++ b/src/stories/components/Line/Line.test.tsx
@@ -176,19 +176,40 @@ describe('Line', () => {
 		expect(await screen.findByText('14')).toBeInTheDocument();
 	});
 
-	test('Tooltip should show on hover', async () => {
-		render(<Tooltip {...Tooltip.args} />);
-		const chart = await findChart();
-		expect(chart).toBeInTheDocument();
+	describe('Tooltip', () => {
+		test('Tooltip should show on hover', async () => {
+			render(<Tooltip {...Tooltip.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
 
-		// get voronoi paths
-		const paths = await findAllMarksByGroupName(chart, 'line0_voronoi');
+			// get voronoi paths
+			const paths = await findAllMarksByGroupName(chart, 'line0_voronoi');
 
-		// hover and validate all hover components are visible
-		await hoverNthElement(paths, 0);
-		const tooltip = await screen.findByTestId('rsc-tooltip');
-		expect(tooltip).toBeInTheDocument();
-		expect(within(tooltip).getByText('Nov 8')).toBeInTheDocument();
+			// hover and validate all hover components are visible
+			await hoverNthElement(paths, 0);
+			const tooltip = await screen.findByTestId('rsc-tooltip');
+			expect(tooltip).toBeInTheDocument();
+			expect(within(tooltip).getByText('Nov 8')).toBeInTheDocument();
+		});
+		test('should fade the opacity of non-hovered lines', async () => {
+			render(<Tooltip {...Tooltip.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const lines = await findAllMarksByGroupName(chart, 'line0');
+			expect(lines).toHaveLength(4);
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
+
+			// get voronoi paths
+			const paths = await findAllMarksByGroupName(chart, 'line0_voronoi');
+
+			// hover and validate all hover components are visible
+			await hoverNthElement(paths, 0);
+
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
+		});
 	});
 
 	test('Static points render', async () => {

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -13,7 +13,7 @@ import React, { ReactElement } from 'react';
 
 import { TRENDLINE_VALUE } from '@constants';
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, ChartProps, ChartTooltip, Legend, Line, Trendline } from '@rsc';
+import { Axis, Chart, ChartPopover, ChartProps, ChartTooltip, Legend, Line, Trendline } from '@rsc';
 import { workspaceTrendsData } from '@stories/data/data';
 import { ComponentStory } from '@storybook/react';
 import { bindWithProps } from 'test-utils/bindWithProps';
@@ -66,6 +66,20 @@ const TrendlineStory: ComponentStory<typeof Trendline> = (args): ReactElement =>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
+				<Trendline {...args} />
+			</Line>
+			<Legend lineWidth={{ value: 0 }} highlight />
+		</Chart>
+	);
+};
+
+const TrendlineWithDialogsStory: ComponentStory<typeof Trendline> = (args): ReactElement => {
+	const chartProps = useChartProps(defaultChartProps);
+	return (
+		<Chart {...chartProps}>
+			<Axis position="left" grid title="Users" />
+			<Axis position="bottom" labelFormat="time" baseline ticks />
+			<Line color="series">
 				<Trendline {...args}>
 					<ChartTooltip>
 						{(item) => (
@@ -75,6 +89,14 @@ const TrendlineStory: ComponentStory<typeof Trendline> = (args): ReactElement =>
 							</>
 						)}
 					</ChartTooltip>
+					<ChartPopover>
+						{(item) => (
+							<>
+								<div>Trendline value: {item[TRENDLINE_VALUE]}</div>
+								<div>Line value: {item.value}</div>
+							</>
+						)}
+					</ChartPopover>
 				</Trendline>
 			</Line>
 			<Legend lineWidth={{ value: 0 }} highlight />
@@ -82,13 +104,29 @@ const TrendlineStory: ComponentStory<typeof Trendline> = (args): ReactElement =>
 	);
 };
 
-const TrendlineStoryWithoutTooltip: ComponentStory<typeof Trendline> = (args): ReactElement => {
+const TrendlineWithDialogsOnParentStory: ComponentStory<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
 		<Chart {...chartProps}>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
+				<ChartTooltip>
+					{(item) => (
+						<>
+							<div>Trendline value: {item[TRENDLINE_VALUE]}</div>
+							<div>Line value: {item.value}</div>
+						</>
+					)}
+				</ChartTooltip>
+				<ChartPopover>
+					{(item) => (
+						<>
+							<div>Trendline value: {item[TRENDLINE_VALUE]}</div>
+							<div>Line value: {item.value}</div>
+						</>
+					)}
+				</ChartPopover>
 				<Trendline {...args} />
 			</Line>
 			<Legend lineWidth={{ value: 0 }} highlight />
@@ -103,7 +141,7 @@ Basic.args = {
 	lineWidth: 'S',
 };
 
-const DimensionRange = bindWithProps(TrendlineStory);
+const DimensionRange = bindWithProps(TrendlineWithDialogsStory);
 DimensionRange.args = {
 	method: 'linear',
 	lineType: 'dashed',
@@ -112,7 +150,7 @@ DimensionRange.args = {
 	dimensionRange: [1668063600000, null],
 };
 
-const DisplayOnHover = bindWithProps(TrendlineStoryWithoutTooltip);
+const DisplayOnHover = bindWithProps(TrendlineStory);
 DisplayOnHover.args = {
 	displayOnHover: true,
 	method: 'linear',
@@ -121,4 +159,16 @@ DisplayOnHover.args = {
 	color: 'gray-600',
 };
 
-export { Basic, DimensionRange, DisplayOnHover };
+const TooltipAndPopover = bindWithProps(TrendlineWithDialogsStory);
+TooltipAndPopover.args = {
+	highlightRawPoint: true,
+};
+
+const TooltipAndPopoverOnParentLine = bindWithProps(TrendlineWithDialogsOnParentStory);
+TooltipAndPopoverOnParentLine.args = {
+	method: 'linear',
+	lineType: 'dashed',
+	lineWidth: 'S',
+};
+
+export { Basic, DimensionRange, DisplayOnHover, TooltipAndPopover, TooltipAndPopoverOnParentLine };

--- a/src/stories/components/Trendline/Trendline.test.tsx
+++ b/src/stories/components/Trendline/Trendline.test.tsx
@@ -15,7 +15,7 @@ import '@matchMediaMock';
 import { Trendline } from '@rsc';
 import { findAllMarksByGroupName, findChart, getAllLegendEntries, hoverNthElement, render } from '@test-utils';
 
-import { Basic, DisplayOnHover } from './Trendline.story';
+import { Basic, DisplayOnHover, TooltipAndPopover, TooltipAndPopoverOnParentLine } from './Trendline.story';
 
 describe('Trendline', () => {
 	// Trendline is not a real React component. This is test just provides test coverage for sonarqube
@@ -76,6 +76,68 @@ describe('Trendline', () => {
 			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
 			// second trendline should still be hidden
 			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0');
+		});
+	});
+
+	describe('TooltipAndPopover', () => {
+		test('Should highlight trendline on hover', async () => {
+			render(<TooltipAndPopover {...TooltipAndPopover.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const lines = await findAllMarksByGroupName(chart, 'line0');
+			expect(lines).toHaveLength(4);
+			const trendlines = await findAllMarksByGroupName(chart, 'line0Trendline0');
+			expect(trendlines).toHaveLength(4);
+
+			// all lines and trendlines are full opacity
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '1');
+
+			// hover over the first point on the first trendline
+			const trendlineHoverAreas = await findAllMarksByGroupName(chart, 'line0Trendline_voronoi');
+			await hoverNthElement(trendlineHoverAreas, 0);
+
+			// highlighted line and trendline are still full opacity
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+
+			// other lines and trendlines are faded
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
+			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0.2');
+		});
+	});
+
+	describe('TooltipAndPopoverOnParentLine', () => {
+		test('Should highlight trendline on hover', async () => {
+			render(<TooltipAndPopoverOnParentLine {...TooltipAndPopoverOnParentLine.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const lines = await findAllMarksByGroupName(chart, 'line0');
+			expect(lines).toHaveLength(4);
+			const trendlines = await findAllMarksByGroupName(chart, 'line0Trendline0');
+			expect(trendlines).toHaveLength(4);
+
+			// all lines and trendlines are full opacity
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '1');
+
+			// hover over the first point on the first trendline
+			const trendlineHoverAreas = await findAllMarksByGroupName(chart, 'line0_voronoi');
+			await hoverNthElement(trendlineHoverAreas, 0);
+
+			// highlighted line and trendline are still full opacity
+			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+
+			// other lines and trendlines are faded
+			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
+			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0.2');
 		});
 	});
 });

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -114,7 +114,15 @@ type LinePropsWithDefaults =
 	| 'colorScheme';
 
 export interface LineSpecProps
-	extends PartiallyRequired<LineProps & { colorScheme?: ColorScheme; index: number }, LinePropsWithDefaults> {
+	extends PartiallyRequired<
+		LineProps & {
+			colorScheme?: ColorScheme;
+			index: number;
+			interactiveMarkName: string | undefined;
+			popoverMarkName: string | undefined;
+		},
+		LinePropsWithDefaults
+	> {
 	children: MarkChildElement[];
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you hover or select a line, the other series lines did not change in opacity. On the other hand, for bar and area, as you hover or select different areas/bars, they get highlighted by all other areas/bars dropping in opacity by 1/5th.

This PR updates line so that it behaves the same way as area and bar on hover/select.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Standardization in behavior across chart types.

## How Has This Been Tested?

All existing tests are passing or were updated to reflect the new behavior.
Unit tests were added to test the spec is as expected
Tests were written for the new stories and existing stories to validate behavior

## Screenshots (if appropriate):

![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/9a6a1bb1-f268-4500-8c34-90e7b5bb82f4)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/46d809b4-1b64-4015-a52f-659d3934cef3)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/5e0c83d6-5bd6-4ca9-ac58-b94e66190368)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
