### PR TITLE
fix: enforce minimum vega-tooltip for custom tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
 		"@adobe/react-spectrum": ">= 3.23.0",
 		"immer": ">= 9.0.0",
 		"uuid": ">= 9.0.0",
-		"vega-embed": ">= 6.23.0"
+		"vega-embed": ">= 6.23.0",
+		"vega-tooltip": ">= 0.26.0"
 	},
 	"peerDependencies": {
 		"@adobe/react-spectrum": ">=3.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13727,6 +13727,13 @@ vega-time@^2.1.1, vega-time@~2.1.1:
     d3-time "^3.1.0"
     vega-util "^1.17.1"
 
+"vega-tooltip@>= 0.26.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.34.0.tgz#e0aa4d9c9bcf155e257650ba7e670fad7b1ff5ab"
+  integrity sha512-TtxwkcLZ5aWQTvKGlfWDou8tISGuxmqAW1AgGZjrDpf75qsXvgtbPdRAAls2LZMqDxpr5T1kMEZs9XbSpiI8yw==
+  dependencies:
+    vega-util "^1.17.2"
+
 vega-tooltip@^0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.33.0.tgz#32bcaad713171d2ae00b47189e6334a318566739"


### PR DESCRIPTION
This PR only adds a dependency in package.json which is a requirement for RSC but wasn't listed. 

## Description

It all started with a bug in CJA where custom tooltip wouldn't work after upgrading to the latest alpha (alpha-12). After a bit of digging I found out:
* tag v0.0.1-alpha.10 is where the tooltip stops working for me, alpha.9 is ok
* if I comment (in alpha.10) src/Chart.tsx lines 287 through 305, the issue goes away

## Solution
List the package `vega-tooltip` as a dependency since it is a requirement for custom tooltips. The custom tooltip support was added in `vega-tooltip v0.26.0`. For the CJA bug, @quarry/react-vega (a dep of CJA) has vega-tooltip@0.19.0 which explains why the custom tooltip wouldn't work. The solution was to add `vega-tooltip` to resolutions.


## Motivation and Context
Adding vega-tooltip as a dependency will enforce a minimum version which is required for custom tooltips. It will help other consumers avoid dependency mismatch and make RSC more robust.

## How Has This Been Tested?

There are no code changes, this PR only updates `package.json`.

## Screenshots (if appropriate):
Before:
<img width="424" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/36204714/769c0435-3da8-4395-b6d8-bb58e4bd02fc">

After:
![image](https://github.com/adobe/react-spectrum-charts/assets/36204714/31926d74-9ef0-48d9-a00c-9e951f61a1f8)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
