### PR TITLE
An 338345/scatter tooltip

### DIFF
--- a/src/specBuilder/scatter/scatterMarkUtils.test.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createElement } from 'react';
+
+import { Trendline } from '@components/Trendline';
+import { GroupMark } from 'vega';
+import { defaultScatterProps } from './scatterTestUtils';
+import { addScatterMarks, getScatterHoverMarks } from './scatterMarkUtils';
+import { ChartTooltip } from '@components/ChartTooltip';
+
+describe('addScatterMarks()', () => {
+	test('should add the scatter group with the symbol marks', () => {
+		const marks = addScatterMarks([], defaultScatterProps);
+		expect(marks).toHaveLength(1);
+		expect(marks[0].name).toBe('scatter0_group');
+		expect(marks[0].type).toBe('group');
+		expect((marks[0] as GroupMark).marks).toHaveLength(1);
+	});
+
+	test('should use "multiply" blend mode in light mode', () => {
+		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'light' });
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'multiply' });
+	});
+	test('should "screen" blend mode in dark mode', () => {
+		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'dark' });
+		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'screen' });
+	});
+	test('should add trendline marks if trendline exists as a child', () => {
+		const marks = addScatterMarks([], { ...defaultScatterProps, children: [createElement(Trendline)] });
+		expect(marks).toHaveLength(2);
+		expect(marks[1].name).toBe('scatter0Trendline0_group');
+	});
+});
+
+describe('getScatterHoverMarks()', () => {
+	test('should retrurn the voronoi mark if there is a tooltip', () => {
+		expect(getScatterHoverMarks(defaultScatterProps)).toHaveLength(0);
+
+		const marks = getScatterHoverMarks({ ...defaultScatterProps, children: [createElement(ChartTooltip)] });
+		expect(marks).toHaveLength(1);
+		expect(marks[0].name).toBe('scatter0_voronoi');
+	});
+});

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FILTERED_TABLE } from '@constants';
+import {
+	getColorProductionRule,
+	getLineWidthProductionRule,
+	getOpacityProductionRule,
+	getStrokeDashProductionRule,
+	getSymbolSizeProductionRule,
+	getVoronoiPath,
+	getXProductionRule,
+	hasInteractiveChildren,
+} from '@specBuilder/marks/markUtils';
+import { getTrendlineMarks } from '@specBuilder/trendline';
+import { produce } from 'immer';
+import { ScatterSpecProps } from 'types';
+import { GroupMark, Mark, PathMark, SymbolMark } from 'vega';
+
+export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props) => {
+	const { name } = props;
+
+	const scatterGroup: GroupMark = {
+		name: `${name}_group`,
+		type: 'group',
+		marks: [getScatterMark(props), ...getScatterHoverMarks(props)],
+	};
+
+	marks.push(scatterGroup);
+	marks.push(...getTrendlineMarks(props));
+});
+
+export const getScatterMark = ({
+	color,
+	colorScheme,
+	dimension,
+	dimensionScaleType,
+	lineType,
+	lineWidth,
+	metric,
+	name,
+	opacity,
+	size,
+}: ScatterSpecProps): SymbolMark => ({
+	name,
+	type: 'symbol',
+	from: {
+		data: FILTERED_TABLE,
+	},
+	encode: {
+		enter: {
+			/**
+			 * the blend mode makes it possible to tell when there are overlapping points
+			 * in light mode, the points are darker when they overlap (multiply)
+			 * in dark mode, the points are lighter when they overlap (screen)
+			 */
+			blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
+			fill: getColorProductionRule(color, colorScheme),
+			shape: { value: 'circle' },
+			strokeDash: getStrokeDashProductionRule(lineType),
+			strokeWidth: getLineWidthProductionRule(lineWidth),
+			stroke: getColorProductionRule(color, colorScheme),
+			size: getSymbolSizeProductionRule(size),
+		},
+		update: {
+			fillOpacity: [getOpacityProductionRule(opacity)],
+			x: getXProductionRule(dimensionScaleType, dimension),
+			y: { scale: 'yLinear', field: metric },
+		},
+	},
+});
+
+/**
+ * Gets the vornoi path mark if there are any interactive children
+ * @param scatterProps ScatterSpecProps
+ * @returns PathMark[]
+ */
+export const getScatterHoverMarks = ({ children, name }: ScatterSpecProps): PathMark[] => {
+	if (!hasInteractiveChildren(children)) {
+		return [];
+	}
+	return [getVoronoiPath(children, name, name)];
+};

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -12,35 +12,11 @@
 import { createElement } from 'react';
 
 import { Trendline } from '@components/Trendline';
-import {
-	DEFAULT_COLOR,
-	DEFAULT_COLOR_SCHEME,
-	DEFAULT_DIMENSION_SCALE_TYPE,
-	DEFAULT_LINEAR_DIMENSION,
-	DEFAULT_METRIC,
-} from '@constants';
+import { DEFAULT_COLOR } from '@constants';
 import { initializeSpec } from '@specBuilder/specUtils';
-import { ScatterSpecProps } from 'types';
-import { GroupMark } from 'vega';
 
-import { addData, addScatterMarks, addSignals, setScales } from './scatterSpecBuilder';
-
-const defaultScatterProps: ScatterSpecProps = {
-	children: [],
-	color: { value: 'categorical-100' },
-	colorScaleType: 'ordinal',
-	colorScheme: DEFAULT_COLOR_SCHEME,
-	dimension: DEFAULT_LINEAR_DIMENSION,
-	dimensionScaleType: DEFAULT_DIMENSION_SCALE_TYPE,
-	index: 0,
-	interactiveMarkName: 'scatter0',
-	lineType: { value: 'solid' },
-	lineWidth: { value: 0 },
-	metric: DEFAULT_METRIC,
-	name: 'scatter0',
-	opacity: { value: 1 },
-	size: { value: 'M' },
-};
+import { addData, addSignals, setScales } from './scatterSpecBuilder';
+import { defaultScatterProps } from './scatterTestUtils';
 
 describe('addData()', () => {
 	test('should add time transform is dimensionScaleType === "time"', () => {
@@ -102,29 +78,5 @@ describe('setScales()', () => {
 		expect(scales).toHaveLength(3);
 		expect(scales[2].name).toBe('symbolSize');
 		expect(scales[2].domain).toEqual({ data: 'table', fields: ['weight'] });
-	});
-});
-
-describe('addScatterMarks()', () => {
-	test('should add the scatter group with the symbol marks', () => {
-		const marks = addScatterMarks([], defaultScatterProps);
-		expect(marks).toHaveLength(1);
-		expect(marks[0].name).toBe('scatter0_group');
-		expect(marks[0].type).toBe('group');
-		expect((marks[0] as GroupMark).marks).toHaveLength(1);
-	});
-
-	test('should use "multiply" blend mode in light mode', () => {
-		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'light' });
-		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'multiply' });
-	});
-	test('should "screen" blend mode in dark mode', () => {
-		const marks = addScatterMarks([], { ...defaultScatterProps, colorScheme: 'dark' });
-		expect((marks[0] as GroupMark).marks?.[0].encode?.enter?.blend).toEqual({ value: 'screen' });
-	});
-	test('should add trendline marks if trendline exists as a child', () => {
-		const marks = addScatterMarks([], { ...defaultScatterProps, children: [createElement(Trendline)] });
-		expect(marks).toHaveLength(2);
-		expect(marks[1].name).toBe('scatter0Trendline0_group');
 	});
 });

--- a/src/specBuilder/scatter/scatterTestUtils.ts
+++ b/src/specBuilder/scatter/scatterTestUtils.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+	DEFAULT_COLOR_SCHEME,
+	DEFAULT_DIMENSION_SCALE_TYPE,
+	DEFAULT_LINEAR_DIMENSION,
+	DEFAULT_METRIC,
+} from '@constants';
+import { ScatterSpecProps } from 'types';
+
+export const defaultScatterProps: ScatterSpecProps = {
+	children: [],
+	color: { value: 'categorical-100' },
+	colorScaleType: 'ordinal',
+	colorScheme: DEFAULT_COLOR_SCHEME,
+	dimension: DEFAULT_LINEAR_DIMENSION,
+	dimensionScaleType: DEFAULT_DIMENSION_SCALE_TYPE,
+	index: 0,
+	interactiveMarkName: 'scatter0',
+	lineType: { value: 'solid' },
+	lineWidth: { value: 0 },
+	metric: DEFAULT_METRIC,
+	name: 'scatter0',
+	opacity: { value: 1 },
+	size: { value: 'M' },
+};

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -94,7 +94,7 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	const legendProps = getLegendProps(args);
 
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
 			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
 			<Scatter {...args} />

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -9,10 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
+import { Content, Flex } from '@adobe/react-spectrum';
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, Legend, LegendProps, Scatter, Title } from '@rsc';
+import { Axis, Chart, ChartProps, ChartTooltip, Datum, Legend, LegendProps, Scatter, ScatterProps, Title } from '@rsc';
 import { characterData } from '@stories/data/marioKartData';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
@@ -73,9 +74,9 @@ const marioKeyTitle: Record<Exclude<MarioDataKey, 'character'>, string> = {
 	miniTurbo: 'Mini-turbo',
 };
 
-const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
-	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
+const defaultChartProps: ChartProps = { data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] };
 
+const getLegendProps = (args: ScatterProps): LegendProps => {
 	const facets = ['color', 'lineType', 'opacity', 'size'];
 	const legendKey = args[facets.find((key) => args[key] !== undefined) ?? 'color'];
 	const legendProps: LegendProps = {
@@ -85,15 +86,56 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	if (typeof args.opacity === 'object') {
 		legendProps.opacity = args.opacity;
 	}
+	return legendProps;
+};
+
+const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
+	const chartProps = useChartProps(defaultChartProps);
+	const legendProps = getLegendProps(args);
 
 	return (
-		<Chart {...chartProps} >
+		<Chart {...chartProps} debug>
 			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
 			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
 			<Scatter {...args} />
 			<Legend {...legendProps} />
 			<Title text="Mario Kart 8 Character Data" />
 		</Chart>
+	);
+};
+
+const ScatterTooltipStory: StoryFn<typeof Scatter> = (args): ReactElement => {
+	const chartProps = useChartProps(defaultChartProps);
+	const legendProps = getLegendProps(args);
+	const dimension = args.dimension as MarioDataKey;
+	const metric = args.metric as MarioDataKey;
+
+	return (
+		<Chart {...chartProps}>
+			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[dimension]} />
+			<Axis position="left" grid ticks baseline title={marioKeyTitle[metric]} />
+			<Scatter {...args}>
+				<ChartTooltip>{(item) => dialog(item, dimension, metric)}</ChartTooltip>
+			</Scatter>
+			<Legend {...legendProps} />
+			<Title text="Mario Kart 8 Character Data" />
+		</Chart>
+	);
+};
+
+const dialog = (item: Datum, dimension: MarioDataKey, metric: MarioDataKey) => {
+	return (
+		<Content>
+			<Flex direction="column">
+				<div style={{ fontWeight: 'bold' }}>{(item.character as string[]).join(', ')}</div>
+				<div>
+					{marioKeyTitle[dimension]}: {item[dimension]}
+				</div>
+				<div>
+					{marioKeyTitle[metric]}: {item[metric]}
+				</div>
+			</Flex>
+		</Content>
 	);
 };
 
@@ -133,4 +175,11 @@ Size.args = {
 	metric: 'handlingNormal',
 };
 
-export { Basic, Color, LineType, Opacity, Size };
+const Tooltip = bindWithProps(ScatterTooltipStory);
+Tooltip.args = {
+	color: 'weightClass',
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
+export { Basic, Color, LineType, Opacity, Size, Tooltip };

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -10,9 +10,17 @@
  * governing permissions and limitations under the License.
  */
 import { Scatter, spectrumColors } from '@rsc';
-import { findAllMarksByGroupName, findChart, getAllLegendEntries, render } from '@test-utils';
+import {
+	findAllMarksByGroupName,
+	findChart,
+	getAllLegendEntries,
+	hoverNthElement,
+	render,
+	screen,
+	within,
+} from '@test-utils';
 
-import { Basic, Color, LineType, Opacity, Size } from './Scatter.story';
+import { Basic, Color, LineType, Opacity, Size, Tooltip } from './Scatter.story';
 
 const colors = spectrumColors.light;
 
@@ -87,5 +95,25 @@ describe('Scatter', () => {
 
 		const legendEntries = getAllLegendEntries(chart);
 		expect(legendEntries).toHaveLength(6);
+	});
+
+	describe('Tooltip', () => {
+		test('should render a tooltip on hover', async () => {
+			render(<Tooltip {...Basic.args} />);
+
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const paths = await findAllMarksByGroupName(chart, 'scatter0_voronoi');
+
+			await hoverNthElement(paths, 0);
+			let tooltip = await screen.findByTestId('rsc-tooltip');
+			expect(tooltip).toBeInTheDocument();
+			expect(within(tooltip).getByText('Baby Peach, Baby Daisy')).toBeInTheDocument();
+
+			await hoverNthElement(paths, 12);
+			tooltip = await screen.findByTestId('rsc-tooltip');
+			expect(within(tooltip).getByText('Metal Mario, Gold Mario, Pink Gold Peach')).toBeInTheDocument();
+		});
 	});
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -14,7 +14,7 @@ import { Fragment, ReactFragment } from 'react';
 import { MARK_ID, SERIES_ID } from '@constants';
 import { View } from 'vega';
 
-import { Area, Axis, AxisAnnotation, Bar, ChartPopover, ChartTooltip, Legend, Line, Trendline } from '..';
+import { Area, Axis, AxisAnnotation, Bar, ChartPopover, ChartTooltip, Legend, Line, Scatter, Trendline } from '..';
 import { Donut } from '../alpha';
 import {
 	AxisAnnotationChildElement,
@@ -41,6 +41,7 @@ type ElementCounts = {
 	donut: number;
 	legend: number;
 	line: number;
+	scatter: number;
 };
 
 // coerces a value that could be a single value or an array of that value to an array
@@ -70,14 +71,14 @@ export const sanitizeAxisChildren = (children: Children<AxisChildElement> | unde
 };
 
 export const sanitizeAxisAnnotationChildren = (
-	children: Children<AxisAnnotationChildElement> | undefined
+	children: Children<AxisAnnotationChildElement> | undefined,
 ): AxisAnnotationChildElement[] => {
 	return toArray(children)
 		.flat()
 		.filter((child): child is AxisAnnotationChildElement => isMarkChildElement(child));
 };
 export const sanitizeTrendlineChildren = (
-	children: Children<ChartTooltipElement> | undefined
+	children: Children<ChartTooltipElement> | undefined,
 ): ChartTooltipElement[] => {
 	return toArray(children)
 		.flat()
@@ -88,7 +89,7 @@ const isChartChildElement = (child: ChildElement<ChartChildElement> | undefined)
 	return isRscComponent(child);
 };
 const isMarkChildElement = <T extends MarkChildElement = MarkChildElement>(
-	child: ChildElement<T> | undefined
+	child: ChildElement<T> | undefined,
 ): child is T => {
 	return isRscComponent(child);
 };
@@ -104,7 +105,7 @@ const isRscComponent = (child?: ChildElement<RscElement>): boolean => {
 			typeof child !== 'boolean' &&
 			'type' in child &&
 			child.type !== Fragment &&
-			'displayName' in child.type
+			'displayName' in child.type,
 	);
 };
 
@@ -149,7 +150,14 @@ export function getElement(
 		| string
 		| ReactFragment
 		| undefined,
-	type: typeof Axis | typeof Legend | typeof Line | typeof Bar | typeof ChartTooltip | typeof ChartPopover
+	type:
+		| typeof Axis
+		| typeof Bar
+		| typeof ChartPopover
+		| typeof ChartTooltip
+		| typeof Legend
+		| typeof Line
+		| typeof Scatter,
 ): ChartElement | RscElement | undefined {
 	// if the element is undefined or 'type' doesn't exist on the element, stop searching
 	if (
@@ -185,9 +193,16 @@ export function getElement(
  */
 export const getAllElements = (
 	target: Children<ChartElement | RscElement>,
-	source: typeof Axis | typeof Legend | typeof Line | typeof Bar | typeof ChartTooltip | typeof ChartPopover,
+	source:
+		| typeof Axis
+		| typeof Bar
+		| typeof ChartPopover
+		| typeof ChartTooltip
+		| typeof Legend
+		| typeof Line
+		| typeof Scatter,
 	elements: MappedElement[] = [],
-	name: string = ''
+	name: string = '',
 ): MappedElement[] => {
 	if (
 		!target ||
@@ -239,6 +254,9 @@ const getElementName = (element: ChildElement<RscElement>, elementCounts: Elemen
 		case Line.displayName:
 			elementCounts.line++;
 			return getComponentName(element, `line${elementCounts.line}`);
+		case Scatter.displayName:
+			elementCounts.scatter++;
+			return getComponentName(element, `scatter${elementCounts.scatter}`);
 		case Trendline.displayName:
 			return getComponentName(element, 'Trendline');
 		default:
@@ -261,6 +279,7 @@ const initElementCounts = (): ElementCounts => ({
 	donut: -1,
 	legend: -1,
 	line: -1,
+	scatter: -1,
 });
 
 /**
@@ -268,7 +287,7 @@ const initElementCounts = (): ElementCounts => ({
  */
 export function debugLog(
 	debug: boolean | undefined,
-	{ title = '', contents }: { contents?: unknown; title?: string }
+	{ title = '', contents }: { contents?: unknown; title?: string },
 ): void {
 	if (debug) {
 		const rainbow = String.fromCodePoint(0x1f308);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Basic scatter plot tooltip support. This is only the logic for displaying the tooltip. This does not include any logic for highlighting.

## Related Issue

[Scatter Plot](https://github.com/adobe/react-spectrum-charts/issues/50)

## Motivation and Context

Tooltips are fundamental and should be supported on all standard mark types

## How Has This Been Tested?

Existing tests pass, new tests added.

## Screenshots (if appropriate):
<img width="571" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/3a38a14a-511c-4fed-a148-5c71f37fc852">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
