### PR TITLE
feat: add getSvg handle

### DIFF
--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -13,7 +13,14 @@ import { FC, MutableRefObject, forwardRef, useEffect, useMemo, useRef, useState 
 
 import { EmptyState } from '@components/EmptyState';
 import { LoadingState } from '@components/LoadingState';
-import { DEFAULT_BACKGROUND_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_LINE_TYPES, LEGEND_TOOLTIP_DELAY, MARK_ID, SERIES_ID } from '@constants';
+import {
+	DEFAULT_BACKGROUND_COLOR,
+	DEFAULT_COLOR_SCHEME,
+	DEFAULT_LINE_TYPES,
+	LEGEND_TOOLTIP_DELAY,
+	MARK_ID,
+	SERIES_ID,
+} from '@constants';
 import useChartImperativeHandle from '@hooks/useChartImperativeHandle';
 import useChartWidth from '@hooks/useChartWidth';
 import useElementSize from '@hooks/useElementSize';

--- a/src/hooks/useChartImperativeHandle.tsx
+++ b/src/hooks/useChartImperativeHandle.tsx
@@ -68,5 +68,17 @@ export default function useChartImperativeHandle(
 				}
 			});
 		},
+		getSvg() {
+			return new Promise<string>((resolve, reject) => {
+				if (chartView.current) {
+					chartView.current.toSVG().then(
+						(value) => resolve(value),
+						() => reject(new Error('Error occurred while converting chart to SVG'))
+					);
+				} else {
+					reject(new Error("There isn't a chart to get the SVG from, get SVG failed"));
+				}
+			});
+		},
 	}));
 }

--- a/src/stories/Chart.test.tsx
+++ b/src/stories/Chart.test.tsx
@@ -212,6 +212,24 @@ describe('Chart', () => {
 				await expect(ref.current.download('My filename')).resolves.toBe('Chart downloaded as My filename.png');
 			}
 		});
+		test('getSvg returns an svg string', async () => {
+			const ref = createRef<ChartHandle>();
+			render(
+				<Chart data={data} ref={ref} width={200}>
+					<Line dimension="x" metric="y" />
+				</Chart>
+			);
+			if (ref.current) {
+				// should reject since the chart isn't done rendering
+				await expect(ref.current.getSvg()).rejects.toThrowError(
+					"There isn't a chart to get the SVG from, get SVG failed"
+				);
+				const chart = await findChart();
+				expect(chart).toBeInTheDocument();
+				// should resolve and return an svg string
+				await expect(ref.current.getSvg()).resolves.toMatch(/^<svg/i);
+			}
+		});
 	});
 
 	describe('getElement()', () => {

--- a/src/stories/ChartHandles.story.tsx
+++ b/src/stories/ChartHandles.story.tsx
@@ -26,10 +26,16 @@ export default {
 	component: Chart,
 };
 
-const HandleStory = ({ variant }: { variant: 'copy' | 'download' }) => {
+const HandleStory = ({ variant }: { variant: 'copy' | 'download' | 'getSvg' }) => {
 	const [loading, setLoading] = useState(false);
 	const ref = useRef<ChartHandle>(null);
 	const props = useChartProps({ data });
+
+	const buttonText: Record<typeof variant, string> = {
+		copy: 'Copy to clipboard',
+		download: 'Download PNG',
+		getSvg: 'Get SVG',
+	};
 	return (
 		<Content>
 			<Chart {...props} ref={ref} loading={loading}>
@@ -42,7 +48,7 @@ const HandleStory = ({ variant }: { variant: 'copy' | 'download' }) => {
 					onPress={() => ref?.current?.[variant]().then(console.log, console.warn)}
 					data-testid={variant}
 				>
-					{variant === 'copy' ? 'Copy to clipboard' : 'Download PNG'}
+					{buttonText[variant]}
 				</ActionButton>
 				<ActionButton onPress={() => setLoading(!loading)}>Toggle loading</ActionButton>
 			</Flex>
@@ -58,8 +64,14 @@ const DownloadStory: ComponentStory<typeof Chart> = (): ReactElement => {
 	return <HandleStory variant="download" />;
 };
 
+const SvgStory: ComponentStory<typeof Chart> = (): ReactElement => {
+	return <HandleStory variant="getSvg" />;
+};
+
 const Copy = bindWithProps(CopyStory);
 
 const Download = bindWithProps(DownloadStory);
 
-export { Copy, Download };
+const GetSvg = bindWithProps(SvgStory);
+
+export { Copy, Download, GetSvg };

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -91,6 +91,7 @@ export type Width = number | string | 'auto';
 export interface ChartHandle {
 	copy: () => Promise<string>;
 	download: (customFileName?: string) => Promise<string>;
+	getSvg: (width?: number, height?: number) => Promise<string>;
 }
 
 export interface AreaProps extends MarkProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a `getSvg()` method that returns the svg string for the chart.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This will be helpful for the figma plugin since it needs the SVG string to pass into the figma API

## How Has This Been Tested?

Added tests and stories

## Screenshots (if appropriate):

<img width="1057" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/17db3691-fc1a-485b-9a46-b9b338b619bb">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
