### PR TITLE
feat: support 'orientation' for trendline

### DIFF
--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -369,12 +369,8 @@ describe('lineSpecBuilder', () => {
 				})[2].transform,
 			).toStrictEqual([
 				{
-					as: [
-						TRENDLINE_VALUE,
-						`${DEFAULT_TRANSFORMED_TIME_DIMENSION}Min`,
-						`${DEFAULT_TRANSFORMED_TIME_DIMENSION}Max`,
-					],
-					fields: [DEFAULT_METRIC, DEFAULT_TRANSFORMED_TIME_DIMENSION, DEFAULT_TRANSFORMED_TIME_DIMENSION],
+					as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
+					fields: [DEFAULT_METRIC, DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],
 					groupby: [DEFAULT_COLOR],
 					ops: ['mean', 'min', 'max'],
 					type: 'aggregate',

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -52,7 +52,6 @@ import {
 	Cursor,
 	NumericValueRef,
 	PathMark,
-	ProductionRule,
 	ScaledValueRef,
 	SignalRef,
 } from 'vega';
@@ -202,7 +201,7 @@ export const getHighlightOpacityValue = (
  * @param dimension
  * @returns x encoding
  */
-export const getXProductionRule = (scaleType: ScaleType, dimension: string): ProductionRule<NumericValueRef> => {
+export const getXProductionRule = (scaleType: ScaleType, dimension: string): NumericValueRef => {
 	const scale = getScaleName('x', scaleType);
 	if (scaleType === 'time') {
 		return { scale, field: DEFAULT_TRANSFORMED_TIME_DIMENSION };

--- a/src/specBuilder/trendline/trendlineDataTransformUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataTransformUtils.test.ts
@@ -22,13 +22,12 @@ import { defaultLineProps, defaultTrendlineProps } from './trendlineTestUtils';
 
 describe('getAggregateTransform()', () => {
 	test('should return the correct method', () => {
-		expect(getAggregateTransform(defaultLineProps, 'average', false, DEFAULT_TIME_DIMENSION)).toHaveProperty(
-			'ops',
-			['mean'],
-		);
-		expect(getAggregateTransform(defaultLineProps, 'median', false, DEFAULT_TIME_DIMENSION)).toHaveProperty('ops', [
-			'median',
-		]);
+		expect(
+			getAggregateTransform(defaultLineProps, { ...defaultTrendlineProps, method: 'average' }, false),
+		).toHaveProperty('ops', ['mean']);
+		expect(
+			getAggregateTransform(defaultLineProps, { ...defaultTrendlineProps, method: 'median' }, false),
+		).toHaveProperty('ops', ['median']);
 	});
 });
 
@@ -95,17 +94,17 @@ describe('getRegressionTransform()', () => {
 
 describe('getWindowTransform()', () => {
 	test('should return a window transform with the correct frame', () => {
-		const transform = getWindowTransform(defaultLineProps, 'movingAverage-7');
+		const transform = getWindowTransform(defaultLineProps, { ...defaultTrendlineProps, method: 'movingAverage-7' });
 		expect(transform).toHaveProperty('type', 'window');
 		expect(transform).toHaveProperty('frame', [6, 0]);
 	});
 	test('should throw error if the method is not of form "moveingAverage-${number}"', () => {
-		expect(() => getWindowTransform(defaultLineProps, 'linear')).toThrow(
+		expect(() => getWindowTransform(defaultLineProps, { ...defaultTrendlineProps, method: 'linear' })).toThrow(
 			'Invalid moving average frame width: NaN, frame width must be an integer greater than 0',
 		);
-		expect(() => getWindowTransform(defaultLineProps, 'movingAverage-0')).toThrow(
-			'Invalid moving average frame width: 0, frame width must be an integer greater than 0',
-		);
+		expect(() =>
+			getWindowTransform(defaultLineProps, { ...defaultTrendlineProps, method: 'movingAverage-0' }),
+		).toThrow('Invalid moving average frame width: 0, frame width must be an integer greater than 0');
 	});
 });
 
@@ -132,39 +131,34 @@ describe('getTrendlineDimensionRangeTransforms()', () => {
 
 describe('getTrendlineParamFormulaTransforms()', () => {
 	test('should return the correct formula for each polynomial method', () => {
-		expect(getTrendlineParamFormulaTransforms('x', 'linear', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'linear')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'quadratic', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'quadratic')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1) + datum.coef[2] * pow(datum.x, 2)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-1', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-1')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-2', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-2')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1) + datum.coef[2] * pow(datum.x, 2)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-3', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-3')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1) + datum.coef[2] * pow(datum.x, 2) + datum.coef[3] * pow(datum.x, 3)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-8', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'polynomial-8')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * pow(datum.x, 1) + datum.coef[2] * pow(datum.x, 2) + datum.coef[3] * pow(datum.x, 3) + datum.coef[4] * pow(datum.x, 4) + datum.coef[5] * pow(datum.x, 5) + datum.coef[6] * pow(datum.x, 6) + datum.coef[7] * pow(datum.x, 7) + datum.coef[8] * pow(datum.x, 8)',
 		);
 	});
 	test('should return the correct formula for other non-polynomial regression methods', () => {
-		expect(getTrendlineParamFormulaTransforms('x', 'exponential', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'exponential')[0].expr).toEqual(
 			'datum.coef[0] + exp(datum.coef[1] * datum.x)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'logarithmic', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'logarithmic')[0].expr).toEqual(
 			'datum.coef[0] + datum.coef[1] * log(datum.x)',
 		);
-		expect(getTrendlineParamFormulaTransforms('x', 'power', 'linear')[0].expr).toEqual(
+		expect(getTrendlineParamFormulaTransforms('x', 'power')[0].expr).toEqual(
 			'datum.coef[0] * pow(datum.x, datum.coef[1])',
-		);
-	});
-	test('should use normalized dimension for time scaleType', () => {
-		expect(getTrendlineParamFormulaTransforms('x', 'exponential', 'time')[0].expr).toEqual(
-			'datum.coef[0] + exp(datum.coef[1] * datum.xNormalized)',
 		);
 	});
 });

--- a/src/specBuilder/trendline/trendlineDataUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.test.ts
@@ -238,4 +238,13 @@ describe('addTableDataTransforms()', () => {
 			}),
 		).toHaveLength(0);
 	});
+	test('should not add normalized dimension transform if it is not a time scale', () => {
+		const transforms = addTableDataTransforms([], {
+			...defaultLineProps,
+			scaleType: 'linear',
+			children: [createElement(Trendline, { method: 'linear' })],
+		});
+		expect(transforms).toHaveLength(1);
+		expect(transforms[0]).toHaveProperty('type', 'extent');
+	});
 });

--- a/src/specBuilder/trendline/trendlineDataUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.test.ts
@@ -14,7 +14,7 @@ import { ChartTooltip } from '@components/ChartTooltip';
 import { Trendline } from '@components/Trendline';
 import {
 	DEFAULT_COLOR,
-	DEFAULT_TRANSFORMED_TIME_DIMENSION,
+	DEFAULT_TIME_DIMENSION,
 	FILTERED_TABLE,
 	MS_PER_DAY,
 	SERIES_ID,
@@ -71,12 +71,8 @@ describe('addTrendlineData()', () => {
 			source: FILTERED_TABLE,
 			transform: [
 				{
-					as: [
-						TRENDLINE_VALUE,
-						`${DEFAULT_TRANSFORMED_TIME_DIMENSION}Min`,
-						`${DEFAULT_TRANSFORMED_TIME_DIMENSION}Max`,
-					],
-					fields: ['value', DEFAULT_TRANSFORMED_TIME_DIMENSION, DEFAULT_TRANSFORMED_TIME_DIMENSION],
+					as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
+					fields: ['value', DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],
 					groupby: ['series'],
 					ops: ['mean', 'min', 'max'],
 					type: 'aggregate',

--- a/src/specBuilder/trendline/trendlineMarkUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.test.ts
@@ -114,8 +114,8 @@ describe('getRuleYEncodings()', () => {
 	});
 	test('should return the correct rules for "domain" extent', () => {
 		const encoding = getRuleYEncodings(['domain', 'domain'], 'count', 'vertical');
-		expect(encoding).toHaveProperty('y', { value: 0 });
-		expect(encoding).toHaveProperty('y2', { signal: 'height' });
+		expect(encoding).toHaveProperty('y', { signal: 'height' });
+		expect(encoding).toHaveProperty('y2', { value: 0 });
 	});
 	test('should return the correct rules for null extent', () => {
 		const encoding = getRuleYEncodings([null, null], 'count', 'vertical');

--- a/src/specBuilder/trendline/trendlineMarkUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.test.ts
@@ -17,6 +17,8 @@ import { spectrumColors } from '@themes';
 import { createElement } from 'react';
 import { Facet, From, GroupMark, Mark } from 'vega';
 import {
+	getLineXProductionRule,
+	getLineYProductionRule,
 	getRuleXEncodings,
 	getRuleYEncodings,
 	getTrendlineLineMark,
@@ -185,5 +187,27 @@ describe('getTrendlineLineMark()', () => {
 	test('should use static color if provided', () => {
 		const mark = getTrendlineLineMark(defaultLineProps, { ...defaultTrendlineProps, color: 'gray-500' });
 		expect(mark.encode?.enter?.stroke).toEqual({ value: spectrumColors.light['gray-500'] });
+	});
+});
+
+describe('getLineYProductionRule()', () => {
+	test('should use trendline dimension for vertical orientation', () => {
+		expect(getLineYProductionRule('count', 'vertical')).toHaveProperty('field', 'count');
+	});
+	test('should use TRENDLINE_VALUE for horizontal orientation', () => {
+		expect(getLineYProductionRule('count', 'horizontal')).toHaveProperty('field', TRENDLINE_VALUE);
+	});
+});
+
+describe('getLineXProductionRule()', () => {
+	test('should use TRENDLINE_VALUE for vertical orientation', () => {
+		expect(getLineXProductionRule('count', 'linear', 'vertical', false)).toHaveProperty('field', TRENDLINE_VALUE);
+	});
+	test('should use xTrendline scale if horizontal and normalized', () => {
+		expect(getLineXProductionRule('count', 'linear', 'horizontal', true)).toHaveProperty('scale', 'xTrendline');
+	});
+	test('should use trendline dimension if horizontal', () => {
+		expect(getLineXProductionRule('count', 'linear', 'horizontal', true)).toHaveProperty('field', 'count');
+		expect(getLineXProductionRule('count', 'linear', 'horizontal', false)).toHaveProperty('field', 'count');
 	});
 });

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -18,16 +18,15 @@ import {
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
 	getStrokeDashProductionRule,
-	getXProductionRule,
 	hasTooltip,
 } from '@specBuilder/marks/markUtils';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
-import { getDimensionField, getFacetsFromProps } from '@specBuilder/specUtils';
-import { ScaleType, TrendlineSpecProps } from 'types';
-import { GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
+import { getFacetsFromProps } from '@specBuilder/specUtils';
+import { Orientation, ScaleType, TrendlineSpecProps } from 'types';
+import { EncodeEntry, GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
 import {
 	TrendlineParentProps,
-	getTrendlineScaleType,
+	getTrendlineDimensionMetric,
 	getTrendlines,
 	isAggregateMethod,
 	isRegressionMethod,
@@ -35,11 +34,11 @@ import {
 } from './trendlineUtils';
 
 export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark | RuleMark)[] => {
-	const { children, color, lineType, name } = markProps;
+	const { color, lineType } = markProps;
 	const { facets } = getFacetsFromProps({ color, lineType });
 
 	const marks: (GroupMark | RuleMark)[] = [];
-	const trendlines = getTrendlines(children, name);
+	const trendlines = getTrendlines(markProps);
 	for (const trendlineProps of trendlines) {
 		if (isAggregateMethod(trendlineProps.method)) {
 			marks.push(getTrendlineRuleMark(markProps, trendlineProps));
@@ -80,11 +79,10 @@ export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark |
  * @returns rule mark
  */
 export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineProps: TrendlineSpecProps): RuleMark => {
-	const { dimension, colorScheme } = markProps;
-	const { dimensionExtent, lineType, lineWidth, metric, name } = trendlineProps;
+	const { dimension, colorScheme, metric } = markProps;
+	const { dimensionExtent, dimensionScaleType, lineType, lineWidth, name, orientation } = trendlineProps;
 	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
-	const scaleType = getTrendlineScaleType(markProps);
-	const dimensionField = getDimensionField(dimension, scaleType);
+	const { trendlineDimension } = getTrendlineDimensionMetric(dimension, metric, orientation, false);
 
 	return {
 		name,
@@ -96,15 +94,14 @@ export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineP
 		interactive: false,
 		encode: {
 			enter: {
-				y: { scale: 'yLinear', field: metric },
+				...getRuleYEncodings(dimensionExtent, trendlineDimension, orientation),
 				stroke: getColorProductionRule(color, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
 				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
 			},
 			update: {
-				x: getRuleXProductionRule(dimensionExtent[0], dimensionField, scaleType),
-				x2: getRuleX2ProductionRule(dimensionExtent[1], dimensionField, scaleType),
+				...getRuleXEncodings(dimensionExtent, trendlineDimension, dimensionScaleType, orientation),
 				opacity: getLineOpacity(getLineMarkProps(markProps, trendlineProps)),
 			},
 		},
@@ -112,18 +109,55 @@ export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineP
 };
 
 /**
- * gets the production rule for the x encoding of a rule mark
- * @param startDimensionExtent
+ * gets the production rules for the y and y2 encoding of a rule mark
+ * @param dimensionExtent
+ * @param dimension
+ * @param orientation
+ * @returns x production rules
+ */
+export const getRuleYEncodings = (
+	dimensionExtent: TrendlineSpecProps['dimensionExtent'],
+	dimension: string,
+	orientation: Orientation,
+): EncodeEntry => {
+	if (orientation === 'horizontal') {
+		return { y: { scale: 'yLinear', field: TRENDLINE_VALUE } };
+	}
+	return {
+		y: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, 'yLinear'),
+		y2: getEndDimensionExtentProductionRule(dimensionExtent[1], dimension, 'yLinear', 'y'),
+	};
+};
+
+/**
+ * gets the production rules for the x and x2 encoding of a rule mark
+ * @param dimensionExtent
  * @param dimension
  * @param scaleType
- * @returns x production rule
+ * @param orientation
+ * @returns x production rules
  */
-export const getRuleXProductionRule = (
-	startDimensionExtent: number | 'domain' | null,
+export const getRuleXEncodings = (
+	dimensionExtent: TrendlineSpecProps['dimensionExtent'],
 	dimension: string,
 	scaleType: ScaleType,
-): NumericValueRef => {
+	orientation: Orientation,
+): EncodeEntry => {
 	const scale = getScaleName('x', scaleType);
+	if (orientation === 'vertical') {
+		return { x: { scale, field: TRENDLINE_VALUE } };
+	}
+	return {
+		x: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, scale),
+		x2: getEndDimensionExtentProductionRule(dimensionExtent[1], dimension, scale, 'x'),
+	};
+};
+
+const getStartDimensionExtentProductionRule = (
+	startDimensionExtent: number | 'domain' | null,
+	dimension: string,
+	scale: string,
+): NumericValueRef => {
 	switch (startDimensionExtent) {
 		case null:
 			return { scale, field: `${dimension}Min` };
@@ -134,24 +168,17 @@ export const getRuleXProductionRule = (
 	}
 };
 
-/**
- * gets the production rule for the x2 encoding of a rule mark
- * @param endDimensionExtent
- * @param dimension
- * @param scaleType
- * @returns x2 production rule
- */
-export const getRuleX2ProductionRule = (
+const getEndDimensionExtentProductionRule = (
 	endDimensionExtent: number | 'domain' | null,
 	dimension: string,
-	scaleType: ScaleType,
+	scale: string,
+	axis: 'x' | 'y',
 ): NumericValueRef => {
-	const scale = getScaleName('x', scaleType);
 	switch (endDimensionExtent) {
 		case null:
 			return { scale, field: `${dimension}Max` };
 		case 'domain':
-			return { signal: 'width' };
+			return { signal: axis === 'x' ? 'width' : 'height' };
 		default:
 			return { scale, value: endDimensionExtent };
 	}
@@ -164,13 +191,13 @@ export const getRuleX2ProductionRule = (
  * @returns
  */
 export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineProps: TrendlineSpecProps): LineMark => {
-	const { colorScheme, dimension } = markProps;
-	const scaleType = getTrendlineScaleType(markProps);
-	const { lineType, lineWidth, metric, name } = trendlineProps;
+	const { colorScheme, dimension, metric } = markProps;
+	const { dimensionScaleType, lineType, lineWidth, method, name, orientation } = trendlineProps;
 
-	const x = trendlineUsesNormalizedDimension(trendlineProps.method, scaleType)
-		? { scale: 'xTrendline', field: `${dimension}Normalized` }
-		: getXProductionRule(scaleType, dimension);
+	const isDimensionNormalized =
+		trendlineUsesNormalizedDimension(method, dimensionScaleType) && orientation === 'horizontal';
+	const { trendlineDimension } = getTrendlineDimensionMetric(dimension, metric, orientation, isDimensionNormalized);
+
 	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
 
 	return {
@@ -180,24 +207,47 @@ export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineP
 		interactive: false,
 		encode: {
 			enter: {
-				y: { scale: 'yLinear', field: metric },
+				y: getLineYProductionRule(trendlineDimension, orientation),
 				stroke: getColorProductionRule(color, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
 				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
 			},
 			update: {
-				x,
+				x: getLineXProductionRule(trendlineDimension, dimensionScaleType, orientation, isDimensionNormalized),
 				opacity: getLineOpacity(getLineMarkProps(markProps, trendlineProps)),
 			},
 		},
 	};
 };
 
-const getTrendlineHoverMarks = (lineProps: TrendlineParentProps, highlightRawPoint: boolean): GroupMark => {
-	const { children, metric, name } = lineProps;
-	const trendlines = getTrendlines(children, name);
-	const trendlineHoverProps: LineMarkProps = getLineMarkProps(lineProps, trendlines[0], {
+const getLineYProductionRule = (trendlineDimension: string, orientation: Orientation): NumericValueRef => {
+	const scale = 'yLinear';
+	if (orientation === 'horizontal') {
+		return { scale, field: TRENDLINE_VALUE };
+	}
+	return { scale, field: trendlineDimension };
+};
+
+const getLineXProductionRule = (
+	trendlineDimension: string,
+	scaleType: ScaleType,
+	orientation: Orientation,
+	isDimensionNormalized: boolean,
+): NumericValueRef => {
+	const scale = getScaleName('x', scaleType);
+	if (orientation === 'vertical') {
+		return { scale, field: TRENDLINE_VALUE };
+	}
+	return isDimensionNormalized
+		? { scale: 'xTrendline', field: trendlineDimension }
+		: { scale, field: trendlineDimension };
+};
+
+const getTrendlineHoverMarks = (markProps: TrendlineParentProps, highlightRawPoint: boolean): GroupMark => {
+	const { metric, name } = markProps;
+	const trendlines = getTrendlines(markProps);
+	const trendlineHoverProps: LineMarkProps = getLineMarkProps(markProps, trendlines[0], {
 		name: `${name}Trendline`,
 		children: trendlines.map((trendline) => trendline.children).flat(),
 		metric: TRENDLINE_VALUE,
@@ -217,12 +267,11 @@ const getTrendlineHoverMarks = (lineProps: TrendlineParentProps, highlightRawPoi
 
 const getLineMarkProps = (
 	markProps: TrendlineParentProps,
-	{ displayOnHover, lineWidth, metric, name, opacity }: TrendlineSpecProps,
+	{ dimensionScaleType, displayOnHover, lineWidth, metric, name, opacity }: TrendlineSpecProps,
 	override?: Partial<LineMarkProps>,
 ): LineMarkProps => {
 	const { children, color, colorScheme, dimension, interactiveMarkName, lineType } = markProps;
 	const popoverMarkName = 'popoverMarkName' in markProps ? markProps.popoverMarkName : undefined;
-	const scaleType = getTrendlineScaleType(markProps);
 	const staticPoint = 'staticPoint' in markProps ? markProps.staticPoint : undefined;
 	return {
 		children,
@@ -237,7 +286,7 @@ const getLineMarkProps = (
 		name,
 		opacity: { value: opacity },
 		popoverMarkName,
-		scaleType,
+		scaleType: dimensionScaleType,
 		staticPoint,
 		...override,
 	};

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -224,7 +224,13 @@ export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineP
 	};
 };
 
-const getLineYProductionRule = (trendlineDimension: string, orientation: Orientation): NumericValueRef => {
+/**
+ * gets the production rule for the y encoding of a line mark
+ * @param trendlineDimension
+ * @param orientation
+ * @returns
+ */
+export const getLineYProductionRule = (trendlineDimension: string, orientation: Orientation): NumericValueRef => {
 	const scale = 'yLinear';
 	if (orientation === 'horizontal') {
 		return { scale, field: TRENDLINE_VALUE };
@@ -232,7 +238,15 @@ const getLineYProductionRule = (trendlineDimension: string, orientation: Orienta
 	return { scale, field: trendlineDimension };
 };
 
-const getLineXProductionRule = (
+/**
+ * gets the production rule for the x encoding of a line mark
+ * @param trendlineDimension
+ * @param scaleType
+ * @param orientation
+ * @param isDimensionNormalized
+ * @returns
+ */
+export const getLineXProductionRule = (
 	trendlineDimension: string,
 	scaleType: ScaleType,
 	orientation: Orientation,

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -124,7 +124,7 @@ export const getRuleYEncodings = (
 		return { y: { scale: 'yLinear', field: TRENDLINE_VALUE } };
 	}
 	return {
-		y: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, 'yLinear'),
+		y: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, 'yLinear', 'y'),
 		y2: getEndDimensionExtentProductionRule(dimensionExtent[1], dimension, 'yLinear', 'y'),
 	};
 };
@@ -148,7 +148,7 @@ export const getRuleXEncodings = (
 		return { x: { scale, field: TRENDLINE_VALUE } };
 	}
 	return {
-		x: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, scale),
+		x: getStartDimensionExtentProductionRule(dimensionExtent[0], dimension, scale, 'x'),
 		x2: getEndDimensionExtentProductionRule(dimensionExtent[1], dimension, scale, 'x'),
 	};
 };
@@ -157,12 +157,14 @@ const getStartDimensionExtentProductionRule = (
 	startDimensionExtent: number | 'domain' | null,
 	dimension: string,
 	scale: string,
+	axis: 'x' | 'y',
 ): NumericValueRef => {
 	switch (startDimensionExtent) {
 		case null:
 			return { scale, field: `${dimension}Min` };
 		case 'domain':
-			return { value: 0 };
+			if (axis === 'x') return { value: 0 };
+			return { signal: 'height' };
 		default:
 			return { scale, value: startDimensionExtent };
 	}
@@ -178,7 +180,8 @@ const getEndDimensionExtentProductionRule = (
 		case null:
 			return { scale, field: `${dimension}Max` };
 		case 'domain':
-			return { signal: axis === 'x' ? 'width' : 'height' };
+			if (axis === 'x') return { signal: 'width' };
+			return { value: 0 };
 		default:
 			return { scale, value: endDimensionExtent };
 	}

--- a/src/specBuilder/trendline/trendlineScaleUtils.ts
+++ b/src/specBuilder/trendline/trendlineScaleUtils.ts
@@ -11,7 +11,7 @@
  */
 
 import { Scale } from 'vega';
-import { TrendlineParentProps, hasTrendlineWithNormailizedDimension } from './trendlineUtils';
+import { TrendlineParentProps, hasTrendlineWithNormalizedDimension } from './trendlineUtils';
 import { FILTERED_TABLE, LINEAR_PADDING } from '@constants';
 
 /**
@@ -23,7 +23,7 @@ export const getTrendlineScales = (props: TrendlineParentProps): Scale[] => {
 	const { dimension } = props;
 
 	// if there is a trendline that requires a normalized dimension, add the scale
-	if (hasTrendlineWithNormailizedDimension(props)) {
+	if (hasTrendlineWithNormalizedDimension(props)) {
 		return [
 			{
 				name: 'xTrendline',

--- a/src/specBuilder/trendline/trendlineSignalUtils.ts
+++ b/src/specBuilder/trendline/trendlineSignalUtils.ts
@@ -21,8 +21,8 @@ import {
 
 export const getTrendlineSignals = (markProps: TrendlineParentProps): Signal[] => {
 	const signals: Signal[] = [];
-	const { children, name: markName } = markProps;
-	const trendlines = getTrendlines(children, markName);
+	const { name: markName } = markProps;
+	const trendlines = getTrendlines(markProps);
 
 	if (trendlines.some((trendline) => hasTooltip(trendline.children))) {
 		signals.push(getUncontrolledHoverSignal(`${markName}Trendline`, true, `${markName}Trendline_voronoi`));

--- a/src/specBuilder/trendline/trendlineTestUtils.ts
+++ b/src/specBuilder/trendline/trendlineTestUtils.ts
@@ -34,6 +34,7 @@ export const defaultTrendlineProps: TrendlineSpecProps = {
 	children: [],
 	dimensionExtent: [null, null],
 	dimensionRange: [null, null],
+	dimensionScaleType: 'time',
 	displayOnHover: false,
 	highlightRawPoint: false,
 	lineType: 'dashed',
@@ -42,4 +43,5 @@ export const defaultTrendlineProps: TrendlineSpecProps = {
 	metric: DEFAULT_METRIC,
 	name: 'line0Trendline0',
 	opacity: 1,
+	orientation: 'horizontal',
 };

--- a/src/specBuilder/trendline/trendlineUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineUtils.test.ts
@@ -16,6 +16,7 @@ import { Trendline } from '@components/Trendline';
 import { FILTERED_TABLE, MS_PER_DAY, TRENDLINE_VALUE } from '@constants';
 
 import { applyTrendlinePropDefaults, getPolynomialOrder, getRegressionExtent, getTrendlines } from './trendlineUtils';
+import { defaultLineProps } from './trendlineTestUtils';
 
 describe('getTrendlines()', () => {
 	test('should return an array of trendline props', () => {
@@ -24,7 +25,7 @@ describe('getTrendlines()', () => {
 			createElement(Trendline, { method: 'average' }),
 			createElement(Trendline, { method: 'linear' }),
 		];
-		const trendlines = getTrendlines(children, 'line0');
+		const trendlines = getTrendlines({ ...defaultLineProps, children });
 		expect(trendlines).toHaveLength(2);
 		expect(trendlines[0]).toHaveProperty('method', 'average');
 		expect(trendlines[1]).toHaveProperty('method', 'linear');
@@ -32,14 +33,14 @@ describe('getTrendlines()', () => {
 
 	test('should return an empty array if there are not any trendline child elements', () => {
 		const children = [createElement(Annotation)];
-		const trendlines = getTrendlines(children, 'line0');
+		const trendlines = getTrendlines({ ...defaultLineProps, children });
 		expect(trendlines).toHaveLength(0);
 	});
 });
 
 describe('applyTrendlinePropDefaults()', () => {
 	test('should add defaults', () => {
-		const props = applyTrendlinePropDefaults({}, 'line0', 0);
+		const props = applyTrendlinePropDefaults(defaultLineProps, {}, 0);
 		expect(props).toHaveProperty('method', 'linear');
 		expect(props).toHaveProperty('dimensionRange', [null, null]);
 		expect(props).toHaveProperty('lineType', 'dashed');

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -13,7 +13,7 @@
 import { ReactElement } from 'react';
 
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, Legend, Scatter, Trendline } from '@rsc';
+import { Axis, Chart, Legend, Scatter, Trendline, TrendlineProps } from '@rsc';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
@@ -24,6 +24,13 @@ export default {
 	component: Chart,
 };
 
+const trendlineProps: TrendlineProps = {
+	method: 'median',
+	lineWidth: 'XS',
+	lineType: 'solid',
+	dimensionExtent: ['domain', 'domain'],
+};
+
 const FeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElement => {
 	const chartProps = useChartProps(args);
 
@@ -32,13 +39,8 @@ const FeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElement => {
 			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
-				<Trendline
-					method="median"
-					lineWidth="XS"
-					lineType="solid"
-					color="gray-900"
-					dimensionExtent={['domain', 'domain']}
-				/>
+				<Trendline {...trendlineProps} color="gray-900" orientation="horizontal" />
+				<Trendline {...trendlineProps} color="gray-900" orientation="vertical" />
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>
@@ -53,13 +55,8 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
-				<Trendline
-					method="median"
-					lineWidth="XS"
-					lineType="solid"
-					dimensionExtent={['domain', 'domain']}
-					displayOnHover
-				/>
+				<Trendline {...trendlineProps} displayOnHover orientation="horizontal" />
+				<Trendline {...trendlineProps} displayOnHover orientation="vertical" />
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
@@ -41,11 +41,19 @@ describe('FeatureMatrix', () => {
 		expect(point).toHaveAttribute('stroke-width', '0');
 
 		// trendline styling
-		const trendline = await findMarksByGroupName(chart, 'scatter0Trendline0', 'line');
-		expect(trendline).toBeInTheDocument();
-		expect(trendline).toHaveAttribute('stroke', colors['gray-900']);
-		expect(trendline).toHaveAttribute('stroke-width', '1');
-		expect(trendline).toHaveAttribute('stroke-dasharray', '');
+		// horizontal trendline
+		const horizontalTrendline = await findMarksByGroupName(chart, 'scatter0Trendline0', 'line');
+		expect(horizontalTrendline).toBeInTheDocument();
+		expect(horizontalTrendline).toHaveAttribute('x2', '453');
+		expect(horizontalTrendline).toHaveAttribute('y2', '0');
+		expect(horizontalTrendline).toHaveAttribute('stroke', colors['gray-900']);
+		expect(horizontalTrendline).toHaveAttribute('stroke-width', '1');
+		expect(horizontalTrendline).toHaveAttribute('stroke-dasharray', '');
+		// vertical trendline
+		const verticalTrendline = await findMarksByGroupName(chart, 'scatter0Trendline1', 'line');
+		expect(verticalTrendline).toBeInTheDocument();
+		expect(verticalTrendline).toHaveAttribute('x2', '0');
+		expect(verticalTrendline).toHaveAttribute('y2', '-397');
 	});
 });
 

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -62,7 +62,7 @@ const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400
 const TrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
@@ -76,7 +76,7 @@ const TrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 const TrendlineWithDialogsStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
@@ -107,7 +107,7 @@ const TrendlineWithDialogsStory: StoryFn<typeof Trendline> = (args): ReactElemen
 const TrendlineWithDialogsOnParentStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -13,10 +13,11 @@ import React, { ReactElement } from 'react';
 
 import { TRENDLINE_VALUE } from '@constants';
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, ChartPopover, ChartProps, ChartTooltip, Legend, Line, Trendline } from '@rsc';
+import { Axis, Chart, ChartPopover, ChartProps, ChartTooltip, Legend, Line, Scatter, Title, Trendline } from '@rsc';
 import { workspaceTrendsData } from '@stories/data/data';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from 'test-utils/bindWithProps';
+import { characterData } from '@stories/data/marioKartData';
 
 export default {
 	title: 'RSC/Trendline',
@@ -134,6 +135,22 @@ const TrendlineWithDialogsOnParentStory: StoryFn<typeof Trendline> = (args): Rea
 	);
 };
 
+const ScatterStory: StoryFn<typeof Trendline> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
+
+	return (
+		<Chart {...chartProps} debug>
+			<Axis position="bottom" grid ticks baseline title="Speed (normal)" />
+			<Axis position="left" grid ticks baseline title="Handling (normal)" />
+			<Scatter color="weightClass" dimension="speedNormal" metric="handlingNormal">
+				<Trendline {...args} />
+			</Scatter>
+			<Legend title="Weight class" highlight position="right" />
+			<Title text="Mario Kart 8 Character Data" />
+		</Chart>
+	);
+};
+
 const Basic = bindWithProps(TrendlineStory);
 Basic.args = {
 	method: 'linear',
@@ -168,6 +185,15 @@ DisplayOnHover.args = {
 	color: 'gray-600',
 };
 
+const Orientation = bindWithProps(ScatterStory);
+Orientation.args = {
+	orientation: 'vertical',
+	method: 'average',
+	lineType: 'solid',
+	lineWidth: 'XS',
+	dimensionExtent: ['domain', 'domain'],
+};
+
 const TooltipAndPopover = bindWithProps(TrendlineWithDialogsStory);
 TooltipAndPopover.args = {
 	highlightRawPoint: true,
@@ -180,4 +206,12 @@ TooltipAndPopoverOnParentLine.args = {
 	lineWidth: 'S',
 };
 
-export { Basic, DimensionExtent, DimensionRange, DisplayOnHover, TooltipAndPopover, TooltipAndPopoverOnParentLine };
+export {
+	Basic,
+	DimensionExtent,
+	DimensionRange,
+	DisplayOnHover,
+	Orientation,
+	TooltipAndPopover,
+	TooltipAndPopoverOnParentLine,
+};

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -139,7 +139,7 @@ const ScatterStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
 
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="bottom" grid ticks baseline title="Speed (normal)" />
 			<Axis position="left" grid ticks baseline title="Handling (normal)" />
 			<Scatter color="weightClass" dimension="speedNormal" metric="handlingNormal">

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -62,7 +62,7 @@ const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400
 const TrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
@@ -76,7 +76,7 @@ const TrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 const TrendlineWithDialogsStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">
@@ -107,7 +107,7 @@ const TrendlineWithDialogsStory: StoryFn<typeof Trendline> = (args): ReactElemen
 const TrendlineWithDialogsOnParentStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	const chartProps = useChartProps(defaultChartProps);
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Axis position="left" grid title="Users" />
 			<Axis position="bottom" labelFormat="time" baseline ticks />
 			<Line color="series">

--- a/src/stories/components/Trendline/Trendline.test.tsx
+++ b/src/stories/components/Trendline/Trendline.test.tsx
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
 import '@matchMediaMock';
 import { Trendline } from '@rsc';
@@ -22,8 +21,14 @@ import {
 	render,
 } from '@test-utils';
 
-import { Basic, DisplayOnHover, TooltipAndPopover, TooltipAndPopoverOnParentLine } from './Trendline.story';
 import { HIGHLIGHT_CONTRAST_RATIO } from '@constants';
+import {
+	Basic,
+	DisplayOnHover,
+	Orientation,
+	TooltipAndPopover,
+	TooltipAndPopoverOnParentLine,
+} from './Trendline.story';
 
 describe('Trendline', () => {
 	// Trendline is not a real React component. This is test just provides test coverage for sonarqube
@@ -122,6 +127,20 @@ describe('Trendline', () => {
 			expect(trendlines[0]).toHaveAttribute('opacity', '1');
 			// second trendline should still be hidden
 			expect(trendlines[1]).toHaveAttribute('opacity', '0');
+		});
+	});
+
+	describe('Orientation', () => {
+		test('Should have vertical trendline', async () => {
+			render(<Orientation {...Orientation.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			const trendlines = await findAllMarksByGroupName(chart, 'scatter0Trendline0', 'line');
+			expect(trendlines).toHaveLength(3);
+			// if x2 is 0, then the trendline is vertical
+			expect(allElementsHaveAttributeValue(trendlines, 'x2', '0')).toBeTruthy();
+			expect(allElementsHaveAttributeValue(trendlines, 'y2', '-387')).toBeTruthy();
 		});
 	});
 

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -562,6 +562,8 @@ export interface TrendlineProps {
 	method?: TrendlineMethod;
 	/** The opacity of the trendlines */
 	opacity?: number;
+	/** Orientation of the trendline. Only supported on scatter plots. */
+	orientation?: Orientation;
 }
 
 /** trendline methods that use a joinaggregate transform */

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -26,6 +26,7 @@ import {
 	LineWidth,
 	MarkChildElement,
 	MetricRangeProps,
+	ScaleType as RscScaleType,
 	ScatterProps,
 	TrendlineProps,
 } from './Chart';
@@ -167,9 +168,11 @@ type TrendlinePropsWithDefaults =
 	| 'lineWidth'
 	| 'method'
 	| 'metric'
-	| 'opacity';
+	| 'opacity'
+	| 'orientation';
 
 export interface TrendlineSpecProps
 	extends PartiallyRequired<TrendlineProps & { metric?: string; name: string }, TrendlinePropsWithDefaults> {
 	children: ChartTooltipElement[];
+	dimensionScaleType: RscScaleType;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `orientation` to `Trendline`. This allows you to flip the dimension and metric if desired.

## Motivation and Context

The main advantage of this feature is it allows for vertical average and median lines on scatter plots.

## Stories
Trendline > Orientation
Chart > Examples > FeatureMatrix
Chart > Examples > MultipleSegmentFeatureMatrix

## Screenshots (if appropriate):
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/dfdea3cf-3226-4719-8e45-fc5d444ed262)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/7e1c93da-8e39-4624-87f4-960a2168bf99)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/ac79aa8a-fa8a-48f1-be4a-c67e0f72928a)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
