### PR TITLE
feat: tooltip point highlighting on scatter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,9 @@ export const MARK_ID = 'rscMarkId';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';
 export const STACK_ID = 'rscStackId';
 
+// encode rules
+export const DEFAULT_OPACITY_RULE = { value: 1 };
+
 // corner radius
 export const CORNER_RADIUS = 6;
 

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -15,7 +15,12 @@ import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { MetricRange } from '@components/MetricRange';
 import { Trendline } from '@components/Trendline';
-import { BACKGROUND_COLOR, DEFAULT_TRANSFORMED_TIME_DIMENSION, HIGHLIGHT_CONTRAST_RATIO } from '@constants';
+import {
+	BACKGROUND_COLOR,
+	DEFAULT_OPACITY_RULE,
+	DEFAULT_TRANSFORMED_TIME_DIMENSION,
+	HIGHLIGHT_CONTRAST_RATIO,
+} from '@constants';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
 import {
 	getColorValue,
@@ -171,7 +176,9 @@ export const getStrokeDashProductionRule = (lineType: LineTypeFacet | DualFacet)
 	return { value: getStrokeDashFromLineType(lineType.value) };
 };
 
-export const getHighlightOpacityValue = (opacityValue: { signal: string } | { value: number }): NumericValueRef => {
+export const getHighlightOpacityValue = (
+	opacityValue: { signal: string } | { value: number } = DEFAULT_OPACITY_RULE,
+): NumericValueRef => {
 	if ('signal' in opacityValue) {
 		return { signal: `${opacityValue.signal} / ${HIGHLIGHT_CONTRAST_RATIO}` };
 	}

--- a/src/specBuilder/scatter/scatterMarkUtils.test.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.test.ts
@@ -12,11 +12,12 @@
 
 import { createElement } from 'react';
 
-import { Trendline } from '@components/Trendline';
-import { GroupMark } from 'vega';
-import { defaultScatterProps } from './scatterTestUtils';
-import { addScatterMarks, getScatterHoverMarks } from './scatterMarkUtils';
 import { ChartTooltip } from '@components/ChartTooltip';
+import { Trendline } from '@components/Trendline';
+import { DEFAULT_OPACITY_RULE, MARK_ID } from '@constants';
+import { GroupMark } from 'vega';
+import { addScatterMarks, getOpacity, getScatterHoverMarks } from './scatterMarkUtils';
+import { defaultScatterProps } from './scatterTestUtils';
 
 describe('addScatterMarks()', () => {
 	test('should add the scatter group with the symbol marks', () => {
@@ -39,6 +40,17 @@ describe('addScatterMarks()', () => {
 		const marks = addScatterMarks([], { ...defaultScatterProps, children: [createElement(Trendline)] });
 		expect(marks).toHaveLength(2);
 		expect(marks[1].name).toBe('scatter0Trendline0_group');
+	});
+});
+
+describe('getOpacity()', () => {
+	test('should return the default rule if there are not any interactive children', () => {
+		expect(getOpacity(defaultScatterProps)).toEqual([DEFAULT_OPACITY_RULE]);
+	});
+	test('should include hover rules if tooltip exists', () => {
+		const opacity = getOpacity({ ...defaultScatterProps, children: [createElement(ChartTooltip)] });
+		expect(opacity).toHaveLength(2);
+		expect(opacity[0]).toHaveProperty('test', `scatter0_hoveredId && scatter0_hoveredId !== datum.${MARK_ID}`);
 	});
 });
 

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -88,7 +88,7 @@ export const getOpacity = ({ children, name }: ScatterSpecProps): ({ test?: stri
 	if (!hasInteractiveChildren(children)) {
 		return [DEFAULT_OPACITY_RULE];
 	}
-	// if a symbol is hovered, all other symbols should be 1/5th opacity
+	// if a point is hovered, all other points should be reduced opacity
 	const hoverSignal = `${name}_hoveredId`;
 	return [
 		{

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -9,9 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FILTERED_TABLE } from '@constants';
+import { FILTERED_TABLE, MARK_ID, DEFAULT_OPACITY_RULE } from '@constants';
 import {
 	getColorProductionRule,
+	getHighlightOpacityValue,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
 	getStrokeDashProductionRule,
@@ -23,7 +24,7 @@ import {
 import { getTrendlineMarks } from '@specBuilder/trendline';
 import { produce } from 'immer';
 import { ScatterSpecProps } from 'types';
-import { GroupMark, Mark, PathMark, SymbolMark } from 'vega';
+import { GroupMark, Mark, NumericValueRef, PathMark, SymbolMark } from 'vega';
 
 export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props) => {
 	const { name } = props;
@@ -38,45 +39,65 @@ export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props
 	marks.push(...getTrendlineMarks(props));
 });
 
-export const getScatterMark = ({
-	color,
-	colorScheme,
-	dimension,
-	dimensionScaleType,
-	lineType,
-	lineWidth,
-	metric,
-	name,
-	opacity,
-	size,
-}: ScatterSpecProps): SymbolMark => ({
-	name,
-	type: 'symbol',
-	from: {
-		data: FILTERED_TABLE,
-	},
-	encode: {
-		enter: {
-			/**
-			 * the blend mode makes it possible to tell when there are overlapping points
-			 * in light mode, the points are darker when they overlap (multiply)
-			 * in dark mode, the points are lighter when they overlap (screen)
-			 */
-			blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
-			fill: getColorProductionRule(color, colorScheme),
-			shape: { value: 'circle' },
-			strokeDash: getStrokeDashProductionRule(lineType),
-			strokeWidth: getLineWidthProductionRule(lineWidth),
-			stroke: getColorProductionRule(color, colorScheme),
-			size: getSymbolSizeProductionRule(size),
+/**
+ * Gets the primary scatter mark
+ * @param scatterProps scatterSpecProps
+ * @returns SymbolMark
+ */
+export const getScatterMark = (props: ScatterSpecProps): SymbolMark => {
+	const { color, colorScheme, dimension, dimensionScaleType, lineType, lineWidth, metric, name, opacity, size } =
+		props;
+	return {
+		name,
+		type: 'symbol',
+		from: {
+			data: FILTERED_TABLE,
 		},
-		update: {
-			fillOpacity: [getOpacityProductionRule(opacity)],
-			x: getXProductionRule(dimensionScaleType, dimension),
-			y: { scale: 'yLinear', field: metric },
+		encode: {
+			enter: {
+				/**
+				 * the blend mode makes it possible to tell when there are overlapping points
+				 * in light mode, the points are darker when they overlap (multiply)
+				 * in dark mode, the points are lighter when they overlap (screen)
+				 */
+				blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
+				fill: getColorProductionRule(color, colorScheme),
+				fillOpacity: getOpacityProductionRule(opacity),
+				shape: { value: 'circle' },
+				size: getSymbolSizeProductionRule(size),
+				strokeDash: getStrokeDashProductionRule(lineType),
+				strokeWidth: getLineWidthProductionRule(lineWidth),
+				stroke: getColorProductionRule(color, colorScheme),
+			},
+			update: {
+				opacity: getOpacity(props),
+				x: getXProductionRule(dimensionScaleType, dimension),
+				y: { scale: 'yLinear', field: metric },
+			},
 		},
-	},
-});
+	};
+};
+
+/**
+ * Gets the opacity production rule for the scatter mark.
+ * This is used for highlighting points on hover and selection.
+ * @param scatterProps ScatterSpecProps
+ * @returns opacity production rule
+ */
+export const getOpacity = ({ children, name }: ScatterSpecProps): ({ test?: string } & NumericValueRef)[] => {
+	if (!hasInteractiveChildren(children)) {
+		return [DEFAULT_OPACITY_RULE];
+	}
+	// if a symbol is hovered, all other symbols should be 1/5th opacity
+	const hoverSignal = `${name}_hoveredId`;
+	return [
+		{
+			test: `${hoverSignal} && ${hoverSignal} !== datum.${MARK_ID}`,
+			...getHighlightOpacityValue(),
+		},
+		DEFAULT_OPACITY_RULE,
+	];
+};
 
 /**
  * Gets the vornoi path mark if there are any interactive children

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -17,6 +17,7 @@ import { initializeSpec } from '@specBuilder/specUtils';
 
 import { addData, addSignals, setScales } from './scatterSpecBuilder';
 import { defaultScatterProps } from './scatterTestUtils';
+import { ChartTooltip } from '@components/ChartTooltip';
 
 describe('addData()', () => {
 	test('should add time transform is dimensionScaleType === "time"', () => {
@@ -37,12 +38,22 @@ describe('addData()', () => {
 });
 
 describe('addSignals()', () => {
+	test('should add hoveredId signal if tooltip exists', () => {
+		const signals = addSignals([], {
+			...defaultScatterProps,
+			children: [createElement(ChartTooltip)],
+		});
+		expect(signals).toHaveLength(1);
+		expect(signals[0]).toHaveProperty('name', 'scatter0_hoveredId');
+	});
 	test('should add trendline signals if trendline exists as a child', () => {
 		const signals = addSignals([], {
 			...defaultScatterProps,
 			children: [createElement(Trendline, { displayOnHover: true })],
 		});
-		expect(signals).toHaveLength(1);
+		expect(signals).toHaveLength(2);
+		expect(signals[0]).toHaveProperty('name', 'scatter0_hoveredSeries');
+		expect(signals[1]).toHaveProperty('name', 'scatter0_hoveredId');
 	});
 });
 

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -94,7 +94,7 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 	const legendProps = getLegendProps(args);
 
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
 			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
 			<Scatter {...args} />

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -21,6 +21,7 @@ import {
 } from '@test-utils';
 
 import { Basic, Color, LineType, Opacity, Size, Tooltip } from './Scatter.story';
+import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 
 const colors = spectrumColors.light;
 
@@ -114,6 +115,25 @@ describe('Scatter', () => {
 			await hoverNthElement(paths, 12);
 			tooltip = await screen.findByTestId('rsc-tooltip');
 			expect(within(tooltip).getByText('Metal Mario, Gold Mario, Pink Gold Peach')).toBeInTheDocument();
+		});
+		test('should highligh hovered points', async () => {
+			render(<Tooltip {...Basic.args} />);
+
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const paths = await findAllMarksByGroupName(chart, 'scatter0_voronoi');
+			const points = await findAllMarksByGroupName(chart, 'scatter0');
+			expect(points).toHaveLength(16);
+
+			await hoverNthElement(paths, 0);
+			expect(points[0]).toHaveAttribute('opacity', '1');
+			expect(points[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+
+			// make sure all points after the first have reduced opacity
+			expect(
+				points.slice(1).every((point) => point.getAttribute('opacity') === `${1 / HIGHLIGHT_CONTRAST_RATIO}`),
+			).toBeTruthy();
 		});
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add highlighting to scatter points when the tooltip is visible

## Related Issue

[Scatter plot](https://github.com/adobe/react-spectrum-charts/pull/129#:~:text=Related%20Issue-,Scatter%20Plot,-Motivation%20and%20Context)

## Motivation and Context

Highlighting helps convey which point the tooltip is for

## How Has This Been Tested?

Added tests. All existing tests are passing.

## Screenshots (if appropriate):

https://github.com/adobe/react-spectrum-charts/assets/40001449/4b7adab4-2408-4c40-b436-0f7634c653b2

## Stories

Scatter > Tooltip

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
