### PR TITLE
fix: two dimensional scale domain

### DIFF
--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -297,11 +297,16 @@ describe('barSpecBuilder', () => {
 						defaultMetricScale,
 						defaultDimensionScale,
 						{
-							domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 							name: 'secondaryColor',
 							type: 'ordinal',
+							domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 						},
-						{ name: 'colors', range: { signal: 'colors' }, type: 'ordinal' },
+						{
+							name: 'colors',
+							type: 'ordinal',
+							range: { signal: 'colors' },
+							domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+						},
 					]
 				);
 			});
@@ -364,11 +369,16 @@ describe('barSpecBuilder', () => {
 			addSecondaryScales(scales, { ...defaultBarProps, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] });
 			expect(scales).toStrictEqual([
 				{
-					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 					name: 'secondaryColor',
 					type: 'ordinal',
+					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 				},
-				{ name: 'colors', range: { signal: 'colors' }, type: 'ordinal' },
+				{
+					name: 'colors',
+					type: 'ordinal',
+					range: { signal: 'colors' },
+					domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+				},
 			]);
 		});
 		test('secondary lineType facet, should add colors secondary scale', () => {
@@ -376,11 +386,16 @@ describe('barSpecBuilder', () => {
 			addSecondaryScales(scales, { ...defaultBarProps, lineType: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] });
 			expect(scales).toStrictEqual([
 				{
-					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 					name: 'secondaryLineType',
 					type: 'ordinal',
+					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 				},
-				{ name: 'lineTypes', range: { signal: 'lineTypes' }, type: 'ordinal' },
+				{
+					name: 'lineTypes',
+					type: 'ordinal',
+					range: { signal: 'lineTypes' },
+					domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+				},
 			]);
 		});
 		test('secondary opacity facet, should add colors secondary scale', () => {
@@ -388,11 +403,16 @@ describe('barSpecBuilder', () => {
 			addSecondaryScales(scales, { ...defaultBarProps, opacity: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] });
 			expect(scales).toStrictEqual([
 				{
-					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 					name: 'secondaryOpacity',
 					type: 'ordinal',
+					domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 				},
-				{ name: 'opacities', range: { signal: 'opacities' }, type: 'ordinal' },
+				{
+					name: 'opacities',
+					type: 'ordinal',
+					range: { signal: 'opacities' },
+					domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+				},
 			]);
 		});
 	});

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -234,12 +234,13 @@ export const addSecondaryScales = (scales: Scale[], props: BarSpecProps) => {
 		].forEach(({ value, scaleName, secondaryScaleName }) => {
 			if (Array.isArray(value) && value.length === 2) {
 				// secondary value scale used for 2D scales
-				const index = getScaleIndexByName(scales, secondaryScaleName, 'ordinal');
-				scales[index] = addDomainFields(scales[index], [value[1]]);
+				const secondaryIndex = getScaleIndexByName(scales, secondaryScaleName, 'ordinal');
+				scales[secondaryIndex] = addDomainFields(scales[secondaryIndex], [value[1]]);
 
-				const i = getScaleIndexByName(scales, scaleName, 'ordinal');
-				const colorsScale = scales[i] as OrdinalScale;
-				colorsScale.range = { signal: scaleName };
+				const primaryIndex = getScaleIndexByName(scales, scaleName, 'ordinal');
+				const primaryScale = scales[primaryIndex] as OrdinalScale;
+				primaryScale.range = { signal: scaleName };
+				scales[primaryIndex] = addDomainFields(primaryScale, [value[0]]);
 			}
 		});
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using two dimensional scales to do stacked/dodged charts, colors were not consistent when hiding and showing series.

This fixes that.

## Motivation and Context

Hide and show was broken for complex dodged/stacked charts 

## How Has This Been Tested?

Confirmed fix in vega editor. All tests pass.

## Screenshots (if appropriate):

<img width="1301" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/ceb35c06-a4ce-4af9-bfb1-dd9607c2b804">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
