### PR TITLE
An 341517/trendline annotation

### DIFF
--- a/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
+++ b/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
@@ -16,10 +16,13 @@ import { TrendlineAnnotationProps } from '../../types';
 
 // destructure props here and set defaults so that storybook can pick them up
 const TrendlineAnnotation: FC<TrendlineAnnotationProps> = ({
-	// TODO: destructure props here
+	align = 'center',
+	numberFormat = '.2f',
+	position = 'top',
+	prefix,
 }) => {
 	return null;
-}
+};
 
 // displayName is used to validate the component type in the spec builder
 TrendlineAnnotation.displayName = 'TrendlineAnnotation';

--- a/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
+++ b/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
@@ -9,20 +9,19 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
 
-export * from './Annotation';
-export * from './Area';
-export * from './Axis';
-export * from './AxisAnnotation';
-export * from './Bar';
-export * from './ChartPopover';
-export * from './ChartTooltip';
-export * from './EmptyState';
-export * from './Legend';
-export * from './Line';
-export * from './MetricRange';
-export * from './ReferenceLine';
-export * from './Title';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
-export * from './Scatter';
+import { TrendlineAnnotationProps } from '../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const TrendlineAnnotation: FC<TrendlineAnnotationProps> = ({
+	// TODO: destructure props here
+}) => {
+	return null;
+}
+
+// displayName is used to validate the component type in the spec builder
+TrendlineAnnotation.displayName = 'TrendlineAnnotation';
+
+export { TrendlineAnnotation };

--- a/src/components/TrendlineAnnotation/index.ts
+++ b/src/components/TrendlineAnnotation/index.ts
@@ -9,20 +9,4 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-export * from './Annotation';
-export * from './Area';
-export * from './Axis';
-export * from './AxisAnnotation';
-export * from './Bar';
-export * from './ChartPopover';
-export * from './ChartTooltip';
-export * from './EmptyState';
-export * from './Legend';
-export * from './Line';
-export * from './MetricRange';
-export * from './ReferenceLine';
-export * from './Title';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
-export * from './Scatter';
+export * from "./TrendlineAnnotation";

--- a/src/specBuilder/trendline/trendlineDataTransformUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataTransformUtils.test.ts
@@ -75,7 +75,13 @@ describe('getRegressionTransform()', () => {
 	test('should use ${dimension}Normalized as ouput dimension if scaleType is time', () => {
 		const transform = getRegressionTransform(
 			{ ...defaultLineProps, dimension: 'x', scaleType: 'time' },
-			{ ...defaultTrendlineProps, method: 'linear' },
+			{
+				...defaultTrendlineProps,
+				dimensionScaleType: 'time',
+				isDimensionNormalized: true,
+				method: 'linear',
+				trendlineDimension: 'xNormalized',
+			},
 			true,
 		);
 		expect(transform.as).toHaveLength(2);

--- a/src/specBuilder/trendline/trendlineDataTransformUtils.ts
+++ b/src/specBuilder/trendline/trendlineDataTransformUtils.ts
@@ -27,13 +27,7 @@ import {
 	Transforms,
 	WindowTransform,
 } from 'vega';
-import {
-	TrendlineParentProps,
-	getPolynomialOrder,
-	getRegressionExtent,
-	getTrendlineDimensionMetric,
-	isPolynomialMethod,
-} from './trendlineUtils';
+import { TrendlineParentProps, getPolynomialOrder, getRegressionExtent, isPolynomialMethod } from './trendlineUtils';
 
 /**
  * Gets the aggreagate transform used for calculating the average trendline
@@ -44,11 +38,10 @@ import {
  */
 export const getAggregateTransform = (
 	markProps: TrendlineParentProps,
-	{ method, orientation }: TrendlineSpecProps,
+	{ method, trendlineDimension, trendlineMetric }: TrendlineSpecProps,
 	isHighResolutionData: boolean,
 ): AggregateTransform | JoinAggregateTransform => {
-	const { color, dimension, lineType, metric } = markProps;
-	const { trendlineDimension, trendlineMetric } = getTrendlineDimensionMetric(dimension, metric, orientation, false);
+	const { color, lineType } = markProps;
 	const { facets } = getFacetsFromProps({ color, lineType });
 	const operations: Record<AggregateMethod, AggregateOp> = {
 		average: 'mean',
@@ -86,16 +79,10 @@ export const getRegressionTransform = (
 	trendlineProps: TrendlineSpecProps,
 	isHighResolutionData: boolean,
 ): RegressionTransform => {
-	const { color, dimension, lineType, metric } = markProps;
-	const { dimensionExtent, dimensionScaleType, method, name, orientation } = trendlineProps;
+	const { color, lineType } = markProps;
+	const { dimensionExtent, isDimensionNormalized, method, name, trendlineDimension, trendlineMetric } =
+		trendlineProps;
 	const { facets } = getFacetsFromProps({ color, lineType });
-	const isDimensionNormalized = dimensionScaleType === 'time';
-	const { trendlineDimension, trendlineMetric } = getTrendlineDimensionMetric(
-		dimension,
-		metric,
-		orientation,
-		isDimensionNormalized,
-	);
 
 	let regressionMethod: RegressionMethod | undefined;
 	let order: number | undefined;
@@ -137,11 +124,11 @@ export const getRegressionTransform = (
  */
 export const getWindowTransform = (
 	markProps: TrendlineParentProps,
-	{ method, orientation }: TrendlineSpecProps,
+	{ method, trendlineMetric }: TrendlineSpecProps,
 ): WindowTransform => {
 	const frameWidth = parseInt(method.split('-')[1]);
 
-	const { color, dimension, lineType, metric } = markProps;
+	const { color, lineType } = markProps;
 	const { facets } = getFacetsFromProps({ color, lineType });
 
 	if (isNaN(frameWidth) || frameWidth < 1) {
@@ -150,7 +137,6 @@ export const getWindowTransform = (
 		);
 	}
 
-	const { trendlineMetric } = getTrendlineDimensionMetric(dimension, metric, orientation, false);
 	return {
 		type: 'window',
 		ops: ['mean'],

--- a/src/specBuilder/trendline/trendlineMarkUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.test.ts
@@ -159,7 +159,12 @@ describe('getRuleXEncondings()', () => {
 describe('getTrendlineLineMark()', () => {
 	test('should use normalized values for x if it is a regression method and scale is time', () => {
 		expect(
-			getTrendlineLineMark(defaultLineProps, { ...defaultTrendlineProps, method: 'linear' }).encode?.update?.x,
+			getTrendlineLineMark(defaultLineProps, {
+				...defaultTrendlineProps,
+				isDimensionNormalized: true,
+				method: 'linear',
+				trendlineDimension: `${DEFAULT_TIME_DIMENSION}Normalized`,
+			}).encode?.update?.x,
 		).toEqual({
 			scale: 'xTrendline',
 			field: `${DEFAULT_TIME_DIMENSION}Normalized`,
@@ -176,7 +181,7 @@ describe('getTrendlineLineMark()', () => {
 		expect(
 			getTrendlineLineMark(
 				{ ...defaultLineProps, scaleType: 'linear', dimension: 'count' },
-				{ ...defaultTrendlineProps, dimensionScaleType: 'linear' },
+				{ ...defaultTrendlineProps, dimensionScaleType: 'linear', trendlineDimension: 'count' },
 			).encode?.update?.x,
 		).toEqual({ field: 'count', scale: 'xLinear' });
 	});

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { ChartTooltip } from '@components/ChartTooltip';
 import { TRENDLINE_VALUE } from '@constants';
 import { getLineHoverMarks, getLineOpacity } from '@specBuilder/line/lineMarkUtils';
 import { LineMarkProps } from '@specBuilder/line/lineUtils';
@@ -22,16 +23,9 @@ import {
 } from '@specBuilder/marks/markUtils';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
 import { getFacetsFromProps } from '@specBuilder/specUtils';
-import { Orientation, ScaleType, TrendlineSpecProps } from 'types';
+import { ChartTooltipElement, Orientation, ScaleType, TrendlineSpecProps } from 'types';
 import { EncodeEntry, GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
-import {
-	TrendlineParentProps,
-	getTrendlineDimensionMetric,
-	getTrendlines,
-	isAggregateMethod,
-	isRegressionMethod,
-	trendlineUsesNormalizedDimension,
-} from './trendlineUtils';
+import { TrendlineParentProps, getTrendlines, isAggregateMethod, isRegressionMethod } from './trendlineUtils';
 
 export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark | RuleMark)[] => {
 	const { color, lineType } = markProps;
@@ -79,10 +73,10 @@ export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark |
  * @returns rule mark
  */
 export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineProps: TrendlineSpecProps): RuleMark => {
-	const { dimension, colorScheme, metric } = markProps;
-	const { dimensionExtent, dimensionScaleType, lineType, lineWidth, name, orientation } = trendlineProps;
+	const { colorScheme } = markProps;
+	const { dimensionExtent, dimensionScaleType, lineType, lineWidth, name, orientation, trendlineDimension } =
+		trendlineProps;
 	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
-	const { trendlineDimension } = getTrendlineDimensionMetric(dimension, metric, orientation, false);
 
 	return {
 		name,
@@ -194,12 +188,9 @@ const getEndDimensionExtentProductionRule = (
  * @returns
  */
 export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineProps: TrendlineSpecProps): LineMark => {
-	const { colorScheme, dimension, metric } = markProps;
-	const { dimensionScaleType, lineType, lineWidth, method, name, orientation } = trendlineProps;
-
-	const isDimensionNormalized =
-		trendlineUsesNormalizedDimension(method, dimensionScaleType) && orientation === 'horizontal';
-	const { trendlineDimension } = getTrendlineDimensionMetric(dimension, metric, orientation, isDimensionNormalized);
+	const { colorScheme } = markProps;
+	const { dimensionScaleType, isDimensionNormalized, lineType, lineWidth, name, orientation, trendlineDimension } =
+		trendlineProps;
 
 	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
 

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -23,6 +23,7 @@ import {
 } from '@specBuilder/marks/markUtils';
 import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
 import { getFacetsFromProps } from '@specBuilder/specUtils';
+import { getTrendlineAnnotationMarks } from '@specBuilder/trendlineAnnotation';
 import { ChartTooltipElement, Orientation, ScaleType, TrendlineSpecProps } from 'types';
 import { EncodeEntry, GroupMark, LineMark, NumericValueRef, RuleMark } from 'vega';
 import { TrendlineParentProps, getTrendlines, isAggregateMethod, isRegressionMethod } from './trendlineUtils';
@@ -52,6 +53,7 @@ export const getTrendlineMarks = (markProps: TrendlineParentProps): (GroupMark |
 				marks: [getTrendlineLineMark(markProps, trendlineProps)],
 			});
 		}
+		marks.push(...getTrendlineAnnotationMarks(trendlineProps, markProps.name));
 	}
 
 	if (trendlines.some((trendline) => hasTooltip(trendline.children))) {
@@ -147,7 +149,15 @@ export const getRuleXEncodings = (
 	};
 };
 
-const getStartDimensionExtentProductionRule = (
+/**
+ * Gets the production rule for the start dimension extent of a trendline
+ * @param startDimensionExtent
+ * @param dimension
+ * @param scale
+ * @param axis
+ * @returns
+ */
+export const getStartDimensionExtentProductionRule = (
 	startDimensionExtent: number | 'domain' | null,
 	dimension: string,
 	scale: string,
@@ -164,7 +174,15 @@ const getStartDimensionExtentProductionRule = (
 	}
 };
 
-const getEndDimensionExtentProductionRule = (
+/**
+ * gets the production rule for the end dimension extent of a trendline
+ * @param endDimensionExtent
+ * @param dimension
+ * @param scale
+ * @param axis
+ * @returns
+ */
+export const getEndDimensionExtentProductionRule = (
 	endDimensionExtent: number | 'domain' | null,
 	dimension: string,
 	scale: string,
@@ -257,7 +275,10 @@ const getTrendlineHoverMarks = (markProps: TrendlineParentProps, highlightRawPoi
 	const trendlines = getTrendlines(markProps);
 	const trendlineHoverProps: LineMarkProps = getLineMarkProps(markProps, trendlines[0], {
 		name: `${name}Trendline`,
-		children: trendlines.map((trendline) => trendline.children).flat(),
+		children: trendlines
+			.map((trendline) => trendline.children)
+			.flat()
+			.filter((child) => child.type === ChartTooltip) as ChartTooltipElement[],
 		metric: TRENDLINE_VALUE,
 	});
 

--- a/src/specBuilder/trendline/trendlineTestUtils.ts
+++ b/src/specBuilder/trendline/trendlineTestUtils.ts
@@ -37,6 +37,7 @@ export const defaultTrendlineProps: TrendlineSpecProps = {
 	dimensionScaleType: 'time',
 	displayOnHover: false,
 	highlightRawPoint: false,
+	isDimensionNormalized: false,
 	lineType: 'dashed',
 	lineWidth: 'M',
 	method: 'average',
@@ -44,4 +45,6 @@ export const defaultTrendlineProps: TrendlineSpecProps = {
 	name: 'line0Trendline0',
 	opacity: 1,
 	orientation: 'horizontal',
+	trendlineDimension: DEFAULT_TIME_DIMENSION,
+	trendlineMetric: DEFAULT_METRIC,
 };

--- a/src/specBuilder/trendlineAnnotation/index.ts
+++ b/src/specBuilder/trendlineAnnotation/index.ts
@@ -9,21 +9,5 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { FC } from 'react';
 
-import { TrendlineAnnotationProps } from '../../types';
-
-// destructure props here and set defaults so that storybook can pick them up
-const TrendlineAnnotation: FC<TrendlineAnnotationProps> = ({
-	dimensionValue = 'end',
-	numberFormat = '',
-	prefix = '',
-}) => {
-	return null;
-};
-
-// displayName is used to validate the component type in the spec builder
-TrendlineAnnotation.displayName = 'TrendlineAnnotation';
-
-export { TrendlineAnnotation };
+export * from './trendlineAnnotationUtils';

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { defaultTrendlineProps } from '@specBuilder/trendline/trendlineTestUtils';
+import {
+	applyTrendlineAnnotationDefaults,
+	getTrendlineAnnotationMarks,
+	getTrendlineAnnotationPointX,
+	getTrendlineAnnotationPointY,
+	getTrendlineAnnotationTextMark,
+	getTrendlineAnnotations,
+} from './trendlineAnnotationUtils';
+import { TrendlineAnnotationSpecProps } from 'types';
+import { DEFAULT_TIME_DIMENSION, TRENDLINE_VALUE } from '@constants';
+import { createElement } from 'react';
+import { TrendlineAnnotation } from '@components/TrendlineAnnotation';
+import { ChartTooltip } from '@components/ChartTooltip';
+
+const defaultAnnotationProps: TrendlineAnnotationSpecProps = {
+	dimensionValue: 'end',
+	markName: 'line0',
+	name: 'line0Trendline0Annotation0',
+	numberFormat: '',
+	prefix: '',
+	trendlineDimension: DEFAULT_TIME_DIMENSION,
+	trendlineDimensionExtent: [null, null],
+	trendlineDimensionScaleType: 'time',
+	trendlineName: 'line0Trendline0',
+	trendlineOrientation: 'horizontal',
+	trendlineWidth: 2,
+};
+
+describe('applyTrendlineAnnotationDefaults()', () => {
+	test('should apply all defaults', () => {
+		const annotationProps = applyTrendlineAnnotationDefaults({}, 0, defaultTrendlineProps, 'line0');
+		expect(annotationProps).toEqual(defaultAnnotationProps);
+	});
+});
+
+describe('getTrendlineAnnotations()', () => {
+	test('should get all annotations from trendline children', () => {
+		expect(
+			getTrendlineAnnotations(
+				{
+					...defaultTrendlineProps,
+					children: [createElement(TrendlineAnnotation), createElement(ChartTooltip)],
+				},
+				'line0',
+			),
+		).toHaveLength(1);
+	});
+});
+
+describe('getTrendlineAnnotationMarks()', () => {
+	test('should return the marks for trendline annotations', () => {
+		expect(getTrendlineAnnotationMarks(defaultTrendlineProps, 'line0')).toHaveLength(0);
+		const annotationGroups = getTrendlineAnnotationMarks(
+			{ ...defaultTrendlineProps, children: [createElement(TrendlineAnnotation)] },
+			'line0',
+		);
+		expect(annotationGroups).toHaveLength(1);
+		expect(annotationGroups[0]).toHaveProperty('type', 'group');
+		expect(annotationGroups[0]).toHaveProperty('name', 'line0Trendline0Annotation0_group');
+	});
+});
+
+describe('getTrendlineAnnotationPointX()', () => {
+	test('should return rule for TRENDLINE_VALUE if vertical', () => {
+		const xRule = getTrendlineAnnotationPointX({ ...defaultAnnotationProps, trendlineOrientation: 'vertical' });
+		expect(xRule).toHaveProperty('scale', 'xTime');
+		expect(xRule).toHaveProperty('field', TRENDLINE_VALUE);
+	});
+	test('should get end rule if dimensionValue is "end"', () => {
+		const xRule = getTrendlineAnnotationPointX({ ...defaultAnnotationProps, dimensionValue: 'end' });
+		expect(xRule).toHaveProperty('field', `${DEFAULT_TIME_DIMENSION}Max`);
+	});
+	test('should get start rule if dimensionValue is "start"', () => {
+		const xRule = getTrendlineAnnotationPointX({ ...defaultAnnotationProps, dimensionValue: 'start' });
+		expect(xRule).toHaveProperty('field', `${DEFAULT_TIME_DIMENSION}Min`);
+	});
+	test('should use dimensionValue as value if it is a number', () => {
+		const xRule = getTrendlineAnnotationPointX({ ...defaultAnnotationProps, dimensionValue: 1 });
+		expect(xRule).toHaveProperty('value', 1);
+	});
+});
+
+describe('getTrendlineAnnotationPointY()', () => {
+	test('should return rule for TRENDLINE_VALUE if horizontal', () => {
+		const xRule = getTrendlineAnnotationPointY({ ...defaultAnnotationProps, trendlineOrientation: 'horizontal' });
+		expect(xRule).toHaveProperty('field', TRENDLINE_VALUE);
+	});
+	test('should get end rule if dimensionValue is "end"', () => {
+		const xRule = getTrendlineAnnotationPointY({
+			...defaultAnnotationProps,
+			trendlineOrientation: 'vertical',
+			dimensionValue: 'end',
+		});
+		expect(xRule).toHaveProperty('field', `${DEFAULT_TIME_DIMENSION}Max`);
+	});
+	test('should get start rule if dimensionValue is "start"', () => {
+		const xRule = getTrendlineAnnotationPointY({
+			...defaultAnnotationProps,
+			trendlineOrientation: 'vertical',
+			dimensionValue: 'start',
+		});
+		expect(xRule).toHaveProperty('field', `${DEFAULT_TIME_DIMENSION}Min`);
+	});
+	test('should use dimensionValue as value if it is a number', () => {
+		const xRule = getTrendlineAnnotationPointY({
+			...defaultAnnotationProps,
+			trendlineOrientation: 'vertical',
+			dimensionValue: 1,
+		});
+		expect(xRule).toHaveProperty('value', 1);
+	});
+});
+
+describe('getTrendlineAnnotationTextMark()', () => {
+	test('should return text mark', () => {
+		const textMark = getTrendlineAnnotationTextMark(defaultAnnotationProps);
+		expect(textMark).toHaveProperty('type', 'text');
+		expect(textMark).toHaveProperty('name', 'line0Trendline0Annotation0');
+		expect(textMark.transform).toHaveLength(1);
+		expect(textMark.transform?.[0]).toHaveProperty('type', 'label');
+	});
+	test('should add the prefix if it is a valid string', () => {
+		const prefix = 'Median times';
+		const textMark = getTrendlineAnnotationTextMark({ ...defaultAnnotationProps, prefix });
+		expect(textMark.encode?.enter?.text).toHaveProperty(
+			'signal',
+			`'${prefix} ' + format(datum.datum.${TRENDLINE_VALUE}, '')`,
+		);
+	});
+	test('should not add the prefix if it is not a valid string', () => {
+		const textMark = getTrendlineAnnotationTextMark({ ...defaultAnnotationProps, prefix: '' });
+		expect(textMark.encode?.enter?.text).toHaveProperty('signal', `format(datum.datum.${TRENDLINE_VALUE}, '')`);
+	});
+});

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { TrendlineAnnotation } from '@components/TrendlineAnnotation';
+import { TRENDLINE_VALUE } from '@constants';
+import { getScaleName } from '@specBuilder/scale/scaleSpecBuilder';
+import { getLineWidthPixelsFromLineWidth } from '@specBuilder/specUtils';
+import {
+	getEndDimensionExtentProductionRule,
+	getStartDimensionExtentProductionRule,
+} from '@specBuilder/trendline/trendlineMarkUtils';
+import {
+	TrendlineAnnotationElement,
+	TrendlineAnnotationProps,
+	TrendlineAnnotationSpecProps,
+	TrendlineSpecProps,
+} from 'types';
+import { GroupMark, NumericValueRef, SymbolMark, TextMark } from 'vega';
+
+/**
+ * Applies all trendline annotation defaults
+ * @param trenlineAnnotationProps
+ * @param index
+ * @param trendlineProps
+ * @param markName
+ * @returns TrendlineAnnotationSpecProps
+ */
+export const applyTrendlineAnnotationDefaults = (
+	{ dimensionValue = 'end', numberFormat = '', prefix = '' }: TrendlineAnnotationProps,
+	index: number,
+	{
+		dimensionExtent,
+		dimensionScaleType,
+		lineWidth,
+		orientation,
+		trendlineDimension,
+		name: trendlineName,
+	}: TrendlineSpecProps,
+	markName: string,
+): TrendlineAnnotationSpecProps => ({
+	dimensionValue,
+	markName,
+	name: `${trendlineName}Annotation${index}`,
+	numberFormat,
+	prefix,
+	trendlineDimension,
+	trendlineDimensionExtent: dimensionExtent,
+	trendlineDimensionScaleType: dimensionScaleType,
+	trendlineName: trendlineName,
+	trendlineOrientation: orientation,
+	trendlineWidth: getLineWidthPixelsFromLineWidth(lineWidth),
+});
+
+/**
+ * Gets all the annotations on a trendline
+ * @param trendlineProps
+ * @param markName
+ * @returns TrendlineAnnotationSpecProps[]
+ */
+export const getTrendlineAnnotations = (
+	trendlineProps: TrendlineSpecProps,
+	markName: string,
+): TrendlineAnnotationSpecProps[] => {
+	const annotationElements = trendlineProps.children.filter(
+		(child) => child.type === TrendlineAnnotation,
+	) as TrendlineAnnotationElement[];
+	return annotationElements.map((annotation, index) =>
+		applyTrendlineAnnotationDefaults(annotation.props, index, trendlineProps, markName),
+	);
+};
+
+/**
+ * Gets all the trendline annotation marks
+ * @param trendlineProps
+ * @param markName
+ * @returns GroupMark[]
+ */
+export const getTrendlineAnnotationMarks = (trendlineProps: TrendlineSpecProps, markName: string): GroupMark[] => {
+	const marks: GroupMark[] = [];
+	const annotations = getTrendlineAnnotations(trendlineProps, markName);
+
+	annotations.forEach((annotation) => {
+		marks.push({
+			name: `${annotation.name}_group`,
+			type: 'group',
+			interactive: false,
+			marks: [getTrendlineAnnotationPoints(annotation), getTrendlineAnnotationTextMark(annotation)],
+		});
+	});
+	return marks;
+};
+
+/**
+ * Gets the annotation points
+ * @param annotationProps
+ * @returns SymbolMark
+ */
+const getTrendlineAnnotationPoints = (annotationProps: TrendlineAnnotationSpecProps): SymbolMark => {
+	const { name, trendlineName, trendlineWidth } = annotationProps;
+	return {
+		name: `${name}_points`,
+		type: 'symbol',
+		from: { data: `${trendlineName}_highResolutionData` },
+		encode: {
+			enter: {
+				x: getTrendlineAnnotationPointX(annotationProps),
+				y: getTrendlineAnnotationPointY(annotationProps),
+				fill: { value: 'transparent' },
+				size: { value: Math.pow(trendlineWidth, 2) },
+			},
+		},
+	};
+};
+
+/**
+ * Gets the correct x rule for the annotation point
+ * @param annotationProps
+ * @returns NumericValueRef
+ */
+export const getTrendlineAnnotationPointX = ({
+	dimensionValue,
+	trendlineDimension,
+	trendlineDimensionExtent,
+	trendlineDimensionScaleType,
+	trendlineOrientation,
+}: TrendlineAnnotationSpecProps): NumericValueRef => {
+	const scale = getScaleName('x', trendlineDimensionScaleType);
+	if (trendlineOrientation === 'vertical') {
+		return { scale, field: TRENDLINE_VALUE };
+	}
+	switch (dimensionValue) {
+		case 'start':
+			return getStartDimensionExtentProductionRule(trendlineDimensionExtent[0], trendlineDimension, scale, 'x');
+		case 'end':
+			return getEndDimensionExtentProductionRule(trendlineDimensionExtent[1], trendlineDimension, scale, 'x');
+		default:
+			return { scale, value: dimensionValue };
+	}
+};
+
+/**
+ * Gets the correct y rule for the annotation point
+ * @param param0
+ * @returns NumericValueRef
+ */
+export const getTrendlineAnnotationPointY = ({
+	dimensionValue,
+	trendlineDimension,
+	trendlineDimensionExtent,
+	trendlineOrientation,
+}: TrendlineAnnotationSpecProps): NumericValueRef => {
+	const scale = 'yLinear';
+	if (trendlineOrientation === 'horizontal') {
+		return { scale, field: TRENDLINE_VALUE };
+	}
+	switch (dimensionValue) {
+		case 'start':
+			return getStartDimensionExtentProductionRule(trendlineDimensionExtent[0], trendlineDimension, scale, 'y');
+		case 'end':
+			return getEndDimensionExtentProductionRule(trendlineDimensionExtent[1], trendlineDimension, scale, 'y');
+		default:
+			return { scale, value: dimensionValue };
+	}
+};
+
+/**
+ * Gets the annotation text mark
+ * @param annotationProps
+ * @returns TextMark
+ */
+export const getTrendlineAnnotationTextMark = ({
+	markName,
+	name,
+	numberFormat,
+	prefix,
+	trendlineName,
+}: TrendlineAnnotationSpecProps): TextMark => {
+	const textPrefix = prefix ? `'${prefix} ' + ` : '';
+	return {
+		name,
+		type: 'text',
+		from: { data: `${name}_points` },
+		encode: {
+			enter: {
+				text: { signal: `${textPrefix}format(datum.datum.${TRENDLINE_VALUE}, '${numberFormat}')` },
+			},
+		},
+		transform: [
+			{
+				type: 'label',
+				size: { signal: '[width, height]' },
+				avoidMarks: [trendlineName, `${markName}_group`],
+				offset: [2],
+				anchor: ['top', 'bottom', 'right', 'left', 'top-right', 'top-left', 'bottom-right', 'bottom-left'],
+			},
+		],
+	};
+};

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -13,7 +13,7 @@
 import { ReactElement } from 'react';
 
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, Legend, Scatter, Trendline, TrendlineProps } from '@rsc';
+import { Axis, Chart, Legend, Scatter, Trendline, TrendlineAnnotation, TrendlineProps } from '@rsc';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
@@ -39,8 +39,12 @@ const FeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElement => {
 			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
-				<Trendline {...trendlineProps} color="gray-900" orientation="horizontal" />
-				<Trendline {...trendlineProps} color="gray-900" orientation="vertical" />
+				<Trendline {...trendlineProps} color="gray-900" orientation="horizontal">
+					<TrendlineAnnotation prefix="Median times" numberFormat=".3" />
+				</Trendline>
+				<Trendline {...trendlineProps} color="gray-900" orientation="vertical">
+					<TrendlineAnnotation prefix="Median %DAU" numberFormat=".2%" />
+				</Trendline>
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
@@ -17,6 +17,7 @@ import {
 	findMarksByGroupName,
 	hoverNthElement,
 	render,
+	screen,
 } from '@test-utils';
 import { spectrumColors } from '@themes';
 
@@ -44,7 +45,7 @@ describe('FeatureMatrix', () => {
 		// horizontal trendline
 		const horizontalTrendline = await findMarksByGroupName(chart, 'scatter0Trendline0', 'line');
 		expect(horizontalTrendline).toBeInTheDocument();
-		expect(horizontalTrendline).toHaveAttribute('x2', '453');
+		expect(horizontalTrendline).toHaveAttribute('x2', '452');
 		expect(horizontalTrendline).toHaveAttribute('y2', '0');
 		expect(horizontalTrendline).toHaveAttribute('stroke', colors['gray-900']);
 		expect(horizontalTrendline).toHaveAttribute('stroke-width', '1');
@@ -53,7 +54,18 @@ describe('FeatureMatrix', () => {
 		const verticalTrendline = await findMarksByGroupName(chart, 'scatter0Trendline1', 'line');
 		expect(verticalTrendline).toBeInTheDocument();
 		expect(verticalTrendline).toHaveAttribute('x2', '0');
-		expect(verticalTrendline).toHaveAttribute('y2', '-397');
+		expect(verticalTrendline).toHaveAttribute('y2', '-396');
+
+		// trendline annotations
+		// horizontal trendline annotation
+		const horizontalAnnotation = await screen.findByText('Median times 2.94');
+		expect(horizontalAnnotation).toBeInTheDocument();
+		expect(horizontalAnnotation).toHaveAttribute('text-anchor', 'end');
+
+		// vertical trendline annotation
+		const verticalAnnotation = await screen.findByText('Median %DAU 8.39%');
+		expect(verticalAnnotation).toBeInTheDocument();
+		expect(verticalAnnotation).toHaveAttribute('text-anchor', 'middle');
 	});
 });
 

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
@@ -9,34 +9,65 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React, { ReactElement } from "react";
+import { ReactElement } from 'react';
 
 import useChartProps from '@hooks/useChartProps';
-import { TrendlineAnnotation, Chart } from "@rsc";
-import { StoryFn } from "@storybook/react";
+import { Axis, Chart, Legend, Scatter, Title, Trendline, TrendlineAnnotation, TrendlineProps } from '@rsc';
+import { characterData } from '@stories/data/marioKartData';
+import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
 export default {
-    title: "RSC/TrendlineAnnotation",
-    component: TrendlineAnnotation,
+	title: 'RSC/Trendline/TrendlineAnnotation',
+	component: TrendlineAnnotation,
+};
+
+const trendlineProps: TrendlineProps = {
+	method: 'median',
+	dimensionExtent: ['domain', 'domain'],
+	lineWidth: 'S',
 };
 
 const TrendlineAnnotationStory: StoryFn<typeof TrendlineAnnotation> = (args): ReactElement => {
-	// TODO: add data
-    const chartProps = useChartProps({ data: [], width: 600 });
+	const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
 
-    // TODO: use TrendlineAnnotation correctly
-    return (
-        <Chart {...chartProps}>
-            <TrendlineAnnotation {...args} />;
-        </Chart>
-    )
-
+	return (
+		<Chart {...chartProps}>
+			<Axis position="bottom" grid ticks baseline title="Speed (normal)" />
+			<Axis position="left" grid ticks baseline title="Handling (normal)" />
+			<Scatter color="weightClass" dimension="speedNormal" metric="handlingNormal">
+				<Trendline {...trendlineProps}>
+					<TrendlineAnnotation {...args} />
+				</Trendline>
+			</Scatter>
+			<Legend title="Weight class" highlight position="right" />
+			<Title text="Mario Kart 8 Character Data" />
+		</Chart>
+	);
 };
 
-// TODO: add component props and additional stories here
 const Basic = bindWithProps(TrendlineAnnotationStory);
-Basic.args = {};
 
+const DimensionValue = bindWithProps(TrendlineAnnotationStory);
+DimensionValue.args = {
+	dimensionValue: 2,
+};
 
-export { Basic };
+const NumberFormat = bindWithProps(TrendlineAnnotationStory);
+NumberFormat.args = {
+	numberFormat: '.2f',
+};
+
+const Prefix = bindWithProps(TrendlineAnnotationStory);
+Prefix.args = {
+	prefix: 'Speed: ',
+};
+
+const Supreme = bindWithProps(TrendlineAnnotationStory);
+Supreme.args = {
+	dimensionValue: 'start',
+	numberFormat: '.2f',
+	prefix: 'Speed: ',
+};
+
+export { Basic, DimensionValue, NumberFormat, Prefix, Supreme };

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React, { ReactElement } from "react";
+
+import useChartProps from '@hooks/useChartProps';
+import { TrendlineAnnotation, Chart } from "@rsc";
+import { StoryFn } from "@storybook/react";
+import { bindWithProps } from '@test-utils';
+
+export default {
+    title: "RSC/TrendlineAnnotation",
+    component: TrendlineAnnotation,
+};
+
+const TrendlineAnnotationStory: StoryFn<typeof TrendlineAnnotation> = (args): ReactElement => {
+	// TODO: add data
+    const chartProps = useChartProps({ data: [], width: 600 });
+
+    // TODO: use TrendlineAnnotation correctly
+    return (
+        <Chart {...chartProps}>
+            <TrendlineAnnotation {...args} />;
+        </Chart>
+    )
+
+};
+
+// TODO: add component props and additional stories here
+const Basic = bindWithProps(TrendlineAnnotationStory);
+Basic.args = {};
+
+
+export { Basic };

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React from "react";
+
+import '@matchMediaMock';
+import { TrendlineAnnotation } from '@rsc';
+import {
+	findChart,
+	render,
+} from '@test-utils';
+
+import { Basic } from "./TrendlineAnnotation.story";
+
+describe("TrendlineAnnotation", () => {
+	// TrendlineAnnotation is not a real React component. This is test just provides test coverage for sonarqube
+	test('TrendlineAnnotation pseudo element', () => {
+		render(<TrendlineAnnotation />);
+	});
+
+	test("Basic renders properly", async () => {
+		render(<Basic {...Basic.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+		// TODO: add expect statements for the basic behavior of TrendlineAnnotation here
+	});
+		// TODO: add tests for each variation of TrendlineAnnotation here
+});

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
@@ -9,28 +9,66 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from "react";
 
 import '@matchMediaMock';
 import { TrendlineAnnotation } from '@rsc';
-import {
-	findChart,
-	render,
-} from '@test-utils';
+import { allElementsHaveAttributeValue, findAllMarksByGroupName, findChart, render } from '@test-utils';
 
-import { Basic } from "./TrendlineAnnotation.story";
+import { Basic, DimensionValue, NumberFormat, Prefix } from './TrendlineAnnotation.story';
 
-describe("TrendlineAnnotation", () => {
+describe('TrendlineAnnotation', () => {
 	// TrendlineAnnotation is not a real React component. This is test just provides test coverage for sonarqube
 	test('TrendlineAnnotation pseudo element', () => {
 		render(<TrendlineAnnotation />);
 	});
 
-	test("Basic renders properly", async () => {
+	test('Basic renders properly', async () => {
 		render(<Basic {...Basic.args} />);
+
 		const chart = await findChart();
 		expect(chart).toBeInTheDocument();
-		// TODO: add expect statements for the basic behavior of TrendlineAnnotation here
+
+		const labels = await findAllMarksByGroupName(chart, 'scatter0Trendline0Annotation0', 'text');
+		expect(labels).toHaveLength(3);
+		expect(allElementsHaveAttributeValue(labels, 'opacity', 1)).toBeTruthy();
+		expect(labels[0]).toHaveTextContent('4.5');
+		expect(labels[1]).toHaveTextContent('3.75');
+		expect(labels[2]).toHaveTextContent('3');
 	});
-		// TODO: add tests for each variation of TrendlineAnnotation here
+
+	test('should render DimensionValue correctly', async () => {
+		render(<DimensionValue {...DimensionValue.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const labels = await findAllMarksByGroupName(chart, 'scatter0Trendline0Annotation0', 'text');
+		expect(labels).toHaveLength(3);
+		expect(allElementsHaveAttributeValue(labels, 'opacity', 1)).toBeTruthy();
+	});
+
+	test('should render NumberFormat', async () => {
+		render(<NumberFormat {...NumberFormat.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const labels = await findAllMarksByGroupName(chart, 'scatter0Trendline0Annotation0', 'text');
+		expect(labels).toHaveLength(3);
+		expect(allElementsHaveAttributeValue(labels, 'opacity', 1)).toBeTruthy();
+		expect(labels[0]).toHaveTextContent('4.50');
+		expect(labels[1]).toHaveTextContent('3.75');
+		expect(labels[2]).toHaveTextContent('3.00');
+	});
+
+	test('should render Prefix', async () => {
+		render(<Prefix {...Prefix.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const labels = await findAllMarksByGroupName(chart, 'scatter0Trendline0Annotation0', 'text');
+		expect(labels).toHaveLength(3);
+		expect(labels[0]).toHaveTextContent('Speed: 4.5');
+		expect(labels[1]).toHaveTextContent('Speed: 3.75');
+		expect(labels[2]).toHaveTextContent('Speed: 3');
+	});
 });

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -571,8 +571,8 @@ export interface TrendlineProps {
 }
 
 export interface TrendlineAnnotationProps {
-	/** horizontal or vertical alignment of the text annotation */
-	align?: 'center' | 'start' | 'end';
+	/** where along the dimension scale to label the trendline value */
+	dimensionValue?: number | 'start' | 'end';
 	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.
 	 *
 	 * @see https://d3js.org/d3-format#locale_format
@@ -580,8 +580,6 @@ export interface TrendlineAnnotationProps {
 	numberFormat?: string;
 	/** text that will be prepended to the trendline value */
 	prefix?: string;
-	/** position of the text relative to the point that it is associated with */
-	position?: Position;
 }
 
 /** trendline methods that use a joinaggregate transform */

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -19,22 +19,26 @@ import { Theme } from '@react-types/provider';
 import { Colors, SpectrumColor } from './SpectrumVizColors';
 import { LocaleCode, NumberLocaleCode, TimeLocaleCode } from './locales';
 
-export type ChartElement = ReactElement<ChartProps, JSXElementConstructor<ChartProps>>;
+export type AnnotationElement = ReactElement<AnnotationProps, JSXElementConstructor<AnnotationProps>>;
 export type AreaElement = ReactElement<AreaProps, JSXElementConstructor<AreaProps>>;
 export type AxisElement = ReactElement<AxisProps, JSXElementConstructor<AxisProps>>;
 export type AxisAnnotationElement = ReactElement<AxisAnnotationProps, JSXElementConstructor<AxisAnnotationProps>>;
 export type BarElement = ReactElement<BarProps, JSXElementConstructor<BarProps>>;
+export type ChartElement = ReactElement<ChartProps, JSXElementConstructor<ChartProps>>;
+export type ChartPopoverElement = ReactElement<ChartPopoverProps, JSXElementConstructor<ChartPopoverProps>>;
+export type ChartTooltipElement = ReactElement<ChartTooltipProps, JSXElementConstructor<ChartTooltipProps>>;
 export type DonutElement = ReactElement<DonutProps, JSXElementConstructor<DonutProps>>;
-export type AnnotationElement = ReactElement<AnnotationProps, JSXElementConstructor<AnnotationProps>>;
 export type LegendElement = ReactElement<LegendProps, JSXElementConstructor<LegendProps>>;
 export type LineElement = ReactElement<LineProps, JSXElementConstructor<LineProps>>;
+export type MetricRangeElement = ReactElement<MetricRangeProps, JSXElementConstructor<MetricRangeProps>>;
+export type ReferenceLineElement = ReactElement<ReferenceLineProps, JSXElementConstructor<ReferenceLineProps>>;
 export type ScatterElement = ReactElement<ScatterProps, JSXElementConstructor<ScatterProps>>;
 export type TitleElement = ReactElement<TitleProps, JSXElementConstructor<TitleProps>>;
-export type ChartTooltipElement = ReactElement<ChartTooltipProps, JSXElementConstructor<ChartTooltipProps>>;
-export type ChartPopoverElement = ReactElement<ChartPopoverProps, JSXElementConstructor<ChartPopoverProps>>;
-export type ReferenceLineElement = ReactElement<ReferenceLineProps, JSXElementConstructor<ReferenceLineProps>>;
+export type TrendlineAnnotationElement = ReactElement<
+	TrendlineAnnotationProps,
+	JSXElementConstructor<TrendlineAnnotationProps>
+>;
 export type TrendlineElement = ReactElement<TrendlineProps, JSXElementConstructor<TrendlineProps>>;
-export type MetricRangeElement = ReactElement<MetricRangeProps, JSXElementConstructor<MetricRangeProps>>;
 
 export type SimpleData = { [key: string]: unknown };
 export type ChartData = SimpleData | Data;
@@ -533,7 +537,7 @@ export interface MetricRangeProps {
 }
 
 export interface TrendlineProps {
-	children?: Children<ChartTooltipElement>;
+	children?: Children<TrendlineChildElement>;
 	/** The line color of the trendline. If undefined, will default to the color of the series that it represents. */
 	color?: SpectrumColor | string;
 	/**
@@ -567,9 +571,16 @@ export interface TrendlineProps {
 }
 
 export interface TrendlineAnnotationProps {
+	/** horizontal or vertical alignment of the text annotation */
 	align?: 'center' | 'start' | 'end';
+	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.
+	 *
+	 * @see https://d3js.org/d3-format#locale_format
+	 */
 	numberFormat?: string;
+	/** text that will be prepended to the trendline value */
 	prefix?: string;
+	/** position of the text relative to the point that it is associated with */
 	position?: Position;
 }
 
@@ -643,6 +654,7 @@ export type Children<T> = ChildElement<T> | ChildElement<T>[];
 
 export type AxisChildElement = ReferenceLineElement | AxisAnnotationElement;
 export type AxisAnnotationChildElement = ChartTooltipElement | ChartPopoverElement;
+export type TrendlineChildElement = ChartTooltipElement | TrendlineAnnotationElement;
 export type ChartChildElement =
 	| AreaElement
 	| AxisElement

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -566,6 +566,13 @@ export interface TrendlineProps {
 	orientation?: Orientation;
 }
 
+export interface TrendlineAnnotationProps {
+	align?: 'center' | 'start' | 'end';
+	numberFormat?: string;
+	prefix?: string;
+	position?: Position;
+}
+
 /** trendline methods that use a joinaggregate transform */
 export type AggregateMethod = 'average' | 'median';
 /** trendline methods that use a regression transform */

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -17,7 +17,6 @@ import {
 	AxisAnnotationProps,
 	AxisProps,
 	BarProps,
-	ChartTooltipElement,
 	ColorScheme,
 	DonutProps,
 	FacetRef,
@@ -26,8 +25,11 @@ import {
 	LineWidth,
 	MarkChildElement,
 	MetricRangeProps,
+	Orientation,
 	ScaleType as RscScaleType,
 	ScatterProps,
+	TrendlineAnnotationProps,
+	TrendlineChildElement,
 	TrendlineProps,
 } from './Chart';
 
@@ -173,9 +175,23 @@ type TrendlinePropsWithDefaults =
 
 export interface TrendlineSpecProps
 	extends PartiallyRequired<TrendlineProps & { metric?: string; name: string }, TrendlinePropsWithDefaults> {
-	children: ChartTooltipElement[];
+	children: TrendlineChildElement[];
 	dimensionScaleType: RscScaleType;
 	isDimensionNormalized: boolean;
 	trendlineDimension: string;
 	trendlineMetric: string;
+}
+
+type TrendlineAnnotationPropsWithDefaults = 'dimensionValue' | 'numberFormat';
+
+export interface TrendlineAnnotationSpecProps
+	extends PartiallyRequired<TrendlineAnnotationProps, TrendlineAnnotationPropsWithDefaults> {
+	markName: string;
+	name: string;
+	trendlineDimension: string;
+	trendlineDimensionExtent: TrendlineSpecProps['dimensionExtent'];
+	trendlineDimensionScaleType: RscScaleType;
+	trendlineName: string;
+	trendlineOrientation: Orientation;
+	trendlineWidth: number;
 }

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -175,4 +175,7 @@ export interface TrendlineSpecProps
 	extends PartiallyRequired<TrendlineProps & { metric?: string; name: string }, TrendlinePropsWithDefaults> {
 	children: ChartTooltipElement[];
 	dimensionScaleType: RscScaleType;
+	isDimensionNormalized: boolean;
+	trendlineDimension: string;
+	trendlineMetric: string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new `TrendlineAnnotation` component that will add annotations to a `Trendline`. This supports `TrendlineAnnotation` for aggregate trendlines (average, median).

The following props are supported:
- dimensionValue
- numberFormat
- prefix

## Motivation and Context

Adding annotations to trendlines allows for more context and information.

## Stories

- Chart > Examples > FeatureMatrix
- Trendline > TrendlineAnnotation > *

## How Has This Been Tested?

Existing and new tests all pass

## Screenshots (if appropriate):
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/8c6844f4-2db9-4c77-8b43-a7b7a76f7733)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/2962489e-0972-4f09-9562-53d592cd444c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
