### PR TITLE
feat: popovers for scatter plot

### DIFF
--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -155,7 +155,7 @@ export const getOpacityProductionRule = (opacity: OpacityFacet | DualFacet): { s
 	return { value: opacity.value };
 };
 
-export const getSymbolSizeProductionRule = (symbolSize: SymbolSizeFacet): NumericValueRef | undefined => {
+export const getSymbolSizeProductionRule = (symbolSize: SymbolSizeFacet): NumericValueRef => {
 	// key reference for setting symbol size
 	if (typeof symbolSize === 'string') {
 		return { scale: 'symbolSize', field: symbolSize };

--- a/src/specBuilder/scatter/scatterMarkUtils.test.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.test.ts
@@ -16,8 +16,9 @@ import { ChartTooltip } from '@components/ChartTooltip';
 import { Trendline } from '@components/Trendline';
 import { DEFAULT_OPACITY_RULE, MARK_ID } from '@constants';
 import { GroupMark } from 'vega';
-import { addScatterMarks, getOpacity, getScatterHoverMarks } from './scatterMarkUtils';
+import { addScatterMarks, getOpacity, getScatterHoverMarks, getSelectRingSize } from './scatterMarkUtils';
 import { defaultScatterProps } from './scatterTestUtils';
+import { ChartPopover } from '@components/ChartPopover';
 
 describe('addScatterMarks()', () => {
 	test('should add the scatter group with the symbol marks', () => {
@@ -52,6 +53,12 @@ describe('getOpacity()', () => {
 		expect(opacity).toHaveLength(2);
 		expect(opacity[0]).toHaveProperty('test', `scatter0_hoveredId && scatter0_hoveredId !== datum.${MARK_ID}`);
 	});
+	test('should include select rule if popover exists', () => {
+		const opacity = getOpacity({ ...defaultScatterProps, children: [createElement(ChartPopover)] });
+		expect(opacity).toHaveLength(3);
+		expect(opacity[0]).toHaveProperty('test', `scatter0_hoveredId && scatter0_hoveredId !== datum.${MARK_ID}`);
+		expect(opacity[1]).toHaveProperty('test', `scatter0_selectedId && scatter0_selectedId !== datum.${MARK_ID}`);
+	});
 });
 
 describe('getScatterHoverMarks()', () => {
@@ -61,5 +68,18 @@ describe('getScatterHoverMarks()', () => {
 		const marks = getScatterHoverMarks({ ...defaultScatterProps, children: [createElement(ChartTooltip)] });
 		expect(marks).toHaveLength(1);
 		expect(marks[0].name).toBe('scatter0_voronoi');
+	});
+});
+
+describe('getScatterSelectMarks()', () => {
+	test('should return a staic value if a static value is provided', () => {
+		const ringSize = getSelectRingSize({ value: 10 });
+		// sqrt of 196 is 14 which is 4 pixels larger than 10;
+		expect(ringSize).toHaveProperty('value', 196);
+	});
+	test('should return a signal if data key is provided', () => {
+		const sizeKey = 'weight';
+		const ringSize = getSelectRingSize(sizeKey);
+		expect(ringSize).toHaveProperty('signal', `pow(sqrt(scale('symbolSize', datum.${sizeKey})) + 4, 2)`);
 	});
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -18,6 +18,7 @@ import { initializeSpec } from '@specBuilder/specUtils';
 import { addData, addSignals, setScales } from './scatterSpecBuilder';
 import { defaultScatterProps } from './scatterTestUtils';
 import { ChartTooltip } from '@components/ChartTooltip';
+import { ChartPopover } from '@components/ChartPopover';
 
 describe('addData()', () => {
 	test('should add time transform is dimensionScaleType === "time"', () => {
@@ -25,6 +26,14 @@ describe('addData()', () => {
 		expect(data).toHaveLength(2);
 		expect(data[0].transform).toHaveLength(2);
 		expect(data[0].transform?.[1].type).toBe('timeunit');
+	});
+	test('should add selectedData if popover exists', () => {
+		const data = addData(initializeSpec().data ?? [], {
+			...defaultScatterProps,
+			children: [createElement(ChartPopover)],
+		});
+		expect(data).toHaveLength(3);
+		expect(data[2].name).toBe('scatter0_selectedData');
 	});
 	test('should add trendline data if trendline exists as a child', () => {
 		const data = addData(initializeSpec().data ?? [], {
@@ -44,7 +53,15 @@ describe('addSignals()', () => {
 			children: [createElement(ChartTooltip)],
 		});
 		expect(signals).toHaveLength(1);
-		expect(signals[0]).toHaveProperty('name', 'scatter0_hoveredId');
+		expect(signals[0].name).toBe('scatter0_hoveredId');
+	});
+	test('should add selectedId signal if popover exists', () => {
+		const signals = addSignals([], {
+			...defaultScatterProps,
+			children: [createElement(ChartPopover)],
+		});
+		expect(signals).toHaveLength(2);
+		expect(signals[1].name).toBe('scatter0_selectedId');
 	});
 	test('should add trendline signals if trendline exists as a child', () => {
 		const signals = addSignals([], {
@@ -52,8 +69,8 @@ describe('addSignals()', () => {
 			children: [createElement(Trendline, { displayOnHover: true })],
 		});
 		expect(signals).toHaveLength(2);
-		expect(signals[0]).toHaveProperty('name', 'scatter0_hoveredSeries');
-		expect(signals[1]).toHaveProperty('name', 'scatter0_hoveredId');
+		expect(signals[0].name).toBe('scatter0_hoveredSeries');
+		expect(signals[1].name).toBe('scatter0_hoveredId');
 	});
 });
 

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -9,11 +9,23 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ReactElement } from 'react';
+import { ReactElement, createElement } from 'react';
 
 import { Content, Flex } from '@adobe/react-spectrum';
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, ChartProps, ChartTooltip, Datum, Legend, LegendProps, Scatter, ScatterProps, Title } from '@rsc';
+import {
+	Axis,
+	Chart,
+	ChartPopover,
+	ChartProps,
+	ChartTooltip,
+	Datum,
+	Legend,
+	LegendProps,
+	Scatter,
+	ScatterProps,
+	Title,
+} from '@rsc';
 import { characterData } from '@stories/data/marioKartData';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
@@ -98,41 +110,22 @@ const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
 			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[args.dimension as MarioDataKey]} />
 			<Axis position="left" grid ticks baseline title={marioKeyTitle[args.metric as MarioDataKey]} />
 			<Scatter {...args} />
-			<Legend {...legendProps} />
-			<Title text="Mario Kart 8 Character Data" />
-		</Chart>
-	);
-};
-
-const ScatterTooltipStory: StoryFn<typeof Scatter> = (args): ReactElement => {
-	const chartProps = useChartProps(defaultChartProps);
-	const legendProps = getLegendProps(args);
-	const dimension = args.dimension as MarioDataKey;
-	const metric = args.metric as MarioDataKey;
-
-	return (
-		<Chart {...chartProps}>
-			<Axis position="bottom" grid ticks baseline title={marioKeyTitle[dimension]} />
-			<Axis position="left" grid ticks baseline title={marioKeyTitle[metric]} />
-			<Scatter {...args}>
-				<ChartTooltip>{(item) => dialog(item, dimension, metric)}</ChartTooltip>
-			</Scatter>
 			<Legend {...legendProps} highlight />
 			<Title text="Mario Kart 8 Character Data" />
 		</Chart>
 	);
 };
 
-const dialog = (item: Datum, dimension: MarioDataKey, metric: MarioDataKey) => {
+const dialog = (item: Datum) => {
 	return (
 		<Content>
 			<Flex direction="column">
 				<div style={{ fontWeight: 'bold' }}>{(item.character as string[]).join(', ')}</div>
 				<div>
-					{marioKeyTitle[dimension]}: {item[dimension]}
+					{marioKeyTitle.speedNormal}: {item.speedNormal}
 				</div>
 				<div>
-					{marioKeyTitle[metric]}: {item[metric]}
+					{marioKeyTitle.handlingNormal}: {item.handlingNormal}
 				</div>
 			</Flex>
 		</Content>
@@ -168,6 +161,14 @@ Opacity.args = {
 	metric: 'handlingNormal',
 };
 
+const Popover = bindWithProps(ScatterStory);
+Popover.args = {
+	color: 'weightClass',
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+	children: [createElement(ChartTooltip, {}, dialog), createElement(ChartPopover, { width: 200 }, dialog)],
+};
+
 const Size = bindWithProps(ScatterStory);
 Size.args = {
 	size: 'weight',
@@ -175,11 +176,12 @@ Size.args = {
 	metric: 'handlingNormal',
 };
 
-const Tooltip = bindWithProps(ScatterTooltipStory);
+const Tooltip = bindWithProps(ScatterStory);
 Tooltip.args = {
 	color: 'weightClass',
 	dimension: 'speedNormal',
 	metric: 'handlingNormal',
+	children: [createElement(ChartTooltip, {}, dialog)],
 };
 
-export { Basic, Color, LineType, Opacity, Size, Tooltip };
+export { Basic, Color, LineType, Opacity, Popover, Size, Tooltip };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Scatter plot popover support.

## Related Issue

[Scatter Plot](https://github.com/adobe/react-spectrum-charts/issues/50)

## Motivation and Context

Popovers are fundamental and should be supported on all standard mark types

## How Has This Been Tested?

Existing tests pass, new tests added.

## Screenshots (if appropriate):
<img width="534" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/bf2ac822-e0ab-44fd-80c5-251c4f905b2b">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
