### PR TITLE
chore: move the vega chart to its own file

### DIFF
--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -9,69 +9,24 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FC, MutableRefObject, forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 
 import { EmptyState } from '@components/EmptyState';
 import { LoadingState } from '@components/LoadingState';
-import {
-	DEFAULT_BACKGROUND_COLOR,
-	DEFAULT_COLOR_SCHEME,
-	DEFAULT_LINE_TYPES,
-	DEFAULT_LOCALE,
-	LEGEND_TOOLTIP_DELAY,
-	MARK_ID,
-	SERIES_ID,
-} from '@constants';
+import { DEFAULT_BACKGROUND_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_LINE_TYPES, DEFAULT_LOCALE } from '@constants';
 import useChartImperativeHandle from '@hooks/useChartImperativeHandle';
 import useChartWidth from '@hooks/useChartWidth';
-import useLegend from '@hooks/useLegend';
-import usePopoverAnchorStyle from '@hooks/usePopoverAnchorStyle';
-import usePopovers, { PopoverDetail } from '@hooks/usePopovers';
 import { useResizeObserver } from '@hooks/useResizeObserver';
-import useSpec from '@hooks/useSpec';
-import useSpecProps from '@hooks/useSpecProps';
-import useTooltips from '@hooks/useTooltips';
 import { getColorValue } from '@specBuilder/specUtils';
-import { getChartConfig } from '@themes/spectrumTheme';
-import {
-	debugLog,
-	getOnMarkClickCallback,
-	getOnMouseInputCallback,
-	sanitizeChartChildren,
-	setSelectedSignals,
-} from '@utils';
-import { VegaChart } from 'VegaChart';
-import { renderToStaticMarkup } from 'react-dom/server';
+import { RscChart } from 'RscChart';
 import { v4 as uuid } from 'uuid';
-import { Item, View } from 'vega';
-import { Handler, Options as TooltipOptions } from 'vega-tooltip';
+import { View } from 'vega';
 
-import {
-	ActionButton,
-	Dialog,
-	DialogTrigger,
-	Provider,
-	View as SpectrumView,
-	defaultTheme,
-} from '@adobe/react-spectrum';
+import { Provider, defaultTheme } from '@adobe/react-spectrum';
 import { Theme } from '@react-types/provider';
 
 import './Chart.css';
-import { ChartData, ChartHandle, ChartProps, Datum, LegendDescription, MarkBounds } from './types';
-
-interface ChartDialogProps {
-	datum: Datum | null;
-	itemName?: string;
-	targetElement: MutableRefObject<HTMLElement | null>;
-	setPopoverState: (isOpen: boolean) => void;
-	popovers: PopoverDetail[];
-}
-
-interface LegendTooltipProps {
-	value: { index: number };
-	descriptions: LegendDescription[];
-	domain: string[];
-}
+import { ChartData, ChartHandle, ChartProps } from './types';
 
 interface PlaceholderContentProps {
 	data: ChartData[];
@@ -116,49 +71,9 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 	) => {
 		// uuid is used to make a unique id so there aren't duplicate ids if there is more than one Chart component in the document
 		const chartId = useRef<string>(`rsc-${uuid()}`);
-		const chartView = useRef<View>(); // view returned by vega
-		const selectedData = useRef<Datum | null>(null); // data that is currently selected, get's set on click if a popover exists
-		const selectedDataName = useRef<string>();
-		const selectedDataBounds = useRef<MarkBounds>();
+		// The view returned by vega. This is above RscChart so it can be used for downloading and copying to clipboard.
+		const chartView = useRef<View>();
 		const [containerWidth, setContainerWidth] = useState<number>(0);
-		const popoverAnchorRef = useRef<HTMLDivElement>(null);
-		const [popoverIsOpen, setPopoverIsOpen] = useState<boolean>(false); // tracks the open/close state of the popover
-
-		const sanitizedChildren = sanitizeChartChildren(props.children);
-
-		// THE MAGIC, builds our spec
-		const spec = useSpec({
-			backgroundColor,
-			children: sanitizedChildren,
-			colors,
-			data,
-			description,
-			hiddenSeries,
-			highlightedSeries,
-			symbolShapes,
-			symbolSizes,
-			lineTypes,
-			lineWidths,
-			opacities,
-			colorScheme,
-			title,
-			UNSAFE_vegaSpec,
-		});
-
-		const { controlledHoverSignal, selectedIdSignalName, selectedSeriesSignalName } = useSpecProps(spec);
-		const chartConfig = useMemo(() => getChartConfig(config, colorScheme), [config, colorScheme]);
-
-		useEffect(() => {
-			const tooltipElement = document.getElementById('vg-tooltip-element');
-			if (!tooltipElement) return;
-			// Hide tooltips on all charts when a popover is open
-			tooltipElement.hidden = popoverIsOpen;
-
-			// if the popover is closed, reset the selected data
-			if (!popoverIsOpen) {
-				selectedData.current = null;
-			}
-		}, [popoverIsOpen]);
 
 		useChartImperativeHandle(forwardedRef, { chartView, title });
 
@@ -168,26 +83,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 		});
 		const chartWidth = useChartWidth(containerWidth, maxWidth, minWidth, width); // calculates the width the vega chart should be
 
-		const {
-			hiddenSeriesState,
-			setHiddenSeries,
-			descriptions: legendDescriptions,
-			isToggleable: legendIsToggleable,
-			onClick: onLegendClick,
-			onMouseOut: onLegendMouseOut,
-			onMouseOver: onLegendMouseOver,
-		} = useLegend(sanitizedChildren); // gets props from the legend if it exists
-
-		const tooltips = useTooltips(sanitizedChildren);
-		const popovers = usePopovers(sanitizedChildren);
-
-		// gets the correct css style to display the anchor in the correct position
-		const targetStyle = usePopoverAnchorStyle(
-			popoverIsOpen,
-			chartView.current,
-			selectedDataBounds.current,
-			padding
-		);
 		const showPlaceholderContent = useMemo(() => Boolean(loading ?? !data.length), [loading, data]);
 		useEffect(() => {
 			// if placeholder content is displayed, clear out the chartview so it can't be downloaded or copied to clipboard
@@ -195,41 +90,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 				chartView.current = undefined;
 			}
 		}, [showPlaceholderContent]);
-
-		const tooltipConfig: TooltipOptions = { theme: colorScheme };
-
-		if (tooltips.length || legendDescriptions) {
-			tooltipConfig.formatTooltip = (value) => {
-				debugLog(debug, { title: 'Tooltip datum', contents: value });
-				if (value.rscComponentName?.startsWith('legend') && legendDescriptions && 'index' in value) {
-					debugLog(debug, {
-						title: 'Legend descriptions',
-						contents: legendDescriptions,
-					});
-					return renderToStaticMarkup(
-						<LegendTooltip
-							value={value}
-							descriptions={legendDescriptions}
-							// TODO: support multiple legends
-							domain={chartView.current?.scale('legend0Entries').domain()}
-						/>
-					);
-				}
-				// get the correct tooltip to render based on the hovered item
-				const tooltip = tooltips.find((t) => t.name === value.rscComponentName)?.callback;
-				if (tooltip && !('index' in value)) {
-					if (controlledHoverSignal) {
-						chartView.current?.signal(controlledHoverSignal.name, value?.[MARK_ID] ?? null);
-					}
-					return renderToStaticMarkup(
-						<div className="rsc-tooltip" data-testid="rsc-tooltip">
-							{tooltip(value)}
-						</div>
-					);
-				}
-				return '';
-			};
-		}
 
 		if (props.children && UNSAFE_vegaSpec) {
 			throw new Error(
@@ -244,23 +104,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 			);
 		}
 
-		const signals = useMemo(() => {
-			const signals: Record<string, unknown> = {
-				backgroundColor: getColorValue('gray-50', colorScheme),
-			};
-			if (legendIsToggleable) {
-				signals.hiddenSeries = hiddenSeriesState;
-			}
-			if (selectedIdSignalName) {
-				signals[selectedIdSignalName] = selectedData?.[MARK_ID] ?? null;
-			}
-			if (selectedSeriesSignalName) {
-				signals[selectedSeriesSignalName] = selectedData?.[SERIES_ID] ?? null;
-			}
-
-			return signals;
-		}, [colorScheme, hiddenSeriesState, legendIsToggleable, selectedIdSignalName, selectedSeriesSignalName]);
-
 		return (
 			<Provider
 				colorScheme={colorScheme}
@@ -274,12 +117,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 					className="rsc-container"
 					style={{ backgroundColor: getColorValue(backgroundColor, colorScheme) }}
 				>
-					<div
-						id={`${chartId.current}-popover-anchor`}
-						data-testid="rsc-popover-anchor"
-						ref={popoverAnchorRef}
-						style={targetStyle}
-					/>
 					{showPlaceholderContent ? (
 						<PlaceholderContent
 							loading={loading}
@@ -288,129 +125,41 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 							emptyStateText={emptyStateText}
 						/>
 					) : (
-						<VegaChart
-							spec={spec}
-							config={chartConfig}
+						<RscChart
+							chartView={chartView}
+							chartId={chartId}
 							data={data}
+							backgroundColor={backgroundColor}
+							colors={colors}
+							colorScheme={colorScheme}
+							config={config}
+							description={description}
 							debug={debug}
-							renderer={renderer}
-							width={chartWidth}
 							height={height}
+							hiddenSeries={hiddenSeries}
+							highlightedSeries={highlightedSeries}
+							lineTypes={lineTypes}
+							lineWidths={lineWidths}
 							locale={locale}
+							opacities={opacities}
 							padding={padding}
-							signals={signals}
-							tooltip={tooltipConfig} // legend show/hide relies on this
-							onNewView={(view) => {
-								chartView.current = view;
-								// Add a delay before displaying legend tooltips on hover.
-								let tooltipTimeout: NodeJS.Timeout | undefined;
-								view.tooltip((_, event, item, value) => {
-									const tooltipHandler = new Handler(tooltipConfig);
-									// Cancel delayed tooltips if the mouse moves before the delay is resolved.
-									if (tooltipTimeout) {
-										clearTimeout(tooltipTimeout);
-										tooltipTimeout = undefined;
-									}
-									if (
-										event &&
-										event.type === 'pointermove' &&
-										itemIsLegendItem(item) &&
-										'tooltip' in item
-									) {
-										tooltipTimeout = setTimeout(() => {
-											tooltipHandler.call(this, event, item, value);
-											tooltipTimeout = undefined;
-										}, LEGEND_TOOLTIP_DELAY);
-									} else {
-										tooltipHandler.call(this, event, item, value);
-									}
-								});
-								if (popovers.length || legendIsToggleable || onLegendClick) {
-									if (legendIsToggleable) {
-										view.signal('hiddenSeries', hiddenSeriesState);
-									}
-									setSelectedSignals({
-										selectedData: selectedData.current,
-										selectedIdSignalName,
-										selectedSeriesSignalName,
-										view,
-									});
-									view.addEventListener(
-										'click',
-										getOnMarkClickCallback(
-											chartView,
-											hiddenSeriesState,
-											chartId,
-											selectedData,
-											selectedDataBounds,
-											selectedDataName,
-											setHiddenSeries,
-											legendIsToggleable,
-											onLegendClick
-										)
-									);
-								}
-								view.addEventListener('mouseover', getOnMouseInputCallback(onLegendMouseOver));
-								view.addEventListener('mouseout', getOnMouseInputCallback(onLegendMouseOut));
-								// this will trigger the autosize calculation making sure that everything is correct size
-							}}
-						/>
+							renderer={renderer}
+							symbolShapes={symbolShapes}
+							symbolSizes={symbolSizes}
+							theme={theme}
+							title={title}
+							chartWidth={chartWidth}
+							UNSAFE_vegaSpec={UNSAFE_vegaSpec}
+						>
+							{props.children}
+						</RscChart>
 					)}
-					<ChartDialog
-						datum={selectedData.current}
-						targetElement={popoverAnchorRef}
-						setPopoverState={setPopoverIsOpen}
-						popovers={popovers}
-						itemName={selectedDataName.current}
-					/>
 				</div>
 			</Provider>
 		);
 	}
 );
 Chart.displayName = 'Chart';
-
-const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers }: ChartDialogProps) => {
-	if (!popovers.length) {
-		return <></>;
-	}
-	const popoverDetail = popovers.find((p) => p.name === itemName);
-	const popover = popoverDetail?.callback;
-	const width = popoverDetail?.width;
-	return (
-		<DialogTrigger
-			type="popover"
-			mobileType="tray"
-			targetRef={targetElement}
-			onOpenChange={setPopoverState}
-			placement="top"
-			hideArrow
-		>
-			<ActionButton UNSAFE_style={{ display: 'none' }}>launch chart popover</ActionButton>
-			{(close) => (
-				<Dialog data-testid="rsc-popover" UNSAFE_className="rsc-popover" minWidth="size-1000" width={width}>
-					<SpectrumView gridColumn="1/-1" gridRow="1/-1" margin={12}>
-						{popover && datum && popover(datum, close)}
-					</SpectrumView>
-				</Dialog>
-			)}
-		</DialogTrigger>
-	);
-};
-
-const LegendTooltip: FC<LegendTooltipProps> = ({ value, descriptions, domain }) => {
-	const series = domain[value.index];
-	const description = descriptions.find((d) => d.seriesName === series);
-	if (!description) {
-		return <></>;
-	}
-	return (
-		<div className="rsc-tooltip legend-tooltip" data-testid="rsc-tooltip">
-			<div className="series">{description.title ?? series}</div>
-			<p className="series-description">{description.description}</p>
-		</div>
-	);
-};
 
 const PlaceholderContent: FC<PlaceholderContentProps> = ({ data, emptyStateText, loading, ...layoutProps }) => {
 	if (loading) {
@@ -425,8 +174,4 @@ const PlaceholderContent: FC<PlaceholderContentProps> = ({ data, emptyStateText,
 
 const isValidTheme = (theme: unknown): theme is Theme => {
 	return typeof theme === 'object' && theme !== null && 'light' in theme && 'dark' in theme;
-};
-
-const itemIsLegendItem = (item: Item<unknown>): boolean => {
-	return 'name' in item.mark && typeof item.mark.name === 'string' && item.mark.name.includes('legend');
 };

--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -146,7 +146,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 							renderer={renderer}
 							symbolShapes={symbolShapes}
 							symbolSizes={symbolSizes}
-							theme={theme}
 							title={title}
 							chartWidth={chartWidth}
 							UNSAFE_vegaSpec={UNSAFE_vegaSpec}

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FC, MutableRefObject, forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+	DEFAULT_BACKGROUND_COLOR,
+	DEFAULT_COLOR_SCHEME,
+	DEFAULT_LINE_TYPES,
+	DEFAULT_LOCALE,
+	LEGEND_TOOLTIP_DELAY,
+	MARK_ID,
+	SERIES_ID,
+} from '@constants';
+import useChartImperativeHandle from '@hooks/useChartImperativeHandle';
+import useLegend from '@hooks/useLegend';
+import usePopoverAnchorStyle from '@hooks/usePopoverAnchorStyle';
+import usePopovers, { PopoverDetail } from '@hooks/usePopovers';
+import useSpec from '@hooks/useSpec';
+import useSpecProps from '@hooks/useSpecProps';
+import useTooltips from '@hooks/useTooltips';
+import { getColorValue } from '@specBuilder/specUtils';
+import { getChartConfig } from '@themes/spectrumTheme';
+import {
+	debugLog,
+	getOnMarkClickCallback,
+	getOnMouseInputCallback,
+	sanitizeRscChartChildren,
+	setSelectedSignals,
+} from '@utils';
+import { VegaChart } from 'VegaChart';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Item } from 'vega';
+import { Handler, Options as TooltipOptions } from 'vega-tooltip';
+
+import { ActionButton, Dialog, DialogTrigger, View as SpectrumView, defaultTheme } from '@adobe/react-spectrum';
+
+import './Chart.css';
+import { ChartHandle, Datum, LegendDescription, MarkBounds, RscChartProps } from './types';
+
+interface ChartDialogProps {
+	datum: Datum | null;
+	itemName?: string;
+	targetElement: MutableRefObject<HTMLElement | null>;
+	setPopoverState: (isOpen: boolean) => void;
+	popovers: PopoverDetail[];
+}
+
+interface LegendTooltipProps {
+	value: { index: number };
+	descriptions: LegendDescription[];
+	domain: string[];
+}
+
+export const RscChart = forwardRef<ChartHandle, RscChartProps>(
+	(
+		{
+			chartView,
+			backgroundColor = DEFAULT_BACKGROUND_COLOR,
+			data,
+			colors = 'categorical12',
+			colorScheme = DEFAULT_COLOR_SCHEME,
+			config,
+			description,
+			debug = false,
+			height = 300,
+			hiddenSeries = [],
+			highlightedSeries,
+			lineTypes = DEFAULT_LINE_TYPES,
+			lineWidths = ['M'],
+			locale = DEFAULT_LOCALE,
+			opacities,
+			padding = 0,
+			renderer = 'svg',
+			symbolShapes,
+			symbolSizes,
+			theme = defaultTheme,
+			title,
+			chartWidth,
+			UNSAFE_vegaSpec,
+			chartId,
+			...props
+		},
+		forwardedRef
+	) => {
+		// uuid is used to make a unique id so there aren't duplicate ids if there is more than one Chart component in the document
+		const selectedData = useRef<Datum | null>(null); // data that is currently selected, get's set on click if a popover exists
+		const selectedDataName = useRef<string>();
+		const selectedDataBounds = useRef<MarkBounds>();
+		const popoverAnchorRef = useRef<HTMLDivElement>(null);
+
+		const [popoverIsOpen, setPopoverIsOpen] = useState<boolean>(false); // tracks the open/close state of the popover
+
+		const sanitizedChildren = sanitizeRscChartChildren(props.children);
+
+		// THE MAGIC, builds our spec
+		const spec = useSpec({
+			backgroundColor,
+			children: sanitizedChildren,
+			colors,
+			data,
+			description,
+			hiddenSeries,
+			highlightedSeries,
+			symbolShapes,
+			symbolSizes,
+			lineTypes,
+			lineWidths,
+			opacities,
+			colorScheme,
+			title,
+			UNSAFE_vegaSpec,
+		});
+
+		const { controlledHoverSignal, selectedIdSignalName, selectedSeriesSignalName } = useSpecProps(spec);
+		const chartConfig = useMemo(() => getChartConfig(config, colorScheme), [config, colorScheme]);
+
+		useEffect(() => {
+			const tooltipElement = document.getElementById('vg-tooltip-element');
+			if (!tooltipElement) return;
+			// Hide tooltips on all charts when a popover is open
+			tooltipElement.hidden = popoverIsOpen;
+
+			// if the popover is closed, reset the selected data
+			if (!popoverIsOpen) {
+				selectedData.current = null;
+			}
+		}, [popoverIsOpen]);
+
+		useChartImperativeHandle(forwardedRef, { chartView, title });
+
+		const {
+			hiddenSeriesState,
+			setHiddenSeries,
+			descriptions: legendDescriptions,
+			isToggleable: legendIsToggleable,
+			onClick: onLegendClick,
+			onMouseOut: onLegendMouseOut,
+			onMouseOver: onLegendMouseOver,
+		} = useLegend(sanitizedChildren); // gets props from the legend if it exists
+
+		const tooltips = useTooltips(sanitizedChildren);
+		const popovers = usePopovers(sanitizedChildren);
+
+		// gets the correct css style to display the anchor in the correct position
+		const targetStyle = usePopoverAnchorStyle(
+			popoverIsOpen,
+			chartView.current,
+			selectedDataBounds.current,
+			padding
+		);
+
+		const tooltipConfig: TooltipOptions = { theme: colorScheme };
+
+		if (tooltips.length || legendDescriptions) {
+			tooltipConfig.formatTooltip = (value) => {
+				debugLog(debug, { title: 'Tooltip datum', contents: value });
+				if (value.rscComponentName?.startsWith('legend') && legendDescriptions && 'index' in value) {
+					debugLog(debug, {
+						title: 'Legend descriptions',
+						contents: legendDescriptions,
+					});
+					return renderToStaticMarkup(
+						<LegendTooltip
+							value={value}
+							descriptions={legendDescriptions}
+							// TODO: support multiple legends
+							domain={chartView.current?.scale('legend0Entries').domain()}
+						/>
+					);
+				}
+				// get the correct tooltip to render based on the hovered item
+				const tooltip = tooltips.find((t) => t.name === value.rscComponentName)?.callback;
+				if (tooltip && !('index' in value)) {
+					if (controlledHoverSignal) {
+						chartView.current?.signal(controlledHoverSignal.name, value?.[MARK_ID] ?? null);
+					}
+					return renderToStaticMarkup(
+						<div className="rsc-tooltip" data-testid="rsc-tooltip">
+							{tooltip(value)}
+						</div>
+					);
+				}
+				return '';
+			};
+		}
+
+		const signals = useMemo(() => {
+			const signals: Record<string, unknown> = {
+				backgroundColor: getColorValue('gray-50', colorScheme),
+			};
+			if (legendIsToggleable) {
+				signals.hiddenSeries = hiddenSeriesState;
+			}
+			if (selectedIdSignalName) {
+				signals[selectedIdSignalName] = selectedData?.[MARK_ID] ?? null;
+			}
+			if (selectedSeriesSignalName) {
+				signals[selectedSeriesSignalName] = selectedData?.[SERIES_ID] ?? null;
+			}
+
+			return signals;
+		}, [colorScheme, hiddenSeriesState, legendIsToggleable, selectedIdSignalName, selectedSeriesSignalName]);
+
+		return (
+			<>
+				<div
+					id={`${chartId.current}-popover-anchor`}
+					data-testid="rsc-popover-anchor"
+					ref={popoverAnchorRef}
+					style={targetStyle}
+				/>
+				<VegaChart
+					spec={spec}
+					config={chartConfig}
+					data={data}
+					debug={debug}
+					renderer={renderer}
+					width={chartWidth}
+					height={height}
+					locale={locale}
+					padding={padding}
+					signals={signals}
+					tooltip={tooltipConfig} // legend show/hide relies on this
+					onNewView={(view) => {
+						chartView.current = view;
+						// Add a delay before displaying legend tooltips on hover.
+						let tooltipTimeout: NodeJS.Timeout | undefined;
+						view.tooltip((_, event, item, value) => {
+							const tooltipHandler = new Handler(tooltipConfig);
+							// Cancel delayed tooltips if the mouse moves before the delay is resolved.
+							if (tooltipTimeout) {
+								clearTimeout(tooltipTimeout);
+								tooltipTimeout = undefined;
+							}
+							if (event && event.type === 'pointermove' && itemIsLegendItem(item) && 'tooltip' in item) {
+								tooltipTimeout = setTimeout(() => {
+									tooltipHandler.call(this, event, item, value);
+									tooltipTimeout = undefined;
+								}, LEGEND_TOOLTIP_DELAY);
+							} else {
+								tooltipHandler.call(this, event, item, value);
+							}
+						});
+						if (popovers.length || legendIsToggleable || onLegendClick) {
+							if (legendIsToggleable) {
+								view.signal('hiddenSeries', hiddenSeriesState);
+							}
+							setSelectedSignals({
+								selectedData: selectedData.current,
+								selectedIdSignalName,
+								selectedSeriesSignalName,
+								view,
+							});
+							view.addEventListener(
+								'click',
+								getOnMarkClickCallback(
+									chartView,
+									hiddenSeriesState,
+									chartId,
+									selectedData,
+									selectedDataBounds,
+									selectedDataName,
+									setHiddenSeries,
+									legendIsToggleable,
+									onLegendClick
+								)
+							);
+						}
+						view.addEventListener('mouseover', getOnMouseInputCallback(onLegendMouseOver));
+						view.addEventListener('mouseout', getOnMouseInputCallback(onLegendMouseOut));
+						// this will trigger the autosize calculation making sure that everything is correct size
+					}}
+				/>
+				<ChartDialog
+					datum={selectedData.current}
+					targetElement={popoverAnchorRef}
+					setPopoverState={setPopoverIsOpen}
+					popovers={popovers}
+					itemName={selectedDataName.current}
+				/>
+			</>
+		);
+	}
+);
+
+const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers }: ChartDialogProps) => {
+	if (!popovers.length) {
+		return <></>;
+	}
+	const popoverDetail = popovers.find((p) => p.name === itemName);
+	const popover = popoverDetail?.callback;
+	const width = popoverDetail?.width;
+	return (
+		<DialogTrigger
+			type="popover"
+			mobileType="tray"
+			targetRef={targetElement}
+			onOpenChange={setPopoverState}
+			placement="top"
+			hideArrow
+		>
+			<ActionButton UNSAFE_style={{ display: 'none' }}>launch chart popover</ActionButton>
+			{(close) => (
+				<Dialog data-testid="rsc-popover" UNSAFE_className="rsc-popover" minWidth="size-1000" width={width}>
+					<SpectrumView gridColumn="1/-1" gridRow="1/-1" margin={12}>
+						{popover && datum && popover(datum, close)}
+					</SpectrumView>
+				</Dialog>
+			)}
+		</DialogTrigger>
+	);
+};
+
+const LegendTooltip: FC<LegendTooltipProps> = ({ value, descriptions, domain }) => {
+	const series = domain[value.index];
+	const description = descriptions.find((d) => d.seriesName === series);
+	if (!description) {
+		return <></>;
+	}
+	return (
+		<div className="rsc-tooltip legend-tooltip" data-testid="rsc-tooltip">
+			<div className="series">{description.title ?? series}</div>
+			<p className="series-description">{description.description}</p>
+		</div>
+	);
+};
+
+const itemIsLegendItem = (item: Item<unknown>): boolean => {
+	return 'name' in item.mark && typeof item.mark.name === 'string' && item.mark.name.includes('legend');
+};

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -41,7 +41,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { Item } from 'vega';
 import { Handler, Options as TooltipOptions } from 'vega-tooltip';
 
-import { ActionButton, Dialog, DialogTrigger, View as SpectrumView, defaultTheme } from '@adobe/react-spectrum';
+import { ActionButton, Dialog, DialogTrigger, View as SpectrumView } from '@adobe/react-spectrum';
 
 import './Chart.css';
 import { ChartHandle, Datum, LegendDescription, MarkBounds, RscChartProps } from './types';
@@ -82,7 +82,6 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 			renderer = 'svg',
 			symbolShapes,
 			symbolSizes,
-			theme = defaultTheme,
 			title,
 			chartWidth,
 			UNSAFE_vegaSpec,
@@ -291,6 +290,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 		);
 	}
 );
+RscChart.displayName = 'RscChart';
 
 const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers }: ChartDialogProps) => {
 	if (!popovers.length) {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -79,23 +79,23 @@ export interface SharedChartProps extends SpecProps {
 	locale?: Locale | LocaleCode | { number?: NumberLocaleCode | NumberLocale; time?: TimeLocaleCode | TimeLocale };
 	padding?: Padding;
 	renderer?: 'svg' | 'canvas';
-	theme?: Theme;
 }
 
 export interface RscChartProps extends SharedChartProps {
-	chartWidth: number;
-	popoverIsOpen?: boolean;
 	chartId: MutableRefObject<string>;
 	chartView: MutableRefObject<View | undefined>;
+	chartWidth: number;
+	popoverIsOpen?: boolean;
 }
 
 export interface ChartProps extends SharedChartProps {
-	emptyStateText?: string;
 	dataTestId?: string;
+	emptyStateText?: string;
 	loading?: boolean;
-	width?: Width; // strings must be in a valid percent format ex. '50%'
 	maxWidth?: number;
 	minWidth?: number;
+	theme?: Theme;
+	width?: Width; // strings must be in a valid percent format ex. '50%'
 }
 
 export interface BaseProps {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -9,10 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { JSXElementConstructor, ReactElement, ReactFragment, ReactNode } from 'react';
+import { JSXElementConstructor, MutableRefObject, ReactElement, ReactFragment, ReactNode } from 'react';
 
 import { MARK_ID, SERIES_ID, TRENDLINE_VALUE } from '@constants';
-import { Config, Data, FontWeight, Locale, NumberLocale, Padding, Spec, SymbolShape, TimeLocale } from 'vega';
+import { Config, Data, FontWeight, Locale, NumberLocale, Padding, Spec, SymbolShape, TimeLocale, View } from 'vega';
 
 import { Theme } from '@react-types/provider';
 
@@ -70,22 +70,32 @@ export type Opacities = number[] | number[][];
 export type SymbolShapes = ChartSymbolShape[] | ChartSymbolShape[][];
 export type ChartSymbolShape = 'rounded-square' | SymbolShape;
 
-export interface ChartProps extends SpecProps {
+export interface SharedChartProps extends SpecProps {
 	config?: Config;
 	data: ChartData[];
 	debug?: boolean;
-	emptyStateText?: string;
 	height?: number;
 	/** number and time locales to use */
 	locale?: Locale | LocaleCode | { number?: NumberLocaleCode | NumberLocale; time?: TimeLocaleCode | TimeLocale };
-	maxWidth?: number;
-	minWidth?: number;
 	padding?: Padding;
 	renderer?: 'svg' | 'canvas';
 	theme?: Theme;
-	width?: Width; // strings must be in a valid percent format ex. '50%'
+}
+
+export interface RscChartProps extends SharedChartProps {
+	chartWidth: number;
+	popoverIsOpen?: boolean;
+	chartId: MutableRefObject<string>;
+	chartView: MutableRefObject<View | undefined>;
+}
+
+export interface ChartProps extends SharedChartProps {
+	emptyStateText?: string;
 	dataTestId?: string;
 	loading?: boolean;
+	width?: Width; // strings must be in a valid percent format ex. '50%'
+	maxWidth?: number;
+	minWidth?: number;
 }
 
 export interface BaseProps {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -49,7 +49,7 @@ export function toArray<Child>(children: Child | Child[] | undefined): Child[] {
 }
 
 // removes all non-chart specific elements
-export const sanitizeChartChildren = (children: Children<RscElement> | undefined): ChartChildElement[] => {
+export const sanitizeRscChartChildren = (children: Children<RscElement> | undefined): ChartChildElement[] => {
 	return toArray(children)
 		.flat()
 		.filter((child): child is ChartChildElement => isChartChildElement(child));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`Chart.tsx` has become large and a little bit difficult to work with. Breaking out the Vega chart into a separate component 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`Chart.tsx` has become large and a little bit difficult to work with. Breaking out the Vega chart into a separate component will make maintenance and feature work easier. 

This will also make it easier for us to add and manage components that aren't pure Vega components, such as Big Number (React component).  

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test suite passes. I did a manual review of our Storybook components. I viewed most chart types and paid close attention to logic that isn't built into the spec: empty state, tooltip, popover.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
