### PR TITLE
fix: use cross-env for storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"prepack": "yarn build",
 		"pack-test": "rm -rf dist & npm pack",
 		"start": "yarn storybook",
-		"storybook": "export SET NODE_OPTIONS=--openssl-legacy-provider && storybook dev -p 6009",
+		"storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider && storybook dev -p 6009",
 		"test": "cross-env BABEL_ENV=test jest",
 		"watch": "cross-env BABEL_ENV=test jest --watch",
 		"skulk": "yarn watch --silent"


### PR DESCRIPTION
## Description

Use `cross-env` for `yarn storybook` so it runs out-of-the-box on Windows.

## Related Issue
Bug report here: https://github.com/adobe/react-spectrum-charts/issues/85

## Motivation and Context

A Windows developer is interested in contributing to this project, but found that any command using `export` needed `setx` instead of `export`.

## How Has This Been Tested?

Manual testing on Windows and Mac machines

## Screenshots (if appropriate):

Windows works out of the box:
<img width="1000" alt="windows" src="https://github.com/adobe/react-spectrum-charts/assets/20342122/4aa8c685-810a-4465-8142-8dd10baa7c0a">

No changes to Mac function:
<img width="1000" alt="mac" src="https://github.com/adobe/react-spectrum-charts/assets/20342122/35bfb45c-d86c-4253-9c58-d8fd6ebb9aad">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
