### PR TITLE
feat: trendline annotation badge

### DIFF
--- a/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
+++ b/src/components/TrendlineAnnotation/TrendlineAnnotation.tsx
@@ -17,6 +17,7 @@ import { TrendlineAnnotationProps } from '../../types';
 
 // destructure props here and set defaults so that storybook can pick them up
 const TrendlineAnnotation: FC<TrendlineAnnotationProps> = ({
+	badge = false,
 	dimensionValue = 'end',
 	numberFormat = '',
 	prefix = '',

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -32,6 +32,7 @@ import {
 
 import {
 	getColorProductionRule,
+	getColorProductionRuleSignalString,
 	getHighlightOpacityValue,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
@@ -194,5 +195,24 @@ describe('getXProductionRule()', () => {
 			scale: 'xPoint',
 			field: DEFAULT_TIME_DIMENSION,
 		});
+	});
+});
+
+describe('getColorProductionRuleSignalString()', () => {
+	test('should return signal reference if color is an array', () => {
+		expect(
+			getColorProductionRuleSignalString([DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR], DEFAULT_COLOR_SCHEME)
+		).toStrictEqual(
+			`scale('colors', datum.${DEFAULT_COLOR})[indexof(domain('secondaryColor'), datum.${DEFAULT_SECONDARY_COLOR})% length(scale('colors', datum.${DEFAULT_COLOR}))]`
+		);
+	});
+	test('should return scale reference if color is a string', () => {
+		expect(getColorProductionRuleSignalString(DEFAULT_COLOR, DEFAULT_COLOR_SCHEME)).toStrictEqual(
+			`scale('${COLOR_SCALE}', datum.${DEFAULT_COLOR})`
+		);
+	});
+	test('should return static value if static value is provided', () => {
+		const color = 'rgb(125, 125, 125)';
+		expect(getColorProductionRuleSignalString({ value: color }, DEFAULT_COLOR_SCHEME)).toStrictEqual(`'${color}'`);
 	});
 });

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -118,6 +118,13 @@ export const hasTooltip = (children: ReactElement[]): boolean => children.some((
 export const childHasTooltip = (children: ReactElement[]): boolean =>
 	children.some((child) => hasTooltip(child.props.children));
 
+/**
+ * Gets the color encoding
+ * @param color
+ * @param colorScheme
+ * @param colorScaleType
+ * @returns ColorValueRef
+ */
 export const getColorProductionRule = (
 	color: ColorFacet | DualFacet,
 	colorScheme: ColorScheme,
@@ -133,6 +140,31 @@ export const getColorProductionRule = (
 		return { scale: colorScaleName, field: color };
 	}
 	return { value: getColorValue(color.value, colorScheme) };
+};
+
+/**
+ * gets the color encoding in a signal string format
+ * @param color
+ * @param colorScheme
+ * @param colorScaleType
+ * @returns string
+ */
+export const getColorProductionRuleSignalString = (
+	color: ColorFacet | DualFacet,
+	colorScheme: ColorScheme,
+	colorScaleType: 'linear' | 'ordinal' = 'ordinal'
+): string => {
+	const colorRule = getColorProductionRule(color, colorScheme, colorScaleType);
+	if ('signal' in colorRule) {
+		return colorRule.signal;
+	}
+	if ('scale' in colorRule && 'field' in colorRule) {
+		return `scale('${colorRule.scale}', datum.${colorRule.field})`;
+	}
+	if ('value' in colorRule && colorRule.value) {
+		return `'${colorRule.value}'`;
+	}
+	return '';
 };
 
 export const getLineWidthProductionRule = (

--- a/src/specBuilder/trendline/trendlineMarkUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.test.ts
@@ -102,7 +102,7 @@ describe('getTrendlineRuleMark()', () => {
 	test('should use static color if provided', () => {
 		const mark = getTrendlineRuleMark(defaultLineProps, {
 			...defaultTrendlineProps,
-			color: 'gray-500',
+			trendlineColor: { value: 'gray-500' },
 			method: 'median',
 		});
 		expect(mark.encode?.enter?.stroke).toEqual({ value: spectrumColors.light['gray-500'] });
@@ -191,7 +191,10 @@ describe('getTrendlineLineMark()', () => {
 		expect(mark.encode?.enter?.stroke).toEqual({ field: 'series', scale: COLOR_SCALE });
 	});
 	test('should use static color if provided', () => {
-		const mark = getTrendlineLineMark(defaultLineProps, { ...defaultTrendlineProps, color: 'gray-500' });
+		const mark = getTrendlineLineMark(defaultLineProps, {
+			...defaultTrendlineProps,
+			trendlineColor: { value: 'gray-500' },
+		});
 		expect(mark.encode?.enter?.stroke).toEqual({ value: spectrumColors.light['gray-500'] });
 	});
 });

--- a/src/specBuilder/trendline/trendlineMarkUtils.ts
+++ b/src/specBuilder/trendline/trendlineMarkUtils.ts
@@ -91,9 +91,9 @@ export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineP
 		lineWidth,
 		name,
 		orientation,
+		trendlineColor,
 		trendlineDimension,
 	} = trendlineProps;
-	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
 
 	const data = displayOnHover ? `${name}_highlightedData` : `${name}_highResolutionData`;
 
@@ -108,7 +108,7 @@ export const getTrendlineRuleMark = (markProps: TrendlineParentProps, trendlineP
 		encode: {
 			enter: {
 				...getRuleYEncodings(dimensionExtent, trendlineDimension, orientation),
-				stroke: getColorProductionRule(color, colorScheme),
+				stroke: getColorProductionRule(trendlineColor, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
 				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
@@ -224,10 +224,16 @@ export const getEndDimensionExtentProductionRule = (
  */
 export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineProps: TrendlineSpecProps): LineMark => {
 	const { colorScheme } = markProps;
-	const { dimensionScaleType, isDimensionNormalized, lineType, lineWidth, name, orientation, trendlineDimension } =
-		trendlineProps;
-
-	const color = trendlineProps.color ? { value: trendlineProps.color } : markProps.color;
+	const {
+		dimensionScaleType,
+		isDimensionNormalized,
+		lineType,
+		lineWidth,
+		name,
+		orientation,
+		trendlineColor,
+		trendlineDimension,
+	} = trendlineProps;
 
 	return {
 		name,
@@ -237,7 +243,7 @@ export const getTrendlineLineMark = (markProps: TrendlineParentProps, trendlineP
 		encode: {
 			enter: {
 				y: getLineYProductionRule(trendlineDimension, orientation),
-				stroke: getColorProductionRule(color, colorScheme),
+				stroke: getColorProductionRule(trendlineColor, colorScheme),
 				strokeDash: getStrokeDashProductionRule({ value: lineType }),
 				strokeOpacity: getOpacityProductionRule({ value: trendlineProps.opacity }),
 				strokeWidth: getLineWidthProductionRule({ value: lineWidth }),

--- a/src/specBuilder/trendline/trendlineTestUtils.ts
+++ b/src/specBuilder/trendline/trendlineTestUtils.ts
@@ -32,6 +32,7 @@ export const defaultLineProps: LineSpecProps = {
 
 export const defaultTrendlineProps: TrendlineSpecProps = {
 	children: [],
+	colorScheme: DEFAULT_COLOR_SCHEME,
 	dimensionExtent: [null, null],
 	dimensionRange: [null, null],
 	dimensionScaleType: 'time',
@@ -45,6 +46,7 @@ export const defaultTrendlineProps: TrendlineSpecProps = {
 	name: 'line0Trendline0',
 	opacity: 1,
 	orientation: 'horizontal',
+	trendlineColor: DEFAULT_COLOR,
 	trendlineDimension: DEFAULT_TIME_DIMENSION,
 	trendlineMetric: DEFAULT_METRIC,
 };

--- a/src/specBuilder/trendline/trendlineUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineUtils.test.ts
@@ -13,7 +13,7 @@ import { createElement } from 'react';
 
 import { Annotation } from '@components/Annotation';
 import { Trendline } from '@components/Trendline';
-import { FILTERED_TABLE, MS_PER_DAY, TRENDLINE_VALUE } from '@constants';
+import { DEFAULT_METRIC, DEFAULT_TIME_DIMENSION, FILTERED_TABLE, MS_PER_DAY, TRENDLINE_VALUE } from '@constants';
 
 import { defaultLineProps } from './trendlineTestUtils';
 import { applyTrendlinePropDefaults, getPolynomialOrder, getRegressionExtent, getTrendlines } from './trendlineUtils';
@@ -46,6 +46,16 @@ describe('applyTrendlinePropDefaults()', () => {
 		expect(props).toHaveProperty('lineType', 'dashed');
 		expect(props).toHaveProperty('lineWidth', 'M');
 		expect(props).toHaveProperty('metric', TRENDLINE_VALUE);
+		expect(props).toHaveProperty('trendlineColor', defaultLineProps.color);
+	});
+	test('should swap dimension and metric if orientation is vertical', () => {
+		const props = applyTrendlinePropDefaults(defaultLineProps, { orientation: 'vertical' }, 0);
+		expect(props).toHaveProperty('trendlineDimension', DEFAULT_METRIC);
+		expect(props).toHaveProperty('trendlineMetric', DEFAULT_TIME_DIMENSION);
+	});
+	test('should use color from trendline if defined', () => {
+		const props = applyTrendlinePropDefaults(defaultLineProps, { color: 'gray-700' }, 0);
+		expect(props).toHaveProperty('trendlineColor', { value: 'gray-700' });
 	});
 });
 

--- a/src/specBuilder/trendline/trendlineUtils.ts
+++ b/src/specBuilder/trendline/trendlineUtils.ts
@@ -52,6 +52,7 @@ export const applyTrendlinePropDefaults = (
 	markProps: TrendlineParentProps,
 	{
 		children,
+		color,
 		dimensionExtent,
 		dimensionRange = [null, null],
 		displayOnHover = false,
@@ -74,8 +75,10 @@ export const applyTrendlinePropDefaults = (
 		orientation,
 		isDimensionNormalized
 	);
+	const trendlineColor = color ? { value: color } : markProps.color;
 	return {
 		children: sanitizeTrendlineChildren(children),
+		colorScheme: markProps.colorScheme,
 		displayOnHover,
 		dimensionExtent: dimensionExtent ?? dimensionRange,
 		dimensionRange,
@@ -89,6 +92,7 @@ export const applyTrendlinePropDefaults = (
 		name: `${markProps.name}Trendline${index}`,
 		opacity,
 		orientation,
+		trendlineColor,
 		trendlineDimension,
 		trendlineMetric,
 		...props,

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
@@ -13,12 +13,15 @@ import { createElement } from 'react';
 
 import { ChartTooltip } from '@components/ChartTooltip';
 import { TrendlineAnnotation } from '@components/TrendlineAnnotation';
-import { DEFAULT_TIME_DIMENSION, TRENDLINE_VALUE } from '@constants';
+import { DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_TIME_DIMENSION, TRENDLINE_VALUE } from '@constants';
 import { defaultTrendlineProps } from '@specBuilder/trendline/trendlineTestUtils';
+import { spectrumColors } from '@themes';
 import { TrendlineAnnotationSpecProps } from 'types';
 
 import {
 	applyTrendlineAnnotationDefaults,
+	getTextFill,
+	getTrendlineAnnotationBadgeMark,
 	getTrendlineAnnotationMarks,
 	getTrendlineAnnotationPointX,
 	getTrendlineAnnotationPointY,
@@ -27,12 +30,15 @@ import {
 } from './trendlineAnnotationUtils';
 
 const defaultAnnotationProps: TrendlineAnnotationSpecProps = {
+	badge: false,
+	colorScheme: DEFAULT_COLOR_SCHEME,
 	displayOnHover: false,
 	dimensionValue: 'end',
 	markName: 'line0',
 	name: 'line0Trendline0Annotation0',
 	numberFormat: '',
 	prefix: '',
+	trendlineColor: DEFAULT_COLOR,
 	trendlineDimension: DEFAULT_TIME_DIMENSION,
 	trendlineDimensionExtent: [null, null],
 	trendlineDimensionScaleType: 'time',
@@ -40,6 +46,8 @@ const defaultAnnotationProps: TrendlineAnnotationSpecProps = {
 	trendlineOrientation: 'horizontal',
 	trendlineWidth: 2,
 };
+
+const colors = spectrumColors.light;
 
 describe('applyTrendlineAnnotationDefaults()', () => {
 	test('should apply all defaults', () => {
@@ -145,5 +153,35 @@ describe('getTrendlineAnnotationTextMark()', () => {
 	test('should not add the prefix if it is not a valid string', () => {
 		const textMark = getTrendlineAnnotationTextMark({ ...defaultAnnotationProps, prefix: '' });
 		expect(textMark.encode?.enter?.text).toHaveProperty('signal', `format(datum.datum.${TRENDLINE_VALUE}, '')`);
+	});
+	test('should increase offset if badge is true', () => {
+		const textMark = getTrendlineAnnotationTextMark({ ...defaultAnnotationProps, badge: true });
+		expect(textMark.transform?.[0]).toHaveProperty('offset', [4, 4, 4, 4, 5.65, 5.65, 5.65, 5.65]);
+	});
+});
+
+describe('getTextFill()', () => {
+	test('should return the correct fill for the text', () => {
+		expect(getTextFill({ ...defaultAnnotationProps, badge: true })).toEqual([
+			{
+				test: `contrast(scale('color', datum.datum.${DEFAULT_COLOR}), '${colors['gray-50']}') > 3.5`,
+				value: colors['gray-50'],
+			},
+			{ value: colors['gray-900'] },
+		]);
+	});
+	test('should return undefined if badge is false', () => {
+		expect(getTextFill(defaultAnnotationProps)).toBeUndefined();
+	});
+});
+
+describe('getTrendlineAnnotationBadgeMark()', () => {
+	test('should return the badge mark', () => {
+		const badgeMark = getTrendlineAnnotationBadgeMark({ ...defaultAnnotationProps, badge: true });
+		expect(badgeMark).toHaveLength(1);
+		expect(badgeMark[0]).toHaveProperty('type', 'rect');
+	});
+	test('should return empty array if badge is false', () => {
+		expect(getTrendlineAnnotationBadgeMark(defaultAnnotationProps)).toHaveLength(0);
 	});
 });

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
@@ -165,7 +165,7 @@ describe('getTextFill()', () => {
 	test('should return the correct fill for the text', () => {
 		expect(getTextFill({ ...defaultAnnotationProps, badge: true })).toEqual([
 			{
-				test: `contrast(scale('color', datum.datum.${DEFAULT_COLOR}), '${colors['gray-50']}') > 3.5`,
+				test: `contrast(scale('color', datum.datum.${DEFAULT_COLOR}), '${colors['gray-50']}') >= 4.5`,
 				value: colors['gray-50'],
 			},
 			{ value: colors['gray-900'] },

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
@@ -20,6 +20,7 @@ import { TrendlineAnnotationSpecProps } from 'types';
 
 import {
 	applyTrendlineAnnotationDefaults,
+	getColorKey,
 	getTextFill,
 	getTrendlineAnnotationBadgeMark,
 	getTrendlineAnnotationMarks,
@@ -183,5 +184,13 @@ describe('getTrendlineAnnotationBadgeMark()', () => {
 	});
 	test('should return empty array if badge is false', () => {
 		expect(getTrendlineAnnotationBadgeMark(defaultAnnotationProps)).toHaveLength(0);
+	});
+});
+
+describe('getColorKey()', () => {
+	test('should return the correct color key', () => {
+		expect(getColorKey(DEFAULT_COLOR)).toEqual(`datum.${DEFAULT_COLOR}`);
+		expect(getColorKey(DEFAULT_COLOR, 2)).toEqual(`datum.datum.${DEFAULT_COLOR}`);
+		expect(getColorKey({ value: 'red-500' })).toEqual({ value: 'red-500' });
 	});
 });

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -238,7 +238,7 @@ export const getTextFill = ({
 	const colorString = getColorProductionRuleSignalString(color, colorScheme);
 	const textColors = [getColorValue('gray-50', colorScheme), getColorValue('gray-900', colorScheme)];
 	return [
-		{ test: `contrast(${colorString}, '${textColors[0]}') > 3.5`, value: textColors[0] },
+		{ test: `contrast(${colorString}, '${textColors[0]}') >= 4.5`, value: textColors[0] },
 		{ value: textColors[1] },
 	];
 };

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -273,7 +273,14 @@ export const getTrendlineAnnotationBadgeMark = ({
 	];
 };
 
-const getColorKey = (trendlineColor: ColorFacet, datumOrder: number = 1): ColorFacet => {
+/**
+ * Gets the key used for color.
+ * Since some of the marks base their data off of previous marks, the datum might be nested.
+ * @param trendlineColor
+ * @param datumOrder how many levels deep the datum is (ex. 1 becomes datum.color, 2 becomes datum.datum.color, etc.)
+ * @returns
+ */
+export const getColorKey = (trendlineColor: ColorFacet, datumOrder: number = 1): ColorFacet => {
 	if (typeof trendlineColor === 'string') {
 		return `${new Array(datumOrder).fill('datum.').join('')}${trendlineColor}`;
 	}

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -59,10 +59,10 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
 				<Trendline {...trendlineProps} displayOnHover orientation="horizontal">
-					<TrendlineAnnotation prefix="Median times" numberFormat=".3" />
+					<TrendlineAnnotation badge prefix="Median times" numberFormat=".3" />
 				</Trendline>
 				<Trendline {...trendlineProps} displayOnHover orientation="vertical">
-					<TrendlineAnnotation prefix="Median %DAU" numberFormat=".2%" />
+					<TrendlineAnnotation badge prefix="Median %DAU" numberFormat=".2%" />
 				</Trendline>
 			</Scatter>
 			<Legend position="bottom" highlight />

--- a/src/stories/components/Trendline/Trendline.test.tsx
+++ b/src/stories/components/Trendline/Trendline.test.tsx
@@ -126,7 +126,7 @@ describe('Trendline', () => {
 			expect(trendline).toHaveAttribute('opacity', '1');
 		});
 
-		test('should display on haver for window methods', async () => {
+		test('should display on hover for window methods', async () => {
 			render(<DisplayOnHover {...DisplayOnHover.args} method="movingAverage-2" />);
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.story.tsx
@@ -48,6 +48,11 @@ const TrendlineAnnotationStory: StoryFn<typeof TrendlineAnnotation> = (args): Re
 
 const Basic = bindWithProps(TrendlineAnnotationStory);
 
+const Badge = bindWithProps(TrendlineAnnotationStory);
+Badge.args = {
+	badge: true,
+};
+
 const DimensionValue = bindWithProps(TrendlineAnnotationStory);
 DimensionValue.args = {
 	dimensionValue: 2,
@@ -60,14 +65,15 @@ NumberFormat.args = {
 
 const Prefix = bindWithProps(TrendlineAnnotationStory);
 Prefix.args = {
-	prefix: 'Speed: ',
+	prefix: 'Speed:',
 };
 
 const Supreme = bindWithProps(TrendlineAnnotationStory);
 Supreme.args = {
+	badge: true,
 	dimensionValue: 'start',
 	numberFormat: '.2f',
-	prefix: 'Speed: ',
+	prefix: 'Speed:',
 };
 
-export { Basic, DimensionValue, NumberFormat, Prefix, Supreme };
+export { Basic, Badge, DimensionValue, NumberFormat, Prefix, Supreme };

--- a/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
+++ b/src/stories/components/TrendlineAnnotation/TrendlineAnnotation.test.tsx
@@ -10,10 +10,12 @@
  * governing permissions and limitations under the License.
  */
 import '@matchMediaMock';
-import { TrendlineAnnotation } from '@rsc';
+import { TrendlineAnnotation, spectrumColors } from '@rsc';
 import { allElementsHaveAttributeValue, findAllMarksByGroupName, findChart, render } from '@test-utils';
 
-import { Basic, DimensionValue, NumberFormat, Prefix } from './TrendlineAnnotation.story';
+import { Badge, Basic, DimensionValue, NumberFormat, Prefix } from './TrendlineAnnotation.story';
+
+const colors = spectrumColors.light;
 
 describe('TrendlineAnnotation', () => {
 	// TrendlineAnnotation is not a real React component. This is test just provides test coverage for sonarqube
@@ -33,6 +35,18 @@ describe('TrendlineAnnotation', () => {
 		expect(labels[0]).toHaveTextContent('4.5');
 		expect(labels[1]).toHaveTextContent('3.75');
 		expect(labels[2]).toHaveTextContent('3');
+	});
+
+	test('should render Badge correctly', async () => {
+		render(<Badge {...Badge.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const badges = await findAllMarksByGroupName(chart, 'scatter0Trendline0Annotation0_badge');
+		expect(badges).toHaveLength(3);
+		expect(badges[0]).toHaveAttribute('fill', colors['categorical-100']);
+		expect(badges[1]).toHaveAttribute('fill', colors['categorical-200']);
+		expect(badges[2]).toHaveAttribute('fill', colors['categorical-300']);
 	});
 
 	test('should render DimensionValue correctly', async () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -571,6 +571,8 @@ export interface TrendlineProps {
 }
 
 export interface TrendlineAnnotationProps {
+	/** Adds a badge around the annotation */
+	badge?: boolean;
 	/** where along the dimension scale to label the trendline value */
 	dimensionValue?: number | 'start' | 'end';
 	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -17,6 +17,7 @@ import {
 	AxisAnnotationProps,
 	AxisProps,
 	BarProps,
+	ColorFacet,
 	ColorScheme,
 	DonutProps,
 	FacetRef,
@@ -174,21 +175,26 @@ type TrendlinePropsWithDefaults =
 	| 'orientation';
 
 export interface TrendlineSpecProps
-	extends PartiallyRequired<TrendlineProps & { metric?: string; name: string }, TrendlinePropsWithDefaults> {
+	extends PartiallyRequired<TrendlineProps & { metric?: string }, TrendlinePropsWithDefaults> {
 	children: TrendlineChildElement[];
+	colorScheme: ColorScheme;
 	dimensionScaleType: RscScaleType;
 	isDimensionNormalized: boolean;
+	name: string;
+	trendlineColor: ColorFacet;
 	trendlineDimension: string;
 	trendlineMetric: string;
 }
 
-type TrendlineAnnotationPropsWithDefaults = 'dimensionValue' | 'numberFormat';
+type TrendlineAnnotationPropsWithDefaults = 'badge' | 'dimensionValue' | 'numberFormat' | 'prefix';
 
 export interface TrendlineAnnotationSpecProps
 	extends PartiallyRequired<TrendlineAnnotationProps, TrendlineAnnotationPropsWithDefaults> {
+	colorScheme: ColorScheme;
 	displayOnHover: boolean;
 	markName: string;
 	name: string;
+	trendlineColor: ColorFacet;
 	trendlineDimension: string;
 	trendlineDimensionExtent: TrendlineSpecProps['dimensionExtent'];
 	trendlineDimensionScaleType: RscScaleType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `badge` prop to `TrendlineAnnotation`. This will display the annotation as a badge where the color of the badge matches the trendline color.


## Motivation and Context

This is good for when you want to ensure readability of the annotation or when you want the color of the badge to help indicate which line it is for.

## Stories

- Trendline > TrendlineAnnotation > Badge
- Trendline > TrendlineAnnotation > Supreme
- Chart > Examples > MultipleSegmentFeatureMatrix

## Screenshots (if appropriate):

<img width="887" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/c2f2981a-4f34-4976-a4c5-2750fad5d45e">
<img width="534" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/06c0241b-1ec3-4043-86e2-99ddec335388">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
