### PR TITLE
feat: update the tick count so that there are more ticks on wider and…

### DIFF
--- a/src/specBuilder/axis/axisUtils.test.ts
+++ b/src/specBuilder/axis/axisUtils.test.ts
@@ -64,7 +64,7 @@ describe('getDefaultAxis()', () => {
 			grid: true,
 			ticks: false,
 			tickCount: {
-				signal: 'clamp(ceil(height/40), 2, 5)',
+				signal: 'clamp(ceil(height/60), 2, 10)',
 			},
 			tickMinStep: 5,
 			title: 'Users',
@@ -127,7 +127,7 @@ describe('getDefaultAxis()', () => {
 			grid: true,
 			ticks: false,
 			tickCount: {
-				signal: 'clamp(ceil(height/40), 2, 5)',
+				signal: 'clamp(ceil(height/60), 2, 10)',
 			},
 			tickMinStep: undefined,
 			title: 'Users',

--- a/src/specBuilder/axis/axisUtils.ts
+++ b/src/specBuilder/axis/axisUtils.ts
@@ -278,7 +278,8 @@ const getDefaultOpposingScaleNameFromPosition = (position: Position) => {
 export const getTickCount = (position: Position, grid: boolean): SignalRef | undefined => {
 	if (!grid) return;
 	const range = ['top', 'bottom'].includes(position) ? 'width' : 'height';
-	// clamp axis tick count to a min of 2 and max of 5
+	// divide the range by 60 to get the ideal number of ticks (grid lines)
+	// clamp axis tick count to a min of 2 and max of 10
 	return { signal: `clamp(ceil(${range}/60), 2, 10)` };
 };
 

--- a/src/specBuilder/axis/axisUtils.ts
+++ b/src/specBuilder/axis/axisUtils.ts
@@ -279,7 +279,7 @@ export const getTickCount = (position: Position, grid: boolean): SignalRef | und
 	if (!grid) return;
 	const range = ['top', 'bottom'].includes(position) ? 'width' : 'height';
 	// clamp axis tick count to a min of 2 and max of 5
-	return { signal: `clamp(ceil(${range}/40), 2, 5)` };
+	return { signal: `clamp(ceil(${range}/60), 2, 10)` };
 };
 
 /**


### PR DESCRIPTION
… taller charts

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating the default tick counts so that there are more ticks on wider and taller charts

## Motivation and Context

When doing grid lines on the x axis, a max of 5 grid lines was too few

## How Has This Been Tested?

Updated existing tests

## Screenshots (if appropriate):

before:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/bdbf6a61-15a0-4311-9aeb-22d8518de695)

after:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/2e0e8aac-e34b-4f63-b68d-e1aaa7883d67)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
