### PR TITLE
feat: support displayOnHover for scatter trendlines

### DIFF
--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -60,21 +60,26 @@ describe('addSignals()', () => {
 			...defaultScatterProps,
 			children: [createElement(ChartTooltip)],
 		});
-		expect(signals).toHaveLength(3);
+		expect(signals).toHaveLength(1);
 		expect(signals[0].name).toBe('scatter0_hoveredId');
+	});
+	test('should add selectedId signal if popover exists', () => {
+		const signals = addSignals([], {
+			...defaultScatterProps,
+			children: [createElement(ChartPopover)],
+		});
+		expect(signals).toHaveLength(2);
 		expect(signals[1].name).toBe('scatter0_selectedId');
-		expect(signals[2].name).toBe('scatter0_selectedSeries');
 	});
 	test('should add trendline signals if trendline exists as a child', () => {
 		const signals = addSignals([], {
 			...defaultScatterProps,
 			children: [createElement(Trendline, { displayOnHover: true })],
 		});
-		expect(signals).toHaveLength(4);
+		expect(signals).toHaveLength(3);
 		expect(signals[0].name).toBe('scatter0_hoveredSeries');
-		expect(signals[1].name).toBe('scatter0_hoveredId');
-		expect(signals[2].name).toBe('scatter0_selectedId');
-		expect(signals[3].name).toBe('scatter0_selectedSeries');
+		expect(signals[1].name).toBe('scatter0_selectedSeries');
+		expect(signals[2].name).toBe('scatter0_hoveredId');
 	});
 });
 

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -60,7 +60,7 @@ describe('addSignals()', () => {
 			...defaultScatterProps,
 			children: [createElement(ChartTooltip)],
 		});
-		expect(signals).toHaveLength(2);
+		expect(signals).toHaveLength(3);
 		expect(signals[0].name).toBe('scatter0_hoveredId');
 		expect(signals[1].name).toBe('scatter0_selectedId');
 		expect(signals[2].name).toBe('scatter0_selectedSeries');
@@ -70,9 +70,11 @@ describe('addSignals()', () => {
 			...defaultScatterProps,
 			children: [createElement(Trendline, { displayOnHover: true })],
 		});
-		expect(signals).toHaveLength(2);
+		expect(signals).toHaveLength(4);
 		expect(signals[0].name).toBe('scatter0_hoveredSeries');
 		expect(signals[1].name).toBe('scatter0_hoveredId');
+		expect(signals[2].name).toBe('scatter0_selectedId');
+		expect(signals[3].name).toBe('scatter0_selectedSeries');
 	});
 });
 

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -60,16 +60,10 @@ describe('addSignals()', () => {
 			...defaultScatterProps,
 			children: [createElement(ChartTooltip)],
 		});
-		expect(signals).toHaveLength(1);
-		expect(signals[0].name).toBe('scatter0_hoveredId');
-	});
-	test('should add selectedId signal if popover exists', () => {
-		const signals = addSignals([], {
-			...defaultScatterProps,
-			children: [createElement(ChartPopover)],
-		});
 		expect(signals).toHaveLength(2);
+		expect(signals[0].name).toBe('scatter0_hoveredId');
 		expect(signals[1].name).toBe('scatter0_selectedId');
+		expect(signals[2].name).toBe('scatter0_selectedSeries');
 	});
 	test('should add trendline signals if trendline exists as a child', () => {
 		const signals = addSignals([], {

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -125,18 +125,15 @@ export const addSignals = produce<Signal[], [ScatterSpecProps]>((signals, props)
 
 	if (!hasInteractiveChildren(children)) return;
 	// interactive signals
-
-	// used to style both hovered and unhovered points
 	if (!hasSignalByName(signals, `${name}_hoveredId`)) {
+		// hover signal
 		signals.push(getUncontrolledHoverSignal(`${name}`, true, `${name}_voronoi`));
 	}
-	// used to style both selected and unselcted points
-	if (!hasSignalByName(signals, `${name}_selectedId`)) {
-		signals.push(getGenericSignal(`${name}_selectedId`));
-	}
-	// used to know which trendline to display when displayOnHover is true
-	if (!hasSignalByName(signals, `${name}_selectedSeries`)) {
-		signals.push(getGenericSignal(`${name}_selectedSeries`));
+	if (hasPopover(children)) {
+		if (!hasSignalByName(signals, `${name}_selectedId`)) {
+			// select signal
+			signals.push(getGenericSignal(`${name}_selectedId`));
+		}
 	}
 });
 

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -125,15 +125,18 @@ export const addSignals = produce<Signal[], [ScatterSpecProps]>((signals, props)
 
 	if (!hasInteractiveChildren(children)) return;
 	// interactive signals
+
+	// used to style both hovered and unhovered points
 	if (!hasSignalByName(signals, `${name}_hoveredId`)) {
-		// hover signal
 		signals.push(getUncontrolledHoverSignal(`${name}`, true, `${name}_voronoi`));
 	}
-	if (hasPopover(children)) {
-		if (!hasSignalByName(signals, `${name}_selectedId`)) {
-			// select signal
-			signals.push(getGenericSignal(`${name}_selectedId`));
-		}
+	// used to style both selected and unselcted points
+	if (!hasSignalByName(signals, `${name}_selectedId`)) {
+		signals.push(getGenericSignal(`${name}_selectedId`));
+	}
+	// used to know which trendline to display when displayOnHover is true
+	if (!hasSignalByName(signals, `${name}_selectedSeries`)) {
+		signals.push(getGenericSignal(`${name}_selectedSeries`));
 	}
 });
 

--- a/src/specBuilder/trendline/trendlineSignalUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineSignalUtils.test.ts
@@ -54,4 +54,14 @@ describe('getTrendlineSignals()', () => {
 		expect(signals).toHaveLength(2);
 		expect(signals[0].name).not.toContain('selected');
 	});
+
+	test('should add displayOnHover signals', () => {
+		const signals = getTrendlineSignals({
+			...defaultLineProps,
+			children: [createElement(Trendline, { displayOnHover: true })],
+		});
+		expect(signals).toHaveLength(2);
+		expect(signals[0]).toHaveProperty('name', 'line0_hoveredSeries');
+		expect(signals[1]).toHaveProperty('name', 'line0_selectedSeries');
+	});
 });

--- a/src/specBuilder/trendline/trendlineSignalUtils.ts
+++ b/src/specBuilder/trendline/trendlineSignalUtils.ts
@@ -31,6 +31,7 @@ export const getTrendlineSignals = (markProps: TrendlineParentProps): Signal[] =
 
 	if (trendlines.some((trendline) => trendline.displayOnHover)) {
 		signals.push(getSeriesHoveredSignal(markName, true, `${markName}_voronoi`));
+		signals.push(getGenericSignal(`${markName}_selectedSeries`));
 	}
 
 	if (trendlines.some((trendline) => hasPopover(trendline.children))) {

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -49,11 +49,17 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 	const chartProps = useChartProps(args);
 
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
-				<Trendline method="median" lineWidth="XS" lineType="solid" dimensionExtent={['domain', 'domain']} />
+				<Trendline
+					method="median"
+					lineWidth="XS"
+					lineType="solid"
+					dimensionExtent={['domain', 'domain']}
+					displayOnHover
+				/>
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -49,7 +49,7 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 	const chartProps = useChartProps(args);
 
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
@@ -10,7 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import { findAllMarksByGroupName, findChart, findMarksByGroupName, render } from '@test-utils';
+import {
+	allElementsHaveAttributeValue,
+	findAllMarksByGroupName,
+	findChart,
+	findMarksByGroupName,
+	hoverNthElement,
+	render,
+} from '@test-utils';
 import { spectrumColors } from '@themes';
 
 import { FeatureMatrix, MultipleSegmentFeatureMatrix } from './FeatureMatrix.story';
@@ -43,7 +50,7 @@ describe('FeatureMatrix', () => {
 });
 
 describe('MultipleSegmentFeatureMatrix', () => {
-	test('Single series should render correctly', async () => {
+	test('multiple series should render correctly', async () => {
 		render(<MultipleSegmentFeatureMatrix {...MultipleSegmentFeatureMatrix.args} />);
 
 		const chart = await findChart();
@@ -60,6 +67,15 @@ describe('MultipleSegmentFeatureMatrix', () => {
 
 		expect(points[6]).toHaveAttribute('fill', colors['categorical-200']);
 		expect(points[12]).toHaveAttribute('fill', colors['categorical-300']);
+	});
+	test('should display trendline on hover', async () => {
+		render(<MultipleSegmentFeatureMatrix {...MultipleSegmentFeatureMatrix.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const hoverAreas = await findAllMarksByGroupName(chart, 'scatter0_voronoi');
+		expect(hoverAreas).toHaveLength(18);
 
 		// trendline styling
 		const trendlines = await findAllMarksByGroupName(chart, 'scatter0Trendline0', 'line');
@@ -72,5 +88,24 @@ describe('MultipleSegmentFeatureMatrix', () => {
 
 		expect(trendlines[1]).toHaveAttribute('stroke', colors['categorical-200']);
 		expect(trendlines[2]).toHaveAttribute('stroke', colors['categorical-300']);
+		expect(allElementsHaveAttributeValue(trendlines, 'opacity', 0)).toBeTruthy();
+
+		// first trendline should be visible on hover
+		await hoverNthElement(hoverAreas, 0);
+		expect(trendlines[0]).toHaveAttribute('opacity', '1');
+		expect(trendlines[1]).toHaveAttribute('opacity', '0');
+		expect(trendlines[2]).toHaveAttribute('opacity', '0');
+
+		// second trendline should be visible on hover
+		await hoverNthElement(hoverAreas, 6);
+		expect(trendlines[0]).toHaveAttribute('opacity', '0');
+		expect(trendlines[1]).toHaveAttribute('opacity', '1');
+		expect(trendlines[2]).toHaveAttribute('opacity', '0');
+
+		// third trendline should be visible on hover
+		await hoverNthElement(hoverAreas, 12);
+		expect(trendlines[0]).toHaveAttribute('opacity', '0');
+		expect(trendlines[1]).toHaveAttribute('opacity', '0');
+		expect(trendlines[2]).toHaveAttribute('opacity', '1');
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add necessary signal so that display on hover works for scatter plot trendlines.

## Related Issue

[Scatter plot](https://github.com/adobe/react-spectrum-charts/issues/50)

## Motivation and Context

displayOnHover should work for all marks that support trendlines

## Stories
Chart > Examples > MultipleSegmentFeatureMatrix

## Screenshots (if appropriate):

https://github.com/adobe/react-spectrum-charts/assets/40001449/cfc2ec8b-9a2b-4296-b22c-8c1922e16ce5

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
