### PR TITLE
Support duration label format

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
 		'\\.(css)$': 'identity-obj-proxy',
 		'single-spa-react/parcel': 'single-spa-react/lib/cjs/parcel.cjs',
 		'^.+\\.(css|less|scss)$': 'babel-jest',
+		'^d3-format$': '<rootDir>/node_modules/d3-format/dist/d3-format.js',
 		...pathsToModuleNameMapper(compilerOptions.paths),
 	},
 	setupFilesAfterEnv: ['@testing-library/jest-dom', 'jest-canvas-mock'],

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"@testing-library/react": "12.1.5",
 		"@testing-library/user-event": "^14.4.3",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",
+		"@types/d3-format": "^3.0.4",
 		"@types/node": "^20.8.2",
 		"@types/react": "17.0.50",
 		"@types/react-dom": "17.0.17",
@@ -116,6 +117,7 @@
 	},
 	"dependencies": {
 		"@adobe/react-spectrum": ">= 3.23.0",
+		"d3-format": "^3.1.0",
 		"immer": ">= 9.0.0",
 		"uuid": ">= 9.0.0",
 		"vega-embed": ">= 6.24.0",

--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -14,7 +14,7 @@ import { FC, useEffect, useMemo, useRef } from 'react';
 import { TABLE } from '@constants';
 import { useDebugSpec } from '@hooks/useDebugSpec';
 import { extractValues, isVegaData } from '@specBuilder/specUtils';
-import { expressionFunctions } from 'expressionFunctions';
+import { expressionFunctions, formatTimeDurationLabels } from 'expressionFunctions';
 import { ChartData, ChartProps } from 'types';
 import { getLocale } from 'utils/locale';
 import { Config, Padding, Renderers, Spec, View } from 'vega';
@@ -89,7 +89,10 @@ export const VegaChart: FC<VegaChartProps> = ({
 			embed(containerRef.current, specCopy, {
 				actions: false,
 				config,
-				expressionFunctions: expressionFunctions,
+				expressionFunctions: {
+					...expressionFunctions,
+					formatTimeDurationLabels: formatTimeDurationLabels(numberLocale),
+				},
 				formatLocale: numberLocale as unknown as Record<string, unknown>, // these are poorly typed by vega-embed
 				height,
 				padding,

--- a/src/expressionFunctions.test.ts
+++ b/src/expressionFunctions.test.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { expressionFunctions } from './expressionFunctions';
+import { numberLocales } from '@locales';
+import { expressionFunctions, formatTimeDurationLabels } from './expressionFunctions';
 
 describe('truncateText()', () => {
 	const longText =
@@ -19,10 +20,29 @@ describe('truncateText()', () => {
 	test('should truncate text that is too long', () => {
 		expect(expressionFunctions.truncateText(longText, 24)).toBe('Lorem ipsum dolor s…');
 		expect(expressionFunctions.truncateText(longText, 100)).toBe(
-			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsu…'
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsu…',
 		);
 	});
 	test('should not truncate text that is shorter than maxLength', () => {
 		expect(expressionFunctions.truncateText(shortText, 100)).toBe(shortText);
+	});
+});
+
+describe('formatTimeDurationLabels()', () => {
+	test('should format durations correctly', () => {
+		const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
+		const formatDurationsFrFr = formatTimeDurationLabels(numberLocales['fr-FR']);
+		const formatDurationsDeDe = formatTimeDurationLabels(numberLocales['de-DE']);
+
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 1 })).toBe('00:00:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 61 })).toBe('00:01:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3661 })).toBe('01:01:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3603661 })).toBe('1,001:01:01');
+		expect(formatDurationsFrFr({ index: 0, label: '0', value: 3603661 })).toBe('1\u00a0001:01:01');
+		expect(formatDurationsDeDe({ index: 0, label: '0', value: 3603661 })).toBe('1.001:01:01');
+	});
+	test('should original string if type of value is string', () => {
+		const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 'hello world!' })).toBe('hello world!');
 	});
 });

--- a/src/expressionFunctions.test.ts
+++ b/src/expressionFunctions.test.ts
@@ -41,6 +41,10 @@ describe('formatTimeDurationLabels()', () => {
 		expect(formatDurationsFrFr({ index: 0, label: '0', value: 3603661 })).toBe('1\u00a0001:01:01');
 		expect(formatDurationsDeDe({ index: 0, label: '0', value: 3603661 })).toBe('1.001:01:01');
 	});
+	test('should default to using en-US', () => {
+		const formatDurations = formatTimeDurationLabels();
+		expect(formatDurations({ index: 0, label: '0', value: 3603661 })).toBe('1,001:01:01');
+	});
 	test('should original string if type of value is string', () => {
 		const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
 		expect(formatDurationsEnUS({ index: 0, label: '0', value: 'hello world!' })).toBe('hello world!');

--- a/src/expressionFunctions.ts
+++ b/src/expressionFunctions.ts
@@ -9,7 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { numberLocales } from '@locales';
 import { ADOBE_CLEAN_FONT } from '@themes/spectrumTheme';
+import { FormatLocaleDefinition, formatLocale } from 'd3-format';
 import { FontWeight } from 'vega';
 
 interface LabelDatum {
@@ -28,6 +30,25 @@ const formatPrimaryTimeLabels = () => {
 		const showLabel = datum.index === 0 || prevLabel !== datum.label;
 		prevLabel = datum.label;
 		return showLabel ? datum.label : '';
+	};
+};
+
+/**
+ * Formats a duration in seconds as HH:MM:SS.
+ * Function is initialized with a number locale. This ensures that the thousands separator is correct for the locale
+ * @param numberLocale
+ * @returns formatted sting (HH:MM:SS)
+ */
+export const formatTimeDurationLabels = (numberLocale: FormatLocaleDefinition = numberLocales['en-US']) => {
+	const d3 = formatLocale(numberLocale);
+	// 0 padded, minimum 2 digits, thousands separator, integer format
+	const formatDuration = d3.format('02,d');
+	return ({ value }: LabelDatum) => {
+		if (typeof value === 'string') return value;
+		const seconds = formatDuration(Math.floor(value % 60));
+		const minutes = formatDuration(Math.floor((value / 60) % 60));
+		const hours = formatDuration(Math.floor(value / 60 / 60));
+		return `${hours}:${minutes}:${seconds}`;
 	};
 };
 

--- a/src/locales/numberLocales/index.ts
+++ b/src/locales/numberLocales/index.ts
@@ -69,7 +69,7 @@ import svse from './sv-SE.json';
 import ukua from './uk-UA.json';
 import zhcn from './zh-CN.json';
 
-export const numberLocale: Record<NumberLocaleCode, NumberLocale> = {
+export const numberLocales: Record<NumberLocaleCode, NumberLocale> = {
 	['ar-AE']: arae as NumberLocale,
 	['ar-BH']: arbh as NumberLocale,
 	['ar-DJ']: ardj as NumberLocale,

--- a/src/locales/timeLocales/index.ts
+++ b/src/locales/timeLocales/index.ts
@@ -48,7 +48,7 @@ import ukua from './uk-UA.json';
 import zhcn from './zh-CN.json';
 import zhtw from './zh-TW.json';
 
-export const timeLocale: Record<TimeLocaleCode, TimeLocale> = {
+export const timeLocales: Record<TimeLocaleCode, TimeLocale> = {
 	['ar-EG']: areg as TimeLocale,
 	['ar-SY']: arsy as TimeLocale,
 	['ca-ES']: caes as TimeLocale,

--- a/src/specBuilder/axis/axisLabelUtils.test.ts
+++ b/src/specBuilder/axis/axisLabelUtils.test.ts
@@ -160,17 +160,17 @@ describe('getLabelFormat()', () => {
 	test('should include the number format test if numberFormat exists', () => {
 		const labelFormat = getLabelFormat(
 			{ ...defaultAxisProps, labelFormat: 'linear', numberFormat: '.2f' },
-			'xLinear'
+			'xLinear',
 		);
 		expect(labelFormat).toHaveLength(4);
 		expect(labelFormat[0]).toEqual({ test: 'isNumber(datum.value)', signal: "format(datum.value, '.2f')" });
 	});
 	test('should not include the number format test if numberFormat does not exist or is an empty string', () => {
 		expect(
-			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: undefined }, 'xLinear')
+			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: undefined }, 'xLinear'),
 		).toHaveLength(3);
 		expect(
-			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: '' }, 'xLinear')
+			getLabelFormat({ ...defaultAxisProps, labelFormat: 'linear', numberFormat: '' }, 'xLinear'),
 		).toHaveLength(3);
 	});
 	test('should include text truncation if truncateText is true', () => {
@@ -180,21 +180,27 @@ describe('getLabelFormat()', () => {
 	});
 	test('should not include text truncation if the scale name does not include band', () => {
 		expect(getLabelFormat({ ...defaultAxisProps, truncateLabels: true }, 'xLinear')[2].signal).not.toContain(
-			'truncateText'
+			'truncateText',
 		);
 	});
 	test('should not include truncae text if labels are perpendicular to the axis', () => {
 		expect(
 			getLabelFormat(
 				{ ...defaultAxisProps, truncateLabels: true, position: 'bottom', labelOrientation: 'vertical' },
-				'xBand'
-			)[2].signal
+				'xBand',
+			)[2].signal,
 		).not.toContain('truncateText');
 		expect(
 			getLabelFormat(
 				{ ...defaultAxisProps, truncateLabels: true, position: 'left', labelOrientation: 'horizontal' },
-				'yBand'
-			)[2].signal
+				'yBand',
+			)[2].signal,
 		).not.toContain('truncateText');
+	});
+	test('should return duration formatter if labelFormat is duration', () => {
+		expect(getLabelFormat({ ...defaultAxisProps, labelFormat: 'duration' }, 'xLinear')).toHaveProperty(
+			'signal',
+			'formatTimeDurationLabels(datum)',
+		);
 	});
 });

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -72,7 +72,7 @@ export const getTimeLabelFormats = (granularity: Granularity): [string, string, 
 export const getControlledLabelAnchorValues = (
 	position: Position,
 	labelOrientaion: Orientation,
-	labelAlign?: LabelAlign
+	labelAlign?: LabelAlign,
 ): { align: Align | undefined; baseline: Baseline | undefined } => {
 	// if there isn't a labelAlign, we don't want to set the align or baseline
 	if (!labelAlign) return { align: undefined, baseline: undefined };
@@ -94,7 +94,7 @@ export const getLabelAnchorValues = (
 	labelOrientaion: Orientation,
 	labelAlign: LabelAlign,
 	vegaLabelAlign?: Align,
-	vegaLabelBaseline?: Baseline
+	vegaLabelBaseline?: Baseline,
 ): { labelAlign: Align; labelBaseline: Baseline } => {
 	const { align, baseline } = getLabelAnchor(position, labelOrientaion, labelAlign);
 	// if vegaLabelAlign or vegaLabelBaseline are set, we want to use those values instead of the calculated values
@@ -114,7 +114,7 @@ export const getLabelAnchorValues = (
 export const getLabelAnchor = (
 	position: Position,
 	labelOrientaion: Orientation,
-	labelAlign: LabelAlign
+	labelAlign: LabelAlign,
 ): { align: Align; baseline: Baseline } => {
 	let align: Align;
 	let baseline: Baseline;
@@ -186,7 +186,7 @@ export const getLabelAngle = (labelOrientaion: Orientation): number => {
 export const getLabelBaseline = (
 	labelAlign: LabelAlign | undefined,
 	position: Position,
-	vegaLabelBaseline?: Baseline
+	vegaLabelBaseline?: Baseline,
 ): Baseline | undefined => {
 	if (vegaLabelBaseline) return vegaLabelBaseline;
 	if (!labelAlign) return;
@@ -212,7 +212,7 @@ export const getLabelBaseline = (
 export const getLabelOffset = (
 	labelAlign: LabelAlign,
 	scaleName: string,
-	vegaLabelOffset?: NumberValue
+	vegaLabelOffset?: NumberValue,
 ): NumberValue | undefined => {
 	if (vegaLabelOffset !== undefined) return vegaLabelOffset;
 	switch (labelAlign) {
@@ -232,10 +232,13 @@ export const getLabelOffset = (
  */
 export const getLabelFormat = (
 	{ labelFormat, labelOrientation, numberFormat, position, truncateLabels }: AxisSpecProps,
-	scaleName: string
+	scaleName: string,
 ): ProductionRule<TextValueRef> => {
 	if (labelFormat === 'percentage') {
 		return [{ test: 'isNumber(datum.value)', signal: "format(datum.value, '~%')" }, { signal: 'datum.value' }];
+	}
+	if (labelFormat === 'duration') {
+		return { signal: 'formatTimeDurationLabels(datum)' };
 	}
 
 	// if it's a number and greater than or equal to 1000, we want to format it in scientific notation (but with B instead of G) ex. 1K, 20M, 1.3B
@@ -270,7 +273,7 @@ export const getAxisLabelsEncoding = (
 	labelKey: 'label' | 'subLabel',
 	labelOrientation: Orientation,
 	position: Position,
-	signalName: string
+	signalName: string,
 ): GuideEncodeEntry<TextEncodeEntry> => ({
 	update: {
 		text: [
@@ -306,7 +309,7 @@ export const getEncodedLabelAnchor = (
 	position: Position,
 	signalName: string,
 	labelOrientation: Orientation,
-	defaultLabelAlign: LabelAlign
+	defaultLabelAlign: LabelAlign,
 ): EncodeEntry => {
 	const baseTestString = `indexof(pluck(${signalName}, 'value'), datum.value) !== -1 && ${signalName}[indexof(pluck(${signalName}, 'value'), datum.value)]`;
 	const baseSignalString = `${signalName}[indexof(pluck(${signalName}, 'value'), datum.value)]`;

--- a/src/stories/components/Axis/Axis.story.tsx
+++ b/src/stories/components/Axis/Axis.story.tsx
@@ -81,6 +81,17 @@ const LinearAxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
 	);
 };
 
+const DurationStory: StoryFn<typeof Axis> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: workspaceTrendsData, width: 600 });
+	return (
+		<Chart {...chartProps}>
+			<Axis {...args} />
+			<Axis position="bottom" labelFormat="time" />
+			<Line color="series" dimension="datetime" scaleType="time" />
+		</Chart>
+	);
+};
+
 const NonLinearAxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: workspaceTrendsData, width: 600 });
 	return (
@@ -120,6 +131,14 @@ Basic.args = {
 	labelFormat: 'percentage',
 	ticks: true,
 	title: 'Conversion Rate',
+};
+
+const DurationLabelFormat = bindWithProps(DurationStory);
+DurationLabelFormat.args = {
+	position: 'left',
+	grid: true,
+	labelFormat: 'duration',
+	title: 'Time spent',
 };
 
 const Time = bindWithProps(TimeAxisStory);
@@ -204,6 +223,7 @@ export {
 	Basic,
 	ControlledLabels,
 	CustomXRange,
+	DurationLabelFormat,
 	NonLinearAxis,
 	NumberFormat,
 	SubLabels,

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -13,7 +13,16 @@ import '@matchMediaMock';
 import { Axis } from '@rsc';
 import { findChart, getAllAxisLabels, render, screen, within } from '@test-utils';
 
-import { Basic, ControlledLabels, NonLinearAxis, NumberFormat, SubLabels, TickMinStep, Time } from './Axis.story';
+import {
+	Basic,
+	ControlledLabels,
+	DurationLabelFormat,
+	NonLinearAxis,
+	NumberFormat,
+	SubLabels,
+	TickMinStep,
+	Time,
+} from './Axis.story';
 
 describe('Axis', () => {
 	test('Renders properly', async () => {
@@ -165,6 +174,18 @@ describe('Axis', () => {
 
 			expect(screen.getByText('$1.00')).toBeInTheDocument();
 			expect(screen.getByText('$0.00')).toBeInTheDocument();
+		});
+	});
+
+	describe('DurationLabelFormat', () => {
+		test('should render duration labels correctly', async () => {
+			render(<DurationLabelFormat {...DurationLabelFormat.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			expect(screen.getByText('00:00:00')).toBeInTheDocument();
+			expect(screen.getByText('01:23:20')).toBeInTheDocument();
+			expect(screen.getByText('02:46:40')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -245,7 +245,7 @@ export type Granularity = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarte
  * `end` will set the align to `right` for horizontal axes and the baseline to `bottom` for vertical axes.
  */
 export type LabelAlign = 'center' | 'start' | 'end';
-export type LabelFormat = 'linear' | 'percentage' | 'time';
+export type LabelFormat = 'duration' | 'linear' | 'percentage' | 'time';
 export type Label = {
 	/** The axis value that this label is anchored to */
 	value: string | number;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { numberLocale, timeLocale } from '@locales';
+import { numberLocales, timeLocales } from '@locales';
 import { ChartProps } from 'types';
 import { NumberLocaleCode, TimeLocaleCode } from 'types/locales';
 import { Locale, NumberLocale, TimeLocale } from 'vega';
@@ -19,8 +19,8 @@ export const getLocale = (locale: ChartProps['locale'] = 'en-US'): Locale => {
 	if (typeof locale === 'string') {
 		// if the locale is a string, we assume that it is a locale code and get the locale from the locale files
 		return {
-			number: numberLocale[locale] ?? numberLocale['en-US'],
-			time: timeLocale[locale] ?? timeLocale['en-US'],
+			number: numberLocales[locale] ?? numberLocales['en-US'],
+			time: timeLocales[locale] ?? timeLocales['en-US'],
 		};
 	}
 
@@ -33,7 +33,7 @@ export const getLocale = (locale: ChartProps['locale'] = 'en-US'): Locale => {
 const getNumberLocale = (locale: NumberLocaleCode | NumberLocale | undefined): NumberLocale | undefined => {
 	if (typeof locale === 'string') {
 		// if the locale is a string, we assume that it is a locale code and get the locale from the locale files
-		return numberLocale[locale] ?? numberLocale['en-US'];
+		return numberLocales[locale] ?? numberLocales['en-US'];
 	}
 	return locale;
 };
@@ -41,7 +41,7 @@ const getNumberLocale = (locale: NumberLocaleCode | NumberLocale | undefined): N
 const getTimeLocale = (locale: TimeLocaleCode | TimeLocale | undefined): TimeLocale | undefined => {
 	if (typeof locale === 'string') {
 		// if the locale is a string, we assume that it is a locale code and get the locale from the locale files
-		return timeLocale[locale] ?? timeLocale['en-US'];
+		return timeLocales[locale] ?? timeLocales['en-US'];
 	}
 	return locale;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,6 +5198,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-format@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
 "@types/detect-port@^1.3.0":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/detect-port/-/detect-port-1.3.5.tgz#deecde143245989dee0e82115f3caba5ee0ea747"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `duration` as an option for labelFormat. This will display seconds as HH:MM:SS.

example:
- `60 = 00:01:00`
- `3600 = 01:00:00`
- `3603661 = 1,001:01:01`

## Stories:
Axis > DurationLabelFormat

## Screenshots (if appropriate):
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/65dbeb3c-1d82-4d32-aa33-f1cc8cb9293b)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
