### PR TITLE
feat: truncateLabels on Axis

### DIFF
--- a/src/expressionFunctions.test.ts
+++ b/src/expressionFunctions.test.ts
@@ -1,0 +1,16 @@
+import { expressionFunctions } from './expressionFunctions';
+
+describe('truncateText()', () => {
+	const longText =
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit.';
+	const shortText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+	test('should truncate text that is too long', () => {
+		expect(expressionFunctions.truncateText(longText, 24)).toBe('Lorem ipsum dolor s…');
+		expect(expressionFunctions.truncateText(longText, 100)).toBe(
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsu…'
+		);
+	});
+	test('should not truncate text that is shorter than maxLength', () => {
+		expect(expressionFunctions.truncateText(shortText, 100)).toBe(shortText);
+	});
+});

--- a/src/expressionFunctions.ts
+++ b/src/expressionFunctions.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { ADOBE_CLEAN_FONT } from '@themes/spectrumTheme';
+import { FontWeight } from 'vega';
 
 interface LabelDatum {
 	index: number;
@@ -47,17 +48,35 @@ const consoleLog = (value) => {
  * @param fontSize
  * @returns width in pixels
  */
-const getLabelWidth = (text, fontWeight = 'bold', fontSize = '12') => {
+const getLabelWidth = (text: string, fontWeight: FontWeight = 'bold', fontSize: number = 12) => {
 	const canvas = document.createElement('canvas');
 	const context = canvas.getContext('2d');
 	if (context === null) return 0;
 
-	context.font = `${fontWeight} ${fontSize}px ${ADOBE_CLEAN_FONT}}`;
-	return context.measureText(text).width + 2;
+	context.font = `${fontWeight} ${fontSize}px ${ADOBE_CLEAN_FONT}`;
+	return context.measureText(text).width;
+};
+
+const truncateText = (text: string, maxWidth: number, fontWeight: FontWeight = 'normal', fontSize: number = 12) => {
+	maxWidth = maxWidth - 4;
+	const textWidth = getLabelWidth(text, fontWeight, fontSize);
+	const elipsisWidth = getLabelWidth('\u2026', fontWeight, fontSize);
+	if (textWidth <= maxWidth) return text;
+
+	let truncatedText = text.slice(0, text.length - 1).trim();
+
+	for (let i = truncatedText.length; i > 0; i--) {
+		truncatedText = truncatedText.slice(0, truncatedText.length - 1).trim();
+		if (getLabelWidth(truncatedText, fontWeight, fontSize) + elipsisWidth <= maxWidth) break;
+	}
+
+	if (truncatedText.length === 0) return text;
+	return truncatedText + '\u2026';
 };
 
 export const expressionFunctions = {
-	getLabelWidth,
-	formatPrimaryTimeLabels: formatPrimaryTimeLabels(),
 	consoleLog,
+	formatPrimaryTimeLabels: formatPrimaryTimeLabels(),
+	getLabelWidth,
+	truncateText,
 };

--- a/src/specBuilder/axis/axisLabelUtils.test.ts
+++ b/src/specBuilder/axis/axisLabelUtils.test.ts
@@ -19,6 +19,7 @@ import {
 	getLabelValue,
 	labelIsParallelToAxis,
 } from './axisLabelUtils';
+import { defaultAxisProps } from './axisTestUtils';
 
 describe('getLabelValue()', () => {
 	test('should return the value key if an object', () => {
@@ -157,12 +158,43 @@ describe('getLabelAngle', () => {
 
 describe('getLabelFormat()', () => {
 	test('should include the number format test if numberFormat exists', () => {
-		const labelFormat = getLabelFormat('linear', '.2f');
+		const labelFormat = getLabelFormat(
+			{ ...defaultAxisProps, labelFormat: 'linear', numberFormat: '.2f' },
+			'xLinear'
+		);
 		expect(labelFormat).toHaveLength(4);
 		expect(labelFormat[0]).toEqual({ test: 'isNumber(datum.value)', signal: "format(datum.value, '.2f')" });
 	});
 	test('should not include the number format test if numberFormat does not exist or is an empty string', () => {
-		expect(getLabelFormat('linear', undefined)).toHaveLength(3);
-		expect(getLabelFormat('linear', '')).toHaveLength(3);
+		expect(
+			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: undefined }, 'xLinear')
+		).toHaveLength(3);
+		expect(
+			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: '' }, 'xLinear')
+		).toHaveLength(3);
+	});
+	test('should include text truncation if truncateText is true', () => {
+		const labelEncodings = getLabelFormat({ ...defaultAxisProps, truncateLabels: true }, 'xBand');
+		expect(labelEncodings).toHaveLength(3);
+		expect(labelEncodings[2].signal).toContain('truncateText');
+	});
+	test('should not include text truncation if the scale name does not include band', () => {
+		expect(getLabelFormat({ ...defaultAxisProps, truncateLabels: true }, 'xLinear')[2].signal).not.toContain(
+			'truncateText'
+		);
+	});
+	test('should not include truncae text if labels are perpendicular to the axis', () => {
+		expect(
+			getLabelFormat(
+				{ ...defaultAxisProps, truncateLabels: true, position: 'bottom', labelOrientation: 'vertical' },
+				'xBand'
+			)[2].signal
+		).not.toContain('truncateText');
+		expect(
+			getLabelFormat(
+				{ ...defaultAxisProps, truncateLabels: true, position: 'left', labelOrientation: 'horizontal' },
+				'yBand'
+			)[2].signal
+		).not.toContain('truncateText');
 	});
 });

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Granularity, Label, LabelAlign, LabelFormat, Orientation, Position } from 'types';
+import { AxisSpecProps, Granularity, Label, LabelAlign, Orientation, Position } from 'types';
 import {
 	Align,
 	Baseline,
@@ -231,10 +231,10 @@ export const getLabelOffset = (
  * @returns
  */
 export const getLabelFormat = (
-	type: LabelFormat | undefined,
-	numberFormat: string | undefined
+	{ labelFormat, labelOrientation, numberFormat, position, truncateLabels }: AxisSpecProps,
+	scaleName: string
 ): ProductionRule<TextValueRef> => {
-	if (type === 'percentage') {
+	if (labelFormat === 'percentage') {
 		return [{ test: 'isNumber(datum.value)', signal: "format(datum.value, '~%')" }, { signal: 'datum.value' }];
 	}
 
@@ -249,7 +249,9 @@ export const getLabelFormat = (
 			test: 'isNumber(datum.value)',
 			signal: 'format(datum.value, ",")',
 		},
-		{ signal: 'datum.value' },
+		...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
+			? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
+			: [{ signal: 'datum.value' }]),
 	];
 };
 

--- a/src/specBuilder/axis/axisUtils.ts
+++ b/src/specBuilder/axis/axisUtils.ts
@@ -27,15 +27,13 @@ import {
  * @param scaleName
  * @returns axis
  */
-export const getDefaultAxis = (
-	{
+export const getDefaultAxis = (axisProps: AxisSpecProps, scaleName: string): Axis => {
+	const {
 		grid,
 		hideDefaultLabels,
 		labelAlign,
 		labelFontWeight,
-		labelFormat,
 		labelOrientation,
-		numberFormat,
 		position,
 		scaleType,
 		ticks,
@@ -45,30 +43,30 @@ export const getDefaultAxis = (
 		vegaLabelBaseline,
 		vegaLabelOffset,
 		vegaLabelPadding,
-	}: AxisSpecProps,
-	scaleName: string
-): Axis => ({
-	scale: scaleName,
-	orient: position,
-	grid,
-	ticks,
-	tickCount: getTickCount(position, grid),
-	tickMinStep: scaleType !== 'linear' ? undefined : tickMinStep, //only supported for linear scales
-	title,
-	labelAngle: getLabelAngle(labelOrientation),
-	labelFontWeight,
-	labelOffset: getLabelOffset(labelAlign, scaleName, vegaLabelOffset),
-	labelPadding: vegaLabelPadding,
-	labels: !hideDefaultLabels,
-	...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
-	encode: {
-		labels: {
-			update: {
-				text: getLabelFormat(labelFormat, numberFormat),
+	} = axisProps;
+	return {
+		scale: scaleName,
+		orient: position,
+		grid,
+		ticks,
+		tickCount: getTickCount(position, grid),
+		tickMinStep: scaleType !== 'linear' ? undefined : tickMinStep, //only supported for linear scales
+		title,
+		labelAngle: getLabelAngle(labelOrientation),
+		labelFontWeight,
+		labelOffset: getLabelOffset(labelAlign, scaleName, vegaLabelOffset),
+		labelPadding: vegaLabelPadding,
+		labels: !hideDefaultLabels,
+		...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
+		encode: {
+			labels: {
+				update: {
+					text: getLabelFormat(axisProps, scaleName),
+				},
 			},
 		},
-	},
-});
+	};
+};
 
 /**
  * Generates the time axes for a time scale from the axis props
@@ -103,6 +101,7 @@ export const getTimeAxes = (
 			format: secondaryFormat,
 			formatType: 'time',
 			labelAngle: getLabelAngle(labelOrientation),
+			labelSeparation: 12,
 			...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
 		},
 		{

--- a/src/specBuilder/bar/barTestUtils.ts
+++ b/src/specBuilder/bar/barTestUtils.ts
@@ -160,7 +160,7 @@ export const stackedLabelBackground = {
 			baseline: { value: 'middle' },
 			fill: [{ test: `datum.textLabel && bandwidth('${stackedXScale}') >= 48`, signal: BACKGROUND_COLOR }],
 			height: { value: 22 },
-			width: { signal: "getLabelWidth(datum.textLabel, 'bold', '12') + 10" },
+			width: { signal: "getLabelWidth(datum.textLabel, 'bold', 12) + 10" },
 			xc: { scale: stackedXScale, field: defaultBarProps.dimension, band: 0.5 },
 			yc: [
 				{

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -457,7 +457,7 @@ describe('barUtils', () => {
 			).toStrictEqual(stackedAnnotationMarks);
 		});
 		test('horizontal orientation should return xc and yc opposite of vertical orientation', () => {
-			const annotationWidthSignal = `getLabelWidth(datum.textLabel, 'bold', '12') + 10`;
+			const annotationWidthSignal = `getLabelWidth(datum.textLabel, 'bold', 12) + 10`;
 			const props: BarSpecProps = { ...defaultBarProps, orientation: 'horizontal', children: annotationChildren };
 			const annotationMarks = getAnnotationMarks(props, FILTERED_TABLE, 'yBand', defaultBarProps.dimension);
 

--- a/src/specBuilder/bar/barUtils.ts
+++ b/src/specBuilder/bar/barUtils.ts
@@ -276,7 +276,7 @@ export const getAnnotationPositionOffset = (
 type AnnotationWidth = { value: number } | { signal: string };
 const getAnnotationWidth = (textKey: string, style?: AnnotationStyleProps): AnnotationWidth => {
 	if (style?.width) return { value: style.width };
-	return { signal: `getLabelWidth(datum.${textKey}, '${ANNOTATION_FONT_WEIGHT}', '${ANNOTATION_FONT_SIZE}') + 10` };
+	return { signal: `getLabelWidth(datum.${textKey}, '${ANNOTATION_FONT_WEIGHT}', ${ANNOTATION_FONT_SIZE}) + 10` };
 };
 
 export const getAnnotationMarks = (

--- a/src/stories/components/Axis/Axis.story.tsx
+++ b/src/stories/components/Axis/Axis.story.tsx
@@ -18,7 +18,7 @@ import { stockPriceData, workspaceTrendsData } from '@stories/data/data';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
-import { barData } from '../Bar/data';
+import { barData, barDataLongLabels } from '../Bar/data';
 import timeData from './timeData.json';
 
 export default {
@@ -41,8 +41,9 @@ const AxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
 };
 
 const TimeAxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: timeData[args.granularity ?? DEFAULT_GRANULARITY], width: 'auto' });
 	return (
-		<Chart data={timeData[args.granularity ?? DEFAULT_GRANULARITY]} width={600}>
+		<Chart {...chartProps}>
 			<Axis {...args} />
 			<Line />
 		</Chart>
@@ -50,8 +51,19 @@ const TimeAxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
 };
 
 const SubLabelStory: StoryFn<typeof Axis> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: barData, width: 600 });
 	return (
-		<Chart data={barData} width={600}>
+		<Chart {...chartProps}>
+			<Axis {...args} />
+			<Bar dimension="browser" metric="downloads" />
+		</Chart>
+	);
+};
+
+const TruncatedLabelStory: StoryFn<typeof Axis> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: barDataLongLabels, width: 450 });
+	return (
+		<Chart {...chartProps}>
 			<Axis {...args} />
 			<Bar dimension="browser" metric="downloads" />
 		</Chart>
@@ -133,6 +145,14 @@ SubLabels.args = {
 	labelAlign: 'start',
 };
 
+const TruncateLabels = bindWithProps(TruncatedLabelStory);
+TruncateLabels.args = {
+	truncateLabels: true,
+	position: 'bottom',
+	baseline: true,
+	title: 'Browser',
+};
+
 const TickMinStep = bindWithProps(LinearAxisStory);
 TickMinStep.args = {
 	position: 'bottom',
@@ -180,4 +200,14 @@ ControlledLabels.args = {
 	],
 };
 
-export { Basic, Time, SubLabels, TickMinStep, NonLinearAxis, NumberFormat, CustomXRange, ControlledLabels };
+export {
+	Basic,
+	ControlledLabels,
+	CustomXRange,
+	NonLinearAxis,
+	NumberFormat,
+	SubLabels,
+	TickMinStep,
+	Time,
+	TruncateLabels,
+};

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
-
 import '@matchMediaMock';
 import { Axis } from '@rsc';
 import { findChart, getAllAxisLabels, render, screen, within } from '@test-utils';

--- a/src/stories/components/Bar/data.ts
+++ b/src/stories/components/Bar/data.ts
@@ -18,6 +18,14 @@ export const barData = [
 	{ browser: 'Explorer', downloads: 500, percentLabel: '1.0%' },
 ];
 
+export const barDataLongLabels = [
+	{ browser: 'Google Chrome', downloads: 27000 },
+	{ browser: 'Mozilla Firefox', downloads: 8000 },
+	{ browser: 'Mac Safari', downloads: 7750 },
+	{ browser: 'Microsoft Edge', downloads: 7600 },
+	{ browser: 'Microsoft Explorer', downloads: 500 },
+];
+
 export const barSeriesData = [
 	{ browser: 'Chrome', value: 5, operatingSystem: 'Windows', order: 2, percentLabel: '50%' },
 	{ browser: 'Chrome', value: 3, operatingSystem: 'Mac', order: 1, percentLabel: '30%' },

--- a/src/themes/spectrumTheme.ts
+++ b/src/themes/spectrumTheme.ts
@@ -71,7 +71,6 @@ function getSpectrumVegaConfig(colorScheme: ColorScheme): Config {
 			labelFontWeight: 'normal',
 			labelPadding: 8,
 			labelOverlap: true,
-			labelSeparation: 20,
 			labelColor: gray800,
 			ticks: false,
 			tickColor: gray300,

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -167,6 +167,8 @@ export interface AxisProps extends BaseProps {
 	tickMinStep?: number;
 	/** Sets the axis title */
 	title?: string;
+	/** If the text is wider than the bandwidth that is labels, it will be truncated so that it stays within that bandwidth. */
+	truncateLabels?: boolean;
 }
 
 export type Granularity = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add ability to set labels to truncate if they are too long instead of hiding them

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/84

## Motivation and Context

Sometimes it is preferable to have the axis labels truncate instead of hide

## How Has This Been Tested?

Existing tests pass. New tests pass.

## Screenshots (if appropriate):

<img width="487" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/29244ced-22b0-47b6-beb3-b4debe19a828">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
