### PR TITLE
An 340716/scatter path

### DIFF
--- a/src/components/ScatterPath/ScatterPath.tsx
+++ b/src/components/ScatterPath/ScatterPath.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { ScatterPathProps } from '../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const ScatterPath: FC<ScatterPathProps> = ({
+	color = 'gray-500',
+	groupBy,
+	pathWidth = { value: 'M' },
+	opacity = 0.5,
+}) => {
+	return null;
+};
+
+// displayName is used to validate the component type in the spec builder
+ScatterPath.displayName = 'ScatterPath';
+
+export { ScatterPath };

--- a/src/components/ScatterPath/index.ts
+++ b/src/components/ScatterPath/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './ScatterPath';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ export * from './ChartTooltip';
 export * from './EmptyState';
 export * from './Legend';
 export * from './Line';
+export * from './ScatterPath';
 export * from './MetricRange';
 export * from './ReferenceLine';
 export * from './Title';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,7 +60,7 @@ export const LINE_WIDTH_SCALE = 'lineWidth';
 export const OPACITY_SCALE = 'opacity';
 export const SYMBOL_SHAPE_SCALE = 'symbolShape';
 export const SYMBOL_SIZE_SCALE = 'symbolSize';
-export const SYMBOL_TRAIL_SIZE_SCALE = 'symbolTrailSize';
+export const SYMBOL_PATH_WIDTH_SCALE = 'symbolPathWidth';
 
 // encode rules
 export const DEFAULT_OPACITY_RULE = { value: 1 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,7 @@ export const LINE_WIDTH_SCALE = 'lineWidth';
 export const OPACITY_SCALE = 'opacity';
 export const SYMBOL_SHAPE_SCALE = 'symbolShape';
 export const SYMBOL_SIZE_SCALE = 'symbolSize';
+export const SYMBOL_TRAIL_SIZE_SCALE = 'symbolTrailSize';
 
 // encode rules
 export const DEFAULT_OPACITY_RULE = { value: 1 };

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -24,9 +24,9 @@ import {
 	SELECTED_ITEM,
 	SELECTED_SERIES,
 	SERIES_ID,
+	SYMBOL_PATH_WIDTH_SCALE,
 	SYMBOL_SHAPE_SCALE,
 	SYMBOL_SIZE_SCALE,
-	SYMBOL_TRAIL_SIZE_SCALE,
 	TABLE,
 } from '@constants';
 import { Area, Axis, Bar, Legend, Line, Scatter, Title } from '@rsc';
@@ -272,7 +272,7 @@ const getDefaultScales = (
 	getOpacityScale(opacities),
 	getSymbolShapeScale(symbolShapes),
 	getSymbolSizeScale(symbolSizes),
-	getSymbolTrailSizeScale(symbolSizes),
+	getSymbolPathWidthScale(symbolSizes),
 ];
 
 export const getColorScale = (colors: ChartColors, colorScheme: ColorScheme): OrdinalScale => {
@@ -322,12 +322,12 @@ export const getSymbolSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): Linea
 });
 
 /**
- * returns the symbol size scale
+ * returns the path width scale
  * @param symbolSizes
  * @returns LinearScale
  */
-export const getSymbolTrailSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): LinearScale => ({
-	name: SYMBOL_TRAIL_SIZE_SCALE,
+export const getSymbolPathWidthScale = (symbolSizes: [SymbolSize, SymbolSize]): LinearScale => ({
+	name: SYMBOL_PATH_WIDTH_SCALE,
 	type: 'linear',
 	zero: false,
 	range: symbolSizes.map((symbolSize) => getSymbolWidthFromRscSymbolSize(symbolSize)),

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -26,6 +26,7 @@ import {
 	SERIES_ID,
 	SYMBOL_SHAPE_SCALE,
 	SYMBOL_SIZE_SCALE,
+	SYMBOL_TRAIL_SIZE_SCALE,
 	TABLE,
 } from '@constants';
 import { Area, Axis, Bar, Legend, Line, Scatter, Title } from '@rsc';
@@ -73,6 +74,7 @@ import {
 	getLineWidthPixelsFromLineWidth,
 	getPathFromSymbolShape,
 	getStrokeDashFromLineType,
+	getSymbolWidthFromRscSymbolSize,
 	getVegaSymbolSizeFromRscSymbolSize,
 	initializeSpec,
 } from './specUtils';
@@ -270,6 +272,7 @@ const getDefaultScales = (
 	getOpacityScale(opacities),
 	getSymbolShapeScale(symbolShapes),
 	getSymbolSizeScale(symbolSizes),
+	getSymbolTrailSizeScale(symbolSizes),
 ];
 
 export const getColorScale = (colors: ChartColors, colorScheme: ColorScheme): OrdinalScale => {
@@ -315,6 +318,19 @@ export const getSymbolSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): Linea
 	type: 'linear',
 	zero: false,
 	range: symbolSizes.map((symbolSize) => getVegaSymbolSizeFromRscSymbolSize(symbolSize)),
+	domain: { data: TABLE, fields: [] },
+});
+
+/**
+ * returns the symbol size scale
+ * @param symbolSizes
+ * @returns LinearScale
+ */
+export const getSymbolTrailSizeScale = (symbolSizes: [SymbolSize, SymbolSize]): LinearScale => ({
+	name: SYMBOL_TRAIL_SIZE_SCALE,
+	type: 'linear',
+	zero: false,
+	range: symbolSizes.map((symbolSize) => getSymbolWidthFromRscSymbolSize(symbolSize)),
 	domain: { data: TABLE, fields: [] },
 });
 

--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -29,32 +29,35 @@ const defaultGroupMark: Mark = {
 
 const defaultOpacityEncoding = {
 	opacity: [
-		{ test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
+		{
+			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
+			value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+		},
 	],
 };
 
 describe('getHighlightOpacityRule()', () => {
 	test('scale ref should divide by highlight contrast ratio', () => {
 		expect(getHighlightOpacityRule({ scale: OPACITY_SCALE, field: DEFAULT_COLOR })).toStrictEqual({
-			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
+			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
 			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
 		});
 	});
 	test('signal ref should divide by highlight contrast ratio', () => {
 		expect(getHighlightOpacityRule({ signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})` })).toStrictEqual({
-			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
+			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
 			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
 		});
 	});
 	test('value ref should divide by highlight contrast ratio', () => {
 		expect(getHighlightOpacityRule({ value: 0.5 })).toStrictEqual({
-			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
+			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
 			value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
 		});
 	});
 	test('empty ref should return default rule', () => {
 		expect(getHighlightOpacityRule({})).toStrictEqual({
-			test: `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`,
+			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
 			value: 1 / HIGHLIGHT_CONTRAST_RATIO,
 		});
 	});

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { COLOR_SCALE, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
+import { COLOR_SCALE, HIGHLIGHTED_SERIES, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
 import { GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
 
 /**
@@ -67,7 +67,7 @@ export const getHighlightOpacityRule = (
 	keys?: string[],
 	name?: string
 ): { test?: string } & NumericValueRef => {
-	let test = `highlightedSeries && highlightedSeries !== datum.${SERIES_ID}`;
+	let test = `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`;
 	if (keys) {
 		test = `${name}_highlight && ${name}_highlight !== datum.${keys[0]}`;
 	}

--- a/src/specBuilder/legend/legendTestUtils.ts
+++ b/src/specBuilder/legend/legendTestUtils.ts
@@ -16,6 +16,7 @@ import {
 	DEFAULT_METRIC,
 	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
+	HIGHLIGHTED_SERIES,
 	HIGHLIGHT_CONTRAST_RATIO,
 	LEGEND_TOOLTIP_DELAY,
 } from '@constants';
@@ -40,7 +41,7 @@ export const cleanupTooltips = () => {
 };
 
 export const opacityEncoding = [
-	{ test: 'highlightedSeries && datum.value !== highlightedSeries', value: 1 / HIGHLIGHT_CONTRAST_RATIO },
+	{ test: `${HIGHLIGHTED_SERIES} && datum.value !== ${HIGHLIGHTED_SERIES}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
 	DEFAULT_OPACITY_RULE,
 ];
 

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -260,6 +260,7 @@ const getSymbolFacetEncoding = <T>({
 		opacity: { scale: 'secondaryOpacity', signal: 'opacities' },
 		symbolShape: { scale: 'secondarySymbolShape', signal: 'symbolShapes' },
 		symbolSize: { scale: 'secondarySymbolSize', signal: 'symbolSizes' },
+		symbolTrailSize: { scale: 'secondarySymbolTrailSize', signal: 'symbolTrailSizes' },
 	};
 
 	const facet = facets.find((f) => f.facetType === facetType);

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -260,7 +260,7 @@ const getSymbolFacetEncoding = <T>({
 		opacity: { scale: 'secondaryOpacity', signal: 'opacities' },
 		symbolShape: { scale: 'secondarySymbolShape', signal: 'symbolShapes' },
 		symbolSize: { scale: 'secondarySymbolSize', signal: 'symbolSizes' },
-		symbolTrailSize: { scale: 'secondarySymbolTrailSize', signal: 'symbolTrailSizes' },
+		symbolPathWidth: { scale: 'secondarySymbolPathWidth', signal: 'symbolPathWidths' },
 	};
 
 	const facet = facets.find((f) => f.facetType === facetType);

--- a/src/specBuilder/line/lineUtils.ts
+++ b/src/specBuilder/line/lineUtils.ts
@@ -30,7 +30,10 @@ export const getInteractiveMarkName = (children: MarkChildElement[], name: strin
 	// if there is a trendline with an interactive component on the line, then the trendline is the target for the interactive component
 	if (
 		children.some(
-			(child) => child.type === Trendline && hasInteractiveChildren(sanitizeMarkChildren(child.props.children))
+			(child) =>
+				child.type === Trendline &&
+				'children' in child.props &&
+				hasInteractiveChildren(sanitizeMarkChildren(child.props.children))
 		)
 	) {
 		return `${name}Trendline`;
@@ -43,7 +46,14 @@ export const getPopoverMarkName = (children: MarkChildElement[], name: string): 
 		return name;
 	}
 	// if there is a trendline with a popover on this line, then the trendline is the target for the popover
-	if (children.some((child) => child.type === Trendline && hasPopover(sanitizeMarkChildren(child.props.children)))) {
+	if (
+		children.some(
+			(child) =>
+				child.type === Trendline &&
+				'children' in child.props &&
+				hasPopover(sanitizeMarkChildren(child.props.children))
+		)
+	) {
 		return `${name}Trendline`;
 	}
 };

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -28,6 +28,7 @@ import {
 	hasInteractiveChildren,
 	hasPopover,
 } from '@specBuilder/marks/markUtils';
+import { getScatterPathMarks } from '@specBuilder/scatterPath/scatterPathUtils';
 import { getTrendlineMarks } from '@specBuilder/trendline';
 import { spectrumColors } from '@themes';
 import { produce } from 'immer';
@@ -43,6 +44,7 @@ export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props
 		marks: [getScatterMark(props), ...getScatterHoverMarks(props), ...getScatterSelectMarks(props)],
 	};
 
+	marks.push(...getScatterPathMarks(props));
 	marks.push(scatterGroup);
 	marks.push(...getTrendlineMarks(props));
 });

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -32,6 +32,7 @@ import {
 	addFieldToFacetScaleDomain,
 	addMetricScale,
 } from '@specBuilder/scale/scaleSpecBuilder';
+import { setScatterPathScales } from '@specBuilder/scatterPath';
 import { addHighlightedItemSignalEvents } from '@specBuilder/signal/signalSpecBuilder';
 import { addTrendlineData, getTrendlineScales, setTrendlineSignals } from '@specBuilder/trendline';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
@@ -157,5 +158,6 @@ export const setScales = produce<Scale[], [ScatterSpecProps]>((scales, props) =>
 	// add size to the size domain
 	addFieldToFacetScaleDomain(scales, SYMBOL_SIZE_SCALE, size);
 
+	setScatterPathScales(scales, props);
 	scales.push(...getTrendlineScales(props));
 });

--- a/src/specBuilder/scatterPath/index.ts
+++ b/src/specBuilder/scatterPath/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './scatterPathUtils';

--- a/src/specBuilder/scatterPath/scatterPathUtils.test.ts
+++ b/src/specBuilder/scatterPath/scatterPathUtils.test.ts
@@ -9,14 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { createElement } from 'react';
 
 import { ScatterPath } from '@components/ScatterPath';
-import { DEFAULT_COLOR, SYMBOL_TRAIL_SIZE_SCALE } from '@constants';
+import { DEFAULT_COLOR, SYMBOL_PATH_WIDTH_SCALE } from '@constants';
 import { defaultScatterProps } from '@specBuilder/scatter/scatterTestUtils';
 
-import { getScatterPathMarks, getScatterPathSpecProps, getTrailSize } from './scatterPathUtils';
+import { getPathWidth, getScatterPathMarks, getScatterPathSpecProps } from './scatterPathUtils';
 
 describe('getScatterPathSpecProps()', () => {
 	test('should apply defaults', () => {
@@ -61,18 +60,18 @@ describe('getScatterPathMarks()', () => {
 	});
 });
 
-describe('getTrailSize()', () => {
+describe('getPathWidth()', () => {
 	test('should use scale if pathWidth is a string', () => {
-		const trailSize = getTrailSize('size');
-		expect(trailSize).toHaveProperty('scale', SYMBOL_TRAIL_SIZE_SCALE);
-		expect(trailSize).toHaveProperty('field', 'size');
+		const pathWidth = getPathWidth('size');
+		expect(pathWidth).toHaveProperty('scale', SYMBOL_PATH_WIDTH_SCALE);
+		expect(pathWidth).toHaveProperty('field', 'size');
 	});
 	test('should convert named pathWidths', () => {
-		const trailSize = getTrailSize({ value: 'M' });
-		expect(trailSize).toHaveProperty('value', 2);
+		const pathWidth = getPathWidth({ value: 'M' });
+		expect(pathWidth).toHaveProperty('value', 2);
 	});
 	test('should pass through static number values', () => {
-		const trailSize = getTrailSize({ value: 3 });
-		expect(trailSize).toHaveProperty('value', 3);
+		const pathWidth = getPathWidth({ value: 3 });
+		expect(pathWidth).toHaveProperty('value', 3);
 	});
 });

--- a/src/specBuilder/scatterPath/scatterPathUtils.test.ts
+++ b/src/specBuilder/scatterPath/scatterPathUtils.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createElement } from 'react';
+
+import { ScatterPath } from '@components/ScatterPath';
+import { DEFAULT_COLOR, SYMBOL_TRAIL_SIZE_SCALE } from '@constants';
+import { defaultScatterProps } from '@specBuilder/scatter/scatterTestUtils';
+
+import { getScatterPathMarks, getScatterPathSpecProps, getTrailSize } from './scatterPathUtils';
+
+describe('getScatterPathSpecProps()', () => {
+	test('should apply defaults', () => {
+		const pathProps = getScatterPathSpecProps({}, 0, defaultScatterProps);
+		expect(pathProps).toHaveProperty('color', 'gray-500');
+		expect(pathProps).toHaveProperty('name', 'scatter0Path0');
+		expect(pathProps).toHaveProperty('pathWidth', { value: 'M' });
+		expect(pathProps).toHaveProperty('opacity', 0.5);
+	});
+	test('should pick up groupBy properties from scatter facets', () => {
+		const pathProps = getScatterPathSpecProps({}, 0, {
+			...defaultScatterProps,
+			color: DEFAULT_COLOR,
+			size: 'size',
+		});
+		expect(pathProps).toHaveProperty('groupBy', [DEFAULT_COLOR, 'size']);
+	});
+	test('should use groupBy instead of scatter facets is supplied', () => {
+		const groupBy = ['test'];
+		const pathProps = getScatterPathSpecProps({ groupBy }, 0, {
+			...defaultScatterProps,
+			color: DEFAULT_COLOR,
+			size: 'size',
+		});
+		expect(pathProps).toHaveProperty('groupBy', groupBy);
+	});
+});
+
+describe('getScatterPathMarks()', () => {
+	test('should return an epmty array if there are not any ScatterPath components', () => {
+		const marks = getScatterPathMarks(defaultScatterProps);
+		expect(marks).toHaveLength(0);
+	});
+	test('should return scatter path marks', () => {
+		const marks = getScatterPathMarks({ ...defaultScatterProps, children: [createElement(ScatterPath)] });
+		expect(marks).toHaveLength(1);
+		expect(marks[0]).toHaveProperty('type', 'group');
+		expect(marks[0]).toHaveProperty('name', 'scatter0Path0_group');
+		expect(marks[0].marks).toHaveLength(1);
+		expect(marks[0]?.marks?.[0]).toHaveProperty('type', 'trail');
+		expect(marks[0]?.marks?.[0]).toHaveProperty('name', 'scatter0Path0');
+	});
+});
+
+describe('getTrailSize()', () => {
+	test('should use scale if pathWidth is a string', () => {
+		const trailSize = getTrailSize('size');
+		expect(trailSize).toHaveProperty('scale', SYMBOL_TRAIL_SIZE_SCALE);
+		expect(trailSize).toHaveProperty('field', 'size');
+	});
+	test('should convert named pathWidths', () => {
+		const trailSize = getTrailSize({ value: 'M' });
+		expect(trailSize).toHaveProperty('value', 2);
+	});
+	test('should pass through static number values', () => {
+		const trailSize = getTrailSize({ value: 3 });
+		expect(trailSize).toHaveProperty('value', 3);
+	});
+});

--- a/src/specBuilder/scatterPath/scatterPathUtils.ts
+++ b/src/specBuilder/scatterPath/scatterPathUtils.ts
@@ -18,7 +18,7 @@ import {
 	HIGHLIGHT_CONTRAST_RATIO,
 	SELECTED_ITEM,
 	SELECTED_SERIES,
-	SYMBOL_TRAIL_SIZE_SCALE,
+	SYMBOL_PATH_WIDTH_SCALE,
 } from '@constants';
 import { getXProductionRule } from '@specBuilder/marks/markUtils';
 import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
@@ -85,7 +85,7 @@ export const setScatterPathScales = (scales: Scale[], scatterProps: ScatterSpecP
 	const paths = getScatterPaths(scatterProps);
 
 	paths.forEach((path) => {
-		addFieldToFacetScaleDomain(scales, SYMBOL_TRAIL_SIZE_SCALE, path.pathWidth);
+		addFieldToFacetScaleDomain(scales, SYMBOL_PATH_WIDTH_SCALE, path.pathWidth);
 	});
 };
 
@@ -132,7 +132,7 @@ export const getScatterPathTrailMark = ({
 					value: getColorValue(color, colorScheme),
 				},
 				fillOpacity: { value: opacity },
-				size: getTrailSize(pathWidth),
+				size: getPathWidth(pathWidth),
 			},
 			update: {
 				opacity: getOpacity(),
@@ -162,9 +162,9 @@ export const getOpacity = (): ({ test?: string } & NumericValueRef)[] => {
 	];
 };
 
-export const getTrailSize = (pathWidth: LineWidthFacet): NumericValueRef => {
+export const getPathWidth = (pathWidth: LineWidthFacet): NumericValueRef => {
 	if (typeof pathWidth === 'string') {
-		return { scale: SYMBOL_TRAIL_SIZE_SCALE, field: pathWidth };
+		return { scale: SYMBOL_PATH_WIDTH_SCALE, field: pathWidth };
 	}
 	return { value: getLineWidthPixelsFromLineWidth(pathWidth.value) };
 };

--- a/src/specBuilder/scatterPath/scatterPathUtils.ts
+++ b/src/specBuilder/scatterPath/scatterPathUtils.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ScatterPath } from '@components/ScatterPath';
+import {
+	DEFAULT_OPACITY_RULE,
+	FILTERED_TABLE,
+	HIGHLIGHTED_ITEM,
+	HIGHLIGHTED_SERIES,
+	HIGHLIGHT_CONTRAST_RATIO,
+	SELECTED_ITEM,
+	SELECTED_SERIES,
+	SYMBOL_TRAIL_SIZE_SCALE,
+} from '@constants';
+import { getXProductionRule } from '@specBuilder/marks/markUtils';
+import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
+import { getColorValue, getFacetsFromProps, getLineWidthPixelsFromLineWidth } from '@specBuilder/specUtils';
+import { LineWidthFacet, ScatterPathElement, ScatterPathProps, ScatterPathSpecProps, ScatterSpecProps } from 'types';
+import { GroupMark, NumericValueRef, Scale, TrailMark } from 'vega';
+
+/**
+ * Gets the path spec props, applying defaults.
+ * @param scatterPathProps
+ * @param index
+ * @param markName
+ * @param colorScheme
+ * @returns ScatterPathSpecProps
+ */
+export const getScatterPathSpecProps = (
+	{ color = 'gray-500', groupBy, pathWidth = { value: 'M' }, opacity = 0.5, ...scatterPathProps }: ScatterPathProps,
+	index: number,
+	{
+		color: scatterColor,
+		colorScheme,
+		dimension,
+		dimensionScaleType,
+		lineType,
+		metric,
+		name: scatterName,
+		opacity: scatterOpacity,
+		size,
+	}: ScatterSpecProps
+): ScatterPathSpecProps => {
+	const { facets } = getFacetsFromProps({ color: scatterColor, lineType, size, opacity: scatterOpacity });
+	return {
+		color,
+		colorScheme,
+		dimension,
+		dimensionScaleType,
+		groupBy: groupBy ?? facets,
+		metric,
+		index,
+		pathWidth,
+		name: `${scatterName}Path${index}`,
+		opacity,
+		...scatterPathProps,
+	};
+};
+
+/**
+ * Gets all the paths on a scatter
+ * @param scatterProps
+ * @returns ScatterPathSpecProps[]
+ */
+export const getScatterPaths = (scatterProps: ScatterSpecProps): ScatterPathSpecProps[] => {
+	const pathElements = scatterProps.children.filter((child) => child.type === ScatterPath) as ScatterPathElement[];
+	return pathElements.map((path, index) => getScatterPathSpecProps(path.props, index, scatterProps));
+};
+
+/**
+ * Sets the scales up for the scatter path marks
+ * Note: This mutates the scales array so it should only be called from an immer produce function
+ * @param scales
+ * @param scatterProps
+ */
+export const setScatterPathScales = (scales: Scale[], scatterProps: ScatterSpecProps) => {
+	const paths = getScatterPaths(scatterProps);
+
+	paths.forEach((path) => {
+		addFieldToFacetScaleDomain(scales, SYMBOL_TRAIL_SIZE_SCALE, path.pathWidth);
+	});
+};
+
+export const getScatterPathMarks = (scatterProps: ScatterSpecProps): GroupMark[] => {
+	const marks: GroupMark[] = [];
+	const paths = getScatterPaths(scatterProps);
+
+	paths.forEach((path) => {
+		const { groupBy, name } = path;
+		marks.push({
+			name: `${name}_group`,
+			type: 'group',
+			from: {
+				facet: {
+					name: `${name}_facet`,
+					data: FILTERED_TABLE,
+					groupby: groupBy,
+				},
+			},
+			marks: [getScatterPathTrailMark(path)],
+		});
+	});
+
+	return marks;
+};
+
+export const getScatterPathTrailMark = ({
+	color,
+	colorScheme,
+	dimension,
+	dimensionScaleType,
+	pathWidth,
+	metric,
+	name,
+	opacity,
+}: ScatterPathSpecProps): TrailMark => {
+	return {
+		name,
+		type: 'trail',
+		from: { data: `${name}_facet` },
+		encode: {
+			enter: {
+				fill: {
+					value: getColorValue(color, colorScheme),
+				},
+				fillOpacity: { value: opacity },
+				size: getTrailSize(pathWidth),
+			},
+			update: {
+				opacity: getOpacity(),
+				x: getXProductionRule(dimensionScaleType, dimension),
+				y: { scale: 'yLinear', field: metric },
+			},
+		},
+	};
+};
+
+/**
+ * Gets the opacity production rule for the scatterPath trail marks.
+ * This is used for highlighting trails on hover and selection.
+ * @param scatterProps ScatterSpecProps
+ * @returns opacity production rule
+ */
+export const getOpacity = (): ({ test?: string } & NumericValueRef)[] => {
+	// if a point is hovered or selected, all other points should be reduced opacity
+	const fadedValue = 1 / HIGHLIGHT_CONTRAST_RATIO;
+
+	return [
+		{
+			test: `${HIGHLIGHTED_SERIES} || ${HIGHLIGHTED_ITEM} || ${SELECTED_SERIES} || ${SELECTED_ITEM}`,
+			value: fadedValue,
+		},
+		DEFAULT_OPACITY_RULE,
+	];
+};
+
+export const getTrailSize = (pathWidth: LineWidthFacet): NumericValueRef => {
+	if (typeof pathWidth === 'string') {
+		return { scale: SYMBOL_TRAIL_SIZE_SCALE, field: pathWidth };
+	}
+	return { value: getLineWidthPixelsFromLineWidth(pathWidth.value) };
+};

--- a/src/specBuilder/specUtils.ts
+++ b/src/specBuilder/specUtils.ts
@@ -182,28 +182,39 @@ export const getPathFromIcon = (icon: Icon | string): string => {
 	return supportedIcons[icon] || icon;
 };
 
+/**
+ * Converts a symbolSize to the vega size
+ * RSC uses the width of the symbol to determine the size
+ * Vega uses the area of the symbol to determine the size
+ * @param symbolSize
+ * @returns size in square pixels
+ */
 export const getVegaSymbolSizeFromRscSymbolSize = (symbolSize: SymbolSize): number => {
+	return Math.pow(getSymbolWidthFromRscSymbolSize(symbolSize), 2);
+};
+
+/**
+ * Gets the width of the symbol or trail from the symbolSize
+ * @param symbolSize
+ * @returns width in pixels
+ */
+export const getSymbolWidthFromRscSymbolSize = (symbolSize: SymbolSize): number => {
 	if (typeof symbolSize === 'number') {
-		return Math.pow(symbolSize, 2);
+		return symbolSize;
 	}
 
 	switch (symbolSize) {
 		case 'XS':
-			// 6 x 6
-			return 36;
+			return 6;
 		case 'S':
-			// 8 x 8
-			return 64;
+			return 8;
 		case 'L':
-			// 12 x 12
-			return 144;
+			return 12;
 		case 'XL':
-			// 16 x 16
-			return 256;
+			return 16;
 		case 'M':
 		default:
-			// 10 x 10
-			return 100;
+			return 10;
 	}
 };
 

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.test.ts
@@ -19,13 +19,13 @@ import { spectrumColors } from '@themes';
 import { TrendlineAnnotationSpecProps } from 'types';
 
 import {
-	applyTrendlineAnnotationDefaults,
 	getColorKey,
 	getTextFill,
 	getTrendlineAnnotationBadgeMark,
 	getTrendlineAnnotationMarks,
 	getTrendlineAnnotationPointX,
 	getTrendlineAnnotationPointY,
+	getTrendlineAnnotationSpecProps,
 	getTrendlineAnnotationTextMark,
 	getTrendlineAnnotations,
 } from './trendlineAnnotationUtils';
@@ -52,7 +52,7 @@ const colors = spectrumColors.light;
 
 describe('applyTrendlineAnnotationDefaults()', () => {
 	test('should apply all defaults', () => {
-		const annotationProps = applyTrendlineAnnotationDefaults({}, 0, defaultTrendlineProps, 'line0');
+		const annotationProps = getTrendlineAnnotationSpecProps({}, 0, defaultTrendlineProps, 'line0');
 		expect(annotationProps).toEqual(defaultAnnotationProps);
 	});
 });

--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -35,7 +35,7 @@ import { ColorValueRef, GroupMark, NumericValueRef, ProductionRule, RectMark, Sy
  * @param markName
  * @returns TrendlineAnnotationSpecProps
  */
-export const applyTrendlineAnnotationDefaults = (
+export const getTrendlineAnnotationSpecProps = (
 	{ badge = false, dimensionValue = 'end', numberFormat = '', prefix = '' }: TrendlineAnnotationProps,
 	index: number,
 	{
@@ -82,7 +82,7 @@ export const getTrendlineAnnotations = (
 		(child) => child.type === TrendlineAnnotation
 	) as TrendlineAnnotationElement[];
 	return annotationElements.map((annotation, index) =>
-		applyTrendlineAnnotationDefaults(annotation.props, index, trendlineProps, markName)
+		getTrendlineAnnotationSpecProps(annotation.props, index, trendlineProps, markName)
 	);
 };
 

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -12,11 +12,11 @@
 import { ReactElement } from 'react';
 
 import useChartProps from '@hooks/useChartProps';
-import { Axis, Chart, Legend, Scatter, Trendline, TrendlineAnnotation, TrendlineProps } from '@rsc';
+import { Axis, Chart, Legend, Scatter, ScatterPath, Trendline, TrendlineAnnotation, TrendlineProps } from '@rsc';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
 
-import { basicFeatureMatrixData, multipleSegmentFeatureMatrixData } from './data';
+import { basicFeatureMatrixData, multipleSegmentFeatureMatrixData, timeCompareFeatureMatrixData } from './data';
 
 export default {
 	title: 'RSC/Chart/Examples',
@@ -59,11 +59,39 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 			<Axis position="left" ticks grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
 				<Trendline {...trendlineProps} displayOnHover orientation="horizontal">
-					<TrendlineAnnotation badge prefix="Median times" numberFormat=".3" />
+					<TrendlineAnnotation prefix="Median times" numberFormat=".3" />
 				</Trendline>
 				<Trendline {...trendlineProps} displayOnHover orientation="vertical">
-					<TrendlineAnnotation badge prefix="Median %DAU" numberFormat=".2%" />
+					<TrendlineAnnotation prefix="Median %DAU" numberFormat=".2%" />
 				</Trendline>
+			</Scatter>
+			<Legend position="bottom" highlight />
+		</Chart>
+	);
+};
+
+const TimeCompareFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElement => {
+	const chartProps = useChartProps(args);
+
+	return (
+		<Chart {...chartProps}>
+			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
+			<Axis position="left" ticks grid title="Average number of times per day" />
+			<Scatter
+				dimension="dauPercent"
+				metric="countAvg"
+				color="segment"
+				lineType="period"
+				opacity="period"
+				lineWidth={{ value: 1 }}
+			>
+				<Trendline {...trendlineProps} displayOnHover orientation="horizontal">
+					<TrendlineAnnotation prefix="Median times" numberFormat=".3" />
+				</Trendline>
+				<Trendline {...trendlineProps} displayOnHover orientation="vertical">
+					<TrendlineAnnotation prefix="Median %DAU" numberFormat=".2%" />
+				</Trendline>
+				<ScatterPath groupBy={['event', 'segment']} pathWidth="trailSize" opacity={0.2} />
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>
@@ -86,4 +114,15 @@ MultipleSegmentFeatureMatrix.args = {
 	data: multipleSegmentFeatureMatrixData,
 };
 
-export { FeatureMatrix, MultipleSegmentFeatureMatrix };
+const TimeCompareFeatureMatrix = bindWithProps(TimeCompareFeatureMatrixStory);
+TimeCompareFeatureMatrix.args = {
+	width: 'auto',
+	maxWidth: 850,
+	height: 500,
+	lineTypes: ['dotted', 'solid'],
+	opacities: [0.5, 1],
+	symbolSizes: [1, 'M'],
+	data: timeCompareFeatureMatrixData,
+};
+
+export { FeatureMatrix, MultipleSegmentFeatureMatrix, TimeCompareFeatureMatrix };

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -91,7 +91,7 @@ const TimeCompareFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElemen
 				<Trendline {...trendlineProps} displayOnHover orientation="vertical">
 					<TrendlineAnnotation prefix="Median %DAU" numberFormat=".2%" />
 				</Trendline>
-				<ScatterPath groupBy={['event', 'segment']} pathWidth="trailSize" opacity={0.2} />
+				<ScatterPath groupBy={['event', 'segment']} pathWidth="pathWidth" opacity={0.2} />
 			</Scatter>
 			<Legend position="bottom" highlight />
 		</Chart>

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+	allElementsHaveAttributeValue,
 	findAllMarksByGroupName,
 	findChart,
 	findMarksByGroupName,
@@ -20,7 +21,7 @@ import {
 } from '@test-utils';
 import { spectrumColors } from '@themes';
 
-import { FeatureMatrix, MultipleSegmentFeatureMatrix } from './FeatureMatrix.story';
+import { FeatureMatrix, MultipleSegmentFeatureMatrix, TimeCompareFeatureMatrix } from './FeatureMatrix.story';
 
 const colors = spectrumColors.light;
 
@@ -148,5 +149,28 @@ describe('MultipleSegmentFeatureMatrix', () => {
 		await hoverNthElement(hoverAreas, 12);
 		expect(screen.getByText('Median times 2.59')).toBeInTheDocument();
 		expect(screen.getByText('Median %DAU 8.96%')).toBeInTheDocument();
+	});
+});
+
+describe('TimeCompareFeatureMatrix', () => {
+	test('should render time comparison correctly', async () => {
+		render(<TimeCompareFeatureMatrix {...TimeCompareFeatureMatrix.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		// point styling
+		const points = await findAllMarksByGroupName(chart, 'scatter0');
+		expect(points).toHaveLength(36);
+		expect(points[0]).toHaveAttribute('fill-opacity', '0.5');
+		expect(points[1]).toHaveAttribute('fill-opacity', '1');
+		expect(points[0]).toHaveAttribute('stroke-dasharray', '2,3');
+		expect(points[1]).toHaveAttribute('stroke-dasharray', '');
+		expect(allElementsHaveAttributeValue(points, 'stroke-width', '1')).toBe(true);
+
+		// path styling
+		const paths = await findAllMarksByGroupName(chart, 'scatter0Path0');
+		expect(paths).toHaveLength(18);
+		expect(allElementsHaveAttributeValue(paths, 'fill-opacity', '0.2')).toBe(true);
+		expect(allElementsHaveAttributeValue(paths, 'fill', spectrumColors.light['gray-500'])).toBe(true);
 	});
 });

--- a/src/stories/ChartExamples/FeatureMatrix/data.ts
+++ b/src/stories/ChartExamples/FeatureMatrix/data.ts
@@ -124,3 +124,161 @@ export const multipleSegmentFeatureMatrixData = [
 		countAvg: 2.98,
 	},
 ];
+
+export const timeCompareFeatureMatrixData = [
+	{
+		event: 'Open-editor',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.1834,
+		countAvg: 1.62,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-express-home',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.2327,
+		countAvg: 2.66,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-quickaction-editor',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.0083,
+		countAvg: 2.95,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-image',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.0015,
+		countAvg: 2.84,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-text-effects',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.1277,
+		countAvg: 2.25,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Search-inspire',
+		segment: 'Day  1 Exporter',
+		dauPercent: 0.0563,
+		countAvg: 5.28,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Open-editor',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.1144,
+		countAvg: 3.75,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-express-home',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.1236,
+		countAvg: 0.84,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-quickaction-editor',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.1167,
+		countAvg: 2.27,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-image',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.0658,
+		countAvg: 2.4,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-text-effects',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.0172,
+		countAvg: 2.21,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Search-inspire',
+		segment: 'Non Day  1 Exporter',
+		dauPercent: 0.1049,
+		countAvg: 5.6,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Open-editor',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.1565,
+		countAvg: 6.68,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-express-home',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.0964,
+		countAvg: 4.22,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'View-quickaction-editor',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.0715,
+		countAvg: 1.59,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-image',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.0678,
+		countAvg: 2.5,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Generate-text-effects',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.0583,
+		countAvg: 0.75,
+		period: 'past',
+		trailSize: 0,
+	},
+	{
+		event: 'Search-inspire',
+		segment: 'Day 7 Exporter',
+		dauPercent: 0.1098,
+		countAvg: 3.98,
+		period: 'past',
+		trailSize: 0,
+	},
+	...multipleSegmentFeatureMatrixData.map((d) => ({ ...d, period: 'present', trailSize: 1 })),
+]
+	.sort((a, b) => {
+		if (a.event > b.event) return 1;
+		if (a.event < b.event) return -1;
+		return 0;
+	})
+	.sort((a, b) => {
+		if (a.segment > b.segment) return 1;
+		if (a.segment < b.segment) return -1;
+		return 0;
+	});

--- a/src/stories/ChartExamples/FeatureMatrix/data.ts
+++ b/src/stories/ChartExamples/FeatureMatrix/data.ts
@@ -132,7 +132,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1834,
 		countAvg: 1.62,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-express-home',
@@ -140,7 +140,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.2327,
 		countAvg: 2.66,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-quickaction-editor',
@@ -148,7 +148,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0083,
 		countAvg: 2.95,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-image',
@@ -156,7 +156,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0015,
 		countAvg: 2.84,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-text-effects',
@@ -164,7 +164,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1277,
 		countAvg: 2.25,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Search-inspire',
@@ -172,7 +172,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0563,
 		countAvg: 5.28,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Open-editor',
@@ -180,7 +180,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1144,
 		countAvg: 3.75,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-express-home',
@@ -188,7 +188,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1236,
 		countAvg: 0.84,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-quickaction-editor',
@@ -196,7 +196,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1167,
 		countAvg: 2.27,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-image',
@@ -204,7 +204,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0658,
 		countAvg: 2.4,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-text-effects',
@@ -212,7 +212,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0172,
 		countAvg: 2.21,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Search-inspire',
@@ -220,7 +220,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1049,
 		countAvg: 5.6,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Open-editor',
@@ -228,7 +228,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1565,
 		countAvg: 6.68,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-express-home',
@@ -236,7 +236,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0964,
 		countAvg: 4.22,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'View-quickaction-editor',
@@ -244,7 +244,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0715,
 		countAvg: 1.59,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-image',
@@ -252,7 +252,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0678,
 		countAvg: 2.5,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Generate-text-effects',
@@ -260,7 +260,7 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.0583,
 		countAvg: 0.75,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
 	{
 		event: 'Search-inspire',
@@ -268,9 +268,9 @@ export const timeCompareFeatureMatrixData = [
 		dauPercent: 0.1098,
 		countAvg: 3.98,
 		period: 'past',
-		trailSize: 0,
+		pathWidth: 0,
 	},
-	...multipleSegmentFeatureMatrixData.map((d) => ({ ...d, period: 'present', trailSize: 1 })),
+	...multipleSegmentFeatureMatrixData.map((d) => ({ ...d, period: 'present', pathWidth: 1 })),
 ]
 	.sort((a, b) => {
 		if (a.event > b.event) return 1;

--- a/src/stories/components/ScatterPath/ScatterPath.story.tsx
+++ b/src/stories/components/ScatterPath/ScatterPath.story.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React, { ReactElement } from 'react';
+
+import useChartProps from '@hooks/useChartProps';
+import { Axis, Chart, Legend, Scatter, ScatterPath, Title } from '@rsc';
+import { characterData } from '@stories/data/marioKartData';
+import { StoryFn } from '@storybook/react';
+import { bindWithProps } from '@test-utils';
+
+export default {
+	title: 'RSC/Scatter/ScatterPath',
+	component: ScatterPath,
+};
+
+const ScatterPathStory: StoryFn<typeof ScatterPath> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: characterData, height: 500, width: 500 });
+
+	return (
+		<Chart {...chartProps}>
+			<Axis position="bottom" grid ticks baseline title="Speed (normal)" />
+			<Axis position="left" grid ticks baseline title="Handling (normal)" />
+			<Scatter color="weightClass" dimension="speedNormal" metric="handlingNormal">
+				<ScatterPath {...args} />
+			</Scatter>
+			<Legend position="right" title="Weight class" highlight />
+			<Title text="Mario Kart 8 Character Data" />
+		</Chart>
+	);
+};
+
+const Basic = bindWithProps(ScatterPathStory);
+Basic.args = {};
+
+const Color = bindWithProps(ScatterPathStory);
+Color.args = {
+	color: 'red-900',
+};
+
+const GroupBy = bindWithProps(ScatterPathStory);
+GroupBy.args = {
+	groupBy: ['weight'],
+};
+
+const PathWidth = bindWithProps(ScatterPathStory);
+PathWidth.args = {
+	pathWidth: 'weight',
+};
+
+const Opacity = bindWithProps(ScatterPathStory);
+Opacity.args = {
+	opacity: 1,
+};
+
+export { Basic, Color, GroupBy, PathWidth, Opacity };

--- a/src/stories/components/ScatterPath/ScatterPath.story.tsx
+++ b/src/stories/components/ScatterPath/ScatterPath.story.tsx
@@ -51,14 +51,14 @@ GroupBy.args = {
 	groupBy: ['weight'],
 };
 
-const PathWidth = bindWithProps(ScatterPathStory);
-PathWidth.args = {
-	pathWidth: 'weight',
-};
-
 const Opacity = bindWithProps(ScatterPathStory);
 Opacity.args = {
 	opacity: 1,
 };
 
-export { Basic, Color, GroupBy, PathWidth, Opacity };
+const PathWidth = bindWithProps(ScatterPathStory);
+PathWidth.args = {
+	pathWidth: 'weight',
+};
+
+export { Basic, Color, GroupBy, Opacity, PathWidth };

--- a/src/stories/components/ScatterPath/ScatterPath.test.tsx
+++ b/src/stories/components/ScatterPath/ScatterPath.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React from 'react';
+
+import '@matchMediaMock';
+import { ScatterPath, spectrumColors } from '@rsc';
+import { characterData } from '@stories/data/marioKartData';
+import { allElementsHaveAttributeValue, findAllMarksByGroupName, findChart, render } from '@test-utils';
+
+import { Basic, Color, GroupBy, Opacity } from './ScatterPath.story';
+
+const colors = spectrumColors.light;
+
+describe('Link', () => {
+	// Link is not a real React component. This is test just provides test coverage for sonarqube
+	test('Link pseudo element', () => {
+		render(<ScatterPath groupBy={['test']} />);
+	});
+
+	test('Basic renders properly', async () => {
+		render(<Basic {...Basic.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const scatterPaths = await findAllMarksByGroupName(chart, 'scatter0Path0');
+		expect(scatterPaths).toHaveLength(3);
+		expect(allElementsHaveAttributeValue(scatterPaths, 'fill', colors['gray-500'])).toBe(true);
+		expect(allElementsHaveAttributeValue(scatterPaths, 'fill-opacity', 0.5)).toBe(true);
+	});
+
+	test('Color renders the correct color', async () => {
+		render(<Color {...Color.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const scatterPaths = await findAllMarksByGroupName(chart, 'scatter0Path0');
+		expect(allElementsHaveAttributeValue(scatterPaths, 'fill', colors['red-900'])).toBe(true);
+	});
+
+	test('GroupBy connects the correct points', async () => {
+		render(<GroupBy {...GroupBy.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		// count of how many unique weights there are
+		const uniqueWeights = characterData.filter(
+			(character, index, self) => self.findIndex((c) => c.weight === character.weight) === index
+		).length;
+
+		const scatterPaths = await findAllMarksByGroupName(chart, 'scatter0Path0');
+		expect(scatterPaths).toHaveLength(uniqueWeights);
+	});
+
+	test('Opacity renders correctly', async () => {
+		render(<Opacity {...Opacity.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const scatterPaths = await findAllMarksByGroupName(chart, 'scatter0Path0');
+		expect(allElementsHaveAttributeValue(scatterPaths, 'fill-opacity', 1)).toBe(true);
+	});
+});

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -30,6 +30,7 @@ export type ChartTooltipElement = ReactElement<ChartTooltipProps, JSXElementCons
 export type DonutElement = ReactElement<DonutProps, JSXElementConstructor<DonutProps>>;
 export type LegendElement = ReactElement<LegendProps, JSXElementConstructor<LegendProps>>;
 export type LineElement = ReactElement<LineProps, JSXElementConstructor<LineProps>>;
+export type ScatterPathElement = ReactElement<ScatterPathProps, JSXElementConstructor<ScatterPathProps>>;
 export type MetricRangeElement = ReactElement<MetricRangeProps, JSXElementConstructor<MetricRangeProps>>;
 export type ReferenceLineElement = ReactElement<ReferenceLineProps, JSXElementConstructor<ReferenceLineProps>>;
 export type ScatterElement = ReactElement<ScatterProps, JSXElementConstructor<ScatterProps>>;
@@ -278,7 +279,15 @@ export interface MarkProps extends BaseProps {
 
 export type StaticValue<T> = { value: T };
 
-export type FacetType = 'color' | 'linearColor' | 'lineType' | 'lineWidth' | 'opacity' | 'symbolShape' | 'symbolSize';
+export type FacetType =
+	| 'color'
+	| 'linearColor'
+	| 'lineType'
+	| 'lineWidth'
+	| 'opacity'
+	| 'symbolShape'
+	| 'symbolSize'
+	| 'symbolTrailSize';
 
 export type SecondaryFacetType =
 	| 'secondaryColor'
@@ -286,7 +295,8 @@ export type SecondaryFacetType =
 	| 'secondaryLineWidth'
 	| 'secondaryOpacity'
 	| 'secondarySymbolShape'
-	| 'secondarySymbolSize';
+	| 'secondarySymbolSize'
+	| 'secondarySymbolTrailSize';
 
 export type FacetRef<T> = string | StaticValue<T>;
 
@@ -294,6 +304,7 @@ export type ColorFacet = FacetRef<string | SpectrumColor>;
 export type LineTypeFacet = FacetRef<LineType>;
 export type LineWidthFacet = FacetRef<LineWidth>;
 export type OpacityFacet = FacetRef<number>;
+export type TrailSizeFacet = FacetRef<TrailSize>;
 export type SymbolShapeFacet = FacetRef<ChartSymbolShape>;
 
 export type DualFacet = [string, string]; // two keys used for a secondary facet on Bar charts
@@ -397,6 +408,17 @@ export interface ScatterProps extends Omit<MarkProps, 'color'> {
 	size?: SymbolSizeFacet;
 }
 
+export interface ScatterPathProps {
+	/** The color of the links.*/
+	color?: SpectrumColor | string;
+	/** The width on the links. Link width can vary by point. */
+	pathWidth?: TrailSizeFacet;
+	/** Data keys that should be used to create the groups that get connected by links. */
+	groupBy?: string[];
+	/** The opacity of the links. */
+	opacity?: number;
+}
+
 export type TitlePosition = 'start' | 'middle' | 'end';
 export type TitleOrient = 'top' | 'bottom' | 'left' | 'right';
 
@@ -436,6 +458,17 @@ export type LineType = 'solid' | 'dashed' | 'dotted' | 'dotDash' | 'shortDash' |
  * XL: 4px
  * */
 export type LineWidth = 'XS' | 'S' | 'M' | 'L' | 'XL' | number;
+
+/**
+ * Width of the trail in pixels
+ *
+ * XS: 6px,
+ * S: 8px,
+ * M: 10px,
+ * L: 12px,
+ * XL: 16px
+ * */
+export type TrailSize = 'XS' | 'S' | 'M' | 'L' | 'XL' | number;
 
 /**
  * Width of the symbol in pixels
@@ -668,6 +701,7 @@ export type MarkChildElement =
 	| AnnotationElement
 	| ChartTooltipElement
 	| ChartPopoverElement
+	| ScatterPathElement
 	| MetricRangeElement
 	| TrendlineElement;
 export type RscElement = ChartChildElement | MarkChildElement;

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -287,7 +287,7 @@ export type FacetType =
 	| 'opacity'
 	| 'symbolShape'
 	| 'symbolSize'
-	| 'symbolTrailSize';
+	| 'symbolPathWidth';
 
 export type SecondaryFacetType =
 	| 'secondaryColor'
@@ -296,7 +296,7 @@ export type SecondaryFacetType =
 	| 'secondaryOpacity'
 	| 'secondarySymbolShape'
 	| 'secondarySymbolSize'
-	| 'secondarySymbolTrailSize';
+	| 'secondarySymbolPathWidth';
 
 export type FacetRef<T> = string | StaticValue<T>;
 
@@ -304,7 +304,7 @@ export type ColorFacet = FacetRef<string | SpectrumColor>;
 export type LineTypeFacet = FacetRef<LineType>;
 export type LineWidthFacet = FacetRef<LineWidth>;
 export type OpacityFacet = FacetRef<number>;
-export type TrailSizeFacet = FacetRef<TrailSize>;
+export type PathWidthFacet = FacetRef<PathWidth>;
 export type SymbolShapeFacet = FacetRef<ChartSymbolShape>;
 
 export type DualFacet = [string, string]; // two keys used for a secondary facet on Bar charts
@@ -412,7 +412,7 @@ export interface ScatterPathProps {
 	/** The color of the links.*/
 	color?: SpectrumColor | string;
 	/** The width on the links. Link width can vary by point. */
-	pathWidth?: TrailSizeFacet;
+	pathWidth?: PathWidthFacet;
 	/** Data keys that should be used to create the groups that get connected by links. */
 	groupBy?: string[];
 	/** The opacity of the links. */
@@ -468,7 +468,7 @@ export type LineWidth = 'XS' | 'S' | 'M' | 'L' | 'XL' | number;
  * L: 12px,
  * XL: 16px
  * */
-export type TrailSize = 'XS' | 'S' | 'M' | 'L' | 'XL' | number;
+export type PathWidth = 'XS' | 'S' | 'M' | 'L' | 'XL' | number;
 
 /**
  * Width of the symbol in pixels

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -28,6 +28,7 @@ import {
 	MetricRangeProps,
 	Orientation,
 	ScaleType as RscScaleType,
+	ScatterPathProps,
 	ScatterProps,
 	TrendlineAnnotationProps,
 	TrendlineChildElement,
@@ -157,6 +158,17 @@ export interface ScatterSpecProps extends PartiallyRequired<ScatterProps, Scatte
 	colorScheme: ColorScheme;
 	index: number;
 	interactiveMarkName: string | undefined;
+}
+
+type ScatterPathPropsWithDefaults = 'color' | 'groupBy' | 'pathWidth' | 'opacity';
+
+export interface ScatterPathSpecProps extends PartiallyRequired<ScatterPathProps, ScatterPathPropsWithDefaults> {
+	colorScheme: ColorScheme;
+	dimension: string;
+	dimensionScaleType: RscScaleType;
+	metric: string;
+	index: number;
+	name: string;
 }
 
 type MetricRangePropsWithDefaults = 'lineType' | 'lineWidth' | 'rangeOpacity' | 'metricEnd' | 'metricStart' | 'metric';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new advanced scatter component called `<ScatterPath/>`. This can be used to draw paths that connect points based off some grouping.

Supported features:

* `color`
* `groupBy`
* `opacity`
* `pathWidth`
  * Can vary at each connecting point

## Motivation and Context

Need to be able to show a visual connection between points on a scatter plot

## Stories
Chart > Examples > TimeCompareFeatureMatrix
Scatter > ScatterPath > *

## Screenshots (if appropriate):
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/43f8bd50-01f1-4b6f-866f-951b969c881d)
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/0351006b-a62a-478d-90ed-44ea6e74c13e)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
