### PR TITLE
feat: continuous data in legends and multiple legends

### DIFF
--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -103,6 +103,7 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 			padding = 0,
 			renderer = 'svg',
 			symbolShapes,
+			symbolSizes,
 			theme = defaultTheme,
 			title,
 			width = 'auto',
@@ -133,6 +134,7 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 			hiddenSeries,
 			highlightedSeries,
 			symbolShapes,
+			symbolSizes,
 			lineTypes,
 			lineWidths,
 			opacities,
@@ -194,7 +196,7 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 		if (tooltips.length || legendDescriptions) {
 			tooltipConfig.formatTooltip = (value) => {
 				debugLog(debug, { title: 'Tooltip datum', contents: value });
-				if (legendDescriptions && 'index' in value) {
+				if (value.rscComponentName?.startsWith('legend') && legendDescriptions && 'index' in value) {
 					debugLog(debug, {
 						title: 'Legend descriptions',
 						contents: legendDescriptions,
@@ -203,7 +205,8 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 						<LegendTooltip
 							value={value}
 							descriptions={legendDescriptions}
-							domain={chartView.current?.scale('legendEntries').domain()}
+							// TODO: support multiple legends
+							domain={chartView.current?.scale('legend0Entries').domain()}
 						/>
 					);
 				}

--- a/src/components/Scatter/Scatter.tsx
+++ b/src/components/Scatter/Scatter.tsx
@@ -23,7 +23,7 @@ export function Scatter({
 	children,
 	metric = DEFAULT_METRIC,
 	name,
-	opacity = 0.8,
+	opacity = 1,
 	size = { value: DEFAULT_SYMBOL_SIZE },
 }: ScatterProps) {
 	return null;

--- a/src/hooks/useSpec.tsx
+++ b/src/hooks/useSpec.tsx
@@ -30,6 +30,7 @@ export default function useSpec({
 	lineWidths,
 	opacities,
 	symbolShapes,
+	symbolSizes,
 	title,
 	UNSAFE_vegaSpec,
 }: SanitizedSpecProps): Spec {
@@ -64,6 +65,7 @@ export default function useSpec({
 					lineWidths,
 					opacities,
 					symbolShapes,
+					symbolSizes,
 					title,
 				})
 			)
@@ -81,6 +83,7 @@ export default function useSpec({
 		lineWidths,
 		opacities,
 		symbolShapes,
+		symbolSizes,
 		title,
 		UNSAFE_vegaSpec,
 	]);

--- a/src/specBuilder/chartSpecBuilder.test.ts
+++ b/src/specBuilder/chartSpecBuilder.test.ts
@@ -37,6 +37,7 @@ import {
 	getLineWidthScale,
 	getOpacityScale,
 	getSymbolShapeScale,
+	getSymbolSizeScale,
 	getTwoDimensionalColorScheme,
 	getTwoDimensionalLineTypes,
 	getTwoDimensionalOpacities,
@@ -316,6 +317,18 @@ describe('Chart spec builder', () => {
 		});
 	});
 
+	describe('getSymbolSizeScale()', () => {
+		test('should return the symbolSize scale', () => {
+			expect(getSymbolSizeScale(['XS', 'XL'])).toStrictEqual({
+				name: 'symbolSize',
+				type: 'linear',
+				zero: false,
+				domain: { data: 'table', fields: [] },
+				range: [36, 256],
+			});
+		});
+	});
+
 	describe('addData()', () => {
 		test('should do nothing if there are not any facets and there is no filteredTable data', () => {
 			expect(addData(defaultData, { facets: [] })[0].transform).toHaveLength(1);
@@ -405,7 +418,7 @@ describe('Chart spec builder', () => {
 				on: [
 					{
 						events: '@legend0_legendEntry:mouseover',
-						update: 'indexof(hiddenSeries, domain("legendEntries")[datum.index]) === -1 ? domain("legendEntries")[datum.index] : ""',
+						update: 'indexof(hiddenSeries, domain("legend0Entries")[datum.index]) === -1 ? domain("legend0Entries")[datum.index] : ""',
 					},
 					{
 						events: '@legend0_legendEntry:mouseout',

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -39,9 +39,10 @@ import {
 	SanitizedSpecProps,
 	ScatterElement,
 	SymbolShapes,
+	SymbolSize,
 	TitleElement,
 } from 'types';
-import { Data, OrdinalScale, PointScale, Scale, Signal, Spec } from 'vega';
+import { Data, LinearScale, OrdinalScale, PointScale, Scale, Signal, Spec } from 'vega';
 
 import { addArea } from './area/areaSpecBuilder';
 import { addAxis } from './axis/axisSpecBuilder';
@@ -58,6 +59,7 @@ import {
 	getLineWidthPixelsFromLineWidth,
 	getPathFromSymbolShape,
 	getStrokeDashFromLineType,
+	getVegaSymbolSizeFromRscSymbolSize,
 	initializeSpec,
 } from './specUtils';
 import { addTitle } from './title/titleSpecBuilder';
@@ -73,12 +75,13 @@ export function buildSpec({
 	lineWidths = ['M'],
 	opacities,
 	symbolShapes = ['rounded-square'],
+	symbolSizes = ['XS', 'XL'],
 	colorScheme = DEFAULT_COLOR_SCHEME,
 	title,
 }: SanitizedSpecProps) {
 	let spec = initializeSpec(null, { backgroundColor, colorScheme, description, title });
 	spec.signals = getDefaultSignals(backgroundColor, colors, colorScheme, lineTypes, opacities, hiddenSeries);
-	spec.scales = getDefaultScales(colors, colorScheme, lineTypes, lineWidths, opacities, symbolShapes);
+	spec.scales = getDefaultScales(colors, colorScheme, lineTypes, lineWidths, opacities, symbolShapes, symbolSizes);
 
 	// need to build the spec in a specific order
 	const buildOrder = new Map();
@@ -221,13 +224,15 @@ const getDefaultScales = (
 	lineTypes: LineTypes,
 	lineWidths: LineWidth[],
 	opacities: Opacities | undefined,
-	symbolShapes: SymbolShapes
+	symbolShapes: SymbolShapes,
+	symbolSizes: [SymbolSize, SymbolSize]
 ): Scale[] => [
 	getColorScale(colors, colorScheme),
 	getLineTypeScale(lineTypes),
 	getLineWidthScale(lineWidths),
 	getOpacityScale(opacities),
 	getSymbolShapeScale(symbolShapes),
+	getSymbolSizeScale(symbolSizes),
 ];
 
 export const getColorScale = (colors: ChartColors, colorScheme: ColorScheme): OrdinalScale => {
@@ -265,6 +270,19 @@ export const getSymbolShapeScale = (symbolShapes: SymbolShapes): OrdinalScale =>
 		domain: { data: TABLE, fields: [] },
 	};
 };
+
+/**
+ * returns the symbol size scale
+ * @param symbolSizes
+ * @returns LinearScale
+ */
+export const getSymbolSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): LinearScale => ({
+	name: 'symbolSize',
+	type: 'linear',
+	zero: false,
+	range: symbolSizes.map((symbolSize) => getVegaSymbolSizeFromRscSymbolSize(symbolSize)),
+	domain: { data: TABLE, fields: [] },
+});
 
 export const getLineWidthScale = (lineWidths: LineWidth[]): OrdinalScale => ({
 	name: 'lineWidth',

--- a/src/specBuilder/legend/legendFacetUtils.test.ts
+++ b/src/specBuilder/legend/legendFacetUtils.test.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_COLOR, TABLE } from '@constants';
+import { Scale } from 'vega';
+
+import { getFacets, getFacetsFromKeys } from './legendFacetUtils';
+
+describe('getFacets()', () => {
+	test('should correctly identify continuous and categorical facets', () => {
+		const scales: Scale[] = [
+			{
+				name: 'color',
+				type: 'ordinal',
+				domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+			},
+			{
+				name: 'lineType',
+				type: 'ordinal',
+			},
+			{
+				name: 'symbolSize',
+				type: 'linear',
+				domain: { data: TABLE, fields: ['weight'] },
+			},
+		];
+		const { ordinalFacets, continuousFacets } = getFacets(scales);
+		expect(ordinalFacets).toHaveLength(1);
+		expect(continuousFacets).toHaveLength(1);
+	});
+});
+
+describe('getFacetsFromKeys()', () => {
+	test('should find the correct facets from the provided keys', () => {
+		const scales: Scale[] = [
+			{
+				name: 'color',
+				type: 'ordinal',
+				domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+			},
+			{
+				name: 'lineType',
+				type: 'ordinal',
+			},
+			{
+				name: 'symbolSize',
+				type: 'linear',
+				domain: { data: TABLE, fields: ['weight'] },
+			},
+		];
+		let facets = getFacetsFromKeys(['weight'], scales);
+		expect(facets.ordinalFacets).toHaveLength(0);
+		expect(facets.continuousFacets).toHaveLength(1);
+		facets = getFacetsFromKeys([DEFAULT_COLOR], scales);
+		expect(facets.ordinalFacets).toHaveLength(1);
+		expect(facets.continuousFacets).toHaveLength(0);
+	});
+});

--- a/src/specBuilder/legend/legendFacetUtils.ts
+++ b/src/specBuilder/legend/legendFacetUtils.ts
@@ -62,7 +62,7 @@ export const getFacetsFromKeys = (
 	const ordinalFacets: Facet[] = [];
 	const continuousFacets: Facet[] = [];
 	scales.forEach((scale) => {
-		if (isScaleWithMultiFields(scale) && scaleHaskey(scale, keys)) {
+		if (isScaleWithMultiFields(scale) && scaleHasKey(scale, keys)) {
 			if (scale.type === 'ordinal' || scale.type === 'point') {
 				ordinalFacets.push({
 					facetType: scale.name as FacetType,
@@ -85,7 +85,7 @@ export const getFacetsFromKeys = (
  * @param keys
  * @returns boolean
  */
-const scaleHaskey = (scale: ScaleWithMultiFields, keys: string[]): boolean =>
+const scaleHasKey = (scale: ScaleWithMultiFields, keys: string[]): boolean =>
 	scale.domain.fields.some((field) => keys.includes(field.toString()));
 
 type ScaleWithMultiFields = Scale & { domain: ScaleMultiFieldsRef };

--- a/src/specBuilder/legend/legendFacetUtils.ts
+++ b/src/specBuilder/legend/legendFacetUtils.ts
@@ -1,0 +1,100 @@
+import { FacetType, SecondaryFacetType } from 'types';
+import { Scale, ScaleMultiFieldsRef } from 'vega';
+
+import { Facet } from './legendUtils';
+
+/**
+ * These are all the scale names that are used for facets
+ */
+const facetScaleNames: (FacetType | SecondaryFacetType)[] = [
+	'color',
+	'lineType',
+	'opacity',
+	'secondaryColor',
+	'secondaryLineType',
+	'secondaryOpacity',
+	'secondarySymbolShape',
+	'symbolShape',
+	'symbolSize',
+];
+
+/**
+ * Goes through all the scales and finds all the facets that are used
+ * A facet is a key in the data that is used to differentiate the data
+ * Examples are color based on 'operatingSystem', size based on 'weight', lineType based on 'timePeriod' etc.
+ * @param scales
+ * @returns Factes
+ */
+export const getFacets = (scales: Scale[]): { ordinalFacets: Facet[]; continuousFacets: Facet[] } => {
+	const ordinalFacets: Facet[] = [];
+	const continuousFacets: Facet[] = [];
+
+	scales.forEach((scale) => {
+		if (
+			facetScaleNames.includes(scale.name as FacetType) &&
+			isScaleWithMultiFields(scale) &&
+			scale.domain.fields.length
+		) {
+			if (scale.type === 'ordinal' || scale.type === 'point') {
+				ordinalFacets.push({
+					facetType: scale.name as FacetType,
+					field: scale.domain.fields[0].toString(),
+				});
+			} else {
+				continuousFacets.push({ facetType: scale.name as FacetType, field: scale.domain.fields[0].toString() });
+			}
+		}
+	});
+	return { ordinalFacets, continuousFacets };
+};
+
+/**
+ * This function goes through all the scales and finds the scales that use the provided keys
+ * Example: if the keys are ['segment', 'event'], this function will find all the scales that use either of those fields so that they can be used to generate the legend
+ * @param keys
+ * @param scales
+ * @returns
+ */
+export const getFacetsFromKeys = (
+	keys: string[],
+	scales: Scale[]
+): { ordinalFacets: Facet[]; continuousFacets: Facet[] } => {
+	const ordinalFacets: Facet[] = [];
+	const continuousFacets: Facet[] = [];
+	scales.forEach((scale) => {
+		if (isScaleWithMultiFields(scale) && scaleHaskey(scale, keys)) {
+			if (scale.type === 'ordinal' || scale.type === 'point') {
+				ordinalFacets.push({
+					facetType: scale.name as FacetType,
+					field: scale.domain.fields.find((field) => keys.includes(field.toString()))?.toString() as string,
+				});
+			} else {
+				continuousFacets.push({
+					facetType: scale.name as FacetType,
+					field: scale.domain.fields.find((field) => keys.includes(field.toString()))?.toString() as string,
+				});
+			}
+		}
+	});
+	return { ordinalFacets, continuousFacets };
+};
+
+/**
+ * Checks if the scale has any of the provided keys
+ * @param scale
+ * @param keys
+ * @returns boolean
+ */
+const scaleHaskey = (scale: ScaleWithMultiFields, keys: string[]): boolean =>
+	scale.domain.fields.some((field) => keys.includes(field.toString()));
+
+type ScaleWithMultiFields = Scale & { domain: ScaleMultiFieldsRef };
+
+/**
+ * Checks that the scale has a domain with a fields array
+ * @param scale
+ * @returns
+ */
+const isScaleWithMultiFields = (scale: Scale): scale is ScaleWithMultiFields => {
+	return Boolean('domain' in scale && scale.domain && 'fields' in scale.domain);
+};

--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -29,7 +29,7 @@ const defaultOpacityEncoding = {
 	],
 };
 
-describe('getHighlightOpacityrule()', () => {
+describe('getHighlightOpacityRule()', () => {
 	test('scale ref should divide by highlight contrast ratio', () => {
 		expect(getHighlightOpacityRule({ scale: 'opacity', field: DEFAULT_COLOR })).toStrictEqual({
 			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
@@ -48,11 +48,20 @@ describe('getHighlightOpacityrule()', () => {
 			value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
 		});
 	});
-	test('empty ref should rturn default rule', () => {
+	test('empty ref should return default rule', () => {
 		expect(getHighlightOpacityRule({})).toStrictEqual({
 			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
 			value: 1 / HIGHLIGHT_CONTRAST_RATIO,
 		});
+	});
+	test('should use the legend name in the test if keys exist', () => {
+		const legendName = 'legend0';
+		const { test } = getHighlightOpacityRule({}, ['series'], legendName);
+		expect(test).toContain(legendName);
+	});
+	test('should use the highlighedSeries in the test if keys do not', () => {
+		const { test } = getHighlightOpacityRule({});
+		expect(test).toContain('highlightedSeries');
 	});
 });
 

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -15,7 +15,7 @@ import { GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
 /**
  * Adds opacity tests for the fill and stroke of marks that use the color scale to set the fill or stroke value.
  */
-export const setHoverOpacityForMarks = (marks: Mark[]) => {
+export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: string) => {
 	if (!marks.length) return;
 	const flatMarks = flattenMarks(marks);
 	const seriesMarks = flatMarks.filter(markUsesSeriesColorScale);
@@ -34,7 +34,7 @@ export const setHoverOpacityForMarks = (marks: Mark[]) => {
 			// the production rule that sets the fill opacity for this mark
 			const fillOpacityRule = getOpacityRule(fillOpacity);
 			// the new production rule for highlighting
-			const highlightFillOpacityRule = getHighlightOpacityRule(fillOpacityRule);
+			const highlightFillOpacityRule = getHighlightOpacityRule(fillOpacityRule, keys, name);
 
 			if (!Array.isArray(update.fillOpacity)) {
 				update.fillOpacity = [];
@@ -48,7 +48,7 @@ export const setHoverOpacityForMarks = (marks: Mark[]) => {
 			// the production rule that sets the stroke opacity for this mark
 			const strokeOpacityRule = getOpacityRule(strokeOpacity);
 			// the new production rule for highlighting
-			const highlightStrokeOpacityRule = getHighlightOpacityRule(strokeOpacityRule);
+			const highlightStrokeOpacityRule = getHighlightOpacityRule(strokeOpacityRule, keys, name);
 			if (!Array.isArray(update.strokeOpacity)) {
 				update.strokeOpacity = [];
 			}
@@ -76,9 +76,14 @@ export const getOpacityRule = (
 };
 
 export const getHighlightOpacityRule = (
-	opacityRule: ProductionRule<NumericValueRef>
+	opacityRule: ProductionRule<NumericValueRef>,
+	keys?: string[],
+	name?: string
 ): { test?: string } & NumericValueRef => {
-	const test = `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`;
+	let test = `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`;
+	if (keys) {
+		test = `${name}_highlight && ${name}_highlight !== datum.${keys[0]}`;
+	}
 	if ('scale' in opacityRule && 'field' in opacityRule) {
 		return {
 			test,

--- a/src/specBuilder/legend/legendUtils.test.ts
+++ b/src/specBuilder/legend/legendUtils.test.ts
@@ -13,14 +13,20 @@ import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, HIGHLIGHT_CONTRAST_RATIO } from '@
 import { spectrumColors } from '@themes';
 
 import { defaultLegendProps, opacityEncoding } from './legendTestUtils';
-import { getOpacityEncoding, getShowHideEncodings, getSymbolEncodings, mergeLegendEncodings } from './legendUtils';
+import {
+	getShowHideEncodings,
+	getSymbolEncodings,
+	getSymbolOpacityEncoding,
+	getSymbolType,
+	mergeLegendEncodings,
+} from './legendUtils';
 
 const defaultOpacitySignalEncoding = [
 	{
 		test: 'highlightedSeries && datum.value !== highlightedSeries',
-		signal: `scale('opacity', data('legendAggregate')[datum.index].${DEFAULT_COLOR}) / 5`,
+		signal: `scale('opacity', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR}) / 5`,
 	},
-	{ signal: `scale('opacity', data('legendAggregate')[datum.index].${DEFAULT_COLOR})` },
+	{ signal: `scale('opacity', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR})` },
 ];
 
 const hiddenSeriesEncoding = {
@@ -42,24 +48,30 @@ const hiddenSeriesLabelUpdateEncoding = {
 	},
 };
 
-describe('getOpacityEncoding()', () => {
+describe('getSymbolOpacityEncoding()', () => {
 	test('should return undefined if highlight is false', () => {
-		expect(getOpacityEncoding(false)).toBeUndefined();
+		expect(getSymbolOpacityEncoding(defaultLegendProps)).toBeUndefined();
 	});
 
 	test('should return default highlight encoding if opacity and facets are undefined', () => {
-		expect(getOpacityEncoding(true)).toStrictEqual(opacityEncoding);
+		expect(getSymbolOpacityEncoding({ ...defaultLegendProps, highlight: true })).toStrictEqual(opacityEncoding);
 	});
 
 	test('should return signal-based encoding if facets includes opacity facet when opacity id undefined', () => {
-		expect(getOpacityEncoding(true, undefined, [{ facetType: 'opacity', field: DEFAULT_COLOR }])).toStrictEqual(
-			defaultOpacitySignalEncoding
-		);
+		expect(
+			getSymbolOpacityEncoding({
+				...defaultLegendProps,
+				highlight: true,
+				facets: [{ facetType: 'opacity', field: DEFAULT_COLOR }],
+			})
+		).toStrictEqual(defaultOpacitySignalEncoding);
 	});
 
 	test('should return value-based encoding if opacity exists and is a static value', () => {
 		const opacity = 0.5;
-		expect(getOpacityEncoding(true, { value: opacity })).toStrictEqual([
+		expect(
+			getSymbolOpacityEncoding({ ...defaultLegendProps, highlight: true, opacity: { value: opacity } })
+		).toStrictEqual([
 			{
 				test: 'highlightedSeries && datum.value !== highlightedSeries',
 				value: opacity / HIGHLIGHT_CONTRAST_RATIO,
@@ -69,15 +81,14 @@ describe('getOpacityEncoding()', () => {
 	});
 
 	test('should return signal based highlight encodings if opacity is a signal ref', () => {
-		expect(getOpacityEncoding(true, DEFAULT_COLOR, [{ facetType: 'opacity', field: 'testing' }])).toStrictEqual(
-			defaultOpacitySignalEncoding
-		);
-	});
-
-	test('should return value based highlight encodings if opacity and facets are valid', () => {
-		expect(getOpacityEncoding(true, DEFAULT_COLOR, [{ facetType: 'opacity', field: 'testing' }])).toStrictEqual(
-			defaultOpacitySignalEncoding
-		);
+		expect(
+			getSymbolOpacityEncoding({
+				...defaultLegendProps,
+				highlight: true,
+				opacity: DEFAULT_COLOR,
+				facets: [{ facetType: 'opacity', field: 'testing' }],
+			})
+		).toStrictEqual(defaultOpacitySignalEncoding);
 	});
 });
 
@@ -177,5 +188,14 @@ describe('mergeLegendEncodings()', () => {
 				enter: { cursor: { value: 'pointer' }, fill: { value: 'transparent' } },
 			},
 		});
+	});
+});
+
+describe('getSymbolType()', () => {
+	test('should return the symbolShape if a static value is provided', () => {
+		expect(getSymbolType({ value: 'diamond' })).toStrictEqual('diamond');
+	});
+	test('should default to circle if static value is not provided', () => {
+		expect(getSymbolType('series')).toStrictEqual('circle');
 	});
 });

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -162,7 +162,7 @@ export const getOpacityEncoding = ({
 }: LegendSpecProps): ProductionRule<NumericValueRef> | undefined => {
 	const highlightSignalName = keys ? `${name}_highlight` : 'highlightedSeries';
 	// only add symbol opacity if highlight is true or highlightedSeries is defined
-	if (Boolean(highlight || highlightedSeries)) {
+	if (highlight || highlightedSeries) {
 		return getHighlightOpacityEncoding({ value: 1 / HIGHLIGHT_CONTRAST_RATIO }, { value: 1 }, highlightSignalName);
 	}
 	return undefined;
@@ -185,7 +185,7 @@ export const getSymbolOpacityEncoding = ({
 }: LegendSpecProps & { facets?: Facet[] }): ProductionRule<NumericValueRef> | undefined => {
 	const highlightSignalName = keys ? `${name}_highlight` : 'highlightedSeries';
 	// only add symbol opacity if highlight is true or highlightedSeries is defined
-	if (Boolean(highlight || highlightedSeries)) {
+	if (highlight || highlightedSeries) {
 		if (facets || opacity) {
 			const opacityEncoding = getSymbolFacetEncoding<number>({
 				facets,
@@ -232,7 +232,7 @@ export const getSymbolEncodings = (facets: Facet[], props: LegendSpecProps): Leg
 	let update: SymbolEncodeEntry = {
 		fill: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
-			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) || {
+			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],
@@ -240,7 +240,7 @@ export const getSymbolEncodings = (facets: Facet[], props: LegendSpecProps): Leg
 		size: getSymbolFacetEncoding<number>({ facets, facetType: 'symbolSize', name }),
 		stroke: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
-			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) || {
+			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -20,7 +20,7 @@ import { initializeSpec } from '@specBuilder/specUtils';
 import { ScatterSpecProps } from 'types';
 import { GroupMark } from 'vega';
 
-import { addData, addScales, addScatterMarks } from './scatterSpecBuilder';
+import { addData, addScatterMarks, setScales } from './scatterSpecBuilder';
 
 const defaultScatterProps: ScatterSpecProps = {
 	children: [],
@@ -45,17 +45,23 @@ describe('addData()', () => {
 	});
 });
 
-describe('addScales()', () => {
+describe('setScales()', () => {
 	test('should add all the correct scales', () => {
-		const scales = addScales([], defaultScatterProps);
+		const scales = setScales([], defaultScatterProps);
 		expect(scales).toHaveLength(2);
 		expect(scales[0].name).toBe('xLinear');
 		expect(scales[1].name).toBe('yLinear');
 	});
 	test('should add the color scale if color is a reference to a key', () => {
-		const scales = addScales([], { ...defaultScatterProps, color: DEFAULT_COLOR });
+		const scales = setScales([], { ...defaultScatterProps, color: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
 		expect(scales[2].name).toBe('color');
+	});
+	test('should add the symbolSize scale if size is a reference to a key', () => {
+		const scales = setScales([], { ...defaultScatterProps, size: 'weight' });
+		expect(scales).toHaveLength(3);
+		expect(scales[2].name).toBe('symbolSize');
+		expect(scales[2].domain).toEqual({ data: 'table', fields: ['weight'] });
 	});
 });
 

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -65,7 +65,7 @@ export const addScatter = produce<Spec, [ScatterProps & { colorScheme?: ColorSch
 		};
 
 		spec.data = addData(spec.data ?? [], scatterProps);
-		spec.scales = addScales(spec.scales ?? [], scatterProps);
+		spec.scales = setScales(spec.scales ?? [], scatterProps);
 		spec.marks = addScatterMarks(spec.marks ?? [], scatterProps);
 	}
 );
@@ -77,14 +77,16 @@ export const addData = produce<Data[], [ScatterSpecProps]>((data, { dimension, d
 	}
 });
 
-export const addScales = produce<Scale[], [ScatterSpecProps]>((scales, props) => {
-	const { color, dimension, dimensionScaleType, metric } = props;
+export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) => {
+	const { color, dimension, dimensionScaleType, metric, size } = props;
 	// add dimension scale
 	addContinuousDimensionScale(scales, { scaleType: dimensionScaleType, dimension });
 	// add metric scale
 	addMetricScale(scales, [metric]);
 	// add color to the color domain
 	addFieldToFacetScaleDomain(scales, 'color', color);
+	// add size to the size domain
+	addFieldToFacetScaleDomain(scales, 'symbolSize', size);
 });
 
 export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props) => {

--- a/src/specBuilder/signal/signalSpecBuilder.test.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.test.ts
@@ -20,7 +20,7 @@ export const defaultHighlightSignal: Signal = {
 	on: [
 		{
 			events: '@legend0_legendEntry:mouseover',
-			update: 'indexof(hiddenSeries, domain("legendEntries")[datum.index]) === -1 ? domain("legendEntries")[datum.index] : ""',
+			update: 'indexof(hiddenSeries, domain("legend0Entries")[datum.index]) === -1 ? domain("legend0Entries")[datum.index] : ""',
 		},
 		{ events: '@legend0_legendEntry:mouseout', update: '""' },
 	],

--- a/src/specBuilder/signal/signalSpecBuilder.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.ts
@@ -63,13 +63,13 @@ export const getSeriesHoveredSignal = (name: string, nestedDatum?: boolean, even
 /**
  * Returns the highlighted series signal
  */
-export const getHighlightSeriesSignal = (name: string, includeHiddenSeries: boolean): Signal => {
-	const hoveredSeries = 'domain("legendEntries")[datum.index]';
+export const getHighlightSeriesSignal = (name: string, includeHiddenSeries: boolean, keys?: string[]): Signal => {
+	const hoveredSeries = `domain("${name}Entries")[datum.index]`;
 	const update = includeHiddenSeries
 		? `indexof(hiddenSeries, ${hoveredSeries}) === -1 ? ${hoveredSeries} : ""`
 		: hoveredSeries;
 	return {
-		name: 'highlightedSeries',
+		name: keys ? `${name}_highlight` : 'highlightedSeries',
 		value: null,
 		on: [
 			{ events: `@${name}_legendEntry:mouseover`, update },

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -20,7 +20,15 @@ import { bindWithProps } from '@test-utils';
 const marioDataKeys = [
 	...Object.keys(characterData[0])
 		.filter((key) => key !== 'character')
-		.sort(),
+		.sort((a, b) => {
+			if (a < b) {
+				return -1;
+			}
+			if (a > b) {
+				return 1;
+			}
+			return 0;
+		}),
 	undefined,
 ];
 
@@ -68,7 +76,7 @@ const marioKeyTitle: Record<Exclude<MarioDataKey, 'character'>, string> = {
 const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: characterData, width: 400 });
 
-	const legendKey = (args.color || args.size) as MarioDataKey;
+	const legendKey = (args.color ?? args.size) as MarioDataKey;
 
 	return (
 		<Chart {...chartProps}>

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -17,20 +17,65 @@ import { characterData } from '@stories/data/marioKartData';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
+const marioDataKeys = [
+	...Object.keys(characterData[0])
+		.filter((key) => key !== 'character')
+		.sort(),
+	undefined,
+];
+
 export default {
 	title: 'RSC/Scatter',
 	component: Scatter,
+	argTypes: {
+		dimension: {
+			control: 'select',
+			options: marioDataKeys,
+		},
+		metric: {
+			control: 'select',
+			options: marioDataKeys,
+		},
+		color: {
+			control: 'select',
+			options: marioDataKeys.filter((key) => key !== 'weight'),
+		},
+		size: {
+			control: 'select',
+			options: marioDataKeys.filter((key) => key !== 'weightClass'),
+		},
+	},
+};
+
+type MarioDataKey = keyof (typeof characterData)[0];
+
+const marioKeyTitle: Record<Exclude<MarioDataKey, 'character'>, string> = {
+	weightClass: 'Weight class',
+	speedNormal: 'Speed (normal)',
+	speedAntigravity: 'Speed (antigravity)',
+	speedWater: 'Speed (water)',
+	speedAir: 'Speed (air)',
+	acceleration: 'Acceleration',
+	weight: 'Weight',
+	handlingNormal: 'Handling (normal)',
+	handlingAntigravity: 'Handling (antigravity)',
+	handlingWater: 'Handling (water)',
+	handlingAir: 'Handling (air)',
+	grip: 'Grip',
+	miniTurbo: 'Mini-turbo',
 };
 
 const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: characterData, width: 400 });
 
+	const legendKey = (args.color || args.size) as MarioDataKey;
+
 	return (
 		<Chart {...chartProps}>
-			<Axis position="bottom" grid ticks baseline title="Speed (normal)" />
-			<Axis position="left" grid ticks baseline title="Handling (normal)" />
-			<Scatter {...args} />;
-			<Legend position="right" title="Weight class" />
+			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
+			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
+			<Scatter {...args} />
+			<Legend position="right" title={marioKeyTitle[legendKey]} />
 			<Title text="Mario Kart 8 Character Data" />
 		</Chart>
 	);
@@ -38,9 +83,29 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 
 const Basic = bindWithProps(ScatterStory);
 Basic.args = {
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
+const Color = bindWithProps(ScatterStory);
+Color.args = {
 	color: 'weightClass',
 	dimension: 'speedNormal',
 	metric: 'handlingNormal',
 };
 
-export { Basic };
+const Opacity = bindWithProps(ScatterStory);
+Opacity.args = {
+	opacity: 0.5,
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
+const Size = bindWithProps(ScatterStory);
+Size.args = {
+	size: 'weight',
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
+export { Basic, Color, Opacity, Size };

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -9,10 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
-
 import { Scatter, spectrumColors } from '@rsc';
-import { findAllMarksByGroupName, findChart, getAllLegendEntries, render, screen } from '@test-utils';
+import { findAllMarksByGroupName, findChart, getAllLegendEntries, render } from '@test-utils';
 
 import { Basic, Color, Opacity, Size } from './Scatter.story';
 

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -11,11 +11,12 @@
  */
 import React from 'react';
 
-import '@matchMediaMock';
-import { Scatter } from '@rsc';
-import { findAllMarksByGroupName, findChart, render } from '@test-utils';
+import { Scatter, spectrumColors } from '@rsc';
+import { findAllMarksByGroupName, findChart, getAllLegendEntries, render, screen } from '@test-utils';
 
-import { Basic } from './Scatter.story';
+import { Basic, Color, Opacity, Size } from './Scatter.story';
+
+const colors = spectrumColors.light;
 
 describe('Scatter', () => {
 	// Scatter is not a real React component. This is test just provides test coverage for sonarqube
@@ -31,5 +32,48 @@ describe('Scatter', () => {
 
 		const points = await findAllMarksByGroupName(chart, 'scatter0');
 		expect(points).toHaveLength(16);
+	});
+
+	test('Color renders properly', async () => {
+		render(<Color {...Color.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+		expect(points).toHaveLength(16);
+		expect(points[0]).toHaveAttribute('fill', colors['categorical-100']);
+		expect(points[6]).toHaveAttribute('fill', colors['categorical-200']);
+		expect(points[11]).toHaveAttribute('fill', colors['categorical-300']);
+
+		const legendEntries = getAllLegendEntries(chart);
+		expect(legendEntries).toHaveLength(3);
+	});
+
+	test('Opacity renders properly', async () => {
+		render(<Opacity {...Opacity.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+		expect(points[0]).toHaveAttribute('fill-opacity', '0.5');
+	});
+
+	test('Size renders properly', async () => {
+		render(<Size {...Size.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+
+		// small circle (radius 3)
+		expect(points[0]).toHaveAttribute('d', 'M3,0A3,3,0,1,1,-3,0A3,3,0,1,1,3,0');
+		// big circle (radius 8)
+		expect(points[15]).toHaveAttribute('d', 'M8,0A8,8,0,1,1,-8,0A8,8,0,1,1,8,0');
+
+		const legendEntries = getAllLegendEntries(chart);
+		expect(legendEntries).toHaveLength(6);
 	});
 });

--- a/src/themes/spectrumTheme.ts
+++ b/src/themes/spectrumTheme.ts
@@ -46,6 +46,7 @@ function getSpectrumVegaConfig(colorScheme: ColorScheme): Config {
 		center: true,
 		offset: 24,
 		bounds: 'full',
+		margin: 48,
 	};
 	const verticalLegendLayout: BaseLegendLayout = {
 		anchor: 'middle',
@@ -53,6 +54,7 @@ function getSpectrumVegaConfig(colorScheme: ColorScheme): Config {
 		center: false,
 		offset: 24,
 		bounds: 'full',
+		margin: 24,
 	};
 
 	const defaultColor = spectrumColors[colorScheme]['categorical-100'];

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -47,6 +47,7 @@ export interface SpecProps {
 	colorScheme?: ColorScheme; // spectrum color scheme
 	description?: string; // chart description
 	symbolShapes?: SymbolShapes;
+	symbolSizes?: [SymbolSize, SymbolSize]; // min and max for symbol size scale
 	lineTypes?: LineTypes; // line types available for the chart
 	lineWidths?: LineWidth[]; // line widths available for the chart
 	opacities?: Opacities; // opacities available for the chart
@@ -331,6 +332,8 @@ export interface LegendProps extends BaseProps {
 	highlight?: boolean;
 	/** allows the user to hide/show series by clicking on the legend entry (uncontrolled) */
 	isToggleable?: boolean;
+	/** keys from the data to generate the legend for. Defaults to all keys used to facet the data. */
+	keys?: string[];
 	/** labels for each of the series */
 	legendLabels?: LegendLabel[];
 	/** max characters before truncating a legend label */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Need to be able to support continuous data in legends. This PR adds that support and makes it possible to use size as a facet for scatter plots.

## Stories
Scatter > *

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/50

## Motivation and Context

Scatter needs to be able to support size as a facet

## How Has This Been Tested?

All existing tests pass and new tests were added

## Screenshots (if appropriate):

![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/f6e7c829-3962-43fc-a7cf-663d63e08d7e)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
