### PR TITLE
feat: support linear color scales for scatter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,9 @@ export const MARK_ID = 'rscMarkId';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';
 export const STACK_ID = 'rscStackId';
 
+// scaleNames
+export const LINEAR_COLOR_SCALE = 'linearColor';
+
 // encode rules
 export const DEFAULT_OPACITY_RULE = { value: 1 };
 

--- a/src/specBuilder/chartSpecBuilder.test.ts
+++ b/src/specBuilder/chartSpecBuilder.test.ts
@@ -27,6 +27,7 @@ import { ROUNDED_SQUARE_PATH } from 'svgPaths';
 import { BarProps, LegendProps } from 'types';
 import { Data } from 'vega';
 
+import colorSchemes from '@themes/colorSchemes';
 import {
 	addData,
 	addHighlight,
@@ -35,6 +36,7 @@ import {
 	getDefaultSignals,
 	getLineTypeScale,
 	getLineWidthScale,
+	getLinearColorScale,
 	getOpacityScale,
 	getSymbolShapeScale,
 	getSymbolSizeScale,
@@ -44,6 +46,7 @@ import {
 } from './chartSpecBuilder';
 import { setHoverOpacityForMarks } from './legend/legendHighlightUtils';
 import { baseData } from './specUtils';
+import { spectrumColors } from '@themes';
 
 const defaultData: Data[] = [{ name: TABLE, values: [], transform: [{ type: 'identifier', as: MARK_ID }] }];
 
@@ -69,7 +72,7 @@ afterEach(() => {
 });
 
 describe('Chart spec builder', () => {
-	describe('setColorScale()', () => {
+	describe('getColorScale()', () => {
 		test('default color scale used', () => {
 			expect(getColorScale('categorical12', 'light')).toStrictEqual({
 				domain: { data: 'table', fields: [] },
@@ -101,6 +104,19 @@ describe('Chart spec builder', () => {
 		});
 	});
 
+	describe('getLinearColorScale()', () => {
+		test('should return color scale from named scale', () => {
+			expect(getLinearColorScale('categorical12', 'light')).toHaveProperty('range', colorSchemes.categorical12);
+		});
+		test('should transform custom color names', () => {
+			const colors = spectrumColors.light;
+			expect(getLinearColorScale(['blue-200', 'rgb(20, 30, 40)', 'static-black'], 'light')).toHaveProperty(
+				'range',
+				[colors['blue-200'], 'rgb(20, 30, 40)', colors['static-black']],
+			);
+		});
+	});
+
 	describe('getTwoDimensionalColorScheme()', () => {
 		test('should get colors from scheme', () => {
 			expect(getTwoDimensionalColorScheme('categorical6', 'light')).toStrictEqual([
@@ -114,7 +130,7 @@ describe('Chart spec builder', () => {
 		});
 		test('should get colors from color names for light and dark mode', () => {
 			expect(
-				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'light')
+				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'light'),
 			).toStrictEqual([
 				['rgb(150, 206, 253)'],
 				['rgb(120, 187, 250)'],
@@ -122,12 +138,12 @@ describe('Chart spec builder', () => {
 				['rgb(56, 146, 243)'],
 			]);
 			expect(
-				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'dark')
+				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'dark'),
 			).toStrictEqual([['rgb(0, 78, 166)'], ['rgb(0, 92, 200)'], ['rgb(6, 108, 231)'], ['rgb(29, 128, 245)']]);
 		});
 		test('should convert color scheme in second dimension to correct colors', () => {
 			expect(
-				getTwoDimensionalColorScheme(['categorical6', 'divergentOrangeYellowSeafoam5'], 'light')
+				getTwoDimensionalColorScheme(['categorical6', 'divergentOrangeYellowSeafoam5'], 'light'),
 			).toStrictEqual([
 				[
 					'rgb(15, 181, 174)',
@@ -242,7 +258,7 @@ describe('Chart spec builder', () => {
 				getOpacityScale([
 					[0.2, 0.4],
 					[0.6, 0.8],
-				])
+				]),
 			).toStrictEqual({
 				name: 'opacity',
 				type: 'ordinal',
@@ -307,7 +323,7 @@ describe('Chart spec builder', () => {
 				getSymbolShapeScale([
 					['circle', 'square'],
 					['triangle,', 'circle'],
-				])
+				]),
 			).toStrictEqual({
 				name: 'symbolShape',
 				type: 'ordinal',
@@ -344,7 +360,7 @@ describe('Chart spec builder', () => {
 
 		test('should join the facets', () => {
 			expect(
-				addData(defaultData, { facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })[0].transform?.at(-1)
+				addData(defaultData, { facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })[0].transform?.at(-1),
 			).toStrictEqual({ as: SERIES_ID, expr: 'datum.series + " | " + datum.subSeries', type: 'formula' });
 		});
 	});
@@ -428,7 +444,7 @@ describe('Chart spec builder', () => {
 			};
 
 			expect(spec.signals?.find((signal) => signal.name === 'highlightedSeries')).toStrictEqual(
-				uncontrolledHighlightSignal
+				uncontrolledHighlightSignal,
 			);
 		});
 	});
@@ -445,8 +461,8 @@ describe('Chart spec builder', () => {
 			expect(
 				addHighlight(
 					{ signals: [testSignal] },
-					{ children: [], hiddenSeries: [], highlightedSeries: undefined }
-				)
+					{ children: [], hiddenSeries: [], highlightedSeries: undefined },
+				),
 			).toStrictEqual({
 				signals: [testSignal, { name: 'highlightedSeries', value: null }],
 			});
@@ -456,7 +472,7 @@ describe('Chart spec builder', () => {
 			expect(addHighlight({}, { children: [], hiddenSeries: [], highlightedSeries: 'testSeries' })).toStrictEqual(
 				{
 					signals: [{ name: 'highlightedSeries', value: 'testSeries' }],
-				}
+				},
 			);
 		});
 
@@ -493,14 +509,14 @@ describe('Chart spec builder', () => {
 
 		test('hiddenSeries is empty when no hidden series', () => {
 			expect(
-				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1])
+				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1]),
 			).toStrictEqual([...defaultSignals, { name: 'hiddenSeries', value: [] }]);
 		});
 
 		test('hiddenSeries contains provided hidden series', () => {
 			const hiddenSeries = ['test'];
 			expect(
-				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1], hiddenSeries)
+				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1], hiddenSeries),
 			).toStrictEqual([...defaultSignals, { name: 'hiddenSeries', value: hiddenSeries }]);
 		});
 	});

--- a/src/specBuilder/legend/legendFacetUtils.ts
+++ b/src/specBuilder/legend/legendFacetUtils.ts
@@ -14,6 +14,7 @@ import { FacetType, SecondaryFacetType } from 'types';
 import { Scale, ScaleMultiFieldsRef } from 'vega';
 
 import { Facet } from './legendUtils';
+import { LINEAR_COLOR_SCALE } from '@constants';
 
 /**
  * These are all the scale names that are used for facets
@@ -21,6 +22,7 @@ import { Facet } from './legendUtils';
 const facetScaleNames: (FacetType | SecondaryFacetType)[] = [
 	'color',
 	'lineType',
+	LINEAR_COLOR_SCALE,
 	'opacity',
 	'secondaryColor',
 	'secondaryLineType',
@@ -69,7 +71,7 @@ export const getFacets = (scales: Scale[]): { ordinalFacets: Facet[]; continuous
  */
 export const getFacetsFromKeys = (
 	keys: string[],
-	scales: Scale[]
+	scales: Scale[],
 ): { ordinalFacets: Facet[]; continuousFacets: Facet[] } => {
 	const ordinalFacets: Facet[] = [];
 	const continuousFacets: Facet[] = [];

--- a/src/specBuilder/legend/legendSpecBuilder.test.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.test.ts
@@ -9,11 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR, TABLE } from '@constants';
+import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR, LINEAR_COLOR_SCALE, TABLE } from '@constants';
 import { Data, Legend, LegendEncode, Scale, Spec, SymbolEncodeEntry } from 'vega';
 
 import { defaultHighlightSignal } from '../signal/signalSpecBuilder.test';
-import { addData, addLegend, addSignals, formatFacetRefsWithPresets } from './legendSpecBuilder';
+import { addData, addLegend, addSignals, formatFacetRefsWithPresets, getContinuousLegend } from './legendSpecBuilder';
 import { defaultLegendProps, opacityEncoding } from './legendTestUtils';
 
 const defaultSpec: Spec = {
@@ -356,5 +356,19 @@ describe('addSignals()', () => {
 				(signal) => signal.name === 'hiddenSeries',
 			),
 		).toBeUndefined();
+	});
+});
+
+describe('getContinuousLegend()', () => {
+	test('should return symbolSize legend if facetType is symbolSize', () => {
+		expect(getContinuousLegend({ facetType: 'symbolSize', field: 'weight' }, defaultLegendProps)).toHaveProperty(
+			'size',
+			'symbolSize',
+		);
+	});
+	test('should return linearColor scale if facetType is linearColor', () => {
+		expect(
+			getContinuousLegend({ facetType: LINEAR_COLOR_SCALE, field: 'weight' }, defaultLegendProps),
+		).toHaveProperty('fill', LINEAR_COLOR_SCALE);
 	});
 });

--- a/src/specBuilder/legend/legendSpecBuilder.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR_SCHEME } from '@constants';
+import { DEFAULT_COLOR_SCHEME, LINEAR_COLOR_SCALE } from '@constants';
 import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
 import {
 	getColorValue,
@@ -56,7 +56,7 @@ export const addLegend = produce<
 			title,
 			colorScheme = DEFAULT_COLOR_SCHEME,
 			...props
-		}
+		},
 	) => {
 		const { formattedColor, formattedLineType, formattedLineWidth, formattedSymbolShape } =
 			formatFacetRefsWithPresets(color, lineType, lineWidth, symbolShape, colorScheme);
@@ -124,7 +124,7 @@ export const addLegend = produce<
 			spec.legends = [];
 		}
 		spec.legends.push(...legends);
-	}
+	},
 );
 
 /**
@@ -140,7 +140,7 @@ export const formatFacetRefsWithPresets = (
 	lineType: LineTypeFacet | undefined,
 	lineWidth: LineWidthFacet | undefined,
 	symbolShape: SymbolShapeFacet | undefined,
-	colorScheme: ColorScheme
+	colorScheme: ColorScheme,
 ) => {
 	let formattedColor: FacetRef<string> | undefined;
 	if (color && typeof color === 'object') {
@@ -198,13 +198,20 @@ const getCategoricalLegend = (facets: Facet[], props: LegendSpecProps): Legend =
  * @param props
  * @returns
  */
-const getContinuousLegend = (_facet: Facet, props: LegendSpecProps): Legend => {
+export const getContinuousLegend = (facet: Facet, props: LegendSpecProps): Legend => {
 	const { symbolShape } = props;
 	// add a switch statement here for the different types of continuous legends
+	if (facet.facetType === 'symbolSize') {
+		return {
+			size: 'symbolSize',
+			...getLegendLayout(props),
+			symbolType: getSymbolType(symbolShape),
+		};
+	}
 	return {
-		size: 'symbolSize',
+		fill: LINEAR_COLOR_SCALE,
+		gradientThickness: 10,
 		...getLegendLayout(props),
-		symbolType: getSymbolType(symbolShape),
 	};
 };
 
@@ -255,7 +262,7 @@ export const addData = produce<Data[], [LegendSpecProps & { facets: string[] }]>
 				...getHiddenEntriesFilter(hiddenEntries, name),
 			],
 		});
-	}
+	},
 );
 
 export const addSignals = produce<Signal[], [LegendSpecProps]>(
@@ -272,5 +279,5 @@ export const addSignals = produce<Signal[], [LegendSpecProps]>(
 				signals.push(getLegendLabelsSeriesSignal(legendLabels));
 			}
 		}
-	}
+	},
 );

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -229,6 +229,7 @@ const getSymbolFacetEncoding = <T>({
 
 	const secondaryFacetMapping: { [key in FacetType]: { scale: SecondaryFacetType; signal: string } } = {
 		color: { scale: 'secondaryColor', signal: 'colors' },
+		linearColor: { scale: 'secondaryColor', signal: 'colors' },
 		lineType: { scale: 'secondaryLineType', signal: 'lineTypes' },
 		lineWidth: { scale: 'secondaryLineWidth', signal: 'lineWidths' },
 		opacity: { scale: 'secondaryOpacity', signal: 'opacities' },

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -22,6 +22,7 @@ import {
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
+	LINEAR_COLOR_SCALE,
 } from '@constants';
 
 import {
@@ -43,6 +44,13 @@ describe('getColorProductionRule', () => {
 			scale: 'color',
 			field: DEFAULT_COLOR,
 		});
+	});
+
+	test('should use linear scale if colorScaleType is linear', () => {
+		expect(getColorProductionRule(DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, 'linear')).toHaveProperty(
+			'scale',
+			LINEAR_COLOR_SCALE,
+		);
 	});
 
 	test('should return static value and convert spectrum name to color, respecting the theme', () => {

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -20,6 +20,7 @@ import {
 	DEFAULT_OPACITY_RULE,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
+	LINEAR_COLOR_SCALE,
 } from '@constants';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
 import {
@@ -113,14 +114,19 @@ export const hasTooltip = (children: ReactElement[]): boolean => children.some((
 export const childHasTooltip = (children: ReactElement[]): boolean =>
 	children.some((child) => hasTooltip(child.props.children));
 
-export const getColorProductionRule = (color: ColorFacet | DualFacet, colorScheme: ColorScheme): ColorValueRef => {
+export const getColorProductionRule = (
+	color: ColorFacet | DualFacet,
+	colorScheme: ColorScheme,
+	colorScaleType: 'linear' | 'ordinal' = 'ordinal',
+): ColorValueRef => {
+	const colorScaleName = colorScaleType === 'linear' ? LINEAR_COLOR_SCALE : 'color';
 	if (Array.isArray(color)) {
 		return {
 			signal: `scale('colors', datum.${color[0]})[indexof(domain('secondaryColor'), datum.${color[1]})% length(scale('colors', datum.${color[0]}))]`,
 		};
 	}
 	if (typeof color === 'string') {
-		return { scale: 'color', field: color };
+		return { scale: colorScaleName, field: color };
 	}
 	return { value: getColorValue(color.value, colorScheme) };
 };

--- a/src/specBuilder/scale/scaleSpecBuilder.ts
+++ b/src/specBuilder/scale/scaleSpecBuilder.ts
@@ -15,7 +15,7 @@ import { getDimensionField } from '@specBuilder/specUtils';
 import { toCamelCase } from '@utils';
 import { produce } from 'immer';
 import { DualFacet, FacetRef, FacetType, Orientation } from 'types';
-import { Scale, ScaleData, ScaleMultiFieldsRef, SignalRef } from 'vega';
+import { OrdinalScale, Scale, ScaleData, ScaleMultiFieldsRef, SignalRef } from 'vega';
 
 type AxisType = 'x' | 'y';
 type SupportedScaleType = 'linear' | 'point' | 'band' | 'time' | 'ordinal';
@@ -202,6 +202,13 @@ export const getPadding = (type: SupportedScaleType | 'band') => {
  * @returns scale name
  */
 export const getScaleName = (axis: AxisType, type: SupportedScaleType) => toCamelCase(`${axis} ${type}`);
+
+export const getOrdinalScale = (name: string, range: OrdinalScale['range']): OrdinalScale => ({
+	name,
+	type: 'ordinal',
+	range,
+	domain: { data: TABLE, fields: [] },
+});
 
 const isScaleMultiFieldsRef = (
 	domain: (null | string | number | boolean | SignalRef)[] | ScaleData | SignalRef | undefined,

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -46,8 +46,19 @@ export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props
  * @returns SymbolMark
  */
 export const getScatterMark = (props: ScatterSpecProps): SymbolMark => {
-	const { color, colorScheme, dimension, dimensionScaleType, lineType, lineWidth, metric, name, opacity, size } =
-		props;
+	const {
+		color,
+		colorScaleType,
+		colorScheme,
+		dimension,
+		dimensionScaleType,
+		lineType,
+		lineWidth,
+		metric,
+		name,
+		opacity,
+		size,
+	} = props;
 	return {
 		name,
 		type: 'symbol',
@@ -62,13 +73,13 @@ export const getScatterMark = (props: ScatterSpecProps): SymbolMark => {
 				 * in dark mode, the points are lighter when they overlap (screen)
 				 */
 				blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
-				fill: getColorProductionRule(color, colorScheme),
+				fill: getColorProductionRule(color, colorScheme, colorScaleType),
 				fillOpacity: getOpacityProductionRule(opacity),
 				shape: { value: 'circle' },
 				size: getSymbolSizeProductionRule(size),
 				strokeDash: getStrokeDashProductionRule(lineType),
 				strokeWidth: getLineWidthProductionRule(lineWidth),
-				stroke: getColorProductionRule(color, colorScheme),
+				stroke: getColorProductionRule(color, colorScheme, colorScaleType),
 			},
 			update: {
 				opacity: getOpacity(props),

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -12,7 +12,7 @@
 import { createElement } from 'react';
 
 import { Trendline } from '@components/Trendline';
-import { DEFAULT_COLOR } from '@constants';
+import { DEFAULT_COLOR, LINEAR_COLOR_SCALE } from '@constants';
 import { initializeSpec } from '@specBuilder/specUtils';
 
 import { addData, addSignals, setScales } from './scatterSpecBuilder';
@@ -85,6 +85,11 @@ describe('setScales()', () => {
 		const scales = setScales([], { ...defaultScatterProps, color: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
 		expect(scales[2].name).toBe('color');
+	});
+	test('should add color to linear color scale if the colorScaleType is linear', () => {
+		const scales = setScales([], { ...defaultScatterProps, color: DEFAULT_COLOR, colorScaleType: 'linear' });
+		expect(scales).toHaveLength(3);
+		expect(scales[2].name).toBe(LINEAR_COLOR_SCALE);
 	});
 	test('should add the lineType scale if lineType is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, lineType: DEFAULT_COLOR });

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -15,6 +15,7 @@ import {
 	DEFAULT_LINEAR_DIMENSION,
 	DEFAULT_METRIC,
 	FILTERED_TABLE,
+	LINEAR_COLOR_SCALE,
 	MARK_ID,
 } from '@constants';
 import { addTimeTransform, getTableData } from '@specBuilder/data/dataUtils';
@@ -137,13 +138,18 @@ export const addSignals = produce<Signal[], [ScatterSpecProps]>((signals, props)
  * @param scatterProps ScatterSpecProps
  */
 export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) => {
-	const { color, dimension, dimensionScaleType, lineType, lineWidth, metric, opacity, size } = props;
+	const { color, colorScaleType, dimension, dimensionScaleType, lineType, lineWidth, metric, opacity, size } = props;
 	// add dimension scale
 	addContinuousDimensionScale(scales, { scaleType: dimensionScaleType, dimension });
 	// add metric scale
 	addMetricScale(scales, [metric]);
-	// add color to the color domain
-	addFieldToFacetScaleDomain(scales, 'color', color);
+	if (colorScaleType === 'linear') {
+		// add color to the color domain
+		addFieldToFacetScaleDomain(scales, LINEAR_COLOR_SCALE, color);
+	} else {
+		// add color to the color domain
+		addFieldToFacetScaleDomain(scales, 'color', color);
+	}
 	// add lineType to the lineType domain
 	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
 	// add lineWidth to the lineWidth domain

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -16,6 +16,7 @@ import useChartProps from '@hooks/useChartProps';
 import {
 	Axis,
 	Chart,
+	ChartColors,
 	ChartPopover,
 	ChartProps,
 	ChartTooltip,
@@ -59,7 +60,7 @@ export default {
 		},
 		color: {
 			control: 'select',
-			options: marioDataKeys.filter((key) => key !== 'weight'),
+			options: marioDataKeys,
 		},
 		size: {
 			control: 'select',
@@ -102,7 +103,8 @@ const getLegendProps = (args: ScatterProps): LegendProps => {
 };
 
 const ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
-	const chartProps = useChartProps(defaultChartProps);
+	const colors: ChartColors = args.colorScaleType === 'linear' ? 'sequentialViridis5' : 'categorical16';
+	const chartProps = useChartProps({ ...defaultChartProps, colors });
 	const legendProps = getLegendProps(args);
 
 	return (
@@ -141,6 +143,14 @@ Basic.args = {
 const Color = bindWithProps(ScatterStory);
 Color.args = {
 	color: 'weightClass',
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+};
+
+const ColorScaleType = bindWithProps(ScatterStory);
+ColorScaleType.args = {
+	color: 'weight',
+	colorScaleType: 'linear',
 	dimension: 'speedNormal',
 	metric: 'handlingNormal',
 };
@@ -184,4 +194,4 @@ Tooltip.args = {
 	children: [createElement(ChartTooltip, {}, dialog)],
 };
 
-export { Basic, Color, LineType, Opacity, Popover, Size, Tooltip };
+export { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip };

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -23,7 +23,7 @@ import {
 	within,
 } from '@test-utils';
 
-import { Basic, Color, LineType, Opacity, Popover, Size, Tooltip } from './Scatter.story';
+import { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip } from './Scatter.story';
 import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
 import userEvent from '@testing-library/user-event';
 
@@ -59,6 +59,25 @@ describe('Scatter', () => {
 
 		const legendEntries = getAllLegendEntries(chart);
 		expect(legendEntries).toHaveLength(3);
+	});
+
+	test('ColorScaleType renders properly', async () => {
+		render(<ColorScaleType {...ColorScaleType.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+		expect(points).toHaveLength(16);
+		expect(points[0]).toHaveAttribute('fill', 'rgb(253, 231, 37)');
+		expect(points[6]).toHaveAttribute('fill', 'rgb(104, 198, 93)');
+		expect(points[11]).toHaveAttribute('fill', 'rgb(52, 99, 140)');
+
+		// legend title
+		expect(screen.getByText('Weight')).toBeInTheDocument();
+		// gradient labels
+		expect(screen.getByText('2.0')).toBeInTheDocument();
+		expect(screen.getByText('4.5')).toBeInTheDocument();
 	});
 
 	test('LineType renders properly', async () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -242,7 +242,7 @@ export interface MarkProps extends BaseProps {
 
 export type StaticValue<T> = { value: T };
 
-export type FacetType = 'color' | 'lineType' | 'lineWidth' | 'opacity' | 'symbolShape' | 'symbolSize';
+export type FacetType = 'color' | 'linearColor' | 'lineType' | 'lineWidth' | 'opacity' | 'symbolShape' | 'symbolSize';
 
 export type SecondaryFacetType =
 	| 'secondaryColor'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support linear color scales. This allows the color of a given scatter mark to be determined by a linear color scale instead of an ordinal one.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/50

## Motivation and Context

Linear color scales is something that has been requested and will likely be needed by some for scatter plot.

## Screenshots (if appropriate):

![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/6bf28838-289c-46e7-bbf7-097ebc44d580)

## Stories

Scatter > ColorScaleType

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
