### PR TITLE
chore: add constants for scale names

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,14 @@ export const MARK_ID = 'rscMarkId';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';
 export const STACK_ID = 'rscStackId';
 
+// scale names
+export const COLOR_SCALE = 'color';
+export const LINE_TYPE_SCALE = 'lineType';
+export const LINE_WIDTH_SCALE = 'lineWidth';
+export const OPACITY_SCALE = 'opacity';
+export const SYMBOL_SHAPE_SCALE = 'symbolShape';
+export const SYMBOL_SIZE_SCALE = 'symbolSize';
+
 // encode rules
 export const DEFAULT_OPACITY_RULE = { value: 1 };
 

--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -14,6 +14,7 @@ import { createElement } from 'react';
 import { ChartTooltip } from '@components/ChartTooltip';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -31,7 +32,7 @@ import { initializeSpec } from '../specUtils';
 import { addArea, addAreaMarks, addData, addSignals, setScales } from './areaSpecBuilder';
 
 const startingSpec: Spec = initializeSpec({
-	scales: [{ name: 'color', type: 'ordinal' }],
+	scales: [{ name: COLOR_SCALE, type: 'ordinal' }],
 });
 
 const defaultAreaProps: AreaSpecProps = {
@@ -84,7 +85,7 @@ const defaultSpec = initializeSpec({
 				{
 					encode: {
 						enter: {
-							fill: { field: DEFAULT_COLOR, scale: 'color' },
+							fill: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 							y: { field: 'value0', scale: 'yLinear' },
 							y2: { field: 'value1', scale: 'yLinear' },
 							stroke: { signal: BACKGROUND_COLOR },
@@ -111,7 +112,7 @@ const defaultSpec = initializeSpec({
 	scales: [
 		{
 			domain: { data: TABLE, fields: [DEFAULT_COLOR] },
-			name: 'color',
+			name: COLOR_SCALE,
 			type: 'ordinal',
 		},
 		{
@@ -187,13 +188,13 @@ describe('areaSpecBuilder', () => {
 		test('scaleTypes "point" and "linear" should not add timeunit transforms return the original data', () => {
 			expect(
 				addData(baseData, { ...defaultAreaProps, scaleType: 'point' })[0].transform?.find(
-					(t) => t.type === 'timeunit'
-				)
+					(t) => t.type === 'timeunit',
+				),
 			).toBeUndefined();
 			expect(
 				addData(baseData, { ...defaultAreaProps, scaleType: 'linear' })[0].transform?.find(
-					(t) => t.type === 'timeunit'
-				)
+					(t) => t.type === 'timeunit',
+				),
 			).toBeUndefined();
 		});
 	});
@@ -206,7 +207,7 @@ describe('areaSpecBuilder', () => {
 		test('children: should add signals', () => {
 			const tooltip = createElement(ChartTooltip);
 			expect(addSignals(startingSpec.signals ?? [], { ...defaultAreaProps, children: [tooltip] })).toStrictEqual(
-				defaultSignals
+				defaultSignals,
 			);
 		});
 	});

--- a/src/specBuilder/area/areaSpecBuilder.ts
+++ b/src/specBuilder/area/areaSpecBuilder.ts
@@ -12,6 +12,7 @@
 import { ChartPopover } from '@components/ChartPopover';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -51,7 +52,7 @@ export const addArea = produce<Spec, [AreaProps & { colorScheme?: ColorScheme; i
 			opacity = 0.8,
 			scaleType = 'time',
 			...props
-		}
+		},
 	) => {
 		// put props back together now that all defaults are set
 		const areaProps: AreaSpecProps = {
@@ -74,7 +75,7 @@ export const addArea = produce<Spec, [AreaProps & { colorScheme?: ColorScheme; i
 			console.error(
 				`${metricEnd ? 'metricEnd' : 'metricStart'} is defined but ${
 					metricEnd ? 'metricStart' : 'metricEnd'
-				} is not. Both must be defined in order to use the "start and end" method. Defaulting back to 'metric = ${metric}'`
+				} is not. Both must be defined in order to use the "start and end" method. Defaulting back to 'metric = ${metric}'`,
 			);
 			areaProps.metricEnd = undefined;
 			areaProps.metricStart = undefined;
@@ -86,7 +87,7 @@ export const addArea = produce<Spec, [AreaProps & { colorScheme?: ColorScheme; i
 		spec.marks = addAreaMarks(spec.marks ?? [], areaProps);
 
 		return spec;
-	}
+	},
 );
 
 export const addData = produce<Data[], [AreaSpecProps]>(
@@ -138,7 +139,7 @@ export const addData = produce<Data[], [AreaSpecProps]>(
 				});
 			}
 		}
-	}
+	},
 );
 
 export const addSignals = produce<Signal[], [AreaSpecProps]>((signals, { children, name }) => {
@@ -162,7 +163,7 @@ export const setScales = produce<Scale[], [AreaSpecProps]>(
 		// add dimension scale
 		addContinuousDimensionScale(scales, { scaleType, dimension, padding });
 		// add color to the color domain
-		addFieldToFacetScaleDomain(scales, 'color', color);
+		addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
 		// find the linear scale and add our field to it
 		if (!metricEnd || !metricStart) {
 			metricStart = `${metric}0`;
@@ -170,7 +171,7 @@ export const setScales = produce<Scale[], [AreaSpecProps]>(
 		}
 		addMetricScale(scales, [metricStart, metricEnd]);
 		return scales;
-	}
+	},
 );
 
 export const addAreaMarks = produce<Mark[], [AreaSpecProps]>((marks, props) => {
@@ -210,7 +211,7 @@ export const addAreaMarks = produce<Mark[], [AreaSpecProps]>((marks, props) => {
 			],
 		},
 		...getSelectedAreaMarks({ children, name, scaleType, color, dimension, metricEnd, metricStart }),
-		...getHoverMarks(props)
+		...getHoverMarks(props),
 	);
 	return marks;
 });
@@ -270,7 +271,7 @@ const getHoverMarks = ({ children, name, dimension, metric, color, scaleType }: 
 			encode: {
 				enter: {
 					y: { scale: 'yLinear', field: `${metric}1` },
-					stroke: { scale: 'color', field: color },
+					stroke: { scale: COLOR_SCALE, field: color },
 					fill: { signal: BACKGROUND_COLOR },
 				},
 				update: {
@@ -313,7 +314,7 @@ const getSelectedAreaMarks = ({
 					y: { scale: 'yLinear', field: metricStart },
 					y2: { scale: 'yLinear', field: metricEnd },
 					// need to fill this so the white border doesn't slightly bleed around the blue select border
-					fill: { scale: 'color', field: color },
+					fill: { scale: COLOR_SCALE, field: color },
 					stroke: { value: spectrumColors.light['static-blue'] },
 					strokeWidth: { value: 2 },
 					strokeJoin: { value: 'round' },

--- a/src/specBuilder/area/areaUtils.test.ts
+++ b/src/specBuilder/area/areaUtils.test.ts
@@ -9,7 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { BACKGROUND_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_TRANSFORMED_TIME_DIMENSION } from '@constants';
+import {
+	BACKGROUND_COLOR,
+	COLOR_SCALE,
+	DEFAULT_COLOR,
+	DEFAULT_COLOR_SCHEME,
+	DEFAULT_TRANSFORMED_TIME_DIMENSION,
+} from '@constants';
 
 import { getAreaMark } from './areaUtils';
 
@@ -18,7 +24,7 @@ describe('getAreaMark', () => {
 		expect(
 			getAreaMark({
 				name: 'area0',
-				color: 'color',
+				color: DEFAULT_COLOR,
 				colorScheme: DEFAULT_COLOR_SCHEME,
 				children: [],
 				metricStart: 'metricStart',
@@ -27,7 +33,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'linear',
 				opacity: 0.5,
-			})
+			}),
 		).toStrictEqual({
 			name: 'area0',
 			type: 'area',
@@ -48,8 +54,8 @@ describe('getAreaMark', () => {
 					tooltip: undefined,
 
 					fill: {
-						scale: 'color',
-						field: 'color',
+						scale: COLOR_SCALE,
+						field: DEFAULT_COLOR,
 					},
 				},
 				update: {
@@ -72,7 +78,7 @@ describe('getAreaMark', () => {
 		expect(
 			getAreaMark({
 				name: 'area0',
-				color: 'color',
+				color: DEFAULT_COLOR,
 				colorScheme: DEFAULT_COLOR_SCHEME,
 				children: [],
 				metricStart: 'metricStart',
@@ -81,7 +87,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'linear',
 				opacity: 0.5,
-			})
+			}),
 		).toStrictEqual({
 			name: 'area0',
 			type: 'area',
@@ -101,8 +107,8 @@ describe('getAreaMark', () => {
 						field: 'metricEnd',
 					},
 					fill: {
-						scale: 'color',
-						field: 'color',
+						scale: COLOR_SCALE,
+						field: DEFAULT_COLOR,
 					},
 					stroke: {
 						signal: BACKGROUND_COLOR,
@@ -134,7 +140,7 @@ describe('getAreaMark', () => {
 		expect(
 			getAreaMark({
 				name: 'area0',
-				color: 'color',
+				color: DEFAULT_COLOR,
 				colorScheme: DEFAULT_COLOR_SCHEME,
 				children: [],
 				metricStart: 'metricStart',
@@ -143,7 +149,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'time',
 				opacity: 0.5,
-			})
+			}),
 		).toStrictEqual({
 			name: 'area0',
 			type: 'area',
@@ -164,8 +170,8 @@ describe('getAreaMark', () => {
 						field: 'metricEnd',
 					},
 					fill: {
-						scale: 'color',
-						field: 'color',
+						scale: COLOR_SCALE,
+						field: DEFAULT_COLOR,
 					},
 				},
 				update: {
@@ -188,7 +194,7 @@ describe('getAreaMark', () => {
 		expect(
 			getAreaMark({
 				name: 'area0',
-				color: 'color',
+				color: DEFAULT_COLOR,
 				colorScheme: DEFAULT_COLOR_SCHEME,
 				children: [],
 				metricStart: 'metricStart',
@@ -197,7 +203,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'point',
 				opacity: 0.5,
-			})
+			}),
 		).toStrictEqual({
 			name: 'area0',
 			type: 'area',
@@ -217,8 +223,8 @@ describe('getAreaMark', () => {
 						field: 'metricEnd',
 					},
 					fill: {
-						scale: 'color',
-						field: 'color',
+						scale: COLOR_SCALE,
+						field: DEFAULT_COLOR,
 					},
 				},
 				update: {

--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -16,13 +16,16 @@ import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
 	DEFAULT_OPACITY_RULE,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
 	MARK_ID,
+	OPACITY_SCALE,
 	STACK_ID,
 	TABLE,
 } from '@constants';
@@ -65,7 +68,7 @@ import {
 import { defaultDodgedMark } from './dodgedBarUtils.test';
 
 const startingSpec: Spec = initializeSpec({
-	scales: [{ name: 'color', type: 'ordinal' }],
+	scales: [{ name: COLOR_SCALE, type: 'ordinal' }],
 });
 
 const defaultMetricScaleDomain: ScaleData = { data: FILTERED_TABLE, fields: ['value1'] };
@@ -90,7 +93,7 @@ const defaultDimensionScale: Scale = {
 
 const defaultColorScaleDomain: ScaleData = { data: TABLE, fields: [DEFAULT_COLOR] };
 const defaultColorScale: Scale = {
-	name: 'color',
+	name: COLOR_SCALE,
 	type: 'ordinal',
 	domain: defaultColorScaleDomain,
 };
@@ -165,7 +168,7 @@ const defaultStackedMark: Mark = {
 		enter: {
 			...defaultStackedYEncodings,
 			...defaultCornerRadiusEncodings,
-			fill: { scale: 'color', field: DEFAULT_COLOR },
+			fill: { scale: COLOR_SCALE, field: DEFAULT_COLOR },
 			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},
@@ -199,7 +202,7 @@ const defaultSpec: Spec = {
 		defaultStacksData,
 	],
 	signals: [defaultPaddingSignal],
-	scales: [{ name: 'color', type: 'ordinal' }, defaultMetricScale, defaultDimensionScale],
+	scales: [{ name: COLOR_SCALE, type: 'ordinal' }, defaultMetricScale, defaultDimensionScale],
 	marks: [
 		defaultBackgroundStackedMark,
 		{
@@ -284,7 +287,7 @@ describe('barSpecBuilder', () => {
 	describe('addScales()', () => {
 		describe('no initial state', () => {
 			test('default props, should add default scales', () => {
-				expect(addScales([{ name: 'color', type: 'ordinal' }], defaultBarProps)).toStrictEqual([
+				expect(addScales([{ name: COLOR_SCALE, type: 'ordinal' }], defaultBarProps)).toStrictEqual([
 					defaultColorScale,
 					defaultMetricScale,
 					defaultDimensionScale,
@@ -292,33 +295,33 @@ describe('barSpecBuilder', () => {
 			});
 
 			test('secondary series, should add default scales', () => {
-				expect(addScales([{ name: 'color', type: 'ordinal' }], defaultBarPropsWithSecondayColor)).toStrictEqual(
-					[
-						defaultColorScale,
-						defaultMetricScale,
-						defaultDimensionScale,
-						{
-							name: 'secondaryColor',
-							type: 'ordinal',
-							domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
-						},
-						{
-							name: 'colors',
-							type: 'ordinal',
-							range: { signal: 'colors' },
-							domain: { data: TABLE, fields: [DEFAULT_COLOR] },
-						},
-					],
-				);
+				expect(
+					addScales([{ name: COLOR_SCALE, type: 'ordinal' }], defaultBarPropsWithSecondayColor),
+				).toStrictEqual([
+					defaultColorScale,
+					defaultMetricScale,
+					defaultDimensionScale,
+					{
+						name: 'secondaryColor',
+						type: 'ordinal',
+						domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
+					},
+					{
+						name: 'colors',
+						type: 'ordinal',
+						range: { signal: 'colors' },
+						domain: { data: TABLE, fields: [DEFAULT_COLOR] },
+					},
+				]);
 			});
 
 			test('should add facet scales', () => {
 				expect(
 					addScales(
 						[
-							{ name: 'color', type: 'ordinal' },
-							{ name: 'lineType', type: 'ordinal' },
-							{ name: 'opacity', type: 'point' },
+							{ name: COLOR_SCALE, type: 'ordinal' },
+							{ name: LINE_TYPE_SCALE, type: 'ordinal' },
+							{ name: OPACITY_SCALE, type: 'point' },
 						],
 						{
 							...defaultBarProps,
@@ -328,8 +331,8 @@ describe('barSpecBuilder', () => {
 					),
 				).toStrictEqual([
 					defaultColorScale,
-					{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: 'lineType', type: 'ordinal' },
-					{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: 'opacity', type: 'point' },
+					{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: LINE_TYPE_SCALE, type: 'ordinal' },
+					{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: OPACITY_SCALE, type: 'point' },
 					defaultMetricScale,
 					defaultDimensionScale,
 				]);
@@ -337,7 +340,7 @@ describe('barSpecBuilder', () => {
 
 			test('should add trellis scales', () => {
 				expect(
-					addScales([{ name: 'color', type: 'ordinal' }], {
+					addScales([{ name: COLOR_SCALE, type: 'ordinal' }], {
 						...defaultBarProps,
 						trellis: 'event',
 						trellisOrientation: 'vertical',

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -10,10 +10,13 @@
  * governing permissions and limitations under the License.
  */
 import {
+	COLOR_SCALE,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
 	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	OPACITY_SCALE,
 	PADDING_RATIO,
 	STACK_ID,
 	TRELLIS_PADDING,
@@ -61,7 +64,7 @@ export const addBar = produce<Spec, [BarProps & { colorScheme?: ColorScheme; ind
 			trellisPadding = TRELLIS_PADDING,
 			type = 'stacked',
 			...props
-		}
+		},
 	) => {
 		// put props back together now that all defaults are set
 		const barProps: BarSpecProps = {
@@ -87,7 +90,7 @@ export const addBar = produce<Spec, [BarProps & { colorScheme?: ColorScheme; ind
 		spec.signals = addSignals(spec.signals ?? [], barProps);
 		spec.scales = addScales(spec.scales ?? [], barProps);
 		spec.marks = addMarks(spec.marks ?? [], barProps);
-	}
+	},
 );
 
 export const addSignals = produce<Signal[], [BarSpecProps]>(
@@ -107,7 +110,7 @@ export const addSignals = produce<Signal[], [BarSpecProps]>(
 				signals.push(getGenericSignal(`${name}_selectedId`));
 			}
 		}
-	}
+	},
 );
 
 export const addData = produce<Data[], [BarSpecProps]>((data, props) => {
@@ -189,15 +192,15 @@ export const addScales = produce<Scale[], [BarSpecProps]>((scales, props) => {
 	addMetricScale(scales, getScaleValues(props), orientation === 'vertical' ? 'y' : 'x');
 	addDimensionScale(scales, props);
 	addTrellisScale(scales, props);
-	addFieldToFacetScaleDomain(scales, 'color', color);
-	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
-	addFieldToFacetScaleDomain(scales, 'opacity', opacity);
+	addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
+	addFieldToFacetScaleDomain(scales, LINE_TYPE_SCALE, lineType);
+	addFieldToFacetScaleDomain(scales, OPACITY_SCALE, opacity);
 	addSecondaryScales(scales, props);
 });
 
 export const addDimensionScale = (
 	scales: Scale[],
-	{ dimension, paddingRatio, paddingOuter: barPaddingOuter, orientation }: BarSpecProps
+	{ dimension, paddingRatio, paddingOuter: barPaddingOuter, orientation }: BarSpecProps,
 ) => {
 	const index = getScaleIndexByType(scales, 'band', orientation === 'vertical' ? 'x' : 'y');
 	scales[index] = addDomainFields(scales[index], [dimension]);

--- a/src/specBuilder/bar/barTestUtils.ts
+++ b/src/specBuilder/bar/barTestUtils.ts
@@ -11,6 +11,7 @@
  */
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	CORNER_RADIUS,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
@@ -320,7 +321,7 @@ export const defaultBarEnterEncodings: RectEncodeEntry = {
 };
 
 export const defaultBarStrokeEncodings: RectEncodeEntry = {
-	stroke: [{ scale: 'color', field: DEFAULT_COLOR }],
+	stroke: [{ scale: COLOR_SCALE, field: DEFAULT_COLOR }],
 	strokeDash: [{ value: [] }],
 	strokeWidth: [{ value: 0 }],
 };

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -15,6 +15,7 @@ import { Annotation } from '@components/Annotation';
 import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import {
+	COLOR_SCALE,
 	CORNER_RADIUS,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
@@ -302,7 +303,7 @@ describe('barUtils', () => {
 		test('should return production rule with one item in array if there is not a popover', () => {
 			const strokeRule = getStroke(defaultBarProps);
 			expect(strokeRule).toHaveLength(1);
-			expect(strokeRule[0]).toStrictEqual({ scale: 'color', field: DEFAULT_COLOR });
+			expect(strokeRule[0]).toStrictEqual({ scale: COLOR_SCALE, field: DEFAULT_COLOR });
 		});
 		test('should return rules for selected data if popover exists', () => {
 			const popover = createElement(ChartPopover);

--- a/src/specBuilder/bar/dodgedBarUtils.test.ts
+++ b/src/specBuilder/bar/dodgedBarUtils.test.ts
@@ -15,6 +15,7 @@ import { Annotation } from '@components/Annotation';
 import { ChartTooltip } from '@components/ChartTooltip';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	CORNER_RADIUS,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
@@ -88,7 +89,7 @@ const defaultMark: Mark = {
 		enter: {
 			...defaultDodgedYEncodings,
 			...defaultDodgedCornerRadiusEncodings,
-			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fill: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},
@@ -110,7 +111,7 @@ const defaultMarkWithTooltip: Mark = {
 		enter: {
 			...defaultDodgedYEncodings,
 			...defaultDodgedCornerRadiusEncodings,
-			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fill: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: { signal: "merge(datum, {'rscComponentName': 'bar0'})" },
 		},

--- a/src/specBuilder/bar/stackedBarUtils.test.ts
+++ b/src/specBuilder/bar/stackedBarUtils.test.ts
@@ -14,6 +14,7 @@ import { createElement } from 'react';
 import { Annotation } from '@components/Annotation';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_OPACITY_RULE,
@@ -53,7 +54,7 @@ const defaultMark = {
 	encode: {
 		enter: {
 			...defaultBarEnterEncodings,
-			fill: { field: DEFAULT_COLOR, scale: 'color' },
+			fill: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 			fillOpacity: DEFAULT_OPACITY_RULE,
 			tooltip: undefined,
 		},

--- a/src/specBuilder/chartSpecBuilder.test.ts
+++ b/src/specBuilder/chartSpecBuilder.test.ts
@@ -15,12 +15,18 @@ import { Bar } from '@components/Bar';
 import { Legend } from '@components/Legend';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_BACKGROUND_COLOR,
 	DEFAULT_COLOR,
 	DEFAULT_SECONDARY_COLOR,
 	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
 	MARK_ID,
+	OPACITY_SCALE,
 	SERIES_ID,
+	SYMBOL_SHAPE_SCALE,
+	SYMBOL_SIZE_SCALE,
 	TABLE,
 } from '@constants';
 import { ROUNDED_SQUARE_PATH } from 'svgPaths';
@@ -73,7 +79,7 @@ describe('Chart spec builder', () => {
 		test('default color scale used', () => {
 			expect(getColorScale('categorical12', 'light')).toStrictEqual({
 				domain: { data: 'table', fields: [] },
-				name: 'color',
+				name: COLOR_SCALE,
 				range: [
 					'rgb(15, 181, 174)',
 					'rgb(64, 70, 202)',
@@ -93,7 +99,7 @@ describe('Chart spec builder', () => {
 		});
 		test('custom colors supplied', () => {
 			expect(getColorScale(['red', 'blue'], 'light')).toStrictEqual({
-				name: 'color',
+				name: COLOR_SCALE,
 				type: 'ordinal',
 				range: ['red', 'blue'],
 				domain: { data: 'table', fields: [] },
@@ -114,7 +120,7 @@ describe('Chart spec builder', () => {
 		});
 		test('should get colors from color names for light and dark mode', () => {
 			expect(
-				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'light')
+				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'light'),
 			).toStrictEqual([
 				['rgb(150, 206, 253)'],
 				['rgb(120, 187, 250)'],
@@ -122,12 +128,12 @@ describe('Chart spec builder', () => {
 				['rgb(56, 146, 243)'],
 			]);
 			expect(
-				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'dark')
+				getTwoDimensionalColorScheme(['blue-400', 'blue-500', 'blue-600', 'blue-700'], 'dark'),
 			).toStrictEqual([['rgb(0, 78, 166)'], ['rgb(0, 92, 200)'], ['rgb(6, 108, 231)'], ['rgb(29, 128, 245)']]);
 		});
 		test('should convert color scheme in second dimension to correct colors', () => {
 			expect(
-				getTwoDimensionalColorScheme(['categorical6', 'divergentOrangeYellowSeafoam5'], 'light')
+				getTwoDimensionalColorScheme(['categorical6', 'divergentOrangeYellowSeafoam5'], 'light'),
 			).toStrictEqual([
 				[
 					'rgb(15, 181, 174)',
@@ -197,7 +203,7 @@ describe('Chart spec builder', () => {
 	describe('getLineTypeScale()', () => {
 		test('should return lineType scale', () => {
 			expect(getLineTypeScale(['solid', 'dashed'])).toStrictEqual({
-				name: 'lineType',
+				name: LINE_TYPE_SCALE,
 				type: 'ordinal',
 				range: [[], [7, 4]],
 				domain: { data: 'table', fields: [] },
@@ -206,7 +212,7 @@ describe('Chart spec builder', () => {
 
 		test('should return lineType scale from 2d input', () => {
 			expect(getLineTypeScale([['solid', 'dashed']])).toStrictEqual({
-				name: 'lineType',
+				name: LINE_TYPE_SCALE,
 				type: 'ordinal',
 				range: [[]],
 				domain: { data: 'table', fields: [] },
@@ -217,7 +223,7 @@ describe('Chart spec builder', () => {
 	describe('getOpacityScale()', () => {
 		test('should return default opacity point scale if no scale provided', () => {
 			const defaultOpacityScale = {
-				name: 'opacity',
+				name: OPACITY_SCALE,
 				type: 'point',
 				range: [1, 0],
 				padding: 1,
@@ -230,7 +236,7 @@ describe('Chart spec builder', () => {
 
 		test('should return opacity ordinal scale if scale values are provided', () => {
 			expect(getOpacityScale([0.2, 0.4, 0.6, 0.8])).toStrictEqual({
-				name: 'opacity',
+				name: OPACITY_SCALE,
 				type: 'ordinal',
 				range: [0.2, 0.4, 0.6, 0.8],
 				domain: { data: 'table', fields: [] },
@@ -242,9 +248,9 @@ describe('Chart spec builder', () => {
 				getOpacityScale([
 					[0.2, 0.4],
 					[0.6, 0.8],
-				])
+				]),
 			).toStrictEqual({
-				name: 'opacity',
+				name: OPACITY_SCALE,
 				type: 'ordinal',
 				range: [0.2, 0.6],
 				domain: { data: 'table', fields: [] },
@@ -255,7 +261,7 @@ describe('Chart spec builder', () => {
 	describe('getLineWidthScale()', () => {
 		test('should return lineWidth scale with line width pixel values provided', () => {
 			expect(getLineWidthScale([1, 2, 3, 4])).toStrictEqual({
-				name: 'lineWidth',
+				name: LINE_WIDTH_SCALE,
 				type: 'ordinal',
 				range: [1, 2, 3, 4],
 				domain: { data: 'table', fields: [] },
@@ -264,7 +270,7 @@ describe('Chart spec builder', () => {
 
 		test('should return corect pixel values in scale if pixels and preset names are passed in', () => {
 			expect(getLineWidthScale(['S', 'L', 2, 4])).toStrictEqual({
-				name: 'lineWidth',
+				name: LINE_WIDTH_SCALE,
 				type: 'ordinal',
 				range: [1.5, 3, 2, 4],
 				domain: { data: 'table', fields: [] },
@@ -275,7 +281,7 @@ describe('Chart spec builder', () => {
 	describe('getSymbolShapeScale()', () => {
 		test('should return symbolShape scale with vega shapes', () => {
 			expect(getSymbolShapeScale(['circle', 'square'])).toStrictEqual({
-				name: 'symbolShape',
+				name: SYMBOL_SHAPE_SCALE,
 				type: 'ordinal',
 				range: ['circle', 'square'],
 				domain: { data: 'table', fields: [] },
@@ -286,7 +292,7 @@ describe('Chart spec builder', () => {
 			const path =
 				'M -0.01 -0.38 C -0.04 -0.27 -0.1 -0.07 -0.15 0.08 H 0.14 C 0.1 -0.03 0.03 -0.26 -0.01 -0.38 H -0.01 M -1 -1 M 0.55 -1 H -0.55 C -0.8 -1 -1 -0.8 -1 -0.55 V 0.55 C -1 0.8 -0.8 1 -0.55 1 H 0.55 C 0.8 1 1 0.8 1 0.55 V -0.55 C 1 -0.8 0.8 -1 0.55 -1 M 0.49 0.55 H 0.3 S 0.29 0.55 0.28 0.55 L 0.18 0.27 H -0.22 L -0.31 0.55 S -0.31 0.56 -0.33 0.56 H -0.5 S -0.51 0.56 -0.51 0.54 L -0.17 -0.44 S -0.16 -0.47 -0.15 -0.53 C -0.15 -0.53 -0.15 -0.54 -0.15 -0.54 H 0.08 S 0.09 -0.54 0.09 -0.53 L 0.48 0.54 S 0.48 0.56 0.48 0.56 Z';
 			expect(getSymbolShapeScale([path])).toStrictEqual({
-				name: 'symbolShape',
+				name: SYMBOL_SHAPE_SCALE,
 				type: 'ordinal',
 				range: [path],
 				domain: { data: 'table', fields: [] },
@@ -295,7 +301,7 @@ describe('Chart spec builder', () => {
 
 		test('should return symbolShape scale with supported shapes', () => {
 			expect(getSymbolShapeScale(['rounded-square'])).toStrictEqual({
-				name: 'symbolShape',
+				name: SYMBOL_SHAPE_SCALE,
 				type: 'ordinal',
 				range: [ROUNDED_SQUARE_PATH],
 				domain: { data: 'table', fields: [] },
@@ -307,9 +313,9 @@ describe('Chart spec builder', () => {
 				getSymbolShapeScale([
 					['circle', 'square'],
 					['triangle,', 'circle'],
-				])
+				]),
 			).toStrictEqual({
-				name: 'symbolShape',
+				name: SYMBOL_SHAPE_SCALE,
 				type: 'ordinal',
 				range: ['circle', 'triangle,'],
 				domain: { data: 'table', fields: [] },
@@ -320,7 +326,7 @@ describe('Chart spec builder', () => {
 	describe('getSymbolSizeScale()', () => {
 		test('should return the symbolSize scale', () => {
 			expect(getSymbolSizeScale(['XS', 'XL'])).toStrictEqual({
-				name: 'symbolSize',
+				name: SYMBOL_SIZE_SCALE,
 				type: 'linear',
 				zero: false,
 				domain: { data: 'table', fields: [] },
@@ -344,7 +350,7 @@ describe('Chart spec builder', () => {
 
 		test('should join the facets', () => {
 			expect(
-				addData(defaultData, { facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })[0].transform?.at(-1)
+				addData(defaultData, { facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })[0].transform?.at(-1),
 			).toStrictEqual({ as: SERIES_ID, expr: 'datum.series + " | " + datum.subSeries', type: 'formula' });
 		});
 	});
@@ -428,7 +434,7 @@ describe('Chart spec builder', () => {
 			};
 
 			expect(spec.signals?.find((signal) => signal.name === 'highlightedSeries')).toStrictEqual(
-				uncontrolledHighlightSignal
+				uncontrolledHighlightSignal,
 			);
 		});
 	});
@@ -445,8 +451,8 @@ describe('Chart spec builder', () => {
 			expect(
 				addHighlight(
 					{ signals: [testSignal] },
-					{ children: [], hiddenSeries: [], highlightedSeries: undefined }
-				)
+					{ children: [], hiddenSeries: [], highlightedSeries: undefined },
+				),
 			).toStrictEqual({
 				signals: [testSignal, { name: 'highlightedSeries', value: null }],
 			});
@@ -456,7 +462,7 @@ describe('Chart spec builder', () => {
 			expect(addHighlight({}, { children: [], hiddenSeries: [], highlightedSeries: 'testSeries' })).toStrictEqual(
 				{
 					signals: [{ name: 'highlightedSeries', value: 'testSeries' }],
-				}
+				},
 			);
 		});
 
@@ -493,14 +499,14 @@ describe('Chart spec builder', () => {
 
 		test('hiddenSeries is empty when no hidden series', () => {
 			expect(
-				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1])
+				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1]),
 			).toStrictEqual([...defaultSignals, { name: 'hiddenSeries', value: [] }]);
 		});
 
 		test('hiddenSeries contains provided hidden series', () => {
 			const hiddenSeries = ['test'];
 			expect(
-				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1], hiddenSeries)
+				getDefaultSignals(DEFAULT_BACKGROUND_COLOR, 'categorical12', 'light', ['dashed'], [1], hiddenSeries),
 			).toStrictEqual([...defaultSignals, { name: 'hiddenSeries', value: hiddenSeries }]);
 		});
 	});

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -11,11 +11,17 @@
  */
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_BACKGROUND_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_LINE_TYPES,
 	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
+	OPACITY_SCALE,
 	SERIES_ID,
+	SYMBOL_SHAPE_SCALE,
+	SYMBOL_SIZE_SCALE,
 	TABLE,
 } from '@constants';
 import { Area, Axis, Bar, Legend, Line, Scatter, Title } from '@rsc';
@@ -196,7 +202,7 @@ export const getDefaultSignals = (
 	colorScheme: ColorScheme,
 	lineTypes: LineTypes,
 	opacities: Opacities | undefined,
-	hiddenSeries?: string[]
+	hiddenSeries?: string[],
 ): Signal[] => {
 	// if the background color is transparent, then we want to set the signal background color to gray-50
 	// if the signal background color were transparent then backgroundMarks and annotation fill would also be transparent
@@ -243,7 +249,7 @@ const getDefaultScales = (
 	lineWidths: LineWidth[],
 	opacities: Opacities | undefined,
 	symbolShapes: SymbolShapes,
-	symbolSizes: [SymbolSize, SymbolSize]
+	symbolSizes: [SymbolSize, SymbolSize],
 ): Scale[] => [
 	getColorScale(colors, colorScheme),
 	getLineTypeScale(lineTypes),
@@ -257,7 +263,7 @@ export const getColorScale = (colors: ChartColors, colorScheme: ColorScheme): Or
 	// if a two dimensional scale was provided, then just grab the first color in each scale and set that as the scale range
 	const range = isColors(colors) ? getColors(colors, colorScheme) : colors.map((c) => getColors(c, colorScheme)[0]);
 	return {
-		name: 'color',
+		name: COLOR_SCALE,
 		type: 'ordinal',
 		range,
 		domain: { data: TABLE, fields: [] },
@@ -270,7 +276,7 @@ export const getLineTypeScale = (lineTypes: LineTypes): OrdinalScale => {
 		? getStrokeDashesFromLineTypes(lineTypes)
 		: lineTypes.map((lineTypesArray) => getStrokeDashFromLineType(lineTypesArray[0]));
 	return {
-		name: 'lineType',
+		name: LINE_TYPE_SCALE,
 		type: 'ordinal',
 		range,
 		domain: { data: TABLE, fields: [] },
@@ -282,7 +288,7 @@ export const getSymbolShapeScale = (symbolShapes: SymbolShapes): OrdinalScale =>
 		? getPathsFromSymbolShapes(symbolShapes)
 		: symbolShapes.map((symbolShape) => getPathFromSymbolShape(symbolShape[0]));
 	return {
-		name: 'symbolShape',
+		name: SYMBOL_SHAPE_SCALE,
 		type: 'ordinal',
 		range,
 		domain: { data: TABLE, fields: [] },
@@ -295,7 +301,7 @@ export const getSymbolShapeScale = (symbolShapes: SymbolShapes): OrdinalScale =>
  * @returns LinearScale
  */
 export const getSymbolSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): LinearScale => ({
-	name: 'symbolSize',
+	name: SYMBOL_SIZE_SCALE,
 	type: 'linear',
 	zero: false,
 	range: symbolSizes.map((symbolSize) => getVegaSymbolSizeFromRscSymbolSize(symbolSize)),
@@ -303,7 +309,7 @@ export const getSymbolSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): Linea
 });
 
 export const getLineWidthScale = (lineWidths: LineWidth[]): OrdinalScale => ({
-	name: 'lineWidth',
+	name: LINE_WIDTH_SCALE,
 	type: 'ordinal',
 	range: lineWidths.map((lineWidth) => getLineWidthPixelsFromLineWidth(lineWidth)),
 	domain: { data: TABLE, fields: [] },
@@ -313,14 +319,14 @@ export const getOpacityScale = (opacities?: Opacities): OrdinalScale | PointScal
 	if (opacities?.length) {
 		const range = isNumberArray(opacities) ? opacities : opacities.map((opacityArray) => opacityArray[0]);
 		return {
-			name: 'opacity',
+			name: OPACITY_SCALE,
 			type: 'ordinal',
 			range: range,
 			domain: { data: TABLE, fields: [] },
 		};
 	}
 	return {
-		name: 'opacity',
+		name: OPACITY_SCALE,
 		type: 'point',
 		range: [1, 0],
 		padding: 1,

--- a/src/specBuilder/donut/donutSpecBuilder.test.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.test.ts
@@ -13,7 +13,7 @@
 import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
-import { FILTERED_TABLE, MARK_ID } from '@constants';
+import { COLOR_SCALE, FILTERED_TABLE, MARK_ID } from '@constants';
 import { DonutSpecProps } from 'types';
 
 import { addData } from './donutSpecBuilder';
@@ -141,7 +141,7 @@ describe('addMarks', () => {
 				props.metric,
 				'min(width, height) / 2',
 				props.holeRatio,
-				props.metricLabel
+				props.metricLabel,
 			),
 		];
 		expect(result).toEqual(expectedMarks);
@@ -171,7 +171,7 @@ describe('addMarks', () => {
 				props.metric,
 				'min(width, height) / 2',
 				props.holeRatio,
-				props.metricLabel
+				props.metricLabel,
 			),
 			getDirectLabelMark(props.name, 'min(width, height) / 2', props.metric, props.segment!),
 		];
@@ -195,7 +195,7 @@ describe('addMarks', () => {
 			children: [],
 		};
 		expect(() => addMarks(marks, props)).toThrow(
-			'If a Donut chart hasDirectLabels, a segment property name must be supplied.'
+			'If a Donut chart hasDirectLabels, a segment property name must be supplied.',
 		);
 	});
 });
@@ -398,7 +398,7 @@ describe('donutSpecBuilder', () => {
 					data: 'table',
 					fields: ['testColor'],
 				},
-				name: 'color',
+				name: COLOR_SCALE,
 				type: undefined,
 			},
 		];

--- a/src/specBuilder/donut/donutSpecBuilder.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_METRIC, FILTERED_TABLE } from '@constants';
+import { COLOR_SCALE, DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_METRIC, FILTERED_TABLE } from '@constants';
 import { hasPopover } from '@specBuilder/marks/markUtils';
 import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
 import { getGenericSignal, getUncontrolledHoverSignal, hasSignalByName } from '@specBuilder/signal/signalSpecBuilder';
@@ -35,7 +35,7 @@ export const addDonut = produce<Spec, [DonutProps & { colorScheme?: ColorScheme;
 			hasDirectLabels = false,
 			isBoolean = false,
 			...props
-		}
+		},
 	) => {
 		// put props back together now that all defaults are set
 		const donutProps: DonutSpecProps = {
@@ -56,7 +56,7 @@ export const addDonut = produce<Spec, [DonutProps & { colorScheme?: ColorScheme;
 		spec.scales = addScales(spec.scales ?? [], donutProps);
 		spec.marks = addMarks(spec.marks ?? [], donutProps);
 		spec.signals = addSignals(spec.signals ?? [], donutProps);
-	}
+	},
 );
 
 export const addData = produce<Data[], [DonutSpecProps]>((data, props) => {
@@ -108,7 +108,7 @@ export const addData = produce<Data[], [DonutSpecProps]>((data, props) => {
 
 export const addScales = produce<Scale[], [DonutSpecProps]>((scales, props) => {
 	const { color } = props;
-	addFieldToFacetScaleDomain(scales, 'color', color);
+	addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
 });
 
 export const addMarks = produce<Mark[], [DonutSpecProps]>((marks, props) => {

--- a/src/specBuilder/donut/donutUtils.test.ts
+++ b/src/specBuilder/donut/donutUtils.test.ts
@@ -13,7 +13,7 @@
 import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
-import { FILTERED_TABLE, HIGHLIGHT_CONTRAST_RATIO, MARK_ID } from '@constants';
+import { COLOR_SCALE, FILTERED_TABLE, HIGHLIGHT_CONTRAST_RATIO, MARK_ID } from '@constants';
 import { getTooltip } from '@specBuilder/marks/markUtils';
 import { MarkChildElement } from 'types';
 
@@ -434,7 +434,7 @@ describe('getArcMark', () => {
 			from: { data: FILTERED_TABLE },
 			encode: {
 				enter: {
-					fill: { scale: 'color', field: 'id' },
+					fill: { scale: COLOR_SCALE, field: 'id' },
 					x: { signal: 'width / 2' },
 					y: { signal: 'height / 2' },
 					tooltip: undefined,
@@ -460,7 +460,7 @@ describe('getArcMark', () => {
 			from: { data: FILTERED_TABLE },
 			encode: {
 				enter: {
-					fill: { scale: 'color', field: 'id' },
+					fill: { scale: COLOR_SCALE, field: 'id' },
 					x: { signal: 'width / 2' },
 					y: { signal: 'height / 2' },
 					tooltip: getTooltip(children, 'Test'),

--- a/src/specBuilder/donut/donutUtils.ts
+++ b/src/specBuilder/donut/donutUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { FILTERED_TABLE, HIGHLIGHT_CONTRAST_RATIO, MARK_ID } from '@constants';
+import { COLOR_SCALE, FILTERED_TABLE, HIGHLIGHT_CONTRAST_RATIO, MARK_ID } from '@constants';
 import { getTooltip, hasPopover } from '@specBuilder/marks/markUtils';
 import { MarkChildElement } from 'types';
 import {
@@ -31,7 +31,7 @@ export const getArcMark = (name: string, holeRatio: number, radius: string, chil
 		from: { data: FILTERED_TABLE },
 		encode: {
 			enter: {
-				fill: { scale: 'color', field: 'id' },
+				fill: { scale: COLOR_SCALE, field: 'id' },
 				x: { signal: 'width / 2' },
 				y: { signal: 'height / 2' },
 				tooltip: getTooltip(children, name),
@@ -76,7 +76,7 @@ export const getAggregateMetricMark = (
 	metric: string,
 	radius: string,
 	holeRatio: number,
-	metricLabel: string | undefined
+	metricLabel: string | undefined,
 ): Mark => {
 	const groupMark: Mark = {
 		type: 'group',
@@ -106,7 +106,7 @@ export const getPercentMetricMark = (
 	metric: string,
 	radius: string,
 	holeRatio: number,
-	metricLabel: string | undefined
+	metricLabel: string | undefined,
 ): Mark => {
 	const groupMark: Mark = {
 		type: 'group',
@@ -136,7 +136,7 @@ export const getMetricNumberEncodeEnter = (
 	radius: string,
 	holeRatio: number,
 	showingLabel: boolean,
-	isBoolean: boolean
+	isBoolean: boolean,
 ): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
 	return {
 		enter: {
@@ -160,7 +160,7 @@ export const getMetricNumberText = (metric: string, isBoolean: boolean): Product
 export const getMetricLabelEncodeEnter = (
 	radius: string,
 	holeRatio: number,
-	metricLabel: string
+	metricLabel: string,
 ): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
 	return {
 		enter: {
@@ -181,7 +181,7 @@ export const metricLabelFontSizes = [24, 18, 12, 0];
 export const getAggregateMetricBaseline = (
 	radius: string,
 	holeRatio: number,
-	showingLabel: boolean
+	showingLabel: boolean,
 ): ProductionRule<TextBaselineValueRef> => {
 	// whenever we aren't showing the label, the metric number should be in the middle
 	// we check if the radius * holeRatio is greater than the second breakpoint because after that point the label dissapears
@@ -193,7 +193,7 @@ export const getAggregateMetricBaseline = (
 export const getFontSize = (
 	radius: string,
 	holeRatio: number,
-	isPrimaryText: boolean
+	isPrimaryText: boolean,
 ): ProductionRule<NumericValueRef> => {
 	return [
 		{
@@ -257,7 +257,7 @@ export const getDirectLabelTextEntry = (
 	radius: string,
 	datumProperty: string,
 	baselinePosition: 'top' | 'bottom',
-	format: boolean = false
+	format: boolean = false,
 ): TextEncodeEntry => {
 	return {
 		text: getDisplayTextForLargeSlice(radius, datumProperty, format),
@@ -278,7 +278,7 @@ export const getDisplayTextForLargeSlice = (
 	radius: string,
 	datumProperty: string,
 	format: boolean,
-	minArcLength: number = 40 // minimum arc length to display text, in pixels
+	minArcLength: number = 40, // minimum arc length to display text, in pixels
 ): ProductionRule<TextValueRef> => {
 	return {
 		//if we want to go back to displaying based on radians rather than arc length, use this if statement:  if(datum['endAngle'] - datum['startAngle'] < 0.3

--- a/src/specBuilder/legend/legendFacetUtils.test.ts
+++ b/src/specBuilder/legend/legendFacetUtils.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { DEFAULT_COLOR, TABLE } from '@constants';
+import { COLOR_SCALE, DEFAULT_COLOR, LINE_TYPE_SCALE, SYMBOL_SIZE_SCALE, TABLE } from '@constants';
 import { Scale } from 'vega';
 
 import { getFacets, getFacetsFromKeys } from './legendFacetUtils';
@@ -19,16 +19,16 @@ describe('getFacets()', () => {
 	test('should correctly identify continuous and categorical facets', () => {
 		const scales: Scale[] = [
 			{
-				name: 'color',
+				name: COLOR_SCALE,
 				type: 'ordinal',
 				domain: { data: TABLE, fields: [DEFAULT_COLOR] },
 			},
 			{
-				name: 'lineType',
+				name: LINE_TYPE_SCALE,
 				type: 'ordinal',
 			},
 			{
-				name: 'symbolSize',
+				name: SYMBOL_SIZE_SCALE,
 				type: 'linear',
 				domain: { data: TABLE, fields: ['weight'] },
 			},
@@ -43,16 +43,16 @@ describe('getFacetsFromKeys()', () => {
 	test('should find the correct facets from the provided keys', () => {
 		const scales: Scale[] = [
 			{
-				name: 'color',
+				name: COLOR_SCALE,
 				type: 'ordinal',
 				domain: { data: TABLE, fields: [DEFAULT_COLOR] },
 			},
 			{
-				name: 'lineType',
+				name: LINE_TYPE_SCALE,
 				type: 'ordinal',
 			},
 			{
-				name: 'symbolSize',
+				name: SYMBOL_SIZE_SCALE,
 				type: 'linear',
 				domain: { data: TABLE, fields: ['weight'] },
 			},

--- a/src/specBuilder/legend/legendFacetUtils.ts
+++ b/src/specBuilder/legend/legendFacetUtils.ts
@@ -14,20 +14,21 @@ import { FacetType, SecondaryFacetType } from 'types';
 import { Scale, ScaleMultiFieldsRef } from 'vega';
 
 import { Facet } from './legendUtils';
+import { COLOR_SCALE, LINE_TYPE_SCALE, OPACITY_SCALE, SYMBOL_SHAPE_SCALE, SYMBOL_SIZE_SCALE } from '@constants';
 
 /**
  * These are all the scale names that are used for facets
  */
 const facetScaleNames: (FacetType | SecondaryFacetType)[] = [
-	'color',
-	'lineType',
-	'opacity',
+	COLOR_SCALE,
+	LINE_TYPE_SCALE,
+	OPACITY_SCALE,
 	'secondaryColor',
 	'secondaryLineType',
 	'secondaryOpacity',
 	'secondarySymbolShape',
-	'symbolShape',
-	'symbolSize',
+	SYMBOL_SHAPE_SCALE,
+	SYMBOL_SIZE_SCALE,
 ];
 
 /**
@@ -69,7 +70,7 @@ export const getFacets = (scales: Scale[]): { ordinalFacets: Facet[]; continuous
  */
 export const getFacetsFromKeys = (
 	keys: string[],
-	scales: Scale[]
+	scales: Scale[],
 ): { ordinalFacets: Facet[]; continuousFacets: Facet[] } => {
 	const ordinalFacets: Facet[] = [];
 	const continuousFacets: Facet[] = [];

--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, DEFAULT_OPACITY_RULE, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
+import { DEFAULT_COLOR, DEFAULT_OPACITY_RULE, HIGHLIGHT_CONTRAST_RATIO, OPACITY_SCALE, SERIES_ID } from '@constants';
 import { Mark } from 'vega';
 
 import { getHighlightOpacityRule, getOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
@@ -28,15 +28,15 @@ const defaultOpacityEncoding = {
 
 describe('getHighlightOpacityRule()', () => {
 	test('scale ref should divide by highlight contrast ratio', () => {
-		expect(getHighlightOpacityRule({ scale: 'opacity', field: DEFAULT_COLOR })).toStrictEqual({
+		expect(getHighlightOpacityRule({ scale: OPACITY_SCALE, field: DEFAULT_COLOR })).toStrictEqual({
 			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
-			signal: `scale('opacity', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
+			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
 		});
 	});
 	test('signal ref should divide by highlight contrast ratio', () => {
-		expect(getHighlightOpacityRule({ signal: `scale('opacity', datum.${DEFAULT_COLOR})` })).toStrictEqual({
+		expect(getHighlightOpacityRule({ signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})` })).toStrictEqual({
 			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
-			signal: `scale('opacity', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
+			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
 		});
 	});
 	test('value ref should divide by highlight contrast ratio', () => {
@@ -65,8 +65,10 @@ describe('getHighlightOpacityRule()', () => {
 describe('getOpacityRule()', () => {
 	test('array, should return the last value', () => {
 		expect(getOpacityRule([{ value: 0.5 }])).toStrictEqual({ value: 0.5 });
-		expect(getOpacityRule([{ value: 0.5 }, { signal: `scale('opacity', datum.${DEFAULT_COLOR})` }])).toStrictEqual({
-			signal: `scale('opacity', datum.${DEFAULT_COLOR})`,
+		expect(
+			getOpacityRule([{ value: 0.5 }, { signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})` }]),
+		).toStrictEqual({
+			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})`,
 		});
 	});
 	test('empty array, should return default value', () => {

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
+import { COLOR_SCALE, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
 import { GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
 
 /**
@@ -96,14 +96,14 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
 	const enter = mark.encode?.enter;
 	if (!enter) return false;
 	const { fill, stroke } = enter;
-	if (fill && 'scale' in fill && fill.scale === 'color') {
+	if (fill && 'scale' in fill && fill.scale === COLOR_SCALE) {
 		return true;
 	}
 	// some marks use a 2d color scale, these will use a signal expression to get the color for that series
 	if (fill && 'signal' in fill && fill.signal.includes("scale('colors',")) {
 		return true;
 	}
-	if (stroke && 'scale' in stroke && stroke.scale === 'color') {
+	if (stroke && 'scale' in stroke && stroke.scale === COLOR_SCALE) {
 		return true;
 	}
 	return false;

--- a/src/specBuilder/legend/legendSpecBuilder.test.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR, TABLE } from '@constants';
+import { COLOR_SCALE, DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_SECONDARY_COLOR, TABLE } from '@constants';
 import { Data, Legend, LegendEncode, Scale, Spec, SymbolEncodeEntry } from 'vega';
 
 import { defaultHighlightSignal } from '../signal/signalSpecBuilder.test';
@@ -20,7 +20,7 @@ const defaultSpec: Spec = {
 	signals: [],
 	scales: [
 		{
-			name: 'color',
+			name: COLOR_SCALE,
 			type: 'ordinal',
 			domain: { data: TABLE, fields: [DEFAULT_COLOR] },
 		},
@@ -28,7 +28,7 @@ const defaultSpec: Spec = {
 	marks: [],
 };
 
-const colorEncoding = { signal: `scale('color', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR})` };
+const colorEncoding = { signal: `scale('${COLOR_SCALE}', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR})` };
 const hiddenSeriesEncoding = {
 	test: 'indexof(hiddenSeries, datum.value) !== -1',
 	value: 'rgb(213, 213, 213)',
@@ -248,12 +248,12 @@ describe('addLegend()', () => {
 
 		test('should add fields to scales if they have not been added', () => {
 			const legendSpec = addLegend(
-				{ ...defaultSpec, scales: [{ name: 'color', type: 'ordinal' }] },
+				{ ...defaultSpec, scales: [{ name: COLOR_SCALE, type: 'ordinal' }] },
 				{ color: 'series' },
 			);
 			expect(legendSpec.scales).toEqual([
 				{
-					name: 'color',
+					name: COLOR_SCALE,
 					type: 'ordinal',
 					domain: { data: 'table', fields: ['series'] },
 				},

--- a/src/specBuilder/legend/legendSpecBuilder.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.ts
@@ -9,7 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR_SCHEME } from '@constants';
+import {
+	COLOR_SCALE,
+	DEFAULT_COLOR_SCHEME,
+	LINE_TYPE_SCALE,
+	OPACITY_SCALE,
+	SYMBOL_SHAPE_SCALE,
+	SYMBOL_SIZE_SCALE,
+} from '@constants';
 import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
 import {
 	getColorValue,
@@ -56,7 +63,7 @@ export const addLegend = produce<
 			title,
 			colorScheme = DEFAULT_COLOR_SCHEME,
 			...props
-		}
+		},
 	) => {
 		const { formattedColor, formattedLineType, formattedLineWidth, formattedSymbolShape } =
 			formatFacetRefsWithPresets(color, lineType, lineWidth, symbolShape, colorScheme);
@@ -124,7 +131,7 @@ export const addLegend = produce<
 			spec.legends = [];
 		}
 		spec.legends.push(...legends);
-	}
+	},
 );
 
 /**
@@ -140,7 +147,7 @@ export const formatFacetRefsWithPresets = (
 	lineType: LineTypeFacet | undefined,
 	lineWidth: LineWidthFacet | undefined,
 	symbolShape: SymbolShapeFacet | undefined,
-	colorScheme: ColorScheme
+	colorScheme: ColorScheme,
 ) => {
 	let formattedColor: FacetRef<string> | undefined;
 	if (color && typeof color === 'object') {
@@ -202,7 +209,7 @@ const getContinuousLegend = (_facet: Facet, props: LegendSpecProps): Legend => {
 	const { symbolShape } = props;
 	// add a switch statement here for the different types of continuous legends
 	return {
-		size: 'symbolSize',
+		size: SYMBOL_SIZE_SCALE,
 		...getLegendLayout(props),
 		symbolType: getSymbolType(symbolShape),
 	};
@@ -218,10 +225,10 @@ const getLegendLayout = ({ position, title }: LegendSpecProps): Partial<Legend> 
 const addScales = produce<Scale[], [LegendSpecProps]>((scales, { color, lineType, opacity, symbolShape }) => {
 	// it is possible to define fields to facet the data off of on the legend
 	// if these fields are not already defined on the scales, we need to add them
-	addFieldToFacetScaleDomain(scales, 'color', color);
-	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
-	addFieldToFacetScaleDomain(scales, 'opacity', opacity);
-	addFieldToFacetScaleDomain(scales, 'symbolShape', symbolShape);
+	addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
+	addFieldToFacetScaleDomain(scales, LINE_TYPE_SCALE, lineType);
+	addFieldToFacetScaleDomain(scales, OPACITY_SCALE, opacity);
+	addFieldToFacetScaleDomain(scales, SYMBOL_SHAPE_SCALE, symbolShape);
 });
 
 const addMarks = produce<Mark[], [LegendSpecProps]>((marks, { highlight, keys, name }) => {
@@ -255,7 +262,7 @@ export const addData = produce<Data[], [LegendSpecProps & { facets: string[] }]>
 				...getHiddenEntriesFilter(hiddenEntries, name),
 			],
 		});
-	}
+	},
 );
 
 export const addSignals = produce<Signal[], [LegendSpecProps]>(
@@ -272,5 +279,5 @@ export const addSignals = produce<Signal[], [LegendSpecProps]>(
 				signals.push(getLegendLabelsSeriesSignal(legendLabels));
 			}
 		}
-	}
+	},
 );

--- a/src/specBuilder/legend/legendTestUtils.ts
+++ b/src/specBuilder/legend/legendTestUtils.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+	COLOR_SCALE,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_METRIC,
@@ -53,7 +54,7 @@ export const defaultMark: LineMark = {
 		enter: {
 			x: { scale: 'x', field: DEFAULT_CATEGORICAL_DIMENSION },
 			y: { scale: 'y', field: DEFAULT_METRIC },
-			stroke: { scale: 'color', field: DEFAULT_COLOR },
+			stroke: { scale: COLOR_SCALE, field: DEFAULT_COLOR },
 		},
 		update: {
 			opacity: [],

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -9,7 +9,16 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_OPACITY_RULE, HIGHLIGHT_CONTRAST_RATIO } from '@constants';
+import {
+	COLOR_SCALE,
+	DEFAULT_OPACITY_RULE,
+	HIGHLIGHT_CONTRAST_RATIO,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
+	OPACITY_SCALE,
+	SYMBOL_SHAPE_SCALE,
+	SYMBOL_SIZE_SCALE,
+} from '@constants';
 import { getColorValue, getPathFromSymbolShape } from '@specBuilder/specUtils';
 import { spectrumColors } from '@themes';
 import merge from 'deepmerge';
@@ -177,22 +186,37 @@ export const getOpacityEncoding = ({
 export const getSymbolEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncode => {
 	const { color, lineType, lineWidth, name, opacity, symbolShape, colorScheme } = props;
 	const enter: SymbolEncodeEntry = {
-		fillOpacity: getSymbolFacetEncoding<number>({ facets, facetType: 'opacity', customValue: opacity, name }),
-		shape: getSymbolFacetEncoding<string>({ facets, facetType: 'symbolShape', customValue: symbolShape, name }),
-		size: getSymbolFacetEncoding<number>({ facets, facetType: 'symbolSize', name }),
-		strokeDash: getSymbolFacetEncoding<number[]>({ facets, facetType: 'lineType', customValue: lineType, name }),
-		strokeWidth: getSymbolFacetEncoding<number>({ facets, facetType: 'lineWidth', customValue: lineWidth, name }),
+		fillOpacity: getSymbolFacetEncoding<number>({ facets, facetType: OPACITY_SCALE, customValue: opacity, name }),
+		shape: getSymbolFacetEncoding<string>({
+			facets,
+			facetType: SYMBOL_SHAPE_SCALE,
+			customValue: symbolShape,
+			name,
+		}),
+		size: getSymbolFacetEncoding<number>({ facets, facetType: SYMBOL_SIZE_SCALE, name }),
+		strokeDash: getSymbolFacetEncoding<number[]>({
+			facets,
+			facetType: LINE_TYPE_SCALE,
+			customValue: lineType,
+			name,
+		}),
+		strokeWidth: getSymbolFacetEncoding<number>({
+			facets,
+			facetType: LINE_WIDTH_SCALE,
+			customValue: lineWidth,
+			name,
+		}),
 	};
 	const update: SymbolEncodeEntry = {
 		fill: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
-			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
+			getSymbolFacetEncoding<Color>({ facets, facetType: COLOR_SCALE, customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],
 		stroke: [
 			...getHiddenSeriesColorRule(props, 'gray-300'),
-			getSymbolFacetEncoding<Color>({ facets, facetType: 'color', customValue: color, name }) ?? {
+			getSymbolFacetEncoding<Color>({ facets, facetType: COLOR_SCALE, customValue: color, name }) ?? {
 				value: spectrumColors[colorScheme]['categorical-100'],
 			},
 		],

--- a/src/specBuilder/line/lineMarkUtils.test.ts
+++ b/src/specBuilder/line/lineMarkUtils.test.ts
@@ -13,7 +13,7 @@ import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
-import { DEFAULT_OPACITY_RULE, DEFAULT_TRANSFORMED_TIME_DIMENSION, SERIES_ID } from '@constants';
+import { COLOR_SCALE, DEFAULT_OPACITY_RULE, DEFAULT_TRANSFORMED_TIME_DIMENSION, SERIES_ID } from '@constants';
 
 import { getLineHoverMarks, getLineMark, getLineOpacity } from './lineMarkUtils';
 import { defaultLineMarkProps } from './lineTestUtils';
@@ -28,7 +28,7 @@ describe('getLineMark()', () => {
 			interactive: false,
 			encode: {
 				enter: {
-					stroke: { field: 'series', scale: 'color' },
+					stroke: { field: 'series', scale: COLOR_SCALE },
 					strokeDash: { value: [] },
 					strokeOpacity: DEFAULT_OPACITY_RULE,
 					strokeWidth: { value: 1 },

--- a/src/specBuilder/line/linePointUtils.test.ts
+++ b/src/specBuilder/line/linePointUtils.test.ts
@@ -12,7 +12,14 @@
 import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
-import { BACKGROUND_COLOR, DEFAULT_COLOR, DEFAULT_SYMBOL_SIZE, DEFAULT_SYMBOL_STROKE_WIDTH, MARK_ID } from '@constants';
+import {
+	BACKGROUND_COLOR,
+	COLOR_SCALE,
+	DEFAULT_COLOR,
+	DEFAULT_SYMBOL_SIZE,
+	DEFAULT_SYMBOL_STROKE_WIDTH,
+	MARK_ID,
+} from '@constants';
 
 import {
 	getHighlightPointFill,
@@ -42,7 +49,7 @@ describe('getHighlightPointFill()', () => {
 		expect(rules).toHaveLength(2);
 		expect(rules[0]).toHaveProperty(
 			'test',
-			`${defaultLineMarkProps.name}_selectedId && ${defaultLineMarkProps.name}_selectedId === datum.${MARK_ID}`
+			`${defaultLineMarkProps.name}_selectedId && ${defaultLineMarkProps.name}_selectedId === datum.${MARK_ID}`,
 		);
 	});
 });
@@ -51,7 +58,7 @@ describe('getHighlightPointStroke()', () => {
 	test('should return simple series color rule with default props', () => {
 		const rules = getHighlightPointStroke(defaultLineMarkProps);
 		expect(rules).toHaveLength(1);
-		expect(rules[0]).toEqual({ scale: 'color', field: DEFAULT_COLOR });
+		expect(rules[0]).toEqual({ scale: COLOR_SCALE, field: DEFAULT_COLOR });
 	});
 
 	test('should include a static point rule if staticPoint is set', () => {
@@ -66,7 +73,7 @@ describe('getHighlightPointStroke()', () => {
 		expect(rules).toHaveLength(2);
 		expect(rules[0]).toHaveProperty(
 			'test',
-			`${defaultLineMarkProps.name}_selectedId && ${defaultLineMarkProps.name}_selectedId === datum.${MARK_ID}`
+			`${defaultLineMarkProps.name}_selectedId && ${defaultLineMarkProps.name}_selectedId === datum.${MARK_ID}`,
 		);
 	});
 });

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -16,6 +16,7 @@ import { MetricRange } from '@components/MetricRange';
 import { Trendline } from '@components/Trendline';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -58,7 +59,7 @@ const getMetricRangeElement = (props?: Partial<MetricRangeProps>): MetricRangeEl
 	});
 
 const startingSpec: Spec = initializeSpec({
-	scales: [{ name: 'color', type: 'ordinal' }],
+	scales: [{ name: COLOR_SCALE, type: 'ordinal' }],
 });
 
 const defaultSpec = initializeSpec({
@@ -88,7 +89,7 @@ const defaultSpec = initializeSpec({
 				{
 					encode: {
 						enter: {
-							stroke: { field: DEFAULT_COLOR, scale: 'color' },
+							stroke: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 							strokeDash: { value: [] },
 							strokeOpacity: DEFAULT_OPACITY_RULE,
 							strokeWidth: undefined,
@@ -110,7 +111,7 @@ const defaultSpec = initializeSpec({
 		},
 	],
 	scales: [
-		{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: 'color', type: 'ordinal' },
+		{ domain: { data: TABLE, fields: [DEFAULT_COLOR] }, name: COLOR_SCALE, type: 'ordinal' },
 		{
 			domain: { data: FILTERED_TABLE, fields: [DEFAULT_TRANSFORMED_TIME_DIMENSION] },
 			name: 'xTime',
@@ -167,7 +168,7 @@ const line0_groupMark = {
 			encode: {
 				enter: {
 					y: { scale: 'yLinear', field: 'value' },
-					stroke: { scale: 'color', field: 'series' },
+					stroke: { scale: COLOR_SCALE, field: 'series' },
 					strokeDash: { value: [] },
 					strokeOpacity: DEFAULT_OPACITY_RULE,
 					strokeWidth: undefined,
@@ -207,7 +208,7 @@ const metricRangeGroupMark = {
 						field: 'value',
 					},
 					stroke: {
-						scale: 'color',
+						scale: COLOR_SCALE,
 						field: 'series',
 					},
 					strokeDash: {
@@ -246,7 +247,7 @@ const metricRangeGroupMark = {
 						scale: 'yLinear',
 					},
 					fill: {
-						scale: 'color',
+						scale: COLOR_SCALE,
 						field: 'series',
 					},
 					tooltip: undefined,
@@ -286,7 +287,7 @@ const metricRangeWithDisplayPointMarks = [
 					field: 'value',
 				},
 				fill: {
-					scale: 'color',
+					scale: COLOR_SCALE,
 					field: 'series',
 				},
 				stroke: {
@@ -320,7 +321,7 @@ const displayPointMarks = [
 					field: 'value',
 				},
 				fill: {
-					scale: 'color',
+					scale: COLOR_SCALE,
 					field: 'series',
 				},
 				stroke: {
@@ -458,7 +459,7 @@ describe('lineSpecBuilder', () => {
 						{
 							encode: {
 								enter: {
-									stroke: { field: DEFAULT_COLOR, scale: 'color' },
+									stroke: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 									strokeOpacity: DEFAULT_OPACITY_RULE,
 									strokeDash: { value: [8, 8] },
 									strokeWidth: undefined,

--- a/src/specBuilder/line/lineSpecBuilder.ts
+++ b/src/specBuilder/line/lineSpecBuilder.ts
@@ -9,7 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR_SCHEME, DEFAULT_METRIC, DEFAULT_TIME_DIMENSION, FILTERED_TABLE } from '@constants';
+import {
+	COLOR_SCALE,
+	DEFAULT_COLOR_SCHEME,
+	DEFAULT_METRIC,
+	DEFAULT_TIME_DIMENSION,
+	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	OPACITY_SCALE,
+} from '@constants';
 import { hasInteractiveChildren, hasPopover } from '@specBuilder/marks/markUtils';
 import {
 	getMetricRangeGroupMarks,
@@ -119,11 +127,11 @@ export const setScales = produce<Scale[], [LineSpecProps]>((scales, props) => {
 	// add dimension scale
 	addContinuousDimensionScale(scales, { scaleType, dimension, padding });
 	// add color to the color domain
-	addFieldToFacetScaleDomain(scales, 'color', color);
+	addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
 	// add lineType to the lineType domain
-	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
+	addFieldToFacetScaleDomain(scales, LINE_TYPE_SCALE, lineType);
 	// add opacity to the opacity domain
-	addFieldToFacetScaleDomain(scales, 'opacity', opacity);
+	addFieldToFacetScaleDomain(scales, OPACITY_SCALE, opacity);
 	// find the linear scale and add our fields to it
 	addMetricScale(scales, getMetricKeys(metric, children, name));
 	// add trendline scales

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -16,12 +16,17 @@ import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { MetricRange } from '@components/MetricRange';
 import {
+	COLOR_SCALE,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_SECONDARY_COLOR,
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
+	OPACITY_SCALE,
+	SYMBOL_SIZE_SCALE,
 } from '@constants';
 
 import {
@@ -40,7 +45,7 @@ import {
 describe('getColorProductionRule', () => {
 	test('should return scale reference if color is a string', () => {
 		expect(getColorProductionRule(DEFAULT_COLOR, DEFAULT_COLOR_SCHEME)).toStrictEqual({
-			scale: 'color',
+			scale: COLOR_SCALE,
 			field: DEFAULT_COLOR,
 		});
 	});
@@ -65,7 +70,10 @@ describe('getLineWidthProductionRule', () => {
 	});
 
 	test('should return scale reference if lineWidth is a string', () => {
-		expect(getLineWidthProductionRule(DEFAULT_COLOR)).toStrictEqual({ scale: 'lineWidth', field: DEFAULT_COLOR });
+		expect(getLineWidthProductionRule(DEFAULT_COLOR)).toStrictEqual({
+			scale: LINE_WIDTH_SCALE,
+			field: DEFAULT_COLOR,
+		});
 	});
 
 	test('should return static value and convert preset line width to pixel value', () => {
@@ -79,7 +87,10 @@ describe('getLineWidthProductionRule', () => {
 
 describe('getStrokeDashProductionRule', () => {
 	test('should return scale reference if lineType is a string', () => {
-		expect(getStrokeDashProductionRule(DEFAULT_COLOR)).toStrictEqual({ scale: 'lineType', field: DEFAULT_COLOR });
+		expect(getStrokeDashProductionRule(DEFAULT_COLOR)).toStrictEqual({
+			scale: LINE_TYPE_SCALE,
+			field: DEFAULT_COLOR,
+		});
 	});
 
 	test('should return static value and convert preset line type to dash array', () => {
@@ -94,7 +105,7 @@ describe('getStrokeDashProductionRule', () => {
 describe('getOpacityProductionRule()', () => {
 	test('shold return signal rule for scale reference input', () => {
 		expect(getOpacityProductionRule(DEFAULT_COLOR)).toStrictEqual({
-			signal: `scale('opacity', datum.${DEFAULT_COLOR})`,
+			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})`,
 		});
 	});
 	test('should return value rule for static value', () => {
@@ -104,7 +115,7 @@ describe('getOpacityProductionRule()', () => {
 
 describe('getSymbolSizeProductionRule()', () => {
 	test('should return scale rule for key reference', () => {
-		expect(getSymbolSizeProductionRule('weight')).toStrictEqual({ scale: 'symbolSize', field: 'weight' });
+		expect(getSymbolSizeProductionRule('weight')).toStrictEqual({ scale: SYMBOL_SIZE_SCALE, field: 'weight' });
 	});
 	test('should return static value squared if static value supplied', () => {
 		expect(getSymbolSizeProductionRule({ value: 5 })).toStrictEqual({ value: 25 });
@@ -151,7 +162,7 @@ describe('getTooltip()', () => {
 describe('getHighlightOpacityValue()', () => {
 	test('should divide a signal ref by the highlight contract ratio', () => {
 		expect(getHighlightOpacityValue(getOpacityProductionRule(DEFAULT_COLOR))).toStrictEqual({
-			signal: `scale('opacity', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
+			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
 		});
 	});
 	test('shold divide a value ref by the highlight contrast ratio', () => {

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -17,9 +17,14 @@ import { MetricRange } from '@components/MetricRange';
 import { Trendline } from '@components/Trendline';
 import {
 	BACKGROUND_COLOR,
+	COLOR_SCALE,
 	DEFAULT_OPACITY_RULE,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
+	OPACITY_SCALE,
+	SYMBOL_SIZE_SCALE,
 } from '@constants';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
 import {
@@ -120,7 +125,7 @@ export const getColorProductionRule = (color: ColorFacet | DualFacet, colorSchem
 		};
 	}
 	if (typeof color === 'string') {
-		return { scale: 'color', field: color };
+		return { scale: COLOR_SCALE, field: color };
 	}
 	return { value: getColorValue(color.value, colorScheme) };
 };
@@ -137,7 +142,7 @@ export const getLineWidthProductionRule = (
 	}
 	// key reference for setting line width
 	if (typeof lineWidth === 'string') {
-		return { scale: 'lineWidth', field: lineWidth };
+		return { scale: LINE_WIDTH_SCALE, field: lineWidth };
 	}
 	// static value for setting line width
 	return { value: getLineWidthPixelsFromLineWidth(lineWidth.value) };
@@ -150,7 +155,7 @@ export const getOpacityProductionRule = (opacity: OpacityFacet | DualFacet): { s
 		};
 	}
 	if (typeof opacity === 'string') {
-		return { signal: `scale('opacity', datum.${opacity})` };
+		return { signal: `scale('${OPACITY_SCALE}', datum.${opacity})` };
 	}
 	return { value: opacity.value };
 };
@@ -158,7 +163,7 @@ export const getOpacityProductionRule = (opacity: OpacityFacet | DualFacet): { s
 export const getSymbolSizeProductionRule = (symbolSize: SymbolSizeFacet): NumericValueRef => {
 	// key reference for setting symbol size
 	if (typeof symbolSize === 'string') {
-		return { scale: 'symbolSize', field: symbolSize };
+		return { scale: SYMBOL_SIZE_SCALE, field: symbolSize };
 	}
 	// static value for setting symbol size
 	return { value: getVegaSymbolSizeFromRscSymbolSize(symbolSize.value) };
@@ -171,7 +176,7 @@ export const getStrokeDashProductionRule = (lineType: LineTypeFacet | DualFacet)
 		};
 	}
 	if (typeof lineType === 'string') {
-		return { scale: 'lineType', field: lineType };
+		return { scale: LINE_TYPE_SCALE, field: lineType };
 	}
 	return { value: getStrokeDashFromLineType(lineType.value) };
 };

--- a/src/specBuilder/metricRange/metricRangeUtils.test.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.test.ts
@@ -13,6 +13,7 @@ import { createElement } from 'react';
 
 import { MetricRange } from '@components/MetricRange';
 import {
+	COLOR_SCALE,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -77,7 +78,7 @@ const basicMetricRangeMarks = [
 		encode: {
 			enter: {
 				y: { scale: 'yLinear', field: 'metric' },
-				stroke: { scale: 'color', field: 'series' },
+				stroke: { scale: COLOR_SCALE, field: 'series' },
 				strokeDash: { value: [3, 4] },
 				strokeOpacity: DEFAULT_OPACITY_RULE,
 				strokeWidth: { value: 1.5 },
@@ -103,7 +104,7 @@ const basicMetricRangeMarks = [
 				tooltip: undefined,
 				y: { scale: 'yLinear', field: 'metricStart' },
 				y2: { scale: 'yLinear', field: 'metricEnd' },
-				fill: { scale: 'color', field: 'series' },
+				fill: { scale: COLOR_SCALE, field: 'series' },
 			},
 			update: {
 				cursor: undefined,

--- a/src/specBuilder/scale/scaleSpecBuilder.test.ts
+++ b/src/specBuilder/scale/scaleSpecBuilder.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_COLOR } from '@constants';
+import { COLOR_SCALE, DEFAULT_COLOR } from '@constants';
 import { OrdinalScale, Scale } from 'vega';
 
 import {
@@ -22,15 +22,15 @@ import {
 
 const defaultColorScale: OrdinalScale = {
 	domain: { data: 'table', fields: [DEFAULT_COLOR] },
-	name: 'color',
+	name: COLOR_SCALE,
 	type: 'ordinal',
 };
 
 describe('addDomainFields()', () => {
 	test('no domain fields', () => {
-		expect(addDomainFields({ name: 'color', type: 'ordinal' }, [DEFAULT_COLOR])).toStrictEqual({
+		expect(addDomainFields({ name: COLOR_SCALE, type: 'ordinal' }, [DEFAULT_COLOR])).toStrictEqual({
 			domain: { data: 'table', fields: [DEFAULT_COLOR] },
-			name: 'color',
+			name: COLOR_SCALE,
 			type: 'ordinal',
 		});
 	});
@@ -72,17 +72,17 @@ describe('getPadding()', () => {
 
 describe('addFieldToFacetScaleDomain()', () => {
 	test('should add fields to correct scale', () => {
-		const scales: Scale[] = [{ name: 'color', type: 'ordinal' }];
-		addFieldToFacetScaleDomain(scales, 'color', DEFAULT_COLOR);
+		const scales: Scale[] = [{ name: COLOR_SCALE, type: 'ordinal' }];
+		addFieldToFacetScaleDomain(scales, COLOR_SCALE, DEFAULT_COLOR);
 		expect(scales).toStrictEqual([
-			{ name: 'color', type: 'ordinal', domain: { data: 'table', fields: [DEFAULT_COLOR] } },
+			{ name: COLOR_SCALE, type: 'ordinal', domain: { data: 'table', fields: [DEFAULT_COLOR] } },
 		]);
 	});
 
 	test('should not add any fields to the domain if the facet value is static', () => {
-		const scales: Scale[] = [{ name: 'color', type: 'ordinal' }];
-		addFieldToFacetScaleDomain(scales, 'color', { value: 'red-500' });
-		expect(scales).toStrictEqual([{ name: 'color', type: 'ordinal' }]);
+		const scales: Scale[] = [{ name: COLOR_SCALE, type: 'ordinal' }];
+		addFieldToFacetScaleDomain(scales, COLOR_SCALE, { value: 'red-500' });
+		expect(scales).toStrictEqual([{ name: COLOR_SCALE, type: 'ordinal' }]);
 	});
 });
 

--- a/src/specBuilder/scatter/scatterMarkUtils.test.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.test.ts
@@ -14,7 +14,7 @@ import { createElement } from 'react';
 
 import { ChartTooltip } from '@components/ChartTooltip';
 import { Trendline } from '@components/Trendline';
-import { DEFAULT_OPACITY_RULE, MARK_ID } from '@constants';
+import { DEFAULT_OPACITY_RULE, MARK_ID, SYMBOL_SIZE_SCALE } from '@constants';
 import { GroupMark } from 'vega';
 import { addScatterMarks, getOpacity, getScatterHoverMarks, getSelectRingSize } from './scatterMarkUtils';
 import { defaultScatterProps } from './scatterTestUtils';
@@ -80,6 +80,6 @@ describe('getScatterSelectMarks()', () => {
 	test('should return a signal if data key is provided', () => {
 		const sizeKey = 'weight';
 		const ringSize = getSelectRingSize(sizeKey);
-		expect(ringSize).toHaveProperty('signal', `pow(sqrt(scale('symbolSize', datum.${sizeKey})) + 4, 2)`);
+		expect(ringSize).toHaveProperty('signal', `pow(sqrt(scale('${SYMBOL_SIZE_SCALE}', datum.${sizeKey})) + 4, 2)`);
 	});
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -12,7 +12,14 @@
 import { createElement } from 'react';
 
 import { Trendline } from '@components/Trendline';
-import { DEFAULT_COLOR } from '@constants';
+import {
+	COLOR_SCALE,
+	DEFAULT_COLOR,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
+	OPACITY_SCALE,
+	SYMBOL_SIZE_SCALE,
+} from '@constants';
 import { initializeSpec } from '@specBuilder/specUtils';
 
 import { addData, addSignals, setScales } from './scatterSpecBuilder';
@@ -84,27 +91,27 @@ describe('setScales()', () => {
 	test('should add the color scale if color is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, color: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
-		expect(scales[2].name).toBe('color');
+		expect(scales[2].name).toBe(COLOR_SCALE);
 	});
 	test('should add the lineType scale if lineType is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, lineType: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
-		expect(scales[2].name).toBe('lineType');
+		expect(scales[2].name).toBe(LINE_TYPE_SCALE);
 	});
 	test('should add the lineWidth scale if lineWidth is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, lineWidth: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
-		expect(scales[2].name).toBe('lineWidth');
+		expect(scales[2].name).toBe(LINE_WIDTH_SCALE);
 	});
 	test('should add the opacity scale if opacity is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, opacity: DEFAULT_COLOR });
 		expect(scales).toHaveLength(3);
-		expect(scales[2].name).toBe('opacity');
+		expect(scales[2].name).toBe(OPACITY_SCALE);
 	});
 	test('should add the symbolSize scale if size is a reference to a key', () => {
 		const scales = setScales([], { ...defaultScatterProps, size: 'weight' });
 		expect(scales).toHaveLength(3);
-		expect(scales[2].name).toBe('symbolSize');
+		expect(scales[2].name).toBe(SYMBOL_SIZE_SCALE);
 		expect(scales[2].domain).toEqual({ data: 'table', fields: ['weight'] });
 	});
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -10,12 +10,17 @@
  * governing permissions and limitations under the License.
  */
 import {
+	COLOR_SCALE,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_DIMENSION_SCALE_TYPE,
 	DEFAULT_LINEAR_DIMENSION,
 	DEFAULT_METRIC,
 	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	LINE_WIDTH_SCALE,
 	MARK_ID,
+	OPACITY_SCALE,
+	SYMBOL_SIZE_SCALE,
 } from '@constants';
 import { addTimeTransform, getTableData } from '@specBuilder/data/dataUtils';
 import { getInteractiveMarkName } from '@specBuilder/line/lineUtils';
@@ -143,15 +148,15 @@ export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) =>
 	// add metric scale
 	addMetricScale(scales, [metric]);
 	// add color to the color domain
-	addFieldToFacetScaleDomain(scales, 'color', color);
+	addFieldToFacetScaleDomain(scales, COLOR_SCALE, color);
 	// add lineType to the lineType domain
-	addFieldToFacetScaleDomain(scales, 'lineType', lineType);
+	addFieldToFacetScaleDomain(scales, LINE_TYPE_SCALE, lineType);
 	// add lineWidth to the lineWidth domain
-	addFieldToFacetScaleDomain(scales, 'lineWidth', lineWidth);
+	addFieldToFacetScaleDomain(scales, LINE_WIDTH_SCALE, lineWidth);
 	// add opacity to the opacity domain
-	addFieldToFacetScaleDomain(scales, 'opacity', opacity);
+	addFieldToFacetScaleDomain(scales, OPACITY_SCALE, opacity);
 	// add size to the size domain
-	addFieldToFacetScaleDomain(scales, 'symbolSize', size);
+	addFieldToFacetScaleDomain(scales, SYMBOL_SIZE_SCALE, size);
 
 	scales.push(...getTrendlineScales(props));
 });

--- a/src/specBuilder/specUtils.test.ts
+++ b/src/specBuilder/specUtils.test.ts
@@ -10,10 +10,12 @@
  * governing permissions and limitations under the License.
  */
 import {
+	COLOR_SCALE,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
 	DEFAULT_SECONDARY_COLOR,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
+	LINE_TYPE_SCALE,
 	TABLE,
 } from '@constants';
 import { ROUNDED_SQUARE_PATH } from 'svgPaths';
@@ -31,17 +33,17 @@ import {
 } from './specUtils';
 
 const defaultColorScale: OrdinalScale = {
-	name: 'color',
+	name: COLOR_SCALE,
 	type: 'ordinal',
 	domain: { data: TABLE, fields: [DEFAULT_COLOR] },
 };
 const defaultLineTypeScale: OrdinalScale = {
-	name: 'lineType',
+	name: LINE_TYPE_SCALE,
 	type: 'ordinal',
 	domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 };
 const defaultOpacityScale: BandScale = {
-	name: 'lineType',
+	name: LINE_TYPE_SCALE,
 	type: 'band',
 	domain: { data: TABLE, fields: [DEFAULT_SECONDARY_COLOR] },
 };
@@ -85,7 +87,7 @@ describe('specUtils', () => {
 				getFacetsFromScales([
 					defaultColorScale,
 					{ ...defaultLineTypeScale, domain: { data: TABLE, fields: [DEFAULT_COLOR] } },
-				])
+				]),
 			).toStrictEqual([DEFAULT_COLOR]);
 			expect(getFacetsFromScales([defaultColorScale, defaultLineTypeScale, defaultOpacityScale])).toStrictEqual([
 				DEFAULT_COLOR,
@@ -103,7 +105,7 @@ describe('specUtils', () => {
 
 		test('should return empty array if no scales have fields', () => {
 			expect(getFacetsFromScales([{ ...defaultColorScale, domain: { data: TABLE, fields: [] } }])).toStrictEqual(
-				[]
+				[],
 			);
 		});
 
@@ -189,7 +191,7 @@ describe('specUtils', () => {
 			expect(getDimensionField(DEFAULT_CATEGORICAL_DIMENSION, 'linear')).toEqual(DEFAULT_CATEGORICAL_DIMENSION);
 			expect(getDimensionField(DEFAULT_CATEGORICAL_DIMENSION, 'point')).toEqual(DEFAULT_CATEGORICAL_DIMENSION);
 			expect(getDimensionField(DEFAULT_CATEGORICAL_DIMENSION, 'time')).toEqual(
-				DEFAULT_TRANSFORMED_TIME_DIMENSION
+				DEFAULT_TRANSFORMED_TIME_DIMENSION,
 			);
 		});
 	});

--- a/src/specBuilder/specUtils.ts
+++ b/src/specBuilder/specUtils.ts
@@ -27,7 +27,15 @@ import {
 } from 'types';
 import { Data, Scale, ScaleType, Spec, ValuesData } from 'vega';
 
-import { DEFAULT_TRANSFORMED_TIME_DIMENSION, FILTERED_TABLE, MARK_ID, TABLE } from '../constants';
+import {
+	COLOR_SCALE,
+	DEFAULT_TRANSFORMED_TIME_DIMENSION,
+	FILTERED_TABLE,
+	LINE_TYPE_SCALE,
+	MARK_ID,
+	OPACITY_SCALE,
+	TABLE,
+} from '../constants';
 import { SanitizedSpecProps } from '../types';
 
 /**
@@ -69,16 +77,20 @@ export const getFacetsFromProps = ({
  * @returns
  */
 export const getFacetsFromScales = (scales: Scale[] = []): string[] => {
-	const facets = ['color', 'lineType', 'opacity', 'secondaryColor', 'secondaryLineType', 'secondaryOpacity'].reduce(
-		(acc, cur) => {
-			const scale = scales.find((scale) => scale.name === cur);
-			if (scale?.domain && 'fields' in scale.domain && scale.domain.fields.length) {
-				return [...acc, scale.domain.fields[0].toString()];
-			}
-			return acc;
-		},
-		[] as string[]
-	);
+	const facets = [
+		COLOR_SCALE,
+		LINE_TYPE_SCALE,
+		OPACITY_SCALE,
+		'secondaryColor',
+		'secondaryLineType',
+		'secondaryOpacity',
+	].reduce((acc, cur) => {
+		const scale = scales.find((scale) => scale.name === cur);
+		if (scale?.domain && 'fields' in scale.domain && scale.domain.fields.length) {
+			return [...acc, scale.domain.fields[0].toString()];
+		}
+		return acc;
+	}, [] as string[]);
 
 	// only want the unique facets
 	return [...new Set(facets)];

--- a/src/specBuilder/trendline/trendlineMarkUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.test.ts
@@ -12,7 +12,7 @@
 
 import { ChartTooltip } from '@components/ChartTooltip';
 import { Trendline } from '@components/Trendline';
-import { DEFAULT_TIME_DIMENSION } from '@constants';
+import { COLOR_SCALE, DEFAULT_TIME_DIMENSION } from '@constants';
 import { spectrumColors } from '@themes';
 import { createElement } from 'react';
 import { Facet, From, GroupMark, Mark } from 'vega';
@@ -94,7 +94,7 @@ describe('getTrendlineMarks()', () => {
 describe('getTrendlineRuleMark()', () => {
 	test('should use series color if static color is not provided', () => {
 		const mark = getTrendlineRuleMark(defaultLineProps, { ...defaultTrendlineProps, method: 'median' });
-		expect(mark.encode?.enter?.stroke).toEqual({ field: 'series', scale: 'color' });
+		expect(mark.encode?.enter?.stroke).toEqual({ field: 'series', scale: COLOR_SCALE });
 	});
 	test('should use static color if provided', () => {
 		const mark = getTrendlineRuleMark(defaultLineProps, {
@@ -158,7 +158,7 @@ describe('getTrendlineLineMark()', () => {
 	});
 	test('should use series color if static color is not provided', () => {
 		const mark = getTrendlineLineMark(defaultLineProps, defaultTrendlineProps);
-		expect(mark.encode?.enter?.stroke).toEqual({ field: 'series', scale: 'color' });
+		expect(mark.encode?.enter?.stroke).toEqual({ field: 'series', scale: COLOR_SCALE });
 	});
 	test('should use static color if provided', () => {
 		const mark = getTrendlineLineMark(defaultLineProps, { ...defaultTrendlineProps, color: 'gray-500' });

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -29,6 +29,7 @@ import {
 import { characterData } from '@stories/data/marioKartData';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
+import { COLOR_SCALE, LINE_TYPE_SCALE, OPACITY_SCALE } from '@constants';
 
 const marioDataKeys = [
 	...Object.keys(characterData[0])
@@ -89,8 +90,8 @@ const marioKeyTitle: Record<Exclude<MarioDataKey, 'character'>, string> = {
 const defaultChartProps: ChartProps = { data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] };
 
 const getLegendProps = (args: ScatterProps): LegendProps => {
-	const facets = ['color', 'lineType', 'opacity', 'size'];
-	const legendKey = args[facets.find((key) => args[key] !== undefined) ?? 'color'];
+	const facets = [COLOR_SCALE, LINE_TYPE_SCALE, OPACITY_SCALE, 'size'];
+	const legendKey = args[facets.find((key) => args[key] !== undefined) ?? COLOR_SCALE];
 	const legendProps: LegendProps = {
 		position: 'right',
 		title: marioKeyTitle[legendKey],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just adding constants for the scale names to help avoid typos and make it easy to change in the future.