### PR TITLE
Change animation duration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,5 +91,5 @@ export const MS_PER_DAY = 86400000;
 
 // chart animation constants
 export const DATA_ANIMATION_DURATION_FRAMES = 78; // 60 fps * 1.3 seconds = 78 frames
-export const DATA_ANIMATION_MILLISECONDS_PER_FRAME = 1 / 60; // 60fps
+export const DATA_ANIMATION_MILLISECONDS_PER_FRAME = 1000 / 60; // 60fps
 export const EASE_OUT_CUBIC = '(1 - pow(1 - timerValue, 3))';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,5 +89,7 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 // time constants
 export const MS_PER_DAY = 86400000;
 
-// chart animation easing functions
+// chart animation constants
+export const DATA_ANIMATION_DURATION_FRAMES = 78; // 60 fps * 1.3 seconds = 78 frames
+export const DATA_ANIMATION_MILLISECONDS_PER_FRAME = 16.6666666666666667; // 1 / 60, which is 60fps
 export const EASE_OUT_CUBIC = '(1 - pow(1 - timerValue, 3))';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,5 +91,5 @@ export const MS_PER_DAY = 86400000;
 
 // chart animation constants
 export const DATA_ANIMATION_DURATION_FRAMES = 78; // 60 fps * 1.3 seconds = 78 frames
-export const DATA_ANIMATION_MILLISECONDS_PER_FRAME = 16.6666666666666667; // 1 / 60, which is 60fps
+export const DATA_ANIMATION_MILLISECONDS_PER_FRAME = 1 / 60; // 60fps
 export const EASE_OUT_CUBIC = '(1 - pow(1 - timerValue, 3))';

--- a/src/specBuilder/chartSpecBuilder.test.ts
+++ b/src/specBuilder/chartSpecBuilder.test.ts
@@ -16,6 +16,8 @@ import { Legend } from '@components/Legend';
 import {
 	BACKGROUND_COLOR,
 	COLOR_SCALE,
+	DATA_ANIMATION_DURATION_FRAMES,
+	DATA_ANIMATION_MILLISECONDS_PER_FRAME,
 	DEFAULT_BACKGROUND_COLOR,
 	DEFAULT_COLOR,
 	DEFAULT_SECONDARY_COLOR,
@@ -445,7 +447,7 @@ describe('Chart spec builder', () => {
 			{
 				name: 'timerValue',
 				value: '0',
-				on: [{ events: 'timer{16}', update: 'min(1, timerValue + (1 / 60))' }],
+				on: [{ events: `timer{${DATA_ANIMATION_MILLISECONDS_PER_FRAME}}`, update: `min(1, timerValue + (1 / ${DATA_ANIMATION_DURATION_FRAMES}))` }],
 			},
 			{ name: BACKGROUND_COLOR, value: 'rgb(255, 255, 255)' },
 			{

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -11,6 +11,8 @@
  */
 import {
 	BACKGROUND_COLOR,
+	DATA_ANIMATION_DURATION_FRAMES,
+	DATA_ANIMATION_MILLISECONDS_PER_FRAME,
 	DEFAULT_BACKGROUND_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_LINE_TYPES,
@@ -258,7 +260,7 @@ export const getTimer = () => {
 	return {
 		name: 'timerValue',
 		value: '0',
-		on: [{ events: 'timer{16}', update: 'min(1, timerValue + (1 / 60))' }],
+		on: [{ events: `timer{${DATA_ANIMATION_MILLISECONDS_PER_FRAME}}`, update: `min(1, timerValue + (1 / ${DATA_ANIMATION_DURATION_FRAMES}))` }],
 	};
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Increase animation duration according to feedback.  Also refactor timer magic numbers into constants.

All tests related to this feature pass.  One Trellis bar test fails due to unrelated error

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://github.com/adobe/react-spectrum-charts/assets/20342122/5d53451e-50b1-488c-8387-043179d5133b



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
