### PR TITLE
Expose trellis padding in Bar Props

### DIFF
--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -11,7 +11,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DEFAULT_CATEGORICAL_DIMENSION, DEFAULT_METRIC, PADDING_RATIO } from '@constants';
+import { DEFAULT_CATEGORICAL_DIMENSION, DEFAULT_METRIC, PADDING_RATIO, TRELLIS_PADDING } from '@constants';
 
 import { BarProps } from '../../types';
 
@@ -24,6 +24,7 @@ export function Bar({
 	lineType = { value: 'solid' },
 	orientation = 'vertical',
 	trellisOrientation = 'horizontal',
+	trellisPadding = TRELLIS_PADDING,
 	paddingRatio = PADDING_RATIO,
 	paddingOuter,
 }: BarProps) {

--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -327,6 +327,26 @@ describe('barSpecBuilder', () => {
 					defaultDimensionScale,
 				]);
 			});
+
+			test('should add trellis scales', () => {
+				expect(addScales([{ name: 'color', type: 'ordinal' }], {
+					...defaultBarProps,
+					trellis: 'event',
+					trellisOrientation: 'vertical',
+					trellisPadding: 0.5,
+				})).toStrictEqual([
+					defaultColorScale,
+					defaultMetricScale,
+					defaultDimensionScale,
+					{
+						name: 'yTrellisBand',
+						type: 'band',
+						domain: { data: TABLE, fields: ['event'] },
+						range: 'height',
+						paddingInner: 0.5,
+					},
+				]);
+			});
 		});
 	});
 

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -16,6 +16,7 @@ import {
 	FILTERED_TABLE,
 	PADDING_RATIO,
 	STACK_ID,
+	TRELLIS_PADDING,
 } from '@constants';
 import { getTransformSort } from '@specBuilder/data/dataUtils';
 import { hasPopover } from '@specBuilder/marks/markUtils';
@@ -57,6 +58,7 @@ export const addBar = produce<Spec, [BarProps & { colorScheme?: ColorScheme; ind
 			orientation = 'vertical',
 			paddingRatio = PADDING_RATIO,
 			trellisOrientation = 'horizontal',
+			trellisPadding = TRELLIS_PADDING,
 			type = 'stacked',
 			...props
 		}
@@ -76,6 +78,7 @@ export const addBar = produce<Spec, [BarProps & { colorScheme?: ColorScheme; ind
 			opacity,
 			paddingRatio,
 			trellisOrientation,
+			trellisPadding,
 			type,
 			...props,
 		};

--- a/src/specBuilder/bar/barTestUtils.ts
+++ b/src/specBuilder/bar/barTestUtils.ts
@@ -21,6 +21,7 @@ import {
 	MARK_ID,
 	PADDING_RATIO,
 	STACK_ID,
+	TRELLIS_PADDING,
 } from '@constants';
 import { BarSpecProps } from 'types';
 import { NumericValueRef, ProductionRule, RectEncodeEntry } from 'vega';
@@ -38,6 +39,7 @@ export const defaultBarProps: BarSpecProps = {
 	paddingRatio: PADDING_RATIO,
 	colorScheme: DEFAULT_COLOR_SCHEME,
 	trellisOrientation: 'horizontal',
+	trellisPadding: TRELLIS_PADDING,
 	type: 'stacked',
 	orientation: 'vertical',
 };

--- a/src/specBuilder/bar/trellisedBarUtils.test.ts
+++ b/src/specBuilder/bar/trellisedBarUtils.test.ts
@@ -111,6 +111,7 @@ describe('trellisedBarUtils', () => {
 				facetName: `${defaultTrellisProps.name}_trellis`,
 				markName: 'yTrellisGroup',
 				scaleName: 'yTrellisBand',
+				paddingInner: 0.2,
 				rangeScale: 'height',
 				axis: 'y',
 			});
@@ -127,18 +128,10 @@ describe('trellisedBarUtils', () => {
 				facetName: `${defaultTrellisProps.name}_trellis`,
 				markName: 'xTrellisGroup',
 				scaleName: 'xTrellisBand',
+				paddingInner: 0.2,
 				rangeScale: 'width',
 				axis: 'x',
 			});
-		});
-
-		test('returns given paddingInner from trellisPadding', () => {
-			const result = getTrellisProperties({
-				...defaultTrellisProps,
-				trellisPadding: 0.5,
-			});
-
-			expect(result).toEqual(expect.objectContaining({ paddingInner: 0.5 }));
 		});
 	});
 

--- a/src/specBuilder/bar/trellisedBarUtils.test.ts
+++ b/src/specBuilder/bar/trellisedBarUtils.test.ts
@@ -131,6 +131,15 @@ describe('trellisedBarUtils', () => {
 				axis: 'x',
 			});
 		});
+
+		test('returns given paddingInner from trellisPadding', () => {
+			const result = getTrellisProperties({
+				...defaultTrellisProps,
+				trellisPadding: 0.5,
+			});
+
+			expect(result).toEqual(expect.objectContaining({ paddingInner: 0.5 }));
+		});
 	});
 
 	describe('getTrellisedEncodeEntries()', () => {

--- a/src/specBuilder/bar/trellisedBarUtils.test.ts
+++ b/src/specBuilder/bar/trellisedBarUtils.test.ts
@@ -14,7 +14,7 @@ import { getTrellisProperties, getTrellisGroupMark, getTrellisedEncodeEntries, i
 import { defaultBarProps } from './barTestUtils';
 import { BarSpecProps } from 'types';
 import { Scale } from 'vega';
-import { FILTERED_TABLE, TABLE } from '@constants';
+import { FILTERED_TABLE, TABLE, TRELLIS_PADDING } from '@constants';
 
 const defaultTrellisProps: BarSpecProps = { ...defaultBarProps, trellis: 'trellisProperty' };
 const defaultRepeatedScale: Scale = { name: 'xLinear', type: 'linear', domain: { data: TABLE, field: 'x' } };
@@ -111,7 +111,7 @@ describe('trellisedBarUtils', () => {
 				facetName: `${defaultTrellisProps.name}_trellis`,
 				markName: 'yTrellisGroup',
 				scaleName: 'yTrellisBand',
-				paddingInner: 0.2,
+				paddingInner: TRELLIS_PADDING,
 				rangeScale: 'height',
 				axis: 'y',
 			});
@@ -128,7 +128,7 @@ describe('trellisedBarUtils', () => {
 				facetName: `${defaultTrellisProps.name}_trellis`,
 				markName: 'xTrellisGroup',
 				scaleName: 'xTrellisBand',
-				paddingInner: 0.2,
+				paddingInner: TRELLIS_PADDING,
 				rangeScale: 'width',
 				axis: 'x',
 			});

--- a/src/specBuilder/bar/trellisedBarUtils.ts
+++ b/src/specBuilder/bar/trellisedBarUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { FILTERED_TABLE, TRELLIS_PADDING } from '@constants';
+import { FILTERED_TABLE } from '@constants';
 import { addDomainFields, getScaleIndexByName } from '@specBuilder/scale/scaleSpecBuilder';
 import { BarSpecProps } from 'types';
 import { GroupMark, Mark, Scale } from 'vega';
@@ -68,13 +68,13 @@ export const addTrellisScale = (scales: Scale[], props: BarSpecProps) => {
 	if (!props.trellis) {
 		return;
 	}
-	const { scaleName, rangeScale } = getTrellisProperties(props);
+	const { scaleName, rangeScale, paddingInner } = getTrellisProperties(props);
 	const trellisScaleIndex = getScaleIndexByName(scales, scaleName, 'band');
 	scales[trellisScaleIndex] = addDomainFields(scales[trellisScaleIndex], [props.trellis]);
 	scales[trellisScaleIndex] = {
 		...scales[trellisScaleIndex],
 		range: rangeScale,
-		paddingInner: TRELLIS_PADDING,
+		paddingInner,
 	} as Scale;
 };
 
@@ -92,9 +92,10 @@ export interface BarTrellisProperties {
 	markName: 'xTrellisGroup' | 'yTrellisGroup';
 	rangeScale: 'width' | 'height';
 	axis: 'x' | 'y';
+	paddingInner: number;
 }
 
-export const getTrellisProperties = ({ trellisOrientation, name }: BarSpecProps): BarTrellisProperties => {
+export const getTrellisProperties = ({ trellisOrientation, name, trellisPadding }: BarSpecProps): BarTrellisProperties => {
 	const axis = trellisOrientation === 'horizontal' ? 'x' : 'y';
 
 	return {
@@ -103,6 +104,7 @@ export const getTrellisProperties = ({ trellisOrientation, name }: BarSpecProps)
 		markName: `${axis}TrellisGroup`,
 		rangeScale: axis === 'x' ? 'width' : 'height',
 		axis,
+		paddingInner: trellisPadding,
 	};
 };
 

--- a/src/stories/components/Bar/TrellisBar.story.tsx
+++ b/src/stories/components/Bar/TrellisBar.story.tsx
@@ -121,10 +121,18 @@ VerticalBarVerticalTrellis.args = {
 	trellisOrientation: 'vertical',
 };
 
+const WithCustomTrellisPadding = bindWithProps<BarProps>(BarStory);
+WithCustomTrellisPadding.args = {
+	...HorizontalBarVerticalTrellis.args,
+	orientation: 'vertical',
+	trellisPadding: 0.33,
+};
+
 export {
 	Dodged,
 	HorizontalBarHorizontalTrellis,
 	HorizontalBarVerticalTrellis,
 	VerticalBarHorizontalTrellis,
 	VerticalBarVerticalTrellis,
+	WithCustomTrellisPadding,
 };

--- a/src/stories/components/Bar/TrellisBar.test.tsx
+++ b/src/stories/components/Bar/TrellisBar.test.tsx
@@ -28,6 +28,7 @@ import {
 	HorizontalBarVerticalTrellis,
 	VerticalBarHorizontalTrellis,
 	VerticalBarVerticalTrellis,
+	WithCustomTrellisPadding,
 } from './TrellisBar.story';
 
 describe('TrellisBar', () => {
@@ -88,6 +89,46 @@ describe('TrellisBar', () => {
 		// get bars
 		const bars = await findAllMarksByGroupName(chart, 'bar0');
 		expect(bars.length).toEqual(90);
+	});
+
+	describe('With custom trellis padding', () => {
+		test('WithCustomTrellisPadding renders correctly', async () => {
+			render(<WithCustomTrellisPadding {...WithCustomTrellisPadding.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+	
+			// get bars
+			const bars = await findAllMarksByGroupName(chart, 'bar0');
+			expect(bars.length).toEqual(90);
+		});
+	
+		test('WithCustomTrellisPadding has correct padding for vertical trellis', async () => {
+			render(<WithCustomTrellisPadding {...WithCustomTrellisPadding.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+			// Get subcharts
+			const trellisCharts = await findAllMarksByGroupName(chart, 'yTrellisGroup', 'g');
+	
+			// Y Trellis Group should have Y Translate. X Translate should be 0.
+			// First chart should not have been tra.
+			expect(trellisCharts[0]).toHaveAttribute('transform', 'translate(0,0)');
+			expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,244.9438202247191)');
+			expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,489.8876404494382)');
+		});
+
+		test('WithCustomTrellisPadding has correct padding for horizontal trellis', async () => {
+			render(<WithCustomTrellisPadding {...WithCustomTrellisPadding.args} trellisOrientation='horizontal' />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+			// Get subcharts
+			const trellisCharts = await findAllMarksByGroupName(chart, 'xTrellisGroup', 'g');
+	
+			// X Trellis Group should have X Translate. Y Translate should be 0.
+			// First chart should not have been transformed.
+			expect(trellisCharts[0]).toHaveAttribute('transform', 'translate(0,0)');
+			expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(283.52059925093636,0)');
+			expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(567.0411985018727,0)');
+		});
 	});
 
 	describe('axis titles', () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -239,6 +239,8 @@ export interface BarProps extends Omit<MarkProps, 'color'> {
 	trellis?: string;
 	/** Orientation of the trellis. Only applicable if `trellis` is also defined. Defaults to "horizontal". */
 	trellisOrientation?: Orientation;
+	/** Padding between trellis groups; ratio between 0 and 1 (https://vega.github.io/vega/docs/scales/#band). Only applicable if `trellis` is also defined. Defaults to 0.2. */
+	trellisPadding?: number;
 	type?: BarType;
 }
 

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -83,6 +83,7 @@ type BarPropsWithDefaults =
 	| 'paddingRatio'
 	| 'orientation'
 	| 'trellisOrientation'
+	| 'trellisPadding'
 	| 'type';
 
 export interface BarSpecProps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows users to increase or decrease padding between charts in a trellis.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Makes it easier to avoid charts crashing into each other.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
