### PR TITLE
fix: short currency wasn't displaying as currency under

### DIFF
--- a/src/specBuilder/axis/axisLabelUtils.test.ts
+++ b/src/specBuilder/axis/axisLabelUtils.test.ts
@@ -192,19 +192,19 @@ describe('getLabelFormat()', () => {
 
 describe('getLabelNumberFormat()', () => {
 	test('should return correct signal for shortNumber', () => {
-		expect(getLabelNumberFormat('shortNumber')).toHaveProperty(
-			'signal',
-			"upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))"
-		);
+		const format = getLabelNumberFormat('shortNumber');
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))");
 	});
 	test('should return correct signal for shortCurrency', () => {
-		expect(getLabelNumberFormat('shortCurrency')).toHaveProperty(
-			'signal',
-			"upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))"
-		);
+		const format = getLabelNumberFormat('shortCurrency');
+		expect(format).toHaveLength(2);
+		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))");
 	});
 	test('should return correct signal for string specifier', () => {
 		const numberFormat = '.2f';
-		expect(getLabelNumberFormat(numberFormat)).toHaveProperty('signal', `format(datum.value, '${numberFormat}')`);
+		const format = getLabelNumberFormat(numberFormat);
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', `format(datum.value, '${numberFormat}')`);
 	});
 });

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -243,7 +243,7 @@ export const getLabelFormat = (
 	}
 
 	return [
-		getLabelNumberFormat(numberFormat),
+		...getLabelNumberFormat(numberFormat),
 		...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
 			? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
 			: [{ signal: 'datum.value' }]),
@@ -257,24 +257,32 @@ export const getLabelFormat = (
  */
 export const getLabelNumberFormat = (
 	numberFormat: NumberFormat | string
-): {
+): ({
 	test?: string;
-} & TextValueRef => {
-	const defaultTest = 'isNumber(datum.value)';
+} & TextValueRef)[] => {
+	const test = 'isNumber(datum.value)';
 	if (numberFormat === 'shortNumber') {
-		return {
-			test: `${defaultTest} && abs(datum.value) >= 1000`,
-			signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
-		};
+		return [
+			{
+				test: `${test} && abs(datum.value) >= 1000`,
+				signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
+			},
+		];
 	}
 	if (numberFormat === 'shortCurrency') {
-		return {
-			test: `${defaultTest} && abs(datum.value) >= 1000`,
-			signal: "upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))",
-		};
+		return [
+			{
+				test: `${test} && abs(datum.value) >= 1000`,
+				signal: "upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))",
+			},
+			{
+				test,
+				signal: "format(datum.value, '$')",
+			},
+		];
 	}
 	const d3FormatSpecifier = getD3FormatSpecifierFromNumberFormat(numberFormat);
-	return { test: defaultTest, signal: `format(datum.value, '${d3FormatSpecifier}')` };
+	return [{ test, signal: `format(datum.value, '${d3FormatSpecifier}')` }];
 };
 
 /**

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -191,6 +191,15 @@ describe('Axis', () => {
 			expect(screen.getByText('$2M')).toBeInTheDocument();
 			expect(screen.getByText('$500K')).toBeInTheDocument();
 		});
+		test('shortCurrency with small range', async () => {
+			render(<NumberFormat {...NumberFormat.args} numberFormat="shortCurrency" range={[0, 0.1]} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			expect(screen.getByText('$0.1')).toBeInTheDocument();
+			expect(screen.getByText('$0.05')).toBeInTheDocument();
+			expect(screen.getByText('$0')).toBeInTheDocument();
+		});
 		test('shortNumber', async () => {
 			render(<NumberFormat {...NumberFormat.args} numberFormat="shortNumber" />);
 			const chart = await findChart();

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -197,7 +197,6 @@ describe('Axis', () => {
 			expect(chart).toBeInTheDocument();
 
 			expect(screen.getByText('$0.1')).toBeInTheDocument();
-			expect(screen.getByText('$0.05')).toBeInTheDocument();
 			expect(screen.getByText('$0')).toBeInTheDocument();
 		});
 		test('shortNumber', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currency values under $1000 were not displayed as currency when using `shortCurrency`. This fixes that.

## Screenshots (if appropriate):

<img width="124" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/24c04378-46e1-4d7f-be3d-f7d1be290c1c">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
