### PR TITLE
feat: support opacity, lineType and lineWidth facets for scatter

### DIFF
--- a/src/components/Scatter/Scatter.tsx
+++ b/src/components/Scatter/Scatter.tsx
@@ -21,9 +21,11 @@ export function Scatter({
 	colorScaleType,
 	dimension = DEFAULT_LINEAR_DIMENSION,
 	children,
+	lineType = { value: 'solid' },
+	lineWidth = { value: 0 },
 	metric = DEFAULT_METRIC,
 	name,
-	opacity = 1,
+	opacity = { value: 1 },
 	size = { value: DEFAULT_SYMBOL_SIZE },
 }: ScatterProps) {
 	return null;

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -30,9 +30,11 @@ const defaultScatterProps: ScatterSpecProps = {
 	dimension: DEFAULT_LINEAR_DIMENSION,
 	dimensionScaleType: DEFAULT_DIMENSION_SCALE_TYPE,
 	index: 0,
+	lineType: { value: 'solid' },
+	lineWidth: { value: 0 },
 	metric: DEFAULT_METRIC,
 	name: 'scatter0',
-	opacity: 0.8,
+	opacity: { value: 1 },
 	size: { value: 'M' },
 };
 
@@ -56,6 +58,21 @@ describe('setScales()', () => {
 		const scales = setScales([], { ...defaultScatterProps, color: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
 		expect(scales[2].name).toBe('color');
+	});
+	test('should add the lineType scale if lineType is a reference to a key', () => {
+		const scales = setScales([], { ...defaultScatterProps, lineType: DEFAULT_COLOR });
+		expect(scales).toHaveLength(3);
+		expect(scales[2].name).toBe('lineType');
+	});
+	test('should add the lineWidth scale if lineWidth is a reference to a key', () => {
+		const scales = setScales([], { ...defaultScatterProps, lineWidth: DEFAULT_COLOR });
+		expect(scales).toHaveLength(3);
+		expect(scales[2].name).toBe('lineWidth');
+	});
+	test('should add the opacity scale if opacity is a reference to a key', () => {
+		const scales = setScales([], { ...defaultScatterProps, opacity: DEFAULT_COLOR });
+		expect(scales).toHaveLength(3);
+		expect(scales[2].name).toBe('opacity');
 	});
 	test('should add the symbolSize scale if size is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, size: 'weight' });

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -30,7 +30,6 @@ import {
 	addFieldToFacetScaleDomain,
 	addMetricScale,
 } from '@specBuilder/scale/scaleSpecBuilder';
-import { addTrendlineData } from '@specBuilder/trendline/trendlineUtils';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
 import { produce } from 'immer';
 import { ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
@@ -88,7 +87,6 @@ export const addData = produce<Data[], [ScatterSpecProps]>((data, props) => {
 		const tableData = getTableData(data);
 		tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
 	}
-	addTrendlineData(data, props);
 });
 
 export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) => {

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -17,12 +17,20 @@ import {
 	FILTERED_TABLE,
 } from '@constants';
 import { addTimeTransform, getTableData } from '@specBuilder/data/dataUtils';
-import { getColorProductionRule, getSymbolSizeProductionRule, getXProductionRule } from '@specBuilder/marks/markUtils';
+import {
+	getColorProductionRule,
+	getLineWidthProductionRule,
+	getOpacityProductionRule,
+	getStrokeDashProductionRule,
+	getSymbolSizeProductionRule,
+	getXProductionRule,
+} from '@specBuilder/marks/markUtils';
 import {
 	addContinuousDimensionScale,
 	addFieldToFacetScaleDomain,
 	addMetricScale,
 } from '@specBuilder/scale/scaleSpecBuilder';
+import { addTrendlineData } from '@specBuilder/trendline/trendlineUtils';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
 import { produce } from 'immer';
 import { ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
@@ -39,9 +47,11 @@ export const addScatter = produce<Spec, [ScatterProps & { colorScheme?: ColorSch
 			dimension = DEFAULT_LINEAR_DIMENSION,
 			dimensionScaleType = DEFAULT_DIMENSION_SCALE_TYPE,
 			index = 0,
+			lineType = { value: 'solid' },
+			lineWidth = { value: 0 },
 			metric = DEFAULT_METRIC,
 			name,
-			opacity = 1,
+			opacity = { value: 1 },
 			size = { value: 'M' },
 			...props
 		}
@@ -57,6 +67,8 @@ export const addScatter = produce<Spec, [ScatterProps & { colorScheme?: ColorSch
 			dimension,
 			dimensionScaleType,
 			index,
+			lineType,
+			lineWidth,
 			metric,
 			name: scatterName,
 			opacity,
@@ -70,21 +82,29 @@ export const addScatter = produce<Spec, [ScatterProps & { colorScheme?: ColorSch
 	}
 );
 
-export const addData = produce<Data[], [ScatterSpecProps]>((data, { dimension, dimensionScaleType }) => {
+export const addData = produce<Data[], [ScatterSpecProps]>((data, props) => {
+	const { dimension, dimensionScaleType } = props;
 	if (dimensionScaleType === 'time') {
 		const tableData = getTableData(data);
 		tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
 	}
+	addTrendlineData(data, props);
 });
 
 export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) => {
-	const { color, dimension, dimensionScaleType, metric, size } = props;
+	const { color, dimension, dimensionScaleType, lineType, lineWidth, metric, opacity, size } = props;
 	// add dimension scale
 	addContinuousDimensionScale(scales, { scaleType: dimensionScaleType, dimension });
 	// add metric scale
 	addMetricScale(scales, [metric]);
 	// add color to the color domain
 	addFieldToFacetScaleDomain(scales, 'color', color);
+	// add lineType to the lineType domain
+	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
+	// add lineWidth to the lineWidth domain
+	addFieldToFacetScaleDomain(scales, 'lineWidth', lineWidth);
+	// add opacity to the opacity domain
+	addFieldToFacetScaleDomain(scales, 'opacity', opacity);
 	// add size to the size domain
 	addFieldToFacetScaleDomain(scales, 'symbolSize', size);
 });
@@ -106,6 +126,8 @@ export const getScatterMark = ({
 	colorScheme,
 	dimension,
 	dimensionScaleType,
+	lineType,
+	lineWidth,
 	metric,
 	name,
 	opacity,
@@ -124,12 +146,15 @@ export const getScatterMark = ({
 			 * in dark mode, the points are lighter when they overlap (screen)
 			 */
 			blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
-			fillOpacity: [{ value: opacity }],
+			fill: getColorProductionRule(color, colorScheme),
 			shape: { value: 'circle' },
+			strokeDash: getStrokeDashProductionRule(lineType),
+			strokeWidth: getLineWidthProductionRule(lineWidth),
+			stroke: getColorProductionRule(color, colorScheme),
+			size: getSymbolSizeProductionRule(size),
 		},
 		update: {
-			size: getSymbolSizeProductionRule(size),
-			fill: getColorProductionRule(color, colorScheme),
+			fillOpacity: [getOpacityProductionRule(opacity)],
 			x: getXProductionRule(dimensionScaleType, dimension),
 			y: { scale: 'yLinear', field: metric },
 		},

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -77,7 +77,7 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
 
 	const facets = ['color', 'lineType', 'opacity', 'size'];
-	const legendKey = args[facets.find((key) => args[key] !== undefined) || 'color'];
+	const legendKey = args[facets.find((key) => args[key] !== undefined) ?? 'color'];
 	const legendProps: LegendProps = {
 		position: 'right',
 		title: marioKeyTitle[legendKey],

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -12,7 +12,7 @@
 import React, { ReactElement } from 'react';
 
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, Legend, Scatter, Title } from '@rsc';
+import { Axis, Chart, Legend, LegendProps, Scatter, Title } from '@rsc';
 import { characterData } from '@stories/data/marioKartData';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
@@ -74,16 +74,24 @@ const marioKeyTitle: Record<Exclude<MarioDataKey, 'character'>, string> = {
 };
 
 const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
-	const chartProps = useChartProps({ data: characterData, width: 400 });
+	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
 
-	const legendKey = (args.color ?? args.size) as MarioDataKey;
+	const facets = ['color', 'lineType', 'opacity', 'size'];
+	const legendKey = args[facets.find((key) => args[key] !== undefined) || 'color'];
+	const legendProps: LegendProps = {
+		position: 'right',
+		title: marioKeyTitle[legendKey],
+	};
+	if (typeof args.opacity === 'object') {
+		legendProps.opacity = args.opacity;
+	}
 
 	return (
 		<Chart {...chartProps}>
 			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
 			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
 			<Scatter {...args} />
-			<Legend position="right" title={marioKeyTitle[legendKey]} />
+			<Legend {...legendProps} />
 			<Title text="Mario Kart 8 Character Data" />
 		</Chart>
 	);
@@ -102,9 +110,18 @@ Color.args = {
 	metric: 'handlingNormal',
 };
 
+const LineType = bindWithProps(ScatterStory);
+LineType.args = {
+	lineType: 'weightClass',
+	lineWidth: { value: 2 },
+	opacity: { value: 0.5 },
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
 const Opacity = bindWithProps(ScatterStory);
 Opacity.args = {
-	opacity: 0.5,
+	opacity: 'weightClass',
 	dimension: 'speedNormal',
 	metric: 'handlingNormal',
 };
@@ -116,4 +133,4 @@ Size.args = {
 	metric: 'handlingNormal',
 };
 
-export { Basic, Color, Opacity, Size };
+export { Basic, Color, LineType, Opacity, Size };

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -12,7 +12,7 @@
 import { Scatter, spectrumColors } from '@rsc';
 import { findAllMarksByGroupName, findChart, getAllLegendEntries, render } from '@test-utils';
 
-import { Basic, Color, Opacity, Size } from './Scatter.story';
+import { Basic, Color, LineType, Opacity, Size } from './Scatter.story';
 
 const colors = spectrumColors.light;
 
@@ -48,6 +48,18 @@ describe('Scatter', () => {
 		expect(legendEntries).toHaveLength(3);
 	});
 
+	test('LineType renders properly', async () => {
+		render(<LineType {...LineType.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+		expect(points[0]).toHaveAttribute('stroke-dasharray', '');
+		expect(points[6]).toHaveAttribute('stroke-dasharray', '7,4');
+		expect(points[11]).toHaveAttribute('stroke-dasharray', '2,3');
+	});
+
 	test('Opacity renders properly', async () => {
 		render(<Opacity {...Opacity.args} />);
 
@@ -55,7 +67,9 @@ describe('Scatter', () => {
 		expect(chart).toBeInTheDocument();
 
 		const points = await findAllMarksByGroupName(chart, 'scatter0');
-		expect(points[0]).toHaveAttribute('fill-opacity', '0.5');
+		expect(points[0]).toHaveAttribute('fill-opacity', '1');
+		expect(points[6]).toHaveAttribute('fill-opacity', '0.75');
+		expect(points[11]).toHaveAttribute('fill-opacity', '0.5');
 	});
 
 	test('Size renders properly', async () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -292,8 +292,21 @@ export interface ScatterProps extends Omit<MarkProps, 'color'> {
 	 * see https://vega.github.io/vega/docs/scales/#types for more information
 	 */
 	dimensionScaleType?: ScaleType;
-	/** point fill and stroke opacity */
-	opacity?: number;
+	/**
+	 * line type of the point border
+	 * uses a key in the data that will map to the line type scale or a static line type value
+	 */
+	lineType?: LineTypeFacet;
+	/**
+	 * line width of the point border
+	 * uses a key in the data that will map to the line width scale or a static line width value
+	 */
+	lineWidth?: LineWidthFacet;
+	/**
+	 * point fill and stroke opacity
+	 * uses a key in the data that will map to the opacity scale or a opacity value
+	 */
+	opacity?: OpacityFacet;
 	/**
 	 * point size
 	 * uses a key in the data that will map to the size scale (linear) or a static size value

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -125,6 +125,8 @@ type ScatterPropsWithDefaults =
 	| 'colorScaleType'
 	| 'dimension'
 	| 'dimensionScaleType'
+	| 'lineType'
+	| 'lineWidth'
 	| 'metric'
 	| 'name'
 	| 'opacity'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support `lineType`, `lineWidth`, and `opacity` as facets for scatter data.

## Motivation and Context

These are supported on other chart types.

## Stories

- Scatter > Line Type
- Scatter > Opacity

## Screenshots (if appropriate):

Line Type:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/683ea663-c602-470b-acd1-0ac5b3954872)

Opacity:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/48a766e5-6396-4ae7-862a-52b9befa4fa6)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
