### PR TITLE
fix: symbol fill opacity wasn't working with highlight enabled

### DIFF
--- a/src/specBuilder/legend/legendUtils.test.ts
+++ b/src/specBuilder/legend/legendUtils.test.ts
@@ -50,19 +50,18 @@ const hiddenSeriesLabelUpdateEncoding = {
 
 describe('getSymbolOpacityEncoding()', () => {
 	test('should return undefined if highlight is false', () => {
-		expect(getSymbolOpacityEncoding(defaultLegendProps)).toBeUndefined();
+		expect(getSymbolOpacityEncoding([], defaultLegendProps)).toBeUndefined();
 	});
 
 	test('should return default highlight encoding if opacity and facets are undefined', () => {
-		expect(getSymbolOpacityEncoding({ ...defaultLegendProps, highlight: true })).toStrictEqual(opacityEncoding);
+		expect(getSymbolOpacityEncoding([], { ...defaultLegendProps, highlight: true })).toStrictEqual(opacityEncoding);
 	});
 
 	test('should return signal-based encoding if facets includes opacity facet when opacity id undefined', () => {
 		expect(
-			getSymbolOpacityEncoding({
+			getSymbolOpacityEncoding([{ facetType: 'opacity', field: DEFAULT_COLOR }], {
 				...defaultLegendProps,
 				highlight: true,
-				facets: [{ facetType: 'opacity', field: DEFAULT_COLOR }],
 			})
 		).toStrictEqual(defaultOpacitySignalEncoding);
 	});
@@ -70,7 +69,7 @@ describe('getSymbolOpacityEncoding()', () => {
 	test('should return value-based encoding if opacity exists and is a static value', () => {
 		const opacity = 0.5;
 		expect(
-			getSymbolOpacityEncoding({ ...defaultLegendProps, highlight: true, opacity: { value: opacity } })
+			getSymbolOpacityEncoding([], { ...defaultLegendProps, highlight: true, opacity: { value: opacity } })
 		).toStrictEqual([
 			{
 				test: 'highlightedSeries && datum.value !== highlightedSeries',
@@ -82,11 +81,10 @@ describe('getSymbolOpacityEncoding()', () => {
 
 	test('should return signal based highlight encodings if opacity is a signal ref', () => {
 		expect(
-			getSymbolOpacityEncoding({
+			getSymbolOpacityEncoding([{ facetType: 'opacity', field: 'testing' }], {
 				...defaultLegendProps,
 				highlight: true,
 				opacity: DEFAULT_COLOR,
-				facets: [{ facetType: 'opacity', field: 'testing' }],
 			})
 		).toStrictEqual(defaultOpacitySignalEncoding);
 	});

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -122,7 +122,7 @@ const getHoverEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncod
 			},
 			symbols: {
 				update: {
-					fillOpacity: getSymbolOpacityEncoding(props),
+					fillOpacity: getSymbolOpacityEncoding(facets, props),
 					strokeOpacity: getOpacityEncoding(props),
 				},
 			},
@@ -175,14 +175,10 @@ export const getOpacityEncoding = ({
  * @param facets
  * @returns
  */
-export const getSymbolOpacityEncoding = ({
-	facets,
-	highlight,
-	highlightedSeries,
-	keys,
-	name,
-	opacity,
-}: LegendSpecProps & { facets?: Facet[] }): ProductionRule<NumericValueRef> | undefined => {
+export const getSymbolOpacityEncoding = (
+	facets: Facet[],
+	{ highlight, highlightedSeries, keys, name, opacity }: LegendSpecProps
+): ProductionRule<NumericValueRef> | undefined => {
 	const highlightSignalName = keys ? `${name}_highlight` : 'highlightedSeries';
 	// only add symbol opacity if highlight is true or highlightedSeries is defined
 	if (highlight || highlightedSeries) {

--- a/src/stories/ChartExamples.test.tsx
+++ b/src/stories/ChartExamples.test.tsx
@@ -16,12 +16,14 @@ import {
 	findChart,
 	findMarksByGroupName,
 	getAllLegendEntries,
+	getAllLegendSymbols,
 	getAllMarksByGroupName,
 	getMarksByGroupName,
 	hoverNthElement,
 	render,
 	screen,
 } from '@test-utils';
+import { spectrumColors } from '@themes';
 
 import {
 	FunnelConversion,
@@ -31,6 +33,8 @@ import {
 	TrendsTimeComparisonStackedBar,
 	UserGrowthTimeComparisonBarGrowth,
 } from './ChartExamples.story';
+
+const colors = spectrumColors.light;
 
 function testBarOpacity(bar: HTMLElement, opacity: string) {
 	expect(bar).toHaveAttribute('fill-opacity', opacity);
@@ -123,6 +127,33 @@ describe('Time comparison stories', () => {
 			// dropoff bars
 			testBarOpacity(bars[3], '1');
 			testBarStroke(bars[3], '', '1.5');
+		});
+
+		test('legend symobls should be styled correctly', async () => {
+			render(<FunnelTimeComparison {...FunnelTimeComparison.args} />);
+
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const legendSymbols = getAllLegendSymbols(chart);
+
+			expect(legendSymbols).toHaveLength(4);
+
+			// fill-opacity
+			expect(legendSymbols[0]).toHaveAttribute('fill-opacity', '0.5');
+			expect(legendSymbols[1]).toHaveAttribute('fill-opacity', '1');
+
+			// stroke-dasharray
+			expect(legendSymbols[0]).toHaveAttribute('stroke-dasharray', '3,4');
+			expect(legendSymbols[1]).toHaveAttribute('stroke-dasharray', '');
+
+			// fill
+			expect(legendSymbols[0]).toHaveAttribute('fill', colors['categorical-100']);
+			expect(legendSymbols[2]).toHaveAttribute('fill', colors['categorical-200']);
+
+			// stroke
+			expect(legendSymbols[0]).toHaveAttribute('stroke', colors['categorical-100']);
+			expect(legendSymbols[2]).toHaveAttribute('stroke', colors['categorical-200']);
 		});
 	});
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the recent multiple legend work, there was a regression where the fill opacity of legend symbols with highlight enabled wasn't working correctly.

## How Has This Been Tested?

Added test that replicates the broken state. That test and all others pass.

## Screenshots (if appropriate):

before:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/db925986-fea6-4a66-8d50-5080d068b62a)

after:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/9ec85655-5f71-4070-924e-ef36b4d3f76e)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
