### PR TITLE
refactor: switch highlight to use opacity instead of fillOpacity and …

### DIFF
--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
 	MARK_ID,
@@ -165,15 +166,15 @@ const defaultStackedMark: Mark = {
 			...defaultStackedYEncodings,
 			...defaultCornerRadiusEncodings,
 			fill: { scale: 'color', field: DEFAULT_COLOR },
+			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},
 		update: {
-			x: { scale: 'xBand', field: DEFAULT_CATEGORICAL_DIMENSION },
 			...defaultBarStrokeEncodings,
-			width: { scale: 'xBand', band: 1 },
 			cursor: undefined,
-			fillOpacity: [{ value: 1 }],
-			strokeOpacity: [{ value: 1 }],
+			opacity: [DEFAULT_OPACITY_RULE],
+			width: { scale: 'xBand', band: 1 },
+			x: { scale: 'xBand', field: DEFAULT_CATEGORICAL_DIMENSION },
 		},
 	},
 };
@@ -269,7 +270,7 @@ describe('barSpecBuilder', () => {
 					addSignals([getUncontrolledHoverSignal('bar0'), defaultHoverSignal, defaultSelectSignal], {
 						...defaultBarProps,
 						children: [popover],
-					})
+					}),
 				).toStrictEqual([
 					getUncontrolledHoverSignal('bar0'),
 					defaultHoverSignal,
@@ -307,7 +308,7 @@ describe('barSpecBuilder', () => {
 							range: { signal: 'colors' },
 							domain: { data: TABLE, fields: [DEFAULT_COLOR] },
 						},
-					]
+					],
 				);
 			});
 
@@ -323,8 +324,8 @@ describe('barSpecBuilder', () => {
 							...defaultBarProps,
 							lineType: DEFAULT_COLOR,
 							opacity: DEFAULT_COLOR,
-						}
-					)
+						},
+					),
 				).toStrictEqual([
 					defaultColorScale,
 					{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: 'lineType', type: 'ordinal' },
@@ -341,7 +342,7 @@ describe('barSpecBuilder', () => {
 						trellis: 'event',
 						trellisOrientation: 'vertical',
 						trellisPadding: 0.5,
-					})
+					}),
 				).toStrictEqual([
 					defaultColorScale,
 					defaultMetricScale,
@@ -434,7 +435,7 @@ describe('barSpecBuilder', () => {
 					addMarks([], {
 						...defaultBarProps,
 						children: [...defaultBarProps.children, annotation],
-					})
+					}),
 				).toStrictEqual([...defaultStackedBarMarks, ...stackedAnnotationMarks]);
 			});
 		});
@@ -466,7 +467,7 @@ describe('barSpecBuilder', () => {
 		describe('existing data "table"', () => {
 			test('new transform should be added to the data table', () => {
 				expect(
-					addData(defaultData, { ...defaultBarProps, metric: 'views', dimension: 'browser' })
+					addData(defaultData, { ...defaultBarProps, metric: 'views', dimension: 'browser' }),
 				).toStrictEqual([
 					defaultTableData,
 					{
@@ -525,7 +526,7 @@ describe('barSpecBuilder', () => {
 		describe('transform already exists', () => {
 			test('no props, new transform should be pushed onto the end with default values', () => {
 				expect(
-					addData([{ ...defaultFilteredTableData, transform: defaultStackedTransforms }], defaultBarProps)
+					addData([{ ...defaultFilteredTableData, transform: defaultStackedTransforms }], defaultBarProps),
 				).toStrictEqual([
 					{
 						...defaultFilteredTableData,
@@ -541,7 +542,7 @@ describe('barSpecBuilder', () => {
 				const popover = createElement(ChartPopover);
 				expect(addData(baseData, { ...defaultBarProps, children: [popover] })[1]).toHaveProperty(
 					'transform',
-					defaultStackedTransforms
+					defaultStackedTransforms,
 				);
 			});
 		});
@@ -552,7 +553,7 @@ describe('barSpecBuilder', () => {
 					...defaultBarProps,
 					type: 'dodged',
 					color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR],
-				})
+				}),
 			).toStrictEqual([
 				defaultTableData,
 				{
@@ -594,7 +595,7 @@ describe('barSpecBuilder', () => {
 		});
 		test('stacked dodged', () => {
 			expect(
-				addData(defaultData, { ...defaultBarProps, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })
+				addData(defaultData, { ...defaultBarProps, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] }),
 			).toStrictEqual([
 				defaultTableData,
 				{
@@ -676,7 +677,7 @@ describe('barSpecBuilder', () => {
 			});
 
 			expect(
-				getStackIdTransform({ ...defaultBarProps, type: 'dodged', opacity: DEFAULT_SECONDARY_COLOR })
+				getStackIdTransform({ ...defaultBarProps, type: 'dodged', opacity: DEFAULT_SECONDARY_COLOR }),
 			).toStrictEqual({
 				as: STACK_ID,
 				expr: `datum.${DEFAULT_CATEGORICAL_DIMENSION} + "," + datum.${DEFAULT_COLOR} + "," + datum.${DEFAULT_SECONDARY_COLOR}`,
@@ -688,7 +689,7 @@ describe('barSpecBuilder', () => {
 	describe('getDodgeGroupTransform()', () => {
 		test('should join facets together', () => {
 			expect(
-				getDodgeGroupTransform({ ...defaultBarProps, type: 'dodged', opacity: DEFAULT_SECONDARY_COLOR })
+				getDodgeGroupTransform({ ...defaultBarProps, type: 'dodged', opacity: DEFAULT_SECONDARY_COLOR }),
 			).toStrictEqual({
 				as: 'bar0_dodgeGroup',
 				expr: `datum.${DEFAULT_COLOR} + "," + datum.${DEFAULT_SECONDARY_COLOR}`,
@@ -700,18 +701,18 @@ describe('barSpecBuilder', () => {
 	describe('getRepeatedScale()', () => {
 		test('should return a linear scale if the bar and trellis orientations are the same', () => {
 			expect(
-				getRepeatedScale({ ...defaultBarProps, orientation: 'horizontal', trellisOrientation: 'horizontal' })
+				getRepeatedScale({ ...defaultBarProps, orientation: 'horizontal', trellisOrientation: 'horizontal' }),
 			).toHaveProperty('type', 'linear');
 			expect(
-				getRepeatedScale({ ...defaultBarProps, orientation: 'vertical', trellisOrientation: 'vertical' })
+				getRepeatedScale({ ...defaultBarProps, orientation: 'vertical', trellisOrientation: 'vertical' }),
 			).toHaveProperty('type', 'linear');
 		});
 		test('should return a band scale if the bar and trellis orientations are not the same', () => {
 			expect(
-				getRepeatedScale({ ...defaultBarProps, orientation: 'horizontal', trellisOrientation: 'vertical' })
+				getRepeatedScale({ ...defaultBarProps, orientation: 'horizontal', trellisOrientation: 'vertical' }),
 			).toHaveProperty('type', 'band');
 			expect(
-				getRepeatedScale({ ...defaultBarProps, orientation: 'vertical', trellisOrientation: 'horizontal' })
+				getRepeatedScale({ ...defaultBarProps, orientation: 'vertical', trellisOrientation: 'horizontal' }),
 			).toHaveProperty('type', 'band');
 		});
 	});

--- a/src/specBuilder/bar/barTestUtils.ts
+++ b/src/specBuilder/bar/barTestUtils.ts
@@ -16,6 +16,7 @@ import {
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
 	HIGHLIGHT_CONTRAST_RATIO,
@@ -107,14 +108,14 @@ export const defaultDodgedCornerRadiusEncodings: RectEncodeEntry = {
 
 export const defaultBarFillOpacity: ProductionRule<NumericValueRef> = [{ value: 1 }];
 
-export const defaultBarPopoverFillOpacity: ProductionRule<NumericValueRef> = [
+export const defaultBarPopoverOpacity: ProductionRule<NumericValueRef> = [
 	{
 		test: `!bar0_selectedId && bar0_hoveredId && bar0_hoveredId !== datum.${MARK_ID}`,
 		value: 1 / HIGHLIGHT_CONTRAST_RATIO,
 	},
 	{ test: `bar0_selectedId && bar0_selectedId !== datum.${MARK_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
 	{ test: `bar0_selectedId && bar0_selectedId === datum.${MARK_ID}`, value: 1 },
-	{ value: 1 },
+	DEFAULT_OPACITY_RULE,
 ];
 
 export const stackedXScale = 'xBand';

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
 	HIGHLIGHT_CONTRAST_RATIO,
 	MARK_ID,
@@ -30,7 +31,7 @@ import { RectEncodeEntry } from 'vega';
 
 import {
 	defaultBarEnterEncodings,
-	defaultBarPopoverFillOpacity,
+	defaultBarPopoverOpacity,
 	defaultBarProps,
 	defaultBarPropsWithSecondayColor,
 	defaultCornerRadiusEncodings,
@@ -55,7 +56,7 @@ import {
 	getCornerRadiusEncodings,
 	getDodgedDimensionEncodings,
 	getDodgedGroupMark,
-	getFillStrokeOpacity,
+	getBarOpacity,
 	getMetricEncodings,
 	getOrientationProperties,
 	getStackedCornerRadiusEncodings,
@@ -78,12 +79,12 @@ describe('barUtils', () => {
 			});
 			test('dodged, should return dodged encodings', () => {
 				expect(getMetricEncodings({ ...defaultBarProps, type: 'dodged' })).toStrictEqual(
-					defaultDodgedYEncodings
+					defaultDodgedYEncodings,
 				);
 			});
 			test('dodged with secdondary color series, should return stacked encodings', () => {
 				expect(getMetricEncodings({ ...defaultBarPropsWithSecondayColor, type: 'dodged' })).toStrictEqual(
-					defaultStackedYEncodings
+					defaultStackedYEncodings,
 				);
 			});
 		});
@@ -140,7 +141,7 @@ describe('barUtils', () => {
 				const encodings = getStackedMetricEncodings(defaultBarProps);
 				expect(encodings.y?.[1]?.test).toEqual(`${endValue} > 0`);
 				expect(encodings.y?.[1]?.signal).toEqual(
-					`max(scale('yLinear', ${startValue}) - 1.5, scale('yLinear', datum.${DEFAULT_METRIC}1))`
+					`max(scale('yLinear', ${startValue}) - 1.5, scale('yLinear', datum.${DEFAULT_METRIC}1))`,
 				);
 			});
 
@@ -148,7 +149,7 @@ describe('barUtils', () => {
 				const encodings = getStackedMetricEncodings(defaultBarProps);
 				expect(encodings.y?.[2]?.test).toBeUndefined();
 				expect(encodings.y?.[2]?.signal).toEqual(
-					`min(scale('yLinear', ${startValue}) + 1.5, scale('yLinear', datum.${DEFAULT_METRIC}1))`
+					`min(scale('yLinear', ${startValue}) + 1.5, scale('yLinear', datum.${DEFAULT_METRIC}1))`,
 				);
 			});
 
@@ -176,7 +177,7 @@ describe('barUtils', () => {
 				const encodings = getStackedMetricEncodings(horizontalProps);
 				expect(encodings.x?.[1]?.test).toEqual(`${endValue} > 0`);
 				expect(encodings.x?.[1]?.signal).toEqual(
-					`min(scale('xLinear', ${startValue}) + 1.5, scale('xLinear', datum.${DEFAULT_METRIC}1))`
+					`min(scale('xLinear', ${startValue}) + 1.5, scale('xLinear', datum.${DEFAULT_METRIC}1))`,
 				);
 			});
 
@@ -184,7 +185,7 @@ describe('barUtils', () => {
 				const encodings = getStackedMetricEncodings(horizontalProps);
 				expect(encodings.x?.[2]?.test).toBeUndefined();
 				expect(encodings.x?.[2]?.signal).toEqual(
-					`max(scale('xLinear', ${startValue}) - 1.5, scale('xLinear', datum.${DEFAULT_METRIC}1))`
+					`max(scale('xLinear', ${startValue}) - 1.5, scale('xLinear', datum.${DEFAULT_METRIC}1))`,
 				);
 			});
 
@@ -201,7 +202,7 @@ describe('barUtils', () => {
 		});
 		test('dodged, return simple radius encodings', () => {
 			expect(getCornerRadiusEncodings({ ...defaultBarProps, type: 'dodged' })).toStrictEqual(
-				defaultDodgedCornerRadiusEncodings
+				defaultDodgedCornerRadiusEncodings,
 			);
 		});
 		test('horizontal, should return stacked radius encodings rotated clockwise', () => {
@@ -240,7 +241,7 @@ describe('barUtils', () => {
 						value: CORNER_RADIUS,
 					},
 					{ value: 0 },
-				]
+				],
 			);
 		});
 		test('dodged with secondary color, should include secondaryColor in singal path', () => {
@@ -248,7 +249,7 @@ describe('barUtils', () => {
 				getStackedCornerRadiusEncodings({
 					...defaultBarPropsWithSecondayColor,
 					type: 'dodged',
-				}).cornerRadiusTopLeft
+				}).cornerRadiusTopLeft,
 			).toStrictEqual([
 				{
 					test: `datum.${DEFAULT_METRIC}1 > 0 && data('bar0_stacks')[indexof(pluck(data('bar0_stacks'), '${STACK_ID}'), datum.${STACK_ID})].max_${DEFAULT_METRIC}1 === datum.${DEFAULT_METRIC}1`,
@@ -280,33 +281,20 @@ describe('barUtils', () => {
 		});
 	});
 
-	describe('getFillStrokeOpacity()', () => {
-		test('no children, should use provided opacity', () => {
-			expect(getFillStrokeOpacity(defaultBarProps)).toStrictEqual([{ value: 1 }]);
-		});
-		test('no children, series key for opacity, should use scale and field for opacity', () => {
-			expect(getFillStrokeOpacity({ ...defaultBarProps, opacity: DEFAULT_COLOR })).toStrictEqual([
-				{ signal: "scale('opacity', datum.series)" },
-			]);
+	describe('getBarOpacity()', () => {
+		test('no children, should use default opacity', () => {
+			expect(getBarOpacity(defaultBarProps)).toStrictEqual([DEFAULT_OPACITY_RULE]);
 		});
 		test('Tooltip child, should return tests for hover and default to opacity', () => {
 			const tooltip = createElement(ChartTooltip);
-			expect(getFillStrokeOpacity({ ...defaultBarProps, children: [tooltip] })).toStrictEqual([
+			expect(getBarOpacity({ ...defaultBarProps, children: [tooltip] })).toStrictEqual([
 				{ test: `bar0_hoveredId && bar0_hoveredId !== datum.${MARK_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-				{ value: 1 },
+				DEFAULT_OPACITY_RULE,
 			]);
 		});
 		test('Popover child, should return tests for hover and select and default to opacity', () => {
 			const popover = createElement(ChartPopover);
-			expect(getFillStrokeOpacity({ ...defaultBarProps, children: [popover] })).toStrictEqual(
-				defaultBarPopoverFillOpacity
-			);
-		});
-		test('isStrokeOpacity with popover, should set opacity to 1 when mark is selected', () => {
-			const popover = createElement(ChartPopover);
-			const rule = getFillStrokeOpacity({ ...defaultBarProps, children: [popover] }, true);
-			expect(rule).toHaveLength(4);
-			expect(rule[2]).toEqual({ test: `bar0_selectedId && bar0_selectedId === datum.${MARK_ID}`, value: 1 });
+			expect(getBarOpacity({ ...defaultBarProps, children: [popover] })).toStrictEqual(defaultBarPopoverOpacity);
 		});
 	});
 
@@ -368,13 +356,13 @@ describe('barUtils', () => {
 
 		test('returns provided value / 2 + 2.5 when value is set and orientation is not vertical', () => {
 			expect(
-				getAnnotationPositionOffset({ ...defaultBarProps, orientation: 'horizontal' }, { value: 50 })
+				getAnnotationPositionOffset({ ...defaultBarProps, orientation: 'horizontal' }, { value: 50 }),
 			).toEqual('27.5');
 		});
 
 		test('returns the signal string wrapped with parens when signal is set and orientation is not vertical', () => {
 			expect(
-				getAnnotationPositionOffset({ ...defaultBarProps, orientation: 'horizontal' }, { signal: 'foo' })
+				getAnnotationPositionOffset({ ...defaultBarProps, orientation: 'horizontal' }, { signal: 'foo' }),
 			).toEqual('((foo) / 2 + 2.5)');
 		});
 	});
@@ -395,8 +383,8 @@ describe('barUtils', () => {
 			expect(
 				getAnnotationMetricAxisPosition(
 					{ ...defaultBarProps, orientation: 'horizontal' },
-					defaultAnnotationWidth
-				)
+					defaultAnnotationWidth,
+				),
 			).toStrictEqual([
 				{
 					test: `datum.${defaultBarProps.metric}1 < 0`,
@@ -407,7 +395,7 @@ describe('barUtils', () => {
 		});
 		test("stacked with seconday scale, should return '${value}1' field", () => {
 			expect(
-				getAnnotationMetricAxisPosition(defaultBarPropsWithSecondayColor, defaultAnnotationWidth)
+				getAnnotationMetricAxisPosition(defaultBarPropsWithSecondayColor, defaultAnnotationWidth),
 			).toStrictEqual([
 				{
 					signal: `max(scale('yLinear', datum.${defaultBarProps.metric}1), scale('yLinear', 0) + 13.5)`,
@@ -418,7 +406,7 @@ describe('barUtils', () => {
 		});
 		test("dodged without secondary scale, should return 'value' field", () => {
 			expect(
-				getAnnotationMetricAxisPosition({ ...defaultBarProps, type: 'dodged' }, defaultAnnotationWidth)
+				getAnnotationMetricAxisPosition({ ...defaultBarProps, type: 'dodged' }, defaultAnnotationWidth),
 			).toStrictEqual([
 				{
 					signal: `max(scale('yLinear', datum.${defaultBarProps.metric}), scale('yLinear', 0) + 13.5)`,
@@ -429,7 +417,7 @@ describe('barUtils', () => {
 		});
 		test("dodged with secondary scale, should return '${value}1' field", () => {
 			expect(
-				getAnnotationMetricAxisPosition(defaultBarPropsWithSecondayColor, defaultAnnotationWidth)
+				getAnnotationMetricAxisPosition(defaultBarPropsWithSecondayColor, defaultAnnotationWidth),
 			).toStrictEqual([
 				{
 					signal: `max(scale('yLinear', datum.${defaultBarProps.metric}1), scale('yLinear', 0) + 13.5)`,
@@ -452,8 +440,8 @@ describe('barUtils', () => {
 					{ ...defaultBarProps, children: annotationChildren },
 					FILTERED_TABLE,
 					stackedXScale,
-					defaultBarProps.dimension
-				)
+					defaultBarProps.dimension,
+				),
 			).toStrictEqual(stackedAnnotationMarks);
 		});
 		test('horizontal orientation should return xc and yc opposite of vertical orientation', () => {
@@ -467,12 +455,12 @@ describe('barUtils', () => {
 				band: 0.5,
 			});
 			expect(annotationMarks[0].encode?.enter?.xc).toStrictEqual(
-				getAnnotationMetricAxisPosition(props, { signal: annotationWidthSignal })
+				getAnnotationMetricAxisPosition(props, { signal: annotationWidthSignal }),
 			);
 
 			expect(annotationMarks[1].encode?.enter?.y).toStrictEqual({ scale: 'yBand', field: 'category', band: 0.5 });
 			expect(annotationMarks[1].encode?.enter?.x).toStrictEqual(
-				getAnnotationMetricAxisPosition(props, { signal: annotationWidthSignal })
+				getAnnotationMetricAxisPosition(props, { signal: annotationWidthSignal }),
 			);
 		});
 		test('defaultBarProps with secondary scale should return text marks when passed with Annotation', () => {
@@ -481,8 +469,8 @@ describe('barUtils', () => {
 					{ ...defaultBarPropsWithSecondayColor, children: annotationChildren },
 					FILTERED_TABLE,
 					stackedXScale,
-					defaultBarProps.dimension
-				)
+					defaultBarProps.dimension,
+				),
 			).toStrictEqual(stackedAnnotationMarks);
 		});
 		test('dodged should return text marks when passed with Annotation', () => {
@@ -491,8 +479,8 @@ describe('barUtils', () => {
 					{ ...defaultBarProps, type: 'dodged', children: annotationChildren },
 					`${defaultBarProps.name}_facet`,
 					dodgedXScale,
-					dodgedGroupField
-				)
+					dodgedGroupField,
+				),
 			).toStrictEqual(dodgedAnnotationMarks);
 		});
 		test('dodged with secondary series should return text marks when passed with Annotation', () => {
@@ -505,8 +493,8 @@ describe('barUtils', () => {
 					},
 					`${defaultBarProps.name}_facet`,
 					dodgedXScale,
-					dodgedGroupField
-				)
+					dodgedGroupField,
+				),
 			).toStrictEqual(dodgedSubSeriesAnnotationMarks);
 		});
 
@@ -516,8 +504,8 @@ describe('barUtils', () => {
 					{ ...defaultBarProps, children: annotationChildrenWithStyles },
 					FILTERED_TABLE,
 					stackedXScale,
-					defaultBarProps.dimension
-				)
+					defaultBarProps.dimension,
+				),
 			).toStrictEqual(stackedAnnotationMarksWithStyles);
 		});
 		test('defaultBarProps with secondary scale returns fixed width annotation background when Annotation has style.width', () => {
@@ -526,8 +514,8 @@ describe('barUtils', () => {
 					{ ...defaultBarPropsWithSecondayColor, children: annotationChildrenWithStyles },
 					FILTERED_TABLE,
 					stackedXScale,
-					defaultBarProps.dimension
-				)
+					defaultBarProps.dimension,
+				),
 			).toStrictEqual(stackedAnnotationMarksWithStyles);
 		});
 		test('dodged should returns fixed width annotation background when Annotation has style.width', () => {
@@ -536,8 +524,8 @@ describe('barUtils', () => {
 					{ ...defaultBarProps, type: 'dodged', children: annotationChildrenWithStyles },
 					`${defaultBarProps.name}_facet`,
 					dodgedXScale,
-					`${defaultBarProps.name}_dodgeGroup`
-				)
+					`${defaultBarProps.name}_dodgeGroup`,
+				),
 			).toStrictEqual(dodgedAnnotationMarksWithStyles);
 		});
 	});

--- a/src/specBuilder/bar/dodgedBarUtils.test.ts
+++ b/src/specBuilder/bar/dodgedBarUtils.test.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
 	HIGHLIGHT_CONTRAST_RATIO,
@@ -87,15 +88,15 @@ const defaultMark: Mark = {
 		enter: {
 			...defaultDodgedYEncodings,
 			...defaultDodgedCornerRadiusEncodings,
-			tooltip: undefined,
 			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fillOpacity: DEFAULT_OPACITY_RULE,
+			tooltip: undefined,
 		},
 		update: {
 			...defaultDodgedXEncodings,
 			...defaultBarStrokeEncodings,
-			fillOpacity: [{ value: 1 }],
-			strokeOpacity: [{ value: 1 }],
 			cursor: undefined,
+			opacity: [DEFAULT_OPACITY_RULE],
 		},
 	},
 };
@@ -109,19 +110,16 @@ const defaultMarkWithTooltip: Mark = {
 		enter: {
 			...defaultDodgedYEncodings,
 			...defaultDodgedCornerRadiusEncodings,
-			tooltip: { signal: "merge(datum, {'rscComponentName': 'bar0'})" },
 			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fillOpacity: DEFAULT_OPACITY_RULE,
+			tooltip: { signal: "merge(datum, {'rscComponentName': 'bar0'})" },
 		},
 		update: {
 			...defaultDodgedXEncodings,
 			...defaultBarStrokeEncodings,
-			fillOpacity: [
+			opacity: [
 				{ test: `bar0_hoveredId && bar0_hoveredId !== datum.${MARK_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-				{ value: 1 },
-			],
-			strokeOpacity: [
-				{ test: `bar0_hoveredId && bar0_hoveredId !== datum.${MARK_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-				{ value: 1 },
+				DEFAULT_OPACITY_RULE,
 			],
 			cursor: undefined,
 		},
@@ -153,20 +151,20 @@ const defaultDodgedStackedMark: Mark = {
 			fill: {
 				signal: `scale('colors', datum.${DEFAULT_COLOR})[indexof(domain('secondaryColor'), datum.${DEFAULT_SECONDARY_COLOR})% length(scale('colors', datum.${DEFAULT_COLOR}))]`,
 			},
+			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},
 		update: {
 			...defaultDodgedXEncodings,
-			fillOpacity: [{ value: 1 }],
+			cursor: undefined,
+			opacity: [DEFAULT_OPACITY_RULE],
 			stroke: [
 				{
 					signal: `scale('colors', datum.${DEFAULT_COLOR})[indexof(domain('secondaryColor'), datum.${DEFAULT_SECONDARY_COLOR})% length(scale('colors', datum.${DEFAULT_COLOR}))]`,
 				},
 			],
 			strokeDash: [{ value: [] }],
-			strokeOpacity: [{ value: 1 }],
 			strokeWidth: [{ value: 0 }],
-			cursor: undefined,
 		},
 	},
 };
@@ -205,7 +203,7 @@ describe('dodgedBarUtils', () => {
 				getDodgedMark({
 					...defaultDodgedProps,
 					children: [...defaultDodgedProps.children, annotationElement],
-				})
+				}),
 			).toStrictEqual(annotationDodgedMarks);
 		});
 		test('should add tooltip keys if ChartTooltip exists as child', () => {
@@ -218,7 +216,7 @@ describe('dodgedBarUtils', () => {
 	describe('getDodgedMark()', () => {
 		test('subseries, should include advanced fill, advanced corner radius, and border strokes,', () => {
 			expect(
-				getDodgedMark({ ...defaultDodgedProps, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })
+				getDodgedMark({ ...defaultDodgedProps, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] }),
 			).toStrictEqual({
 				...defaultDodgedMark,
 				marks: [defaultDodgedStackedBackgroundMark, defaultDodgedStackedMark],

--- a/src/specBuilder/bar/stackedBarUtils.test.ts
+++ b/src/specBuilder/bar/stackedBarUtils.test.ts
@@ -16,6 +16,7 @@ import {
 	BACKGROUND_COLOR,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
 } from '@constants';
@@ -23,7 +24,6 @@ import { GroupMark, Mark, RectEncodeEntry } from 'vega';
 
 import {
 	defaultBarEnterEncodings,
-	defaultBarFillOpacity,
 	defaultBarProps,
 	defaultBarStrokeEncodings,
 	stackedAnnotationMarks,
@@ -54,12 +54,12 @@ const defaultMark = {
 		enter: {
 			...defaultBarEnterEncodings,
 			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},
 		update: {
 			cursor: undefined,
-			fillOpacity: defaultBarFillOpacity,
-			strokeOpacity: defaultBarFillOpacity,
+			opacity: [DEFAULT_OPACITY_RULE],
 			...defaultStackedBarXEncondings,
 			...defaultBarStrokeEncodings,
 		},
@@ -81,7 +81,7 @@ describe('stackedBarUtils', () => {
 				getStackedBarMarks({
 					...defaultBarProps,
 					children: [...defaultBarProps.children, annotationElement],
-				})
+				}),
 			).toStrictEqual([defaultBackgroundMark, defaultMark, ...stackedAnnotationMarks]);
 		});
 	});
@@ -164,7 +164,7 @@ describe('stackedBarUtils', () => {
 				getStackedDimensionEncodings({
 					...defaultBarProps,
 					color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR],
-				})
+				}),
 			).toStrictEqual({
 				width: { band: 1, scale: 'bar0_position' },
 				x: { field: 'bar0_dodgeGroup', scale: 'bar0_position' },

--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
+import { DEFAULT_COLOR, DEFAULT_OPACITY_RULE, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
 import { Mark } from 'vega';
 
 import { getHighlightOpacityRule, getOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
@@ -21,10 +21,7 @@ const defaultGroupMark: Mark = {
 };
 
 const defaultOpacityEncoding = {
-	fillOpacity: [
-		{ test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-	],
-	strokeOpacity: [
+	opacity: [
 		{ test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
 	],
 };
@@ -92,21 +89,21 @@ describe('setHoverOpacityForMarks()', () => {
 		});
 	});
 	describe('bar mark initial state', () => {
-		test('encoding should be added for fillOpacity and strokOpacity', () => {
+		test('encoding should be added for opacity', () => {
 			const marks = JSON.parse(JSON.stringify([defaultMark]));
 			setHoverOpacityForMarks(marks);
 			expect(marks).toStrictEqual([
 				{ ...defaultMark, encode: { ...defaultMark.encode, update: defaultOpacityEncoding } },
 			]);
 		});
-		test('fillOpacity encoding already exists, rules should be added in the correct spot', () => {
+		test('opacity encoding already exists, rules should be added in the correct spot', () => {
 			const marks = JSON.parse(
 				JSON.stringify([
 					{
 						...defaultMark,
-						encode: { ...defaultMark.encode, update: { strokeOpacity: [], fillOpacity: [{ value: 1 }] } },
+						encode: { ...defaultMark.encode, update: { opacity: [DEFAULT_OPACITY_RULE] } },
 					},
-				])
+				]),
 			);
 			setHoverOpacityForMarks(marks);
 			expect(marks).toStrictEqual([
@@ -116,7 +113,7 @@ describe('setHoverOpacityForMarks()', () => {
 						...defaultMark.encode,
 						update: {
 							...defaultOpacityEncoding,
-							fillOpacity: [...defaultOpacityEncoding.fillOpacity, { value: 1 }],
+							opacity: [...defaultOpacityEncoding.opacity, DEFAULT_OPACITY_RULE],
 						},
 					},
 				},
@@ -124,7 +121,7 @@ describe('setHoverOpacityForMarks()', () => {
 		});
 	});
 	describe('group mark initial state', () => {
-		test('encoding should be added for fillOpacity and strokOpacity', () => {
+		test('encoding should be added for opacity', () => {
 			const marks = JSON.parse(JSON.stringify([defaultGroupMark]));
 			setHoverOpacityForMarks(marks);
 			expect(marks).toStrictEqual([

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -39,7 +39,7 @@ export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: s
 			if (!Array.isArray(update.opacity)) {
 				update.opacity = [];
 			}
-			// // need to insert the new test in the second to last slot
+			// need to insert the new test in the second to last slot
 			const opacityRuleInsertIndex = Math.max(update.opacity.length - 1, 0);
 			update.opacity.splice(opacityRuleInsertIndex, 0, highlightOpacityRule);
 		}

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -28,39 +28,26 @@ export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: s
 			mark.encode.update = {};
 		}
 		const { update } = mark.encode;
-		const { fillOpacity, strokeOpacity } = update;
+		const { opacity } = update;
 
-		if ('fillOpacity' in update) {
+		if (opacity !== undefined) {
 			// the production rule that sets the fill opacity for this mark
-			const fillOpacityRule = getOpacityRule(fillOpacity);
+			const opacityRule = getOpacityRule(opacity);
 			// the new production rule for highlighting
-			const highlightFillOpacityRule = getHighlightOpacityRule(fillOpacityRule, keys, name);
+			const highlightOpacityRule = getHighlightOpacityRule(opacityRule, keys, name);
 
-			if (!Array.isArray(update.fillOpacity)) {
-				update.fillOpacity = [];
+			if (!Array.isArray(update.opacity)) {
+				update.opacity = [];
 			}
 			// // need to insert the new test in the second to last slot
-			const fillRuleInsertIndex = Math.max(update.fillOpacity.length - 1, 0);
-			update.fillOpacity.splice(fillRuleInsertIndex, 0, highlightFillOpacityRule);
-		}
-
-		if ('strokeOpacity' in update) {
-			// the production rule that sets the stroke opacity for this mark
-			const strokeOpacityRule = getOpacityRule(strokeOpacity);
-			// the new production rule for highlighting
-			const highlightStrokeOpacityRule = getHighlightOpacityRule(strokeOpacityRule, keys, name);
-			if (!Array.isArray(update.strokeOpacity)) {
-				update.strokeOpacity = [];
-			}
-			// // need to insert the new test in the second to last slot
-			const strokeRuleInsertIndex = Math.max(update.strokeOpacity.length - 1, 0);
-			update.strokeOpacity.splice(strokeRuleInsertIndex, 0, highlightStrokeOpacityRule);
+			const opacityRuleInsertIndex = Math.max(update.opacity.length - 1, 0);
+			update.opacity.splice(opacityRuleInsertIndex, 0, highlightOpacityRule);
 		}
 	});
 };
 
 export const getOpacityRule = (
-	opacityRule: ProductionRule<NumericValueRef> | undefined
+	opacityRule: ProductionRule<NumericValueRef> | undefined,
 ): ProductionRule<NumericValueRef> => {
 	if (opacityRule) {
 		// if it's an array and length > 0, get the last value
@@ -78,7 +65,7 @@ export const getOpacityRule = (
 export const getHighlightOpacityRule = (
 	opacityRule: ProductionRule<NumericValueRef>,
 	keys?: string[],
-	name?: string
+	name?: string,
 ): { test?: string } & NumericValueRef => {
 	let test = `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`;
 	if (keys) {

--- a/src/specBuilder/legend/legendSpecBuilder.test.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.test.ts
@@ -56,8 +56,8 @@ const defaultTooltipLegendEncoding: LegendEncode = {
 		enter: { tooltip: { signal: "merge(datum, {'rscComponentName': 'legend0'})" } },
 		update: { fill: { value: 'transparent' } },
 	},
-	labels: { update: { ...hiddenSeriesLabelUpdateEncoding, fillOpacity: undefined } },
-	symbols: { update: { ...defaultSymbolUpdateEncodings, fillOpacity: undefined, strokeOpacity: undefined } },
+	labels: { update: { ...hiddenSeriesLabelUpdateEncoding, opacity: undefined } },
+	symbols: { enter: {}, update: { ...defaultSymbolUpdateEncodings, opacity: undefined } },
 };
 
 const defaultHighlightLegendEncoding: LegendEncode = {
@@ -67,12 +67,12 @@ const defaultHighlightLegendEncoding: LegendEncode = {
 		enter: { tooltip: undefined },
 		update: { fill: { value: 'transparent' } },
 	},
-	labels: { update: { ...hiddenSeriesLabelUpdateEncoding, fillOpacity: opacityEncoding } },
+	labels: { update: { ...hiddenSeriesLabelUpdateEncoding, opacity: opacityEncoding } },
 	symbols: {
+		enter: {},
 		update: {
 			...defaultSymbolUpdateEncodings,
-			fillOpacity: opacityEncoding,
-			strokeOpacity: opacityEncoding,
+			opacity: opacityEncoding,
 		},
 	},
 };
@@ -82,7 +82,7 @@ const defaultLegend: Legend = {
 	encode: {
 		entries: { name: 'legend0_legendEntry' },
 		labels: { update: { ...hiddenSeriesLabelUpdateEncoding } },
-		symbols: { update: { ...defaultSymbolUpdateEncodings } },
+		symbols: { enter: {}, update: { ...defaultSymbolUpdateEncodings } },
 	},
 	fill: 'legend0Entries',
 	labelLimit: undefined,
@@ -126,7 +126,7 @@ describe('addLegend()', () => {
 
 		test('descriptions, should add encoding', () => {
 			expect(
-				addLegend(defaultSpec, { descriptions: [{ seriesName: 'test', description: 'test' }] })
+				addLegend(defaultSpec, { descriptions: [{ seriesName: 'test', description: 'test' }] }),
 			).toStrictEqual({
 				...defaultSpec,
 				data: [defaultLegendAggregateData],
@@ -162,7 +162,7 @@ describe('addLegend()', () => {
 						{ seriesName: 1, label: 'Any event' },
 						{ seriesName: 2, label: 'Any event' },
 					],
-				}).legends?.[0].encode
+				}).legends?.[0].encode,
 			).toStrictEqual({
 				entries: {
 					name: 'legend0_legendEntry',
@@ -181,7 +181,7 @@ describe('addLegend()', () => {
 						],
 					},
 				},
-				symbols: { update: { ...defaultSymbolUpdateEncodings } },
+				symbols: { enter: {}, update: { ...defaultSymbolUpdateEncodings } },
 			});
 		});
 
@@ -193,7 +193,7 @@ describe('addLegend()', () => {
 						{ seriesName: 1, label: 'Any event' },
 						{ seriesName: 2, label: 'Any event' },
 					],
-				}).legends?.[0].encode
+				}).legends?.[0].encode,
 			).toStrictEqual({
 				...defaultHighlightLegendEncoding,
 				labels: {
@@ -220,7 +220,7 @@ describe('addLegend()', () => {
 						{ seriesName: 1, label: 'Any event' },
 						{ seriesName: 2, label: 'Any event' },
 					],
-				}).signals
+				}).signals,
 			).toStrictEqual([
 				{
 					name: 'legendLabels',
@@ -249,7 +249,7 @@ describe('addLegend()', () => {
 		test('should add fields to scales if they have not been added', () => {
 			const legendSpec = addLegend(
 				{ ...defaultSpec, scales: [{ name: 'color', type: 'ordinal' }] },
-				{ color: 'series' }
+				{ color: 'series' },
 			);
 			expect(legendSpec.scales).toEqual([
 				{
@@ -302,7 +302,7 @@ describe('formatFacetRefsWithPresets()', () => {
 				{ value: 'dotDash' },
 				{ value: 'XL' },
 				{ value: 'wedge' },
-				DEFAULT_COLOR_SCHEME
+				DEFAULT_COLOR_SCHEME,
 			);
 		expect(formattedColor).toStrictEqual({ value: 'rgb(255, 155, 136)' });
 		expect(formattedLineType).toStrictEqual({ value: [2, 3, 7, 4] });
@@ -326,7 +326,7 @@ describe('formatFacetRefsWithPresets()', () => {
 				{ value: [3, 4, 5, 6] },
 				{ value: 10 },
 				{ value: svgPath },
-				DEFAULT_COLOR_SCHEME
+				DEFAULT_COLOR_SCHEME,
 			);
 		expect(formattedColor).toStrictEqual({ value: 'rgb(50, 50, 50)' });
 		expect(formattedLineType).toStrictEqual({ value: [3, 4, 5, 6] });
@@ -339,20 +339,22 @@ describe('addSignals()', () => {
 	test('should add highlightedSeries signal if highlight is true', () => {
 		expect(
 			addSignals([], { ...defaultLegendProps, highlight: true }).find(
-				(signal) => signal.name === 'highlightedSeries'
-			)
+				(signal) => signal.name === 'highlightedSeries',
+			),
 		).toBeDefined();
 	});
 	test('should add legendLabels signal if legendLabels are defined', () => {
 		expect(
-			addSignals([], { ...defaultLegendProps, legendLabels: [] }).find((signal) => signal.name === 'legendLabels')
+			addSignals([], { ...defaultLegendProps, legendLabels: [] }).find(
+				(signal) => signal.name === 'legendLabels',
+			),
 		).toBeDefined();
 	});
 	test('should NOT add hiddenSeries signal if isToggleable is false', () => {
 		expect(
 			addSignals([], { ...defaultLegendProps, isToggleable: false }).find(
-				(signal) => signal.name === 'hiddenSeries'
-			)
+				(signal) => signal.name === 'hiddenSeries',
+			),
 		).toBeUndefined();
 	});
 });

--- a/src/specBuilder/legend/legendTestUtils.ts
+++ b/src/specBuilder/legend/legendTestUtils.ts
@@ -13,6 +13,7 @@ import {
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
 	HIGHLIGHT_CONTRAST_RATIO,
 	LEGEND_TOOLTIP_DELAY,
@@ -39,7 +40,7 @@ export const cleanupTooltips = () => {
 
 export const opacityEncoding = [
 	{ test: 'highlightedSeries && datum.value !== highlightedSeries', value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-	{ value: 1 },
+	DEFAULT_OPACITY_RULE,
 ];
 
 export const defaultMark: LineMark = {
@@ -55,8 +56,7 @@ export const defaultMark: LineMark = {
 			stroke: { scale: 'color', field: DEFAULT_COLOR },
 		},
 		update: {
-			strokeOpacity: [],
-			fillOpacity: [],
+			opacity: [],
 		},
 	},
 };

--- a/src/specBuilder/legend/legendUtils.test.ts
+++ b/src/specBuilder/legend/legendUtils.test.ts
@@ -9,25 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, HIGHLIGHT_CONTRAST_RATIO } from '@constants';
+import { DEFAULT_COLOR_SCHEME } from '@constants';
 import { spectrumColors } from '@themes';
 
-import { defaultLegendProps, opacityEncoding } from './legendTestUtils';
-import {
-	getShowHideEncodings,
-	getSymbolEncodings,
-	getSymbolOpacityEncoding,
-	getSymbolType,
-	mergeLegendEncodings,
-} from './legendUtils';
-
-const defaultOpacitySignalEncoding = [
-	{
-		test: 'highlightedSeries && datum.value !== highlightedSeries',
-		signal: `scale('opacity', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR}) / 5`,
-	},
-	{ signal: `scale('opacity', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR})` },
-];
+import { defaultLegendProps } from './legendTestUtils';
+import { getShowHideEncodings, getSymbolEncodings, getSymbolType, mergeLegendEncodings } from './legendUtils';
 
 const hiddenSeriesEncoding = {
 	test: 'indexof(hiddenSeries, datum.value) !== -1',
@@ -48,48 +34,6 @@ const hiddenSeriesLabelUpdateEncoding = {
 	},
 };
 
-describe('getSymbolOpacityEncoding()', () => {
-	test('should return undefined if highlight is false', () => {
-		expect(getSymbolOpacityEncoding([], defaultLegendProps)).toBeUndefined();
-	});
-
-	test('should return default highlight encoding if opacity and facets are undefined', () => {
-		expect(getSymbolOpacityEncoding([], { ...defaultLegendProps, highlight: true })).toStrictEqual(opacityEncoding);
-	});
-
-	test('should return signal-based encoding if facets includes opacity facet when opacity id undefined', () => {
-		expect(
-			getSymbolOpacityEncoding([{ facetType: 'opacity', field: DEFAULT_COLOR }], {
-				...defaultLegendProps,
-				highlight: true,
-			})
-		).toStrictEqual(defaultOpacitySignalEncoding);
-	});
-
-	test('should return value-based encoding if opacity exists and is a static value', () => {
-		const opacity = 0.5;
-		expect(
-			getSymbolOpacityEncoding([], { ...defaultLegendProps, highlight: true, opacity: { value: opacity } })
-		).toStrictEqual([
-			{
-				test: 'highlightedSeries && datum.value !== highlightedSeries',
-				value: opacity / HIGHLIGHT_CONTRAST_RATIO,
-			},
-			{ value: opacity },
-		]);
-	});
-
-	test('should return signal based highlight encodings if opacity is a signal ref', () => {
-		expect(
-			getSymbolOpacityEncoding([{ facetType: 'opacity', field: 'testing' }], {
-				...defaultLegendProps,
-				highlight: true,
-				opacity: DEFAULT_COLOR,
-			})
-		).toStrictEqual(defaultOpacitySignalEncoding);
-	});
-});
-
 describe('getSymbolEncodings()', () => {
 	test('no factes and no custom values, should return all the defaults', () => {
 		expect(
@@ -102,10 +46,11 @@ describe('getSymbolEncodings()', () => {
 				isToggleable: false,
 				name: 'legend0',
 				position: 'bottom',
-			})
+			}),
 		).toStrictEqual({
 			entries: { name: 'legend0_legendEntry' },
 			symbols: {
+				enter: {},
 				update: {
 					fill: [hiddenSeriesEncoding, { value: spectrumColors.light['categorical-100'] }],
 					stroke: [hiddenSeriesEncoding, { value: spectrumColors.light['categorical-100'] }],
@@ -122,7 +67,7 @@ describe('getShowHideEncodings()', () => {
 				...defaultLegendProps,
 				isToggleable: false,
 				onClick: undefined,
-			})
+			}),
 		).toEqual({ labels: hiddenSeriesLabelUpdateEncoding });
 	});
 	test('should return encodings if isToggleable', () => {
@@ -150,7 +95,7 @@ describe('mergeLegendEncodings()', () => {
 				{ entries: { name: 'legendEntry' } },
 				{ entries: { name: 'legendEntry2' } },
 				{ entries: { name: 'legendEntry3' } },
-			])
+			]),
 		).toStrictEqual({ entries: { name: 'legendEntry3' } });
 	});
 
@@ -160,7 +105,7 @@ describe('mergeLegendEncodings()', () => {
 				{ entries: { name: 'legendEntry' } },
 				{ labels: { name: 'legendLabel' } },
 				{ title: { name: 'legendTitle' } },
-			])
+			]),
 		).toStrictEqual({
 			entries: { name: 'legendEntry' },
 			labels: { name: 'legendLabel' },
@@ -178,7 +123,7 @@ describe('mergeLegendEncodings()', () => {
 					},
 				},
 				{ entries: { name: 'legendEntry', interactive: true, enter: { cursor: { value: 'pointer' } } } },
-			])
+			]),
 		).toStrictEqual({
 			entries: {
 				name: 'legendEntry',

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -174,35 +174,6 @@ export const getOpacityEncoding = ({
 	return undefined;
 };
 
-// /**
-//  * Gets the fill opacity encoding for the legend symbols.
-//  * Highlight encoding is handled separately using `opacity` on update
-//  * @param highlight
-//  * @param opacity
-//  * @param facets
-//  * @returns
-//  */
-// export const getSymbolFillOpacityEncoding = (
-// 	facets: Facet[],
-// 	{ highlight, highlightedSeries, name, opacity }: LegendSpecProps,
-// ): ProductionRule<NumericValueRef> | undefined => {
-// 	// only add symbol opacity if highlight is true or highlightedSeries is defined
-// 	if (highlight || highlightedSeries) {
-// 		if (facets || opacity) {
-// 			return (
-// 				getSymbolFacetEncoding<number>({
-// 					facets,
-// 					facetType: 'opacity',
-// 					customValue: opacity,
-// 					name,
-// 				}) ?? DEFAULT_OPACITY_RULE
-// 			);
-// 		}
-// 		return DEFAULT_OPACITY_RULE;
-// 	}
-// 	return undefined;
-// };
-
 export const getSymbolEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncode => {
 	const { color, lineType, lineWidth, name, opacity, symbolShape, colorScheme } = props;
 	const enter: SymbolEncodeEntry = {

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
+import { DEFAULT_OPACITY_RULE, HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import { getColorValue, getPathFromSymbolShape } from '@specBuilder/specUtils';
 import { spectrumColors } from '@themes';
 import merge from 'deepmerge';
@@ -27,6 +27,7 @@ import {
 	Color,
 	ColorValueRef,
 	FilterTransform,
+	GuideEncodeEntry,
 	LegendEncode,
 	NumericValueRef,
 	ProductionRule,
@@ -117,13 +118,12 @@ const getHoverEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncod
 			},
 			labels: {
 				update: {
-					fillOpacity: getOpacityEncoding(props),
+					opacity: getOpacityEncoding(props),
 				},
 			},
 			symbols: {
 				update: {
-					fillOpacity: getSymbolOpacityEncoding(facets, props),
-					strokeOpacity: getOpacityEncoding(props),
+					opacity: getOpacityEncoding(props),
 				},
 			},
 		};
@@ -163,97 +163,76 @@ export const getOpacityEncoding = ({
 	const highlightSignalName = keys ? `${name}_highlight` : 'highlightedSeries';
 	// only add symbol opacity if highlight is true or highlightedSeries is defined
 	if (highlight || highlightedSeries) {
-		return getHighlightOpacityEncoding({ value: 1 / HIGHLIGHT_CONTRAST_RATIO }, { value: 1 }, highlightSignalName);
+		return [
+			{
+				test: `${highlightSignalName} && datum.value !== ${highlightSignalName}`,
+				value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+			},
+			DEFAULT_OPACITY_RULE,
+		];
 	}
 	return undefined;
 };
 
-/**
- * Combines the opacity facet encodings with the highlight behavior which halves the opacity of non-highlighted legend entries
- * @param highlight
- * @param opacity
- * @param facets
- * @returns
- */
-export const getSymbolOpacityEncoding = (
-	facets: Facet[],
-	{ highlight, highlightedSeries, keys, name, opacity }: LegendSpecProps
-): ProductionRule<NumericValueRef> | undefined => {
-	const highlightSignalName = keys ? `${name}_highlight` : 'highlightedSeries';
-	// only add symbol opacity if highlight is true or highlightedSeries is defined
-	if (highlight || highlightedSeries) {
-		if (facets || opacity) {
-			const opacityEncoding = getSymbolFacetEncoding<number>({
-				facets,
-				facetType: 'opacity',
-				customValue: opacity,
-				name,
-			}) ?? { value: 1 };
-			if ('signal' in opacityEncoding) {
-				return getHighlightOpacityEncoding(
-					{ signal: opacityEncoding.signal + ` / ${HIGHLIGHT_CONTRAST_RATIO}` },
-					opacityEncoding,
-					highlightSignalName
-				);
-			}
-			if ('value' in opacityEncoding && typeof opacityEncoding.value === 'number') {
-				return getHighlightOpacityEncoding(
-					{ value: opacityEncoding.value / HIGHLIGHT_CONTRAST_RATIO },
-					opacityEncoding,
-					highlightSignalName
-				);
-			}
-		}
-		return getHighlightOpacityEncoding({ value: 1 / HIGHLIGHT_CONTRAST_RATIO }, { value: 1 }, highlightSignalName);
-	}
-	return undefined;
-};
-
-const getHighlightOpacityEncoding = (
-	highlightOpacity: BaseValueRef<number>,
-	defaultOpacity: BaseValueRef<number>,
-	highlightSignalName: string
-): ProductionRule<NumericValueRef> => {
-	return [
-		{
-			test: `${highlightSignalName} && datum.value !== ${highlightSignalName}`,
-			...highlightOpacity,
-		},
-		defaultOpacity,
-	];
-};
+// /**
+//  * Gets the fill opacity encoding for the legend symbols.
+//  * Highlight encoding is handled separately using `opacity` on update
+//  * @param highlight
+//  * @param opacity
+//  * @param facets
+//  * @returns
+//  */
+// export const getSymbolFillOpacityEncoding = (
+// 	facets: Facet[],
+// 	{ highlight, highlightedSeries, name, opacity }: LegendSpecProps,
+// ): ProductionRule<NumericValueRef> | undefined => {
+// 	// only add symbol opacity if highlight is true or highlightedSeries is defined
+// 	if (highlight || highlightedSeries) {
+// 		if (facets || opacity) {
+// 			return (
+// 				getSymbolFacetEncoding<number>({
+// 					facets,
+// 					facetType: 'opacity',
+// 					customValue: opacity,
+// 					name,
+// 				}) ?? DEFAULT_OPACITY_RULE
+// 			);
+// 		}
+// 		return DEFAULT_OPACITY_RULE;
+// 	}
+// 	return undefined;
+// };
 
 export const getSymbolEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncode => {
 	const { color, lineType, lineWidth, name, opacity, symbolShape, colorScheme } = props;
-	let update: SymbolEncodeEntry = {
+	const enter: SymbolEncodeEntry = {
+		fillOpacity: getSymbolFacetEncoding<number>({ facets, facetType: 'opacity', customValue: opacity, name }),
+		shape: getSymbolFacetEncoding<string>({ facets, facetType: 'symbolShape', customValue: symbolShape, name }),
+		size: getSymbolFacetEncoding<number>({ facets, facetType: 'symbolSize', name }),
+		strokeDash: getSymbolFacetEncoding<number[]>({ facets, facetType: 'lineType', customValue: lineType, name }),
+		strokeWidth: getSymbolFacetEncoding<number>({ facets, facetType: 'lineWidth', customValue: lineWidth, name }),
+	};
+	const update: SymbolEncodeEntry = {
 		fill: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
 			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],
-		fillOpacity: getSymbolFacetEncoding<number>({ facets, facetType: 'opacity', customValue: opacity, name }),
-		size: getSymbolFacetEncoding<number>({ facets, facetType: 'symbolSize', name }),
 		stroke: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
 			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],
-		strokeDash: getSymbolFacetEncoding<number[]>({ facets, facetType: 'lineType', customValue: lineType, name }),
-		strokeOpacity: getSymbolFacetEncoding<number>({ facets, facetType: 'opacity', name }),
-		strokeWidth: getSymbolFacetEncoding<number>({ facets, facetType: 'lineWidth', customValue: lineWidth, name }),
-		shape: getSymbolFacetEncoding<string>({ facets, facetType: 'symbolShape', customValue: symbolShape, name }),
 	};
 	// Remove undefined values
-	update = JSON.parse(JSON.stringify(update));
+	const symbols: GuideEncodeEntry<SymbolEncodeEntry> = JSON.parse(JSON.stringify({ enter, update }));
 	return {
 		entries: {
 			name: `${name}_legendEntry`,
 		},
-		symbols: {
-			update,
-		},
+		symbols,
 	};
 };
 
@@ -301,7 +280,7 @@ const getSymbolFacetEncoding = <T>({
 
 export const getHiddenSeriesColorRule = (
 	{ colorScheme, hiddenSeries, isToggleable, keys }: LegendSpecProps,
-	colorValue: ColorValueV6
+	colorValue: ColorValueV6,
 ): ({
 	test?: string;
 } & ColorValueRef)[] => {

--- a/src/specBuilder/line/lineMarkUtils.test.ts
+++ b/src/specBuilder/line/lineMarkUtils.test.ts
@@ -13,9 +13,9 @@ import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
-import { DEFAULT_TRANSFORMED_TIME_DIMENSION, SERIES_ID } from '@constants';
+import { DEFAULT_OPACITY_RULE, DEFAULT_TRANSFORMED_TIME_DIMENSION, SERIES_ID } from '@constants';
 
-import { getLineHoverMarks, getLineMark, getLineStrokeOpacity } from './lineMarkUtils';
+import { getLineHoverMarks, getLineMark, getLineOpacity } from './lineMarkUtils';
 import { defaultLineMarkProps } from './lineTestUtils';
 
 describe('getLineMark()', () => {
@@ -30,12 +30,13 @@ describe('getLineMark()', () => {
 				enter: {
 					stroke: { field: 'series', scale: 'color' },
 					strokeDash: { value: [] },
+					strokeOpacity: DEFAULT_OPACITY_RULE,
 					strokeWidth: { value: 1 },
 					y: { field: 'value', scale: 'yLinear' },
 				},
 				update: {
 					x: { field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' },
-					strokeOpacity: [{ value: 1 }],
+					opacity: [DEFAULT_OPACITY_RULE],
 				},
 			},
 		});
@@ -49,9 +50,9 @@ describe('getLineMark()', () => {
 	test('adds metric range opacity rules if isMetricRange and displayOnHover', () => {
 		const lineMark = getLineMark(
 			{ ...defaultLineMarkProps, interactiveMarkName: 'line0', displayOnHover: true },
-			'line0_facet'
+			'line0_facet',
 		);
-		expect(lineMark.encode?.update?.strokeOpacity).toEqual([
+		expect(lineMark.encode?.update?.opacity).toEqual([
 			{
 				test: `line0_hoveredSeries && line0_hoveredSeries !== datum.${SERIES_ID}`,
 				value: 0,
@@ -71,7 +72,7 @@ describe('getLineMark()', () => {
 
 	test('does not add metric range opacity rules if displayOnHover is false and isMetricRange', () => {
 		const lineMark = getLineMark({ ...defaultLineMarkProps, displayOnHover: false }, 'line0_facet');
-		expect(lineMark.encode?.update?.strokeOpacity).toEqual([{ value: 1 }]);
+		expect(lineMark.encode?.update?.opacity).toEqual([{ value: 1 }]);
 	});
 });
 
@@ -81,14 +82,14 @@ describe('getLineHoverMarks()', () => {
 	});
 });
 
-describe('getLineStrokeOpacity()', () => {
+describe('getLineOpacity()', () => {
 	test('should return a basic opacity rule when using default line props', () => {
-		const opacityRule = getLineStrokeOpacity(defaultLineMarkProps);
+		const opacityRule = getLineOpacity(defaultLineMarkProps);
 		expect(opacityRule).toEqual([{ value: 1 }]);
 	});
 
 	test('should include hover rules if line has a tooltip', () => {
-		const opacityRule = getLineStrokeOpacity({
+		const opacityRule = getLineOpacity({
 			...defaultLineMarkProps,
 			interactiveMarkName: 'line0',
 			children: [createElement(ChartTooltip)],
@@ -100,7 +101,7 @@ describe('getLineStrokeOpacity()', () => {
 	});
 
 	test('should include select rules if line has a popover', () => {
-		const opacityRule = getLineStrokeOpacity({
+		const opacityRule = getLineOpacity({
 			...defaultLineMarkProps,
 			interactiveMarkName: 'line0',
 			popoverMarkName: 'line0',
@@ -114,7 +115,7 @@ describe('getLineStrokeOpacity()', () => {
 	});
 
 	test('should include displayOnHover rules if displayOnHover is true', () => {
-		const opacityRule = getLineStrokeOpacity({
+		const opacityRule = getLineOpacity({
 			...defaultLineMarkProps,
 			interactiveMarkName: 'line0',
 			displayOnHover: true,

--- a/src/specBuilder/line/lineMarkUtils.ts
+++ b/src/specBuilder/line/lineMarkUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { SERIES_ID } from '@constants';
+import { DEFAULT_OPACITY_RULE, SERIES_ID } from '@constants';
 import {
 	getColorProductionRule,
 	getHighlightOpacityValue,
@@ -38,7 +38,7 @@ import { LineMarkProps } from './lineUtils';
  * @returns LineMark
  */
 export const getLineMark = (lineMarkProps: LineMarkProps, dataSource: string): LineMark => {
-	const { name, color, metric, dimension, scaleType, lineType, lineWidth, colorScheme } = lineMarkProps;
+	const { color, colorScheme, dimension, lineType, lineWidth, metric, name, opacity, scaleType } = lineMarkProps;
 
 	return {
 		name,
@@ -50,25 +50,26 @@ export const getLineMark = (lineMarkProps: LineMarkProps, dataSource: string): L
 				y: { scale: 'yLinear', field: metric },
 				stroke: getColorProductionRule(color, colorScheme),
 				strokeDash: getStrokeDashProductionRule(lineType),
+				strokeOpacity: getOpacityProductionRule(opacity),
 				strokeWidth: getLineWidthProductionRule(lineWidth),
 			},
 			update: {
 				// this has to be in update because when you resize the window that doesn't rebuild the spec
 				// but it may change the x position if it causes the chart to resize
 				x: getXProductionRule(scaleType, dimension),
-				strokeOpacity: getLineStrokeOpacity(lineMarkProps),
+				opacity: getLineOpacity(lineMarkProps),
 			},
 		},
 	};
 };
 
-export const getLineStrokeOpacity = ({
+export const getLineOpacity = ({
 	displayOnHover,
 	interactiveMarkName,
 	opacity,
 	popoverMarkName,
 }: LineMarkProps): ProductionRule<NumericValueRef> => {
-	const baseRule = getOpacityProductionRule(displayOnHover ? { value: 0 } : opacity);
+	const baseRule = displayOnHover ? { value: 0 } : DEFAULT_OPACITY_RULE;
 	if (!interactiveMarkName) return [baseRule];
 	const strokeOpacityRules: ProductionRule<NumericValueRef> = [];
 

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	FILTERED_TABLE,
@@ -89,12 +90,13 @@ const defaultSpec = initializeSpec({
 						enter: {
 							stroke: { field: DEFAULT_COLOR, scale: 'color' },
 							strokeDash: { value: [] },
+							strokeOpacity: DEFAULT_OPACITY_RULE,
 							strokeWidth: undefined,
 							y: { field: 'value', scale: 'yLinear' },
 						},
 						update: {
 							x: { field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' },
-							strokeOpacity: [{ value: 1 }],
+							opacity: [DEFAULT_OPACITY_RULE],
 						},
 					},
 					from: { data: 'line0_facet' },
@@ -164,29 +166,15 @@ const line0_groupMark = {
 			interactive: false,
 			encode: {
 				enter: {
-					y: {
-						scale: 'yLinear',
-						field: 'value',
-					},
-					stroke: {
-						scale: 'color',
-						field: 'series',
-					},
-					strokeDash: {
-						value: [],
-					},
+					y: { scale: 'yLinear', field: 'value' },
+					stroke: { scale: 'color', field: 'series' },
+					strokeDash: { value: [] },
+					strokeOpacity: DEFAULT_OPACITY_RULE,
 					strokeWidth: undefined,
 				},
 				update: {
-					x: {
-						scale: 'xTime',
-						field: DEFAULT_TRANSFORMED_TIME_DIMENSION,
-					},
-					strokeOpacity: [
-						{
-							value: 1,
-						},
-					],
+					x: { scale: 'xTime', field: DEFAULT_TRANSFORMED_TIME_DIMENSION },
+					opacity: [DEFAULT_OPACITY_RULE],
 				},
 			},
 		},
@@ -225,6 +213,7 @@ const metricRangeGroupMark = {
 					strokeDash: {
 						value: [7, 4],
 					},
+					strokeOpacity: DEFAULT_OPACITY_RULE,
 					strokeWidth: {
 						value: 1.5,
 					},
@@ -234,11 +223,7 @@ const metricRangeGroupMark = {
 						scale: 'xTime',
 						field: DEFAULT_TRANSFORMED_TIME_DIMENSION,
 					},
-					strokeOpacity: [
-						{
-							value: 1,
-						},
-					],
+					opacity: [DEFAULT_OPACITY_RULE],
 				},
 			},
 		},
@@ -474,13 +459,14 @@ describe('lineSpecBuilder', () => {
 							encode: {
 								enter: {
 									stroke: { field: DEFAULT_COLOR, scale: 'color' },
+									strokeOpacity: DEFAULT_OPACITY_RULE,
 									strokeDash: { value: [8, 8] },
 									strokeWidth: undefined,
 									y: { field: 'value', scale: 'yLinear' },
 								},
 								update: {
 									x: { field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' },
-									strokeOpacity: [{ value: 1 }],
+									opacity: [DEFAULT_OPACITY_RULE],
 								},
 							},
 							from: { data: 'line0_facet' },

--- a/src/specBuilder/metricRange/metricRangeUtils.test.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.test.ts
@@ -16,6 +16,7 @@ import {
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
+	DEFAULT_OPACITY_RULE,
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	FILTERED_TABLE,
@@ -75,31 +76,18 @@ const basicMetricRangeMarks = [
 		interactive: false,
 		encode: {
 			enter: {
-				y: {
-					scale: 'yLinear',
-					field: 'metric',
-				},
-				stroke: {
-					scale: 'color',
-					field: 'series',
-				},
-				strokeDash: {
-					value: [3, 4],
-				},
-				strokeWidth: {
-					value: 1.5,
-				},
+				y: { scale: 'yLinear', field: 'metric' },
+				stroke: { scale: 'color', field: 'series' },
+				strokeDash: { value: [3, 4] },
+				strokeOpacity: DEFAULT_OPACITY_RULE,
+				strokeWidth: { value: 1.5 },
 			},
 			update: {
 				x: {
 					scale: 'xTime',
 					field: DEFAULT_TRANSFORMED_TIME_DIMENSION,
 				},
-				strokeOpacity: [
-					{
-						value: 1,
-					},
-				],
+				opacity: [DEFAULT_OPACITY_RULE],
 			},
 		},
 	},
@@ -113,30 +101,14 @@ const basicMetricRangeMarks = [
 		encode: {
 			enter: {
 				tooltip: undefined,
-				y: {
-					scale: 'yLinear',
-					field: 'metricStart',
-				},
-				y2: {
-					scale: 'yLinear',
-					field: 'metricEnd',
-				},
-				fill: {
-					scale: 'color',
-					field: 'series',
-				},
+				y: { scale: 'yLinear', field: 'metricStart' },
+				y2: { scale: 'yLinear', field: 'metricEnd' },
+				fill: { scale: 'color', field: 'series' },
 			},
 			update: {
 				cursor: undefined,
-				x: {
-					scale: 'xTime',
-					field: DEFAULT_TRANSFORMED_TIME_DIMENSION,
-				},
-				fillOpacity: [
-					{
-						value: 0.2,
-					},
-				],
+				x: { scale: 'xTime', field: DEFAULT_TRANSFORMED_TIME_DIMENSION },
+				fillOpacity: [{ value: 0.2 }],
 			},
 		},
 	},
@@ -145,7 +117,7 @@ const basicMetricRangeMarks = [
 describe('applyMetricRangePropDefaults', () => {
 	test('applies defaults', () => {
 		expect(
-			applyMetricRangePropDefaults({ metricEnd: 'metricStart', metricStart: 'metricEnd' }, 'line0', 0)
+			applyMetricRangePropDefaults({ metricEnd: 'metricStart', metricStart: 'metricEnd' }, 'line0', 0),
 		).toEqual({
 			children: {},
 			displayOnHover: false,
@@ -171,8 +143,8 @@ describe('applyMetricRangePropDefaults', () => {
 					displayOnHover: true,
 				},
 				'line0',
-				0
-			)
+				0,
+			),
 		).toEqual({
 			children: {},
 			displayOnHover: true,

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -10,7 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
+import { TRENDLINE_VALUE } from '@constants';
+import { getLineHoverMarks, getLineOpacity } from '@specBuilder/line/lineMarkUtils';
+import { LineMarkProps } from '@specBuilder/line/lineUtils';
+import {
+	getColorProductionRule,
+	getLineWidthProductionRule,
+	getOpacityProductionRule,
+	getStrokeDashProductionRule,
+	getXProductionRule,
+	hasTooltip,
+} from '@specBuilder/marks/markUtils';
+import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
+import { getDimensionField, getFacetsFromProps } from '@specBuilder/specUtils';
 import { ScaleType, TrendlineSpecProps } from 'types';
+import { GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
 import {
 	TrendlineParentProps,
 	getTrendlineScaleType,
@@ -19,19 +33,6 @@ import {
 	isRegressionMethod,
 	trendlineUsesNormalizedDimension,
 } from './trendlineUtils';
-import { GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
-import { getDimensionField, getFacetsFromProps } from '@specBuilder/specUtils';
-import {
-	getColorProductionRule,
-	getLineWidthProductionRule,
-	getStrokeDashProductionRule,
-	getXProductionRule,
-	hasTooltip,
-} from '@specBuilder/marks/markUtils';
-import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
-import { getLineHoverMarks, getLineStrokeOpacity } from '@specBuilder/line/lineMarkUtils';
-import { LineMarkProps } from '@specBuilder/line/lineUtils';
-import { TRENDLINE_VALUE } from '@constants';
 
 export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark | RuleMark)[] => {
 	const { children, color, lineType, name } = markProps;
@@ -98,12 +99,13 @@ export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineP
 				y: { scale: 'yLinear', field: metric },
 				stroke: getColorProductionRule(color, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
+				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
 			},
 			update: {
 				x: getRuleXProductionRule(dimensionExtent[0], dimensionField, scaleType),
 				x2: getRuleX2ProductionRule(dimensionExtent[1], dimensionField, scaleType),
-				strokeOpacity: getLineStrokeOpacity(getLineMarkProps(markProps, trendlineProps)),
+				opacity: getLineOpacity(getLineMarkProps(markProps, trendlineProps)),
 			},
 		},
 	};
@@ -181,11 +183,12 @@ export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineP
 				y: { scale: 'yLinear', field: metric },
 				stroke: getColorProductionRule(color, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
+				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
 			},
 			update: {
 				x,
-				strokeOpacity: getLineStrokeOpacity(getLineMarkProps(markProps, trendlineProps)),
+				opacity: getLineOpacity(getLineMarkProps(markProps, trendlineProps)),
 			},
 		},
 	};

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -13,8 +13,9 @@ import React from 'react';
 
 import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import '@matchMediaMock';
-import { ChartPopover } from '@rsc';
+import { ChartPopover, spectrumColors } from '@rsc';
 import {
+	allElementsHaveAttributeValue,
 	clickNthElement,
 	findAllMarksByGroupName,
 	findChart,
@@ -96,12 +97,11 @@ describe('ChartPopover', () => {
 
 		bars = getAllMarksByGroupName(chart, 'bar0');
 		// validate the highlight visuals are present
-		expect(bars[1]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(bars[1]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(bars[0]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[0]).toHaveAttribute('stroke', 'rgb(20, 115, 230)');
-		expect(bars[0]).toHaveAttribute('stroke-opacity', '1');
+		expect(bars[0]).toHaveAttribute('opacity', '1');
+		expect(bars[0]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
 		expect(bars[0]).toHaveAttribute('stroke-width', '2');
+		// all other bars should be faded
+		expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
 	});
 
 	test('Line popover opens and closes corectly when clicking on the chart', async () => {
@@ -142,18 +142,15 @@ describe('ChartPopover', () => {
 		// lines should have full opacity
 		const lines = await findAllMarksByGroupName(chart, 'line0');
 		expect(lines).toHaveLength(3);
-		expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
-		expect(lines[2]).toHaveAttribute('stroke-opacity', '1');
+		expect(allElementsHaveAttributeValue(lines, 'opacity', 1)).toBeTruthy();
 
 		// click on the first line
 		const points = await findAllMarksByGroupName(chart, 'line0_voronoi');
 		await clickNthElement(points, 0);
 
 		// validate the first line is still full opacity, but the other lines are faded
-		expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
-		expect(lines[2]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(lines[0]).toHaveAttribute('opacity', '1');
+		expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
 	});
 
 	test('Dodged bar popover opens on mark click and closes when clicking outside', async () => {
@@ -176,11 +173,9 @@ describe('ChartPopover', () => {
 		bars = getAllMarksByGroupName(chart, 'bar0');
 
 		// validate the highlight visuals are present
-		expect(bars[0]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(bars[0]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(bars[4]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[4]).toHaveAttribute('stroke', 'rgb(20, 115, 230)');
-		expect(bars[4]).toHaveAttribute('stroke-opacity', '1');
+		expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[4]).toHaveAttribute('opacity', '1');
+		expect(bars[4]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
 		expect(bars[4]).toHaveAttribute('stroke-width', '2');
 	});
 });

--- a/src/stories/components/ChartTooltip/ChartTooltip.test.tsx
+++ b/src/stories/components/ChartTooltip/ChartTooltip.test.tsx
@@ -15,6 +15,7 @@ import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import '@matchMediaMock';
 import { ChartTooltip } from '@rsc';
 import {
+	allElementsHaveAttributeValue,
 	findAllMarksByGroupName,
 	findChart,
 	findMarksByGroupName,
@@ -47,11 +48,11 @@ describe('ChartTooltip', () => {
 		const tooltip = await screen.findByTestId('rsc-tooltip');
 		expect(tooltip).toBeInTheDocument();
 		expect(within(tooltip).getByText('Operating system: Windows')).toBeInTheDocument();
-		expect(bars[1].getAttribute('fill-opacity')).toEqual(`${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[1].getAttribute('opacity')).toEqual(`${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 
 		// unhover and validate the highlights go away
 		await unhoverNthElement(bars, 0);
-		expect(bars[1].getAttribute('fill-opacity')).toEqual('1');
+		expect(bars[1].getAttribute('opacity')).toEqual('1');
 	});
 
 	test('Line renders properly and hover works as expected', async () => {
@@ -98,11 +99,10 @@ describe('ChartTooltip', () => {
 		expect(within(tooltip).getByText('Users: 3')).toBeInTheDocument();
 
 		// validate the highlight visuals are present
-		expect(bars[0]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(bars[4]).toHaveAttribute('fill-opacity', '1');
+		expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[4]).toHaveAttribute('opacity', '1');
 
 		await unhoverNthElement(bars, 4);
-		expect(bars[0]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[4]).toHaveAttribute('fill-opacity', '1');
+		expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
 	});
 });

--- a/src/stories/components/Legend/LegendHideShow.test.tsx
+++ b/src/stories/components/Legend/LegendHideShow.test.tsx
@@ -25,6 +25,7 @@ import {
 import { spectrumColors } from '@themes';
 
 import { DefaultHiddenSeries, HiddenSeries, IsToggleable } from './LegendHideShow.story';
+import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 
 const colors = spectrumColors.light;
 
@@ -112,10 +113,10 @@ test('Hidden series should not highlight any marks', async () => {
 	// hovering the second entry should lower the opacity of the first series
 	await hoverNthElement(entries, 1);
 	let bars = await findAllMarksByGroupName(chart, 'bar0');
-	expect(bars[0]).toHaveAttribute('fill-opacity', '0.2');
+	expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 
 	// hovering the third entry should not adjust the opcity of any of the bars since it is a hidden series
 	await hoverNthElement(entries, 2);
 	bars = await findAllMarksByGroupName(chart, 'bar0');
-	expect(bars[0]).toHaveAttribute('fill-opacity', '1');
+	expect(bars[0]).toHaveAttribute('opacity', '1');
 });

--- a/src/stories/components/Legend/LegendHighlight.test.tsx
+++ b/src/stories/components/Legend/LegendHighlight.test.tsx
@@ -11,9 +11,18 @@
  */
 import React from 'react';
 
-import { findAllMarksByGroupName, findChart, getAllLegendEntries, hoverNthElement, render, screen } from '@test-utils';
+import {
+	allElementsHaveAttributeValue,
+	findAllMarksByGroupName,
+	findChart,
+	getAllLegendEntries,
+	hoverNthElement,
+	render,
+	screen,
+} from '@test-utils';
 
 import { Basic, Controlled } from './LegendHighlight.story';
+import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 
 describe('Controlled', () => {
 	test('non highlighted series bars should have opacity applied', async () => {
@@ -22,13 +31,9 @@ describe('Controlled', () => {
 
 		const bars = await findAllMarksByGroupName(chart, 'bar0');
 		expect(bars.length).toEqual(9);
-		expect(bars[0]).toHaveAttribute('fill-opacity', '0.2');
-		expect(bars[1]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[2]).toHaveAttribute('fill-opacity', '0.2');
-
-		expect(bars[0]).toHaveAttribute('stroke-opacity', '0.2');
-		expect(bars[1]).toHaveAttribute('stroke-opacity', '1');
-		expect(bars[2]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[1]).toHaveAttribute('opacity', '1');
+		expect(bars[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 	});
 
 	test('non highlighted series legend symbols should have opacity applied', async () => {
@@ -37,13 +42,9 @@ describe('Controlled', () => {
 
 		const legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
 		expect(legendSymbols.length).toEqual(3);
-		expect(legendSymbols[0]).toHaveAttribute('fill-opacity', '0.2');
-		expect(legendSymbols[1]).toHaveAttribute('fill-opacity', '1');
-		expect(legendSymbols[2]).toHaveAttribute('fill-opacity', '0.2');
-
-		expect(legendSymbols[0]).toHaveAttribute('stroke-opacity', '0.2');
-		expect(legendSymbols[1]).toHaveAttribute('stroke-opacity', '1');
-		expect(legendSymbols[2]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(legendSymbols[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
+		expect(legendSymbols[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 	});
 
 	test('non highlighted series legend labels should have opacity applied', async () => {
@@ -52,9 +53,9 @@ describe('Controlled', () => {
 
 		const legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
 		expect(legendLabels.length).toEqual(3);
-		expect(legendLabels[0]).toHaveAttribute('fill-opacity', '0.2');
-		expect(legendLabels[1]).toHaveAttribute('fill-opacity', '1');
-		expect(legendLabels[2]).toHaveAttribute('fill-opacity', '0.2');
+		expect(legendLabels[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(legendLabels[1]).toHaveAttribute('opacity', '1');
+		expect(legendLabels[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 	});
 });
 
@@ -71,25 +72,15 @@ describe('Uncontrolled', () => {
 
 		let bars = await findAllMarksByGroupName(chart, 'bar0');
 		expect(bars.length).toEqual(9);
-		expect(bars[0]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[1]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[2]).toHaveAttribute('fill-opacity', '1');
-
-		expect(bars[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(bars[1]).toHaveAttribute('stroke-opacity', '1');
-		expect(bars[2]).toHaveAttribute('stroke-opacity', '1');
+		expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
 
 		const legendEntries = getAllLegendEntries(chart);
 		await hoverNthElement(legendEntries, 0);
 
 		bars = await findAllMarksByGroupName(chart, 'bar0');
-		expect(bars[0]).toHaveAttribute('fill-opacity', '1');
-		expect(bars[1]).toHaveAttribute('fill-opacity', '0.2');
-		expect(bars[2]).toHaveAttribute('fill-opacity', '0.2');
-
-		expect(bars[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(bars[1]).toHaveAttribute('stroke-opacity', '0.2');
-		expect(bars[2]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(bars[0]).toHaveAttribute('opacity', '1');
+		expect(bars[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 	});
 
 	test('hovering over legend items adds opacity to the non hovered legend symbols', async () => {
@@ -98,25 +89,16 @@ describe('Uncontrolled', () => {
 
 		let legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
 		expect(legendSymbols.length).toEqual(3);
-		expect(legendSymbols[0]).toHaveAttribute('fill-opacity', '1');
-		expect(legendSymbols[1]).toHaveAttribute('fill-opacity', '1');
-		expect(legendSymbols[2]).toHaveAttribute('fill-opacity', '1');
-
-		expect(legendSymbols[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(legendSymbols[1]).toHaveAttribute('stroke-opacity', '1');
-		expect(legendSymbols[2]).toHaveAttribute('stroke-opacity', '1');
+		expect(allElementsHaveAttributeValue(legendSymbols, 'opacity', 1)).toBeTruthy();
 
 		const legendEntries = getAllLegendEntries(chart);
 		await hoverNthElement(legendEntries, 0);
 
 		legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
-		expect(legendSymbols[0]).toHaveAttribute('fill-opacity', '1');
-		expect(legendSymbols[1]).toHaveAttribute('fill-opacity', '0.2');
-		expect(legendSymbols[2]).toHaveAttribute('fill-opacity', '0.2');
-
-		expect(legendSymbols[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(legendSymbols[1]).toHaveAttribute('stroke-opacity', '0.2');
-		expect(legendSymbols[2]).toHaveAttribute('stroke-opacity', '0.2');
+		expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
+		expect(
+			allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO),
+		).toBeTruthy();
 	});
 
 	test('hovering over legend items adds opacity to the non hovered legend labels', async () => {
@@ -125,17 +107,16 @@ describe('Uncontrolled', () => {
 
 		let legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
 		expect(legendLabels.length).toEqual(3);
-		expect(legendLabels[0]).toHaveAttribute('fill-opacity', '1');
-		expect(legendLabels[1]).toHaveAttribute('fill-opacity', '1');
-		expect(legendLabels[2]).toHaveAttribute('fill-opacity', '1');
+		expect(allElementsHaveAttributeValue(legendLabels, 'opacity', 1)).toBeTruthy();
 
 		const legendEntries = getAllLegendEntries(chart);
 		await hoverNthElement(legendEntries, 0);
 
 		legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
 		expect(legendLabels.length).toEqual(3);
-		expect(legendLabels[0]).toHaveAttribute('fill-opacity', '1');
-		expect(legendLabels[1]).toHaveAttribute('fill-opacity', '0.2');
-		expect(legendLabels[2]).toHaveAttribute('fill-opacity', '0.2');
+		expect(legendLabels[0]).toHaveAttribute('opacity', '1');
+		expect(
+			allElementsHaveAttributeValue(legendLabels.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO),
+		).toBeTruthy();
 	});
 });

--- a/src/stories/components/Line/Line.test.tsx
+++ b/src/stories/components/Line/Line.test.tsx
@@ -15,6 +15,7 @@ import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import '@matchMediaMock';
 import { Line } from '@rsc';
 import {
+	allElementsHaveAttributeValue,
 	clickNthElement,
 	findAllMarksByGroupName,
 	findChart,
@@ -118,6 +119,7 @@ describe('Line', () => {
 	});
 
 	test('Hovering over the entries on HistoricalCompare should highlight hovered series', async () => {
+		const reducedOpacity = 1 / HIGHLIGHT_CONTRAST_RATIO;
 		render(<HistoricalCompare {...HistoricalCompare.args} />);
 		const chart = await findChart();
 		expect(chart).toBeInTheDocument();
@@ -126,44 +128,28 @@ describe('Line', () => {
 		expect(entries.length).toEqual(4);
 		await hoverNthElement(entries, 0);
 
-		// symbol stroke and fill opacity should be divided by the HIGHLIGHT_CONTRAST_RATIO for all but the first symbol
+		// symbol opacity should be reduced for all but the first symbol
 		let symbols = getAllLegendSymbols(chart);
-		expect(symbols[0]).toHaveAttribute('fill-opacity', '0.5');
-		expect(symbols[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(symbols[1]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[1]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[2]).toHaveAttribute('fill-opacity', `${0.5 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[2]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[3]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[3]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(symbols[0]).toHaveAttribute('opacity', '1');
+		expect(allElementsHaveAttributeValue(symbols.slice(1), 'opacity', reducedOpacity)).toBeTruthy();
 
-		// stroke opacity should be divided by the HIGHLIGHT_CONTRAST_RATIO for all but the first line
+		// line opacity should be reduced for all but the first line
 		let lines = await findAllMarksByGroupName(chart, 'line0');
-		expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-		expect(lines[1]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(lines[2]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(lines[3]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(lines[0]).toHaveAttribute('opacity', '1');
+		expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', reducedOpacity)).toBeTruthy();
 
 		await unhoverNthElement(entries, 0);
 		await hoverNthElement(entries, 3);
 
-		// symbol stroke and fill opacity should be divided by the HIGHLIGHT_CONTRAST_RATIO for all but the last symbol
+		// symbol opacity should be reduced for all but the last symbol
 		symbols = getAllLegendSymbols(chart);
-		expect(symbols[0]).toHaveAttribute('fill-opacity', `${0.5 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[0]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[1]).toHaveAttribute('fill-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[1]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[2]).toHaveAttribute('fill-opacity', `${0.5 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[2]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(symbols[3]).toHaveAttribute('fill-opacity', '1');
-		expect(symbols[3]).toHaveAttribute('stroke-opacity', '1');
+		expect(allElementsHaveAttributeValue(symbols.slice(0, 3), 'opacity', reducedOpacity)).toBeTruthy();
+		expect(symbols[3]).toHaveAttribute('opacity', '1');
 
-		// stroke opacity should be divided by the HIGHLIGHT_CONTRAST_RATIO for all but the last line
+		// line opacity should be reduced for all but the last line
 		lines = await findAllMarksByGroupName(chart, 'line0');
-		expect(lines[0]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(lines[1]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(lines[2]).toHaveAttribute('stroke-opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-		expect(lines[3]).toHaveAttribute('stroke-opacity', '1');
+		expect(allElementsHaveAttributeValue(lines.slice(0, 3), 'opacity', reducedOpacity)).toBeTruthy();
+		expect(lines[3]).toHaveAttribute('opacity', '1');
 	});
 
 	test('Trend scale renders', async () => {
@@ -200,8 +186,8 @@ describe('Line', () => {
 
 			const lines = await findAllMarksByGroupName(chart, 'line0');
 			expect(lines).toHaveLength(4);
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[0]).toHaveAttribute('opacity', '1');
+			expect(lines[1]).toHaveAttribute('opacity', '1');
 
 			// get voronoi paths
 			const paths = await findAllMarksByGroupName(chart, 'line0_voronoi');
@@ -209,8 +195,8 @@ describe('Line', () => {
 			// hover and validate all hover components are visible
 			await hoverNthElement(paths, 0);
 
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
+			expect(lines[0]).toHaveAttribute('opacity', '1');
+			expect(lines[1]).toHaveAttribute('opacity', '0.2');
 		});
 	});
 

--- a/src/stories/components/MetricRange/MetricRange.test.tsx
+++ b/src/stories/components/MetricRange/MetricRange.test.tsx
@@ -53,7 +53,7 @@ describe('MetricRange', () => {
 		expect(metricRange0Children).toHaveLength(2);
 
 		let metricRangeLines = await findAllMarksByGroupName(metricRange0Children[0], 'line0');
-		expect(metricRangeLines[0]).toHaveAttribute('stroke-opacity', '0');
+		expect(metricRangeLines[0]).toHaveAttribute('opacity', '0');
 		expect(metricRangeLines[0]).toHaveAttribute('stroke-dasharray', '3,4');
 		expect(metricRangeLines[0]).toHaveAttribute('stroke-width', '1.5');
 

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -117,7 +117,7 @@ const ScatterTooltipStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 			<Scatter {...args}>
 				<ChartTooltip>{(item) => dialog(item, dimension, metric)}</ChartTooltip>
 			</Scatter>
-			<Legend {...legendProps} />
+			<Legend {...legendProps} highlight />
 			<Title text="Mario Kart 8 Character Data" />
 		</Chart>
 	);

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -11,6 +11,7 @@
  */
 import { Scatter, spectrumColors } from '@rsc';
 import {
+	allElementsHaveAttributeValue,
 	findAllMarksByGroupName,
 	findChart,
 	getAllLegendEntries,
@@ -128,11 +129,10 @@ describe('Scatter', () => {
 
 			await hoverNthElement(paths, 0);
 			expect(points[0]).toHaveAttribute('opacity', '1');
-			expect(points[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 
 			// make sure all points after the first have reduced opacity
 			expect(
-				points.slice(1).every((point) => point.getAttribute('opacity') === `${1 / HIGHLIGHT_CONTRAST_RATIO}`),
+				allElementsHaveAttributeValue(points.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO),
 			).toBeTruthy();
 		});
 	});

--- a/src/stories/components/Trendline/Trendline.test.tsx
+++ b/src/stories/components/Trendline/Trendline.test.tsx
@@ -13,9 +13,17 @@ import React from 'react';
 
 import '@matchMediaMock';
 import { Trendline } from '@rsc';
-import { findAllMarksByGroupName, findChart, getAllLegendEntries, hoverNthElement, render } from '@test-utils';
+import {
+	allElementsHaveAttributeValue,
+	findAllMarksByGroupName,
+	findChart,
+	getAllLegendEntries,
+	hoverNthElement,
+	render,
+} from '@test-utils';
 
 import { Basic, DisplayOnHover, TooltipAndPopover, TooltipAndPopoverOnParentLine } from './Trendline.story';
+import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 
 describe('Trendline', () => {
 	// Trendline is not a real React component. This is test just provides test coverage for sonarqube
@@ -84,17 +92,18 @@ describe('Trendline', () => {
 			expect(trendlines).toHaveLength(4);
 
 			// trendlines should be hidden by default
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '0');
+			expect(trendlines[0]).toHaveAttribute('opacity', '0');
 
 			// hover over the first point on the first line
 			const hoverAreas = await findAllMarksByGroupName(chart, 'line0_voronoi');
 			await hoverNthElement(hoverAreas, 0);
 
 			// first trendline should be visible
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('opacity', '1');
 			// second trendline should still be hidden
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0');
+			expect(trendlines[1]).toHaveAttribute('opacity', '0');
 		});
+
 		test('should display trendlines on legend hover', async () => {
 			render(<DisplayOnHover {...DisplayOnHover.args} />);
 			const chart = await findChart();
@@ -103,16 +112,16 @@ describe('Trendline', () => {
 			expect(trendlines).toHaveLength(4);
 
 			// trendlines should be hidden by default
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '0');
+			expect(trendlines[0]).toHaveAttribute('opacity', '0');
 
 			// hover over the first point on the first line
 			const legendEntries = getAllLegendEntries(chart);
 			await hoverNthElement(legendEntries, 0);
 
 			// first trendline should be visible
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(trendlines[0]).toHaveAttribute('opacity', '1');
 			// second trendline should still be hidden
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0');
+			expect(trendlines[1]).toHaveAttribute('opacity', '0');
 		});
 	});
 
@@ -128,22 +137,19 @@ describe('Trendline', () => {
 			expect(trendlines).toHaveLength(4);
 
 			// all lines and trendlines are full opacity
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '1');
+			expect(allElementsHaveAttributeValue([...lines, ...trendlines], 'opacity', 1)).toBeTruthy();
 
 			// hover over the first point on the first trendline
 			const trendlineHoverAreas = await findAllMarksByGroupName(chart, 'line0Trendline_voronoi');
 			await hoverNthElement(trendlineHoverAreas, 0);
 
 			// highlighted line and trendline are still full opacity
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(allElementsHaveAttributeValue([lines[0], trendlines[0]], 'opacity', 1)).toBeTruthy();
 
 			// other lines and trendlines are faded
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0.2');
+			expect(
+				allElementsHaveAttributeValue([lines[1], trendlines[1]], 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO),
+			).toBeTruthy();
 		});
 	});
 
@@ -159,22 +165,17 @@ describe('Trendline', () => {
 			expect(trendlines).toHaveLength(4);
 
 			// all lines and trendlines are full opacity
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '1');
+			expect(allElementsHaveAttributeValue([...lines, ...trendlines], 'opacity', 1)).toBeTruthy();
 
 			// hover over the first point on the first trendline
 			const trendlineHoverAreas = await findAllMarksByGroupName(chart, 'line0_voronoi');
 			await hoverNthElement(trendlineHoverAreas, 0);
 
 			// highlighted line and trendline are still full opacity
-			expect(lines[0]).toHaveAttribute('stroke-opacity', '1');
-			expect(trendlines[0]).toHaveAttribute('stroke-opacity', '1');
+			expect(lines[0]).toHaveAttribute('opacity', '1');
 
 			// other lines and trendlines are faded
-			expect(lines[1]).toHaveAttribute('stroke-opacity', '0.2');
-			expect(trendlines[1]).toHaveAttribute('stroke-opacity', '0.2');
+			expect(lines[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
 		});
 	});
 });

--- a/src/test-utils/utils.ts
+++ b/src/test-utils/utils.ts
@@ -27,3 +27,6 @@ export const unhoverNthElement = async (elements: HTMLElement[], index: number) 
 export const clickNthElement = async (elements: HTMLElement[], index: number) => {
 	await userEvent.click(elements[index]);
 };
+
+export const allElementsHaveAttributeValue = (elements: HTMLElement[], attribute: string, value: number | string) =>
+	elements.every((element) => element.getAttribute(attribute) === value.toString());


### PR DESCRIPTION
…strokeOpacity

<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor so that highlight styling uses `opacity` instead of `fillOpacity` and `strokeOpacity`.

`fillOpacity` and `strokeOpacity` are still used to set the default opacity state respectively.

The advantage of this is it simplifies the highlight logic significantly and it makes the faded state more accurate. When using the stroke and fill opacities to fade a mark, the area where the two overlap gets exaggerated. Lowering the opacity as a whole using `opacity` doesn't for this.

## How Has This Been Tested?

Validated with like 200 tests (no exaggeration)

## Screenshots (if appropriate):

before:
<img width="554" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/081b1024-d060-49df-b685-84ee692dcb57">

after:
<img width="539" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/7a9dff01-14b6-4841-9cc5-e603302e11f5">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
