### PR TITLE
Add animation spec backwards compatibility with existing tests

### DIFF
--- a/src/Chart.tsx
+++ b/src/Chart.tsx
@@ -85,8 +85,6 @@ export const Chart = forwardRef<ChartHandle, ChartProps>(
 
 		const previousChartData = usePreviousChartData(data);
 
-		console.warn('Previous data is', previousChartData);
-
 		const containerRef = useResizeObserver<HTMLDivElement>((_target, entry) => {
 			if (typeof width === 'number') return;
 			setContainerWidth(entry.contentRect.width);

--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -32,7 +32,7 @@ import { initializeSpec } from '../specUtils';
 import { addArea, addAreaMarks, addData, addSignals, setScales } from './areaSpecBuilder';
 
 const startingSpec: Spec = initializeSpec({
-	scales: [{ name: 'color', type: 'ordinal' }],
+	scales: [{ name: 'color', type: 'ordinal' }]
 });
 
 const defaultAreaProps: AreaSpecProps = {
@@ -45,6 +45,7 @@ const defaultAreaProps: AreaSpecProps = {
 	name: 'area0',
 	opacity: 0.8,
 	scaleType: 'time',
+	animations: false
 };
 
 const defaultSpec = initializeSpec({
@@ -90,8 +91,8 @@ const defaultSpec = initializeSpec({
 					encode: {
 						enter: {
 							fill: { field: DEFAULT_COLOR, scale: 'color' },
-							y: undefined,
-							y2: undefined,
+							y: { field: 'value0', scale: 'yLinear' },
+							y2: { field: 'value1', scale: 'yLinear' },
 							stroke: { signal: BACKGROUND_COLOR },
 							strokeWidth: { value: 1.5 },
 							strokeJoin: { value: 'round' },
@@ -99,14 +100,6 @@ const defaultSpec = initializeSpec({
 						},
 						update: {
 							x: { field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' },
-							y: {
-								scale: 'yLinear',
-								signal: 'datum.value0'
-							},
-							y2: {
-								scale: 'yLinear',
-								signal: 'datum.value1 * timerValue'
-							},
 							cursor: undefined,
 							fillOpacity: [{ value: 0.8 }],
 						},
@@ -179,11 +172,11 @@ const defaultSignals = [
 describe('areaSpecBuilder', () => {
 	describe('addArea()', () => {
 		test('should add area', () => {
-			expect(addArea(startingSpec, {})).toStrictEqual(defaultSpec);
+			expect(addArea(startingSpec, { animations: false })).toStrictEqual(defaultSpec);
 		});
 
 		test('metricStart defined but valueEnd not defined, should default to value', () => {
-			expect(addArea(startingSpec, { metricStart: 'test' })).toStrictEqual(defaultSpec);
+			expect(addArea(startingSpec, { metricStart: 'test', animations: false })).toStrictEqual(defaultSpec);
 		});
 	});
 
@@ -265,8 +258,6 @@ describe('areaSpecBuilder', () => {
 								update: {
 									...groupMark.marks?.[0]?.encode?.update,
 									x: { scale: 'xLinear', field: DEFAULT_TIME_DIMENSION },
-									y: undefined,
-									y2: undefined
 								},
 							},
 						},

--- a/src/specBuilder/area/areaUtils.test.ts
+++ b/src/specBuilder/area/areaUtils.test.ts
@@ -27,6 +27,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'linear',
 				opacity: 0.5,
+				animations: false,
 			})
 		).toStrictEqual({
 			name: 'area0',
@@ -81,6 +82,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'linear',
 				opacity: 0.5,
+				animations: false,
 			})
 		).toStrictEqual({
 			name: 'area0',
@@ -143,6 +145,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'time',
 				opacity: 0.5,
+				animations: false,
 			})
 		).toStrictEqual({
 			name: 'area0',
@@ -197,6 +200,7 @@ describe('getAreaMark', () => {
 				dimension: 'dimension',
 				scaleType: 'point',
 				opacity: 0.5,
+				animations: false,
 			})
 		).toStrictEqual({
 			name: 'area0',

--- a/src/specBuilder/area/areaUtils.ts
+++ b/src/specBuilder/area/areaUtils.ts
@@ -61,8 +61,10 @@ export const getAreaMark = ({
 	interactive: getInteractive(children),
 	encode: {
 		enter: {
-			y: animations === false ? { scale: 'yLinear', field: metricStart } : undefined,
-			y2: animations === false ? { scale: 'yLinear', field: metricEnd } : undefined,
+			...(animations === false && {
+				y: { scale: 'yLinear', field: metricStart },
+				y2: { scale: 'yLinear', field: metricEnd },
+			}),
 			fill: getColorProductionRule(color, colorScheme),
 			tooltip: getTooltip(children, name),
 			...getBorderStrokeEncodings(isStacked, true),
@@ -70,8 +72,10 @@ export const getAreaMark = ({
 		update: {
 			// this has to be in update because when you resize the window that doesn't rebuild the spec
 			// but it may change the x position if it causes the chart to resize
-			y: animations !== false ? getAnimationMarks(dimension, metricStart) : undefined,
-			y2: animations !== false ? getAnimationMarks(dimension, metricEnd) : undefined,
+			...(animations !== false && {
+				y: getAnimationMarks(dimension, metricStart),
+				y2: getAnimationMarks(dimension, metricEnd)
+			}),
 			x: getX(scaleType, dimension),
 			cursor: getCursor(children),
 			fillOpacity: getFillOpacity(name, color, opacity, children, isMetricRange, parentName, displayOnHover),

--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -236,7 +236,7 @@ const defaultSelectSignal = { name: 'bar0_selectedId', value: null };
 describe('barSpecBuilder', () => {
 	describe('addBar()', () => {
 		test('no props', () => {
-			expect(addBar(startingSpec, {})).toStrictEqual(defaultSpec);
+			expect(addBar(startingSpec, { animations: false })).toStrictEqual(defaultSpec);
 		});
 	});
 

--- a/src/specBuilder/bar/barTestUtils.ts
+++ b/src/specBuilder/bar/barTestUtils.ts
@@ -43,6 +43,7 @@ export const defaultBarProps: BarSpecProps = {
 	trellisPadding: TRELLIS_PADDING,
 	type: 'stacked',
 	orientation: 'vertical',
+	animations: false
 };
 
 export const defaultBarPropsWithSecondayColor: BarSpecProps = {
@@ -145,11 +146,6 @@ export const stackedLabelWithStyles = {
 			],
 			cornerRadius: { value: 4 },
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	},
 };
 
@@ -178,11 +174,6 @@ export const stackedLabelBackground = {
 			],
 			cornerRadius: { value: 4 },
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	},
 };
 
@@ -210,11 +201,6 @@ export const stackedLabelText = {
 			baseline: { value: 'middle' },
 			align: { value: 'center' },
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	}
 };
 
@@ -237,11 +223,6 @@ export const dodgedLabelWithStyles = {
 			],
 			fill: [{ test: `datum.textLabel && bandwidth('${dodgedXScale}') >= 48`, signal: BACKGROUND_COLOR }],
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	},
 };
 
@@ -264,11 +245,6 @@ export const dodgedLabelBackground = {
 			],
 			fill: [{ test: `datum.textLabel && bandwidth('${dodgedXScale}') >= 48`, signal: BACKGROUND_COLOR }],
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	},
 };
 
@@ -291,11 +267,6 @@ export const dodgedLabelText = {
 			],
 			text: [{ test: `bandwidth('${dodgedXScale}') >= 48`, field: 'textLabel' }],
 		},
-		update: {
-			fillOpacity: {
-				signal: 'timerValue === 1 ? 1 : 0'
-			}
-		}
 	},
 };
 

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -67,14 +67,6 @@ import {
 
 const defaultDodgedXEncodings: RectEncodeEntry = {
 	x: { scale: 'bar0_position', field: 'bar0_dodgeGroup' },
-	y: {
-		scale: 'yLinear',
-		signal: 'datum.value * timerValue'
-	},
-	y2: {
-		scale: 'yLinear',
-		signal: '0'
-	},
 	width: { scale: 'bar0_position', band: 1 },
 };
 

--- a/src/specBuilder/bar/barUtils.ts
+++ b/src/specBuilder/bar/barUtils.ts
@@ -113,9 +113,11 @@ export const getDodgedDimensionEncodings = (props: BarSpecProps): RectEncodeEntr
 	const endKey = `${startKey}2`;
 
 	return {
+		...(animations !== false && {
+			[startKey]: getAnimationMarks(dimension, startMetric, data, previousData, scaleKey),
+			[endKey]: endAnimations
+		}),
 		[dimensionAxis]: { scale, field },
-		[startKey]: animations !== false ? getAnimationMarks(dimension, startMetric, data, previousData, scaleKey) : undefined,
-		[endKey]: animations !== false ? endAnimations : undefined,
 		[rangeScale]: { scale, band: 1 },
 	};
 };
@@ -334,11 +336,13 @@ export const getAnnotationMarks = (
 					],
 					width: annotationWidth,
 				},
-				update: animations !== false ?  {
-					fillOpacity: {
-						signal: 'timerValue === 1 ? 1 : 0'
+				...(animations !== false && {
+					update: {
+						fillOpacity: {
+							signal: 'timerValue === 1 ? 1 : 0'
+						}
 					}
-				} : undefined
+				})
 			},
 		});
 		marks.push({
@@ -360,11 +364,13 @@ export const getAnnotationMarks = (
 					baseline: { value: 'middle' },
 					align: { value: 'center' },
 				},
-				update: animations !== false ?  {
-					fillOpacity: {
-						signal: 'timerValue === 1 ? 1 : 0'
+				...(animations !== false && {
+					update: {
+						fillOpacity: {
+							signal: 'timerValue === 1 ? 1 : 0'
+						}
 					}
-				} : undefined
+				})
 			},
 		});
 	}

--- a/src/specBuilder/bar/dodgedBarUtils.test.ts
+++ b/src/specBuilder/bar/dodgedBarUtils.test.ts
@@ -40,14 +40,6 @@ const defaultDodgedProps: BarSpecProps = { ...defaultBarProps, type: 'dodged' };
 
 const defaultDodgedXEncodings: RectEncodeEntry = {
 	x: { scale: 'bar0_position', field: 'bar0_dodgeGroup' },
-	y: {
-		scale: 'yLinear',
-		signal: 'datum.value * timerValue'
-	},
-	y2: {
-		scale: 'yLinear',
-		signal: "0"
-	},
 	width: { scale: 'bar0_position', band: 1 },
 };
 

--- a/src/specBuilder/bar/stackedBarUtils.test.ts
+++ b/src/specBuilder/bar/stackedBarUtils.test.ts
@@ -30,7 +30,7 @@ import {
 } from './barTestUtils';
 import { getDodgedAndStackedBarMark, getStackedBarMarks, getStackedDimensionEncodings } from './stackedBarUtils';
 
-const defaultStackedBarXEncondings: RectEncodeEntry = {
+const defaultStackedBarXEncodings: RectEncodeEntry = {
 	x: { scale: 'xBand', field: DEFAULT_CATEGORICAL_DIMENSION },
 	width: { scale: 'xBand', band: 1 },
 };
@@ -41,7 +41,7 @@ const defaultBackgroundMark: Mark = {
 			...defaultBarEnterEncodings,
 			fill: { signal: BACKGROUND_COLOR },
 		},
-		update: defaultStackedBarXEncondings,
+		update: defaultStackedBarXEncodings,
 	},
 	from: { data: FILTERED_TABLE },
 	interactive: false,
@@ -60,7 +60,7 @@ const defaultMark = {
 			cursor: undefined,
 			fillOpacity: defaultBarFillOpacity,
 			strokeOpacity: defaultBarFillOpacity,
-			...defaultStackedBarXEncondings,
+			...defaultStackedBarXEncodings,
 			...defaultBarStrokeEncodings,
 		},
 	},
@@ -156,7 +156,7 @@ describe('stackedBarUtils', () => {
 
 	describe('getStackedDimensionEncodings()', () => {
 		test('should return x and width encodings', () => {
-			expect(getStackedDimensionEncodings(defaultBarProps)).toStrictEqual(defaultStackedBarXEncondings);
+			expect(getStackedDimensionEncodings(defaultBarProps)).toStrictEqual(defaultStackedBarXEncodings);
 		});
 
 		test('should get dodged x encoding if stacked/dodged', () => {

--- a/src/specBuilder/bar/stackedBarUtils.ts
+++ b/src/specBuilder/bar/stackedBarUtils.ts
@@ -116,8 +116,10 @@ export const getStackedDimensionEncodings = (props: BarSpecProps): RectEncodeEnt
 	const endKey = `${startKey}2`;
 
 	return {
-		[startKey]: animations !== false ? getAnimationMarks(dimension, `${metric}0`, data, previousData, scaleKey) : undefined,
-		[endKey]: animations !== false ? getAnimationMarks(dimension, `${metric}1`, data, previousData, scaleKey) : undefined,
+		...(animations !== false && {
+			[startKey]: getAnimationMarks(dimension, `${metric}0`, data, previousData, scaleKey),
+			[endKey]: getAnimationMarks(dimension, `${metric}1`, data, previousData, scaleKey)
+		}),
 		[dimensionAxis]: { scale: dimensionScaleKey, field: dimension },
 		[rangeScale]: { scale: dimensionScaleKey, band: 1 },
 	};

--- a/src/specBuilder/bar/stackedBarUtils.ts
+++ b/src/specBuilder/bar/stackedBarUtils.ts
@@ -36,8 +36,6 @@ export const getStackedBarMarks = (props: BarSpecProps): Mark[] => {
 	// bar mark
 	marks.push(getStackedBar(props));
 
-	console.warn('marks after adding stacked bar and background bar are', marks);
-
 	// add annotation marks
 	marks.push(
 		...getAnnotationMarks(

--- a/src/specBuilder/line/lineMarkUtils.ts
+++ b/src/specBuilder/line/lineMarkUtils.ts
@@ -60,7 +60,7 @@ export const getLineMark = (lineMarkProps: LineMarkProps, dataSource: string): L
 				// but it may change the x position if it causes the chart to resize
 				x: getXProductionRule(scaleType, dimension),
 				strokeOpacity: getLineStrokeOpacity(lineMarkProps),
-				y: animations !== false ? getAnimationMarks(dimension, metric, data, previousData) : undefined
+				...(animations !== false && { y: getAnimationMarks(dimension, metric, data, previousData) })
 			},
 		},
 	};

--- a/src/specBuilder/line/linePointUtils.ts
+++ b/src/specBuilder/line/linePointUtils.ts
@@ -55,7 +55,7 @@ export const getLineStaticPoint = ({
 			},
 			update: {
 				x: getXProductionRule(scaleType, dimension),
-				y: animations !== false ? getAnimationMarks(dimension, metric, data, previousData) : undefined
+				...(animations !== false && { y: getAnimationMarks(dimension, metric, data, previousData) })
 			},
 		},
 	};

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -48,6 +48,7 @@ const defaultLineProps: LineSpecProps = {
 	colorScheme: DEFAULT_COLOR_SCHEME,
 	interactiveMarkName: undefined,
 	popoverMarkName: undefined,
+	animations: false
 };
 
 const getMetricRangeElement = (props?: Partial<MetricRangeProps>): MetricRangeElement =>
@@ -360,7 +361,7 @@ const displayPointMarks = [
 describe('lineSpecBuilder', () => {
 	describe('addLine()', () => {
 		test('should add line', () => {
-			expect(addLine(startingSpec, { color: DEFAULT_COLOR })).toStrictEqual(defaultSpec);
+			expect(addLine(startingSpec, { color: DEFAULT_COLOR, animations: false })).toStrictEqual(defaultSpec);
 		});
 	});
 

--- a/src/specBuilder/line/lineTestUtils.ts
+++ b/src/specBuilder/line/lineTestUtils.ts
@@ -24,4 +24,5 @@ export const defaultLineMarkProps: LineMarkProps = {
 	opacity: { value: 1 },
 	metric: DEFAULT_METRIC,
 	scaleType: 'time',
+	animations: false
 };

--- a/src/specBuilder/metricRange/metricRangeUtils.test.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.test.ts
@@ -63,6 +63,7 @@ const defaultLineProps: LineSpecProps = {
 	colorScheme: DEFAULT_COLOR_SCHEME,
 	interactiveMarkName: undefined,
 	popoverMarkName: undefined,
+	animations: false
 };
 
 const basicMetricRangeMarks = [

--- a/src/specBuilder/metricRange/metricRangeUtils.ts
+++ b/src/specBuilder/metricRange/metricRangeUtils.ts
@@ -101,6 +101,7 @@ export const getMetricRangeMark = (
 		isMetricRange: true,
 		parentName: lineMarkProps.name,
 		displayOnHover: metricRangeProps.displayOnHover,
+		animations: lineMarkProps.animations
 	};
 	const lineProps: LineMarkProps = {
 		...lineMarkProps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes almost all tests broken by animations feature

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Allows us to keep existing test suite while adding animations.  Note that one functional test (Trellised Dodged bar) is failing and unaffected by these test changes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

yarn test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
