### PR TITLE
fix: use legendEntries scale for description matching

### DIFF
--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -194,7 +194,7 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 						<LegendTooltip
 							value={value}
 							descriptions={legendDescriptions}
-							domain={chartView.current?.scale('color').domain()}
+							domain={chartView.current?.scale('legendEntries').domain()}
 						/>
 					);
 				}

--- a/src/stories/components/Legend/Legend.test.tsx
+++ b/src/stories/components/Legend/Legend.test.tsx
@@ -128,6 +128,8 @@ describe('Legend', () => {
 		expect(tooltip).toBeVisible();
 		expect(tooltip).toHaveTextContent('Series | Previous perioddescription previous');
 
+		cleanupTooltips();
+
 		await hoverNthElement(entries, 1);
 
 		tooltip = await screen.findByTestId('rsc-tooltip');

--- a/src/stories/components/Legend/Legend.test.tsx
+++ b/src/stories/components/Legend/Legend.test.tsx
@@ -14,14 +14,8 @@ import React from 'react';
 import { Legend } from '@components/Legend';
 import '@matchMediaMock';
 import { cleanupTooltips, waitForLegendTooltip } from '@specBuilder/legend/legendTestUtils';
-import {
-	clickNthElement,
-	findChart,
-	getAllLegendEntries,
-	hoverNthElement,
-	render,
-	screen,
-} from '@test-utils';
+import { clickNthElement, findChart, getAllLegendEntries, hoverNthElement, render, screen } from '@test-utils';
+import { Chart } from 'Chart';
 
 import { Basic, Descriptions, LabelLimit, OnClick, Position, Supreme, Title } from './Legend.story';
 
@@ -81,6 +75,64 @@ describe('Legend', () => {
 
 		const tooltip = screen.queryByTestId('rsc-tooltip');
 		expect(tooltip).toBeNull();
+	});
+
+	test('Description tooltips display for multiple entries with one series', async () => {
+		const data = [
+			{
+				period: 'Previous period',
+				series: 'series',
+			},
+			{
+				period: 'Current period',
+				series: 'series',
+			},
+		];
+
+		const descriptions = [
+			{
+				seriesName: 'series | Previous period',
+				description: 'description previous',
+				title: 'Series | Previous period',
+			},
+			{
+				seriesName: 'series | Current period',
+				description: 'description current',
+				title: 'Series | Current period',
+			},
+		];
+
+		const legendLabels = [
+			{
+				seriesName: descriptions[0].seriesName,
+				label: descriptions[0].title,
+			},
+			{
+				seriesName: descriptions[1].seriesName,
+				label: descriptions[1].title,
+			},
+		];
+
+		render(
+			<Chart data={data} width={700}>
+				<Legend color="series" lineType="period" descriptions={descriptions} legendLabels={legendLabels} />
+			</Chart>
+		);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const entries = getAllLegendEntries(chart);
+		await hoverNthElement(entries, 0);
+
+		let tooltip = await screen.findByTestId('rsc-tooltip');
+		expect(tooltip).toBeVisible();
+		expect(tooltip).toHaveTextContent('Series | Previous perioddescription previous');
+
+		await hoverNthElement(entries, 1);
+
+		tooltip = await screen.findByTestId('rsc-tooltip');
+		expect(tooltip).toBeVisible();
+		expect(tooltip).toHaveTextContent('Series | Current perioddescription current');
 	});
 
 	test('Disconnected renders properly', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We should use the `legendEntries` scale to match `descriptions` with the appropriate legend entry. 

You can see that descriptions still work after this change by viewing the legend descriptions story and hovering over a legend entry: https://opensource.adobe.com/react-spectrum-charts/PR-44/?path=/story/rsc-legend--descriptions

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It's possible to have a chart with multiple legend entries but only one series. If we match descriptions using series (color), it won't be possible to have descriptions for these types of charts. Matching based on legend entries resolves the issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
