### PR TITLE
feat: use screen blend mode in dark mode

### DIFF
--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import {
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
@@ -67,5 +66,14 @@ describe('addScatterMarks()', () => {
 		expect(marks[0].name).toBe('scatter0_group');
 		expect(marks[0].type).toBe('group');
 		expect((marks[0] as GroupMark).marks).toHaveLength(1);
+	});
+
+	test('should use "multiply" blend mode in light mode', () => {
+		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'light' });
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toBe('multiply');
+	});
+	test('should "screen" blend mode in dark mode', () => {
+		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'dark' });
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toBe('screen');
 	});
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -70,10 +70,10 @@ describe('addScatterMarks()', () => {
 
 	test('should use "multiply" blend mode in light mode', () => {
 		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'light' });
-		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toBe('multiply');
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'multiply' });
 	});
 	test('should "screen" blend mode in dark mode', () => {
 		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'dark' });
-		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toBe('screen');
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'screen' });
 	});
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -41,7 +41,7 @@ export const addScatter = produce<Spec, [ScatterProps & { colorScheme?: ColorSch
 			index = 0,
 			metric = DEFAULT_METRIC,
 			name,
-			opacity = 0.8,
+			opacity = 1,
 			size = { value: 'M' },
 			...props
 		}
@@ -116,7 +116,7 @@ export const getScatterMark = ({
 	},
 	encode: {
 		enter: {
-			blend: { value: 'multiply' },
+			blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
 			fillOpacity: [{ value: opacity }],
 			shape: { value: 'circle' },
 		},

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -116,6 +116,11 @@ export const getScatterMark = ({
 	},
 	encode: {
 		enter: {
+			/**
+			 * the blend mode makes it possible to tell when there are overlapping points
+			 * in light mode, the points are darker when they overlap (multiply)
+			 * in dark mode, the points are lighter when they overlap (screen)
+			 */
 			blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
 			fillOpacity: [{ value: opacity }],
 			shape: { value: 'circle' },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For light mode, scatter uses the `multiply` blend mode but this doesn't work in dark mode. The reason is, `multiply` always darkens the given color.

Instead we need to use `screen` blend mode when in dark mode.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/50

## Motivation and Context

Need to support light and dark mode for all features

## How Has This Been Tested?

Added tests to make sure correct blend mode is set.

## Screenshots (if appropriate):

https://github.com/adobe/react-spectrum-charts/assets/40001449/e47445ef-f5e5-443b-ad5e-0ba38317c2a5

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
