### PR TITLE
Remove unnecessary code from bigNumberFormatUtils

### DIFF
--- a/src/components/BigNumber/bigNumberFormatUtils.ts
+++ b/src/components/BigNumber/bigNumberFormatUtils.ts
@@ -16,7 +16,7 @@ export const getFormattedString = (
 
 	if (Math.abs(value) >= 1000) {
 		// Format in scientific notation with B instead of G (e.g., 1K, 20M, 1.3B)
-		let formattedValue = formatter.format('.3s')(value);
+		const formattedValue = formatter.format('.3s')(value);
 		return formattedValue.replace('G', 'B').toUpperCase();
 	}
 

--- a/src/components/BigNumber/bigNumberFormatUtils.ts
+++ b/src/components/BigNumber/bigNumberFormatUtils.ts
@@ -2,42 +2,24 @@ import { BigNumberProps } from 'types';
 import { NumberLocale } from 'vega';
 import { numberFormatLocale } from 'vega-format';
 
-const createD3LocaleFormatter = (numberLocale: NumberLocale) => {
-	// Create a custom d3 locale based on the provided NumberLocale
-	return numberFormatLocale({
-		decimal: numberLocale.decimal,
-		thousands: numberLocale.thousands,
-		grouping: numberLocale.grouping,
-		currency: numberLocale.currency,
-	});
-};
-
-const defaultNumberLocale: NumberLocale = {
-	decimal: '.',
-	thousands: ',',
-	grouping: [3],
-	currency: ['$', ''],
-};
-
 export const getFormattedString = (
 	value: number,
 	numberLocale: NumberLocale | undefined,
 	numberFormat: string | undefined,
 	numberType: BigNumberProps['numberType']
 ): string => {
-	// Create a formatter based on the provided locale
-	const d3Formatter = createD3LocaleFormatter(numberLocale ? numberLocale : defaultNumberLocale);
+	const formatter = numberFormatLocale(numberLocale);
 
 	if (numberType === 'percentage') {
-		return d3Formatter.format('~%')(value);
+		return formatter.format('~%')(value);
 	}
 
 	if (Math.abs(value) >= 1000) {
 		// Format in scientific notation with B instead of G (e.g., 1K, 20M, 1.3B)
-		let formattedValue = d3Formatter.format('.3s')(value);
+		let formattedValue = formatter.format('.3s')(value);
 		return formattedValue.replace('G', 'B').toUpperCase();
 	}
 
 	// Format with commas for thousands, etc., or use the provided numberFormat
-	return numberFormat ? d3Formatter.format(numberFormat)(value) : d3Formatter.format(',')(value);
+	return numberFormat ? formatter.format(numberFormat)(value) : formatter.format(',')(value);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Remove unnecessary handling of default formatter in bigNumberFormatUtils.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Remove unnecessary code that doesn't affect test or storybook output.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Exisiting Number Format tests still pass.  Some other BigNumber tests fail due to an unrelated issue that is unaffected by this change.

## Screenshots (if appropriate):

<img width="1552" alt="Screenshot 2024-02-05 at 11 43 49 AM" src="https://github.com/adobe/react-spectrum-charts/assets/20342122/177be77d-582c-45c6-8a25-11bc226e00e7">
