### PR TITLE
Ability to disable tooltip for chart data based on key

### DIFF
--- a/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/src/components/ChartTooltip/ChartTooltip.tsx
@@ -14,7 +14,7 @@ import { FC } from 'react';
 import { ChartTooltipProps } from '../../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ChartTooltip: FC<ChartTooltipProps> = ({ children, excludeDataKey }) => {
+const ChartTooltip: FC<ChartTooltipProps> = ({ children, excludeDataKeys: excludeDataKey }) => {
 	return null;
 };
 

--- a/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/src/components/ChartTooltip/ChartTooltip.tsx
@@ -14,7 +14,7 @@ import { FC } from 'react';
 import { ChartTooltipProps } from '../../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ChartTooltip: FC<ChartTooltipProps> = ({ children }) => {
+const ChartTooltip: FC<ChartTooltipProps> = ({ children, excludeDataKey }) => {
 	return null;
 };
 

--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -205,6 +205,15 @@ describe('areaSpecBuilder', () => {
 			expect(signals[3]).toHaveProperty('name', SELECTED_SERIES);
 			expect(signals[4]).toHaveProperty('name', 'area0_controlledHoveredId');
 		});
+
+		test('should exclude data with key from update if tooltip has excludeDataKey', () => {
+			const tooltip = createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' });
+			const signals = addSignals(defaultSignals, { ...defaultAreaProps, children: [tooltip] });
+			expect(signals).toHaveLength(5);
+			expect(signals[1]).toHaveProperty('name', HIGHLIGHTED_SERIES);
+			expect(signals[1].on?.[0]).toHaveProperty('events', '@area0:mouseover');
+			expect(signals[1].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscSeriesId');
+		});
 	});
 
 	describe('setScales()', () => {

--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -207,12 +207,12 @@ describe('areaSpecBuilder', () => {
 		});
 
 		test('should exclude data with key from update if tooltip has excludeDataKey', () => {
-			const tooltip = createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' });
+			const tooltip = createElement(ChartTooltip, { excludeDataKeys: ['excludeFromTooltip'] });
 			const signals = addSignals(defaultSignals, { ...defaultAreaProps, children: [tooltip] });
 			expect(signals).toHaveLength(5);
 			expect(signals[1]).toHaveProperty('name', HIGHLIGHTED_SERIES);
 			expect(signals[1].on?.[0]).toHaveProperty('events', '@area0:mouseover');
-			expect(signals[1].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscSeriesId');
+			expect(signals[1].on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum.rscSeriesId');
 		});
 	});
 

--- a/src/specBuilder/area/areaSpecBuilder.ts
+++ b/src/specBuilder/area/areaSpecBuilder.ts
@@ -36,6 +36,7 @@ import { Data, Mark, Scale, Signal, Spec } from 'vega';
 import { addTimeTransform, getFilteredTableData, getTableData, getTransformSort } from '../data/dataUtils';
 import { addContinuousDimensionScale, addFieldToFacetScaleDomain, addMetricScale } from '../scale/scaleSpecBuilder';
 import { getAreaMark, getX } from './areaUtils';
+import { getTooltipProps } from '@specBuilder/marks/markUtils';
 
 export const addArea = produce<Spec, [AreaProps & { colorScheme?: ColorScheme; index?: number }]>(
 	(
@@ -146,7 +147,7 @@ export const addSignals = produce<Signal[], [AreaSpecProps]>((signals, { childre
 	if (!hasSignalByName(signals, `${name}_controlledHoveredId`)) {
 		signals.push(getControlledHoverSignal(name));
 	}
-	addHighlightedSeriesSignalEvents(signals, name);
+	addHighlightedSeriesSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
 });
 
 export const setScales = produce<Scale[], [AreaSpecProps]>(

--- a/src/specBuilder/area/areaSpecBuilder.ts
+++ b/src/specBuilder/area/areaSpecBuilder.ts
@@ -147,7 +147,7 @@ export const addSignals = produce<Signal[], [AreaSpecProps]>((signals, { childre
 	if (!hasSignalByName(signals, `${name}_controlledHoveredId`)) {
 		signals.push(getControlledHoverSignal(name));
 	}
-	addHighlightedSeriesSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
+	addHighlightedSeriesSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKeys);
 });
 
 export const setScales = produce<Scale[], [AreaSpecProps]>(

--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -241,6 +241,13 @@ describe('barSpecBuilder', () => {
 			expect(signals[0].on).toHaveLength(2);
 			expect(signals[0].on?.[0]).toHaveProperty('events', '@bar0:mouseover');
 		});
+		test('should exclude data with key from update if tooltip has excludeDataKey', () => {
+			const signals = addSignals(defaultSignals, { ...defaultBarProps, children: [createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })] });
+			expect(signals[0]).toHaveProperty('on');
+			expect(signals[0].on).toHaveLength(2);
+			expect(signals[0].on?.[0]).toHaveProperty('events', '@bar0:mouseover');
+			expect(signals[0].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+		});
 	});
 
 	describe('addScales()', () => {

--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -242,11 +242,11 @@ describe('barSpecBuilder', () => {
 			expect(signals[0].on?.[0]).toHaveProperty('events', '@bar0:mouseover');
 		});
 		test('should exclude data with key from update if tooltip has excludeDataKey', () => {
-			const signals = addSignals(defaultSignals, { ...defaultBarProps, children: [createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })] });
+			const signals = addSignals(defaultSignals, { ...defaultBarProps, children: [createElement(ChartTooltip, { excludeDataKeys: ['excludeFromTooltip'] })] });
 			expect(signals[0]).toHaveProperty('on');
 			expect(signals[0].on).toHaveLength(2);
 			expect(signals[0].on?.[0]).toHaveProperty('events', '@bar0:mouseover');
-			expect(signals[0].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+			expect(signals[0].on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum.rscMarkId');
 		});
 	});
 

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -102,7 +102,7 @@ export const addSignals = produce<Signal[], [BarSpecProps]>(
 		if (!children.length) {
 			return;
 		}
-		addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
+		addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKeys);
 	}
 );
 

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -42,6 +42,7 @@ import { getBarPadding, getScaleValues, isDodgedAndStacked } from './barUtils';
 import { getDodgedMark } from './dodgedBarUtils';
 import { getDodgedAndStackedBarMark, getStackedBarMarks } from './stackedBarUtils';
 import { addTrellisScale, getTrellisGroupMark, isTrellised } from './trellisedBarUtils';
+import { getTooltipProps } from '@specBuilder/marks/markUtils';
 
 export const addBar = produce<Spec, [BarProps & { colorScheme?: ColorScheme; index?: number }]>(
 	(
@@ -101,7 +102,7 @@ export const addSignals = produce<Signal[], [BarSpecProps]>(
 		if (!children.length) {
 			return;
 		}
-		addHighlightedItemSignalEvents(signals, name);
+		addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
 	}
 );
 

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -72,15 +72,11 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
  */
 export const getFilteredTooltipData = (children: MarkChildElement[]) => {
 	let transform: { type: 'filter'; expr: string }[] | undefined;
-	const excludeDataKey = getTooltipProps(children)?.excludeDataKey;
-	if (excludeDataKey) {
-		transform = [
-			{
-			  type: 'filter',
-			  expr: `!datum.${excludeDataKey}`
-			}
-		];
-	}
+	const excludeDataKeys = getTooltipProps(children)?.excludeDataKeys;
+	transform = excludeDataKeys?.map((excludeDataKey) => ({
+		type: 'filter',
+		expr: `!datum.${excludeDataKey}`
+	}));
 
 	return {
 		name: `${FILTERED_TABLE}ForTooltip`,

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ChartTooltip } from '@components/index';
 import {
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
@@ -17,8 +16,9 @@ import {
 	SERIES_ID,
 	TABLE,
 } from '@constants';
+import { getTooltipProps } from '@specBuilder/marks/markUtils';
 import { produce } from 'immer';
-import { ChartTooltipProps, MarkChildElement } from 'types';
+import { MarkChildElement } from 'types';
 import { Compare, Data, FormulaTransform, SourceData, Transforms, ValuesData } from 'vega';
 
 export const addTimeTransform = produce<Transforms[], [string]>((transforms, dimension) => {
@@ -67,18 +67,13 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
 };
 
 /**
- * 
- * @param name the name of the component, i.e. `scatter0`
  * @param children 
  * @returns spec data that filters out items where the `excludeDataKey` is true
  */
 export const getFilteredTooltipData = (children: MarkChildElement[]) => {
-	const tooltipElement = children.find((child) => child.type === ChartTooltip && (child.props as ChartTooltipProps).excludeDataKey); 
-	const tooltipProps = tooltipElement?.props as ChartTooltipProps | undefined;
-
 	let transform: { type: 'filter'; expr: string }[] | undefined;
-	if (tooltipProps?.excludeDataKey) {
-		const excludeDataKey = tooltipProps.excludeDataKey;
+	const excludeDataKey = getTooltipProps(children)?.excludeDataKey;
+	if (excludeDataKey) {
 		transform = [
 			{
 			  type: 'filter',

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -72,7 +72,7 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
  * @param children 
  * @returns spec data that filters out items where the `excludeDataKey` is true
  */
-export const getFilteredTooltipData = (name: string, children: MarkChildElement[]) => {
+export const getFilteredTooltipData = (children: MarkChildElement[]) => {
 	const tooltipElement = children.find((child) => child.type === ChartTooltip && (child.props as ChartTooltipProps).excludeDataKey); 
 	const tooltipProps = tooltipElement?.props as ChartTooltipProps | undefined;
 

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -72,7 +72,7 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
  */
 export const getFilteredTooltipData = (children: MarkChildElement[]) => {
 	const excludeDataKeys = getTooltipProps(children)?.excludeDataKeys;
-	const transform = excludeDataKeys?.map((excludeDataKey) => ({
+	const transform: { type: 'filter'; expr: string }[] | undefined = excludeDataKeys?.map((excludeDataKey) => ({
 		type: 'filter',
 		expr: `!datum.${excludeDataKey}`
 	}));

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { ChartTooltip } from '@components/index';
 import {
 	DEFAULT_TIME_DIMENSION,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
@@ -17,6 +18,7 @@ import {
 	TABLE,
 } from '@constants';
 import { produce } from 'immer';
+import { ChartTooltipProps, MarkChildElement } from 'types';
 import { Compare, Data, FormulaTransform, SourceData, Transforms, ValuesData } from 'vega';
 
 export const addTimeTransform = produce<Transforms[], [string]>((transforms, dimension) => {
@@ -61,5 +63,33 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
 		type: 'formula',
 		as: SERIES_ID,
 		expr,
+	};
+};
+
+/**
+ * 
+ * @param name the name of the component, i.e. `scatter0`
+ * @param children 
+ * @returns spec data that filters out items where the `excludeDataKey` is true
+ */
+export const getFilteredTooltipData = (name: string, children: MarkChildElement[]) => {
+	const tooltipElement = children.find((child) => child.type === ChartTooltip && (child.props as ChartTooltipProps).excludeDataKey); 
+	const tooltipProps = tooltipElement?.props as ChartTooltipProps | undefined;
+
+	let transform: { type: 'filter'; expr: string }[] | undefined;
+	if (tooltipProps?.excludeDataKey) {
+		const excludeDataKey = tooltipProps.excludeDataKey;
+		transform = [
+			{
+			  type: 'filter',
+			  expr: `!datum.${excludeDataKey}`
+			}
+		];
+	}
+
+	return {
+		name: `${name}_${FILTERED_TABLE}`,
+		source: FILTERED_TABLE,
+		transform,
 	};
 };

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -88,7 +88,7 @@ export const getFilteredTooltipData = (name: string, children: MarkChildElement[
 	}
 
 	return {
-		name: `${name}_${FILTERED_TABLE}`,
+		name: `${FILTERED_TABLE}ForTooltip`,
 		source: FILTERED_TABLE,
 		transform,
 	};

--- a/src/specBuilder/data/dataUtils.ts
+++ b/src/specBuilder/data/dataUtils.ts
@@ -71,9 +71,8 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform => {
  * @returns spec data that filters out items where the `excludeDataKey` is true
  */
 export const getFilteredTooltipData = (children: MarkChildElement[]) => {
-	let transform: { type: 'filter'; expr: string }[] | undefined;
 	const excludeDataKeys = getTooltipProps(children)?.excludeDataKeys;
-	transform = excludeDataKeys?.map((excludeDataKey) => ({
+	const transform = excludeDataKeys?.map((excludeDataKey) => ({
 		type: 'filter',
 		expr: `!datum.${excludeDataKey}`
 	}));

--- a/src/specBuilder/donut/donutSpecBuilder.test.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.test.ts
@@ -180,6 +180,15 @@ describe('addSignals()', () => {
 		expect(signals[0].on?.[0]).toHaveProperty('events', '@testName:mouseover');
 		expect(signals[0].on?.[1]).toHaveProperty('events', '@testName:mouseout');
 	});
+	test('should exclude data with key from update if tooltip has excludeDataKey', () => {
+		const signals = addSignals(defaultSignals, { ...defaultDonutProps, children: [createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })] });
+		expect(signals).toHaveLength(4);
+		expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
+		expect(signals[0].on).toHaveLength(2);
+		expect(signals[0].on?.[0]).toHaveProperty('events', '@testName:mouseover');
+		expect(signals[0].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+		expect(signals[0].on?.[1]).toHaveProperty('events', '@testName:mouseout');
+	});
 });
 
 describe('donutSpecBuilder', () => {

--- a/src/specBuilder/donut/donutSpecBuilder.test.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.test.ts
@@ -181,12 +181,12 @@ describe('addSignals()', () => {
 		expect(signals[0].on?.[1]).toHaveProperty('events', '@testName:mouseout');
 	});
 	test('should exclude data with key from update if tooltip has excludeDataKey', () => {
-		const signals = addSignals(defaultSignals, { ...defaultDonutProps, children: [createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })] });
+		const signals = addSignals(defaultSignals, { ...defaultDonutProps, children: [createElement(ChartTooltip, { excludeDataKeys: ['excludeFromTooltip'] })] });
 		expect(signals).toHaveLength(4);
 		expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
 		expect(signals[0].on).toHaveLength(2);
 		expect(signals[0].on?.[0]).toHaveProperty('events', '@testName:mouseover');
-		expect(signals[0].on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+		expect(signals[0].on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum.rscMarkId');
 		expect(signals[0].on?.[1]).toHaveProperty('events', '@testName:mouseout');
 	});
 });

--- a/src/specBuilder/donut/donutSpecBuilder.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.ts
@@ -132,5 +132,5 @@ export const addMarks = produce<Mark[], [DonutSpecProps]>((marks, props) => {
 export const addSignals = produce<Signal[], [DonutSpecProps]>((signals, props) => {
 	const { name, children } = props;
 	if (!hasInteractiveChildren(children)) return;
-	addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
+	addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKeys);
 });

--- a/src/specBuilder/donut/donutSpecBuilder.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { COLOR_SCALE, DEFAULT_COLOR, DEFAULT_COLOR_SCHEME, DEFAULT_METRIC, FILTERED_TABLE } from '@constants';
-import { hasInteractiveChildren } from '@specBuilder/marks/markUtils';
+import { getTooltipProps, hasInteractiveChildren } from '@specBuilder/marks/markUtils';
 import { addFieldToFacetScaleDomain } from '@specBuilder/scale/scaleSpecBuilder';
 import { addHighlightedItemSignalEvents } from '@specBuilder/signal/signalSpecBuilder';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
@@ -132,5 +132,5 @@ export const addMarks = produce<Mark[], [DonutSpecProps]>((marks, props) => {
 export const addSignals = produce<Signal[], [DonutSpecProps]>((signals, props) => {
 	const { name, children } = props;
 	if (!hasInteractiveChildren(children)) return;
-	addHighlightedItemSignalEvents(signals, name);
+	addHighlightedItemSignalEvents(signals, name, 1, getTooltipProps(children)?.excludeDataKey);
 });

--- a/src/specBuilder/line/lineMarkUtils.ts
+++ b/src/specBuilder/line/lineMarkUtils.ts
@@ -22,7 +22,7 @@ import {
 	hasPopover,
 } from '@specBuilder/marks/markUtils';
 import { ScaleType } from 'types';
-import { LineMark, Mark, NumericValueRef, ProductionRule, RuleMark, SymbolMark } from 'vega';
+import { LineMark, Mark, NumericValueRef, ProductionRule, RuleMark } from 'vega';
 
 import {
 	getHighlightBackgroundPoint,

--- a/src/specBuilder/line/lineMarkUtils.ts
+++ b/src/specBuilder/line/lineMarkUtils.ts
@@ -15,6 +15,7 @@ import {
 	getHighlightOpacityValue,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
+	getPointsForVoronoi,
 	getStrokeDashProductionRule,
 	getVoronoiPath,
 	getXProductionRule,
@@ -131,31 +132,6 @@ const getHoverRule = (dimension: string, name: string, scaleType: ScaleType): Ru
 				y: { value: 0 },
 				y2: { signal: 'height' },
 				strokeWidth: { value: 1 },
-			},
-			update: {
-				x: getXProductionRule(scaleType, dimension),
-			},
-		},
-	};
-};
-
-const getPointsForVoronoi = (
-	dataSource: string,
-	dimension: string,
-	metric: string,
-	name: string,
-	scaleType: ScaleType
-): SymbolMark => {
-	return {
-		name: `${name}_pointsForVoronoi`,
-		type: 'symbol',
-		from: { data: dataSource },
-		interactive: false,
-		encode: {
-			enter: {
-				y: { scale: 'yLinear', field: metric },
-				fill: { value: 'transparent' },
-				stroke: { value: 'transparent' },
 			},
 			update: {
 				x: getXProductionRule(scaleType, dimension),

--- a/src/specBuilder/line/lineSpecBuilder.ts
+++ b/src/specBuilder/line/lineSpecBuilder.ts
@@ -93,7 +93,7 @@ export const addData = produce<Data[], [LineSpecProps]>((data, props) => {
 	}
 	if (hasInteractiveChildren(children)) {
 		data.push(getLineHighlightedData(name, FILTERED_TABLE, hasPopover(children)));
-		data.push(getFilteredTooltipData(name, children));
+		data.push(getFilteredTooltipData(children));
 	}
 	if (staticPoint) data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE));
 	addTrendlineData(data, props);

--- a/src/specBuilder/line/lineSpecBuilder.ts
+++ b/src/specBuilder/line/lineSpecBuilder.ts
@@ -148,7 +148,7 @@ export const addLineMarks = produce<Mark[], [LineSpecProps]>((marks, props) => {
 	if (staticPoint) marks.push(getLineStaticPoint(props));
 	marks.push(...getMetricRangeGroupMarks(props));
 	if (hasInteractiveChildren(children)) {
-		marks.push(...getLineHoverMarks(props, `${name}_${FILTERED_TABLE}`));
+		marks.push(...getLineHoverMarks(props, `${FILTERED_TABLE}ForTooltip`));
 	}
 	marks.push(...getTrendlineMarks(props));
 });

--- a/src/specBuilder/line/lineSpecBuilder.ts
+++ b/src/specBuilder/line/lineSpecBuilder.ts
@@ -32,7 +32,7 @@ import { produce } from 'immer';
 import { ColorScheme, LineProps, LineSpecProps, MarkChildElement } from 'types';
 import { Data, Mark, Scale, Signal, Spec } from 'vega';
 
-import { addTimeTransform, getTableData } from '../data/dataUtils';
+import { addTimeTransform, getFilteredTooltipData, getTableData } from '../data/dataUtils';
 import { addContinuousDimensionScale, addFieldToFacetScaleDomain, addMetricScale } from '../scale/scaleSpecBuilder';
 import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents } from '../signal/signalSpecBuilder';
 import { getLineHighlightedData, getLineStaticPointData } from './lineDataUtils';
@@ -93,6 +93,7 @@ export const addData = produce<Data[], [LineSpecProps]>((data, props) => {
 	}
 	if (hasInteractiveChildren(children)) {
 		data.push(getLineHighlightedData(name, FILTERED_TABLE, hasPopover(children)));
+		data.push(getFilteredTooltipData(name, children));
 	}
 	if (staticPoint) data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE));
 	addTrendlineData(data, props);
@@ -147,7 +148,7 @@ export const addLineMarks = produce<Mark[], [LineSpecProps]>((marks, props) => {
 	if (staticPoint) marks.push(getLineStaticPoint(props));
 	marks.push(...getMetricRangeGroupMarks(props));
 	if (hasInteractiveChildren(children)) {
-		marks.push(...getLineHoverMarks(props, FILTERED_TABLE));
+		marks.push(...getLineHoverMarks(props, `${name}_${FILTERED_TABLE}`));
 	}
 	marks.push(...getTrendlineMarks(props));
 });

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -169,13 +169,13 @@ describe('getTooltip()', () => {
 		expect(rule.signal).toContain('datum.datum');
 	});
 	test('should add condition test when excludeDataKey is present', () => {
-		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })], 'line0', false) as ProductionRuleTests<SignalRef>;
+		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKeys: ['excludeFromTooltip'] })], 'line0', false) as ProductionRuleTests<SignalRef>;
 		expect(rule).toHaveLength(2);
 		expect(rule[0].test).toBe('datum.excludeFromTooltip');
 		expect(rule[0].signal).toBe('false');
 	});
 	test('should have default tooltip as second item when excludeDataKey is present', () => {
-		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })], 'line0', false) as ProductionRuleTests<SignalRef>;
+		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKeys: ['excludeFromTooltip'] })], 'line0', false) as ProductionRuleTests<SignalRef>;
 		expect(rule).toHaveLength(2);
 		expect(rule[1]).toHaveProperty('signal');
 	});

--- a/src/specBuilder/marks/markUtils.test.ts
+++ b/src/specBuilder/marks/markUtils.test.ts
@@ -43,6 +43,8 @@ import {
 	hasMetricRange,
 	hasTooltip,
 } from './markUtils';
+import { SignalRef } from 'vega';
+import { ProductionRuleTests } from 'types';
 
 describe('getColorProductionRule', () => {
 	test('should return scale reference if color is a string', () => {
@@ -163,8 +165,19 @@ describe('getTooltip()', () => {
 		expect(rule).toHaveProperty('signal');
 	});
 	test('should reference a nested datum if nestedDatum is true', () => {
-		const rule = getTooltip([createElement(ChartTooltip)], 'line0', true);
-		expect(rule?.signal).toContain('datum.datum');
+		const rule = getTooltip([createElement(ChartTooltip)], 'line0', true) as SignalRef;
+		expect(rule.signal).toContain('datum.datum');
+	});
+	test('should add condition test when excludeDataKey is present', () => {
+		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })], 'line0', false) as ProductionRuleTests<SignalRef>;
+		expect(rule).toHaveLength(2);
+		expect(rule[0].test).toBe('datum.excludeFromTooltip');
+		expect(rule[0].signal).toBe('false');
+	});
+	test('should have default tooltip as second item when excludeDataKey is present', () => {
+		const rule = getTooltip([createElement(ChartTooltip, { excludeDataKey: 'excludeFromTooltip' })], 'line0', false) as ProductionRuleTests<SignalRef>;
+		expect(rule).toHaveLength(2);
+		expect(rule[1]).toHaveProperty('signal');
 	});
 });
 

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -54,6 +54,7 @@ import {
 	PathMark,
 	ScaledValueRef,
 	SignalRef,
+	SymbolMark,
 } from 'vega';
 
 /**
@@ -239,6 +240,40 @@ export const getXProductionRule = (scaleType: ScaleType, dimension: string): Num
 		return { scale, field: DEFAULT_TRANSFORMED_TIME_DIMENSION };
 	}
 	return { scale, field: dimension };
+};
+
+/**
+ * Gets the points used for the voronoi calculation
+ * @param dataSource the name of the data source that will be used in the voronoi calculation
+ * @param dimension the dimension for the x encoding
+ * @param metric the metric for the y encoding
+ * @param name the name of the component the voronoi is associated with, i.e. `scatter0`
+ * @param scaleType the scale type for the x encoding
+ * @returns SymbolMark
+ */
+export const getPointsForVoronoi = (
+	dataSource: string,
+	dimension: string,
+	metric: string,
+	name: string,
+	scaleType: ScaleType
+): SymbolMark => {
+	return {
+		name: `${name}_pointsForVoronoi`,
+		type: 'symbol',
+		from: { data: dataSource },
+		interactive: false,
+		encode: {
+			enter: {
+				y: { scale: 'yLinear', field: metric },
+				fill: { value: 'transparent' },
+				stroke: { value: 'transparent' },
+			},
+			update: {
+				x: getXProductionRule(scaleType, dimension),
+			},
+		},
+	};
 };
 
 /**

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -85,9 +85,9 @@ export function getTooltip(children: MarkChildElement[], name: string, nestedDat
 	if (hasTooltip(children)) {
 		const defaultTooltip = { signal: `merge(datum${nestedDatum ? '.datum' : ''}, {'rscComponentName': '${name}'})` };
 		// if the tooltip has an excludeDataKey prop, then disable the tooltip where that key is present
-		const excludeDataKey = getTooltipProps(children)?.excludeDataKey;
-		if (excludeDataKey) {
-			return [{ test: `datum.${excludeDataKey}`, signal: 'false' }, defaultTooltip];
+		const excludeDataKeys = getTooltipProps(children)?.excludeDataKeys;
+		if (excludeDataKeys?.length) {
+			return [...excludeDataKeys.map(excludeDataKey => ({ test: `datum.${excludeDataKey}`, signal: 'false' })), defaultTooltip];
 		}
 
 		return defaultTooltip;

--- a/src/specBuilder/scatter/scatterMarkUtils.test.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.test.ts
@@ -62,12 +62,20 @@ describe('getOpacity()', () => {
 });
 
 describe('getScatterHoverMarks()', () => {
-	test('should retrurn the voronoi mark if there is a tooltip', () => {
+	test('should return the pointsForVoronoi mark if there is a tooltip', () => {
 		expect(getScatterHoverMarks(defaultScatterProps)).toHaveLength(0);
 
 		const marks = getScatterHoverMarks({ ...defaultScatterProps, children: [createElement(ChartTooltip)] });
-		expect(marks).toHaveLength(1);
-		expect(marks[0].name).toBe('scatter0_voronoi');
+		expect(marks).toHaveLength(2);
+		expect(marks[0].name).toBe('scatter0_pointsForVoronoi');
+	});
+
+	test('should return the voronoi mark if there is a tooltip', () => {
+		expect(getScatterHoverMarks(defaultScatterProps)).toHaveLength(0);
+
+		const marks = getScatterHoverMarks({ ...defaultScatterProps, children: [createElement(ChartTooltip)] });
+		expect(marks).toHaveLength(2);
+		expect(marks[1].name).toBe('scatter0_voronoi');
 	});
 });
 

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ChartTooltip } from '@components/index';
 import {
 	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
@@ -34,8 +33,8 @@ import { getScatterPathMarks } from '@specBuilder/scatterPath/scatterPathUtils';
 import { getTrendlineMarks } from '@specBuilder/trendline';
 import { spectrumColors } from '@themes';
 import { produce } from 'immer';
-import { ChartTooltipProps, ScatterSpecProps, SymbolSizeFacet } from 'types';
-import { GroupMark, Mark, NumericValueRef, PathMark, SymbolMark } from 'vega';
+import { ScatterSpecProps, SymbolSizeFacet } from 'types';
+import { GroupMark, Mark, NumericValueRef, SymbolMark } from 'vega';
 
 export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props) => {
 	const { name } = props;

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { ChartTooltip } from '@components/index';
 import {
 	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
@@ -21,6 +22,7 @@ import {
 	getColorProductionRule,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
+	getPointsForVoronoi,
 	getStrokeDashProductionRule,
 	getSymbolSizeProductionRule,
 	getVoronoiPath,
@@ -32,7 +34,7 @@ import { getScatterPathMarks } from '@specBuilder/scatterPath/scatterPathUtils';
 import { getTrendlineMarks } from '@specBuilder/trendline';
 import { spectrumColors } from '@themes';
 import { produce } from 'immer';
-import { ScatterSpecProps, SymbolSizeFacet } from 'types';
+import { ChartTooltipProps, ScatterSpecProps, SymbolSizeFacet } from 'types';
 import { GroupMark, Mark, NumericValueRef, PathMark, SymbolMark } from 'vega';
 
 export const addScatterMarks = produce<Mark[], [ScatterSpecProps]>((marks, props) => {
@@ -131,13 +133,18 @@ export const getOpacity = ({ children }: ScatterSpecProps): ({ test?: string } &
 /**
  * Gets the vornoi path mark if there are any interactive children
  * @param scatterProps ScatterSpecProps
- * @returns PathMark[]
+ * @returns Mark[]
  */
-export const getScatterHoverMarks = ({ children, name }: ScatterSpecProps): PathMark[] => {
+export const getScatterHoverMarks = ({ children, name, metric, dimension, dimensionScaleType }: ScatterSpecProps): Mark[] => {
+
 	if (!hasInteractiveChildren(children)) {
 		return [];
 	}
-	return [getVoronoiPath(children, name, name)];
+
+	return [
+		getPointsForVoronoi(`${name}_${FILTERED_TABLE}`, dimension, metric, name, dimensionScaleType),
+		getVoronoiPath(children, `${name}_pointsForVoronoi`, name)
+	];
 };
 
 const getScatterSelectMarks = ({

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -142,7 +142,7 @@ export const getScatterHoverMarks = ({ children, name, metric, dimension, dimens
 	}
 
 	return [
-		getPointsForVoronoi(`${name}_${FILTERED_TABLE}`, dimension, metric, name, dimensionScaleType),
+		getPointsForVoronoi(`${FILTERED_TABLE}ForTooltip`, dimension, metric, name, dimensionScaleType),
 		getVoronoiPath(children, `${name}_pointsForVoronoi`, name)
 	];
 };

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -43,7 +43,7 @@ describe('addData()', () => {
 			children: [createElement(ChartTooltip)],
 		});
 		expect(data).toHaveLength(3);
-		expect(data[2].name).toBe('scatter0_filteredTable');
+		expect(data[2].name).toBe('filteredTableForTooltip');
 	});
 	test('tooltipFilteredData has undefined transform by default', () => {
 		const data = addData(initializeSpec().data ?? [], {

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -56,7 +56,7 @@ describe('addData()', () => {
 	test('tooltipFilteredData has undefined transform by default', () => {
 		const data = addData(initializeSpec().data ?? [], {
 			...defaultScatterProps,
-			children: [createElement(ChartTooltip, { excludeDataKey: 'exclude' })],
+			children: [createElement(ChartTooltip, { excludeDataKeys: ['exclude'] })],
 		});
 
 		expect(data[2].transform).toStrictEqual([{

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -37,6 +37,33 @@ describe('addData()', () => {
 		expect(data[0].transform).toHaveLength(2);
 		expect(data[0].transform?.[1].type).toBe('timeunit');
 	});
+	test('should add additional filteredData if tooltip exists', () => {
+		const data = addData(initializeSpec().data ?? [], {
+			...defaultScatterProps,
+			children: [createElement(ChartTooltip)],
+		});
+		expect(data).toHaveLength(3);
+		expect(data[2].name).toBe('scatter0_filteredTable');
+	});
+	test('tooltipFilteredData has undefined transform by default', () => {
+		const data = addData(initializeSpec().data ?? [], {
+			...defaultScatterProps,
+			children: [createElement(ChartTooltip)],
+		});
+
+		expect(data[2].transform).toBeUndefined();
+	});
+	test('tooltipFilteredData has undefined transform by default', () => {
+		const data = addData(initializeSpec().data ?? [], {
+			...defaultScatterProps,
+			children: [createElement(ChartTooltip, { excludeDataKey: 'exclude' })],
+		});
+
+		expect(data[2].transform).toStrictEqual([{
+			type: 'filter',
+			expr: '!datum.exclude',
+		}]);
+	});
 	test('should add selectedData if popover exists', () => {
 		const data = addData(initializeSpec().data ?? [], {
 			...defaultScatterProps,

--- a/src/specBuilder/scatter/scatterSpecBuilder.test.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.test.ts
@@ -69,8 +69,8 @@ describe('addData()', () => {
 			...defaultScatterProps,
 			children: [createElement(ChartPopover)],
 		});
-		expect(data).toHaveLength(3);
-		expect(data[2].name).toBe('scatter0_selectedData');
+		expect(data).toHaveLength(4);
+		expect(data[3].name).toBe('scatter0_selectedData');
 	});
 	test('should add trendline data if trendline exists as a child', () => {
 		const data = addData(initializeSpec().data ?? [], {

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -103,7 +103,7 @@ export const addData = produce<Data[], [ScatterSpecProps]>((data, props) => {
 		tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
 	}
 
-	if (hasTooltip(children)) {
+	if (hasInteractiveChildren(children)) {
 		data.push(getFilteredTooltipData(name, children));
 	}
 

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -24,9 +24,9 @@ import {
 	SELECTED_ITEM,
 	SYMBOL_SIZE_SCALE,
 } from '@constants';
-import { addTimeTransform, getTableData } from '@specBuilder/data/dataUtils';
+import { addTimeTransform, getFilteredTooltipData, getTableData } from '@specBuilder/data/dataUtils';
 import { getInteractiveMarkName } from '@specBuilder/line/lineUtils';
-import { hasInteractiveChildren, hasPopover } from '@specBuilder/marks/markUtils';
+import { hasInteractiveChildren, hasPopover, hasTooltip } from '@specBuilder/marks/markUtils';
 import {
 	addContinuousDimensionScale,
 	addFieldToFacetScaleDomain,
@@ -37,10 +37,11 @@ import { addHighlightedItemSignalEvents } from '@specBuilder/signal/signalSpecBu
 import { addTrendlineData, getTrendlineScales, setTrendlineSignals } from '@specBuilder/trendline';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
 import { produce } from 'immer';
-import { ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
+import { ChartTooltipProps, ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
 import { Data, Scale, Signal, Spec } from 'vega';
 
 import { addScatterMarks } from './scatterMarkUtils';
+import { ChartTooltip } from '@components/ChartTooltip';
 
 /**
  * Adds all the necessary parts of a scatter to the spec
@@ -101,6 +102,11 @@ export const addData = produce<Data[], [ScatterSpecProps]>((data, props) => {
 		const tableData = getTableData(data);
 		tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
 	}
+
+	if (hasTooltip(children)) {
+		data.push(getFilteredTooltipData(name, children));
+	}
+
 	if (hasPopover(children)) {
 		data.push({
 			name: `${name}_selectedData`,

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -104,7 +104,7 @@ export const addData = produce<Data[], [ScatterSpecProps]>((data, props) => {
 	}
 
 	if (hasInteractiveChildren(children)) {
-		data.push(getFilteredTooltipData(name, children));
+		data.push(getFilteredTooltipData(children));
 	}
 
 	if (hasPopover(children)) {

--- a/src/specBuilder/scatter/scatterSpecBuilder.ts
+++ b/src/specBuilder/scatter/scatterSpecBuilder.ts
@@ -26,7 +26,7 @@ import {
 } from '@constants';
 import { addTimeTransform, getFilteredTooltipData, getTableData } from '@specBuilder/data/dataUtils';
 import { getInteractiveMarkName } from '@specBuilder/line/lineUtils';
-import { hasInteractiveChildren, hasPopover, hasTooltip } from '@specBuilder/marks/markUtils';
+import { hasInteractiveChildren, hasPopover } from '@specBuilder/marks/markUtils';
 import {
 	addContinuousDimensionScale,
 	addFieldToFacetScaleDomain,
@@ -37,11 +37,10 @@ import { addHighlightedItemSignalEvents } from '@specBuilder/signal/signalSpecBu
 import { addTrendlineData, getTrendlineScales, setTrendlineSignals } from '@specBuilder/trendline';
 import { sanitizeMarkChildren, toCamelCase } from '@utils';
 import { produce } from 'immer';
-import { ChartTooltipProps, ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
+import { ColorScheme, ScatterProps, ScatterSpecProps } from 'types';
 import { Data, Scale, Signal, Spec } from 'vega';
 
 import { addScatterMarks } from './scatterMarkUtils';
-import { ChartTooltip } from '@components/ChartTooltip';
 
 /**
  * Adds all the necessary parts of a scatter to the spec

--- a/src/specBuilder/signal/signalSpecBuilder.test.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.test.ts
@@ -42,6 +42,17 @@ describe('signalSpecBuilder', () => {
 			addHighlightedItemSignalEvents(signals, 'line0');
 			expect(signals).toEqual(signalsCopy);
 		});
+		test('should include update condition if excludeDataKey is provided', () => {
+			addHighlightedItemSignalEvents(signals, 'bar0', 1, 'excludeFromTooltip');
+			expect(signals).toHaveLength(4);
+			expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
+			expect(signals[0].on).toHaveLength(2);
+			expect(signals[0]?.on?.[0]).toHaveProperty('events', '@bar0:mouseover');
+			expect(signals[0]?.on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+			expect(signals[1].on).toBeUndefined();
+			expect(signals[2].on).toBeUndefined();
+			expect(signals[3].on).toBeUndefined();
+		});
 	});
 
 	describe('addHighlightedSeriesSignalEvents()', () => {
@@ -61,6 +72,19 @@ describe('signalSpecBuilder', () => {
 			const signalsCopy = JSON.parse(JSON.stringify(signals));
 			addHighlightedSeriesSignalEvents(signals, 'line0');
 			expect(signals).toEqual(signalsCopy);
+		});
+		test('should include update condition if excludeDataKey is provided', () => {
+			addHighlightedSeriesSignalEvents(signals, 'bar0', 1, 'excludeFromTooltip');
+			expect(signals).toHaveLength(4);
+			expect(signals[0].on).toBeUndefined();
+			expect(signals[1]).toHaveProperty('name', HIGHLIGHTED_SERIES);
+			expect(signals[1].on).toHaveLength(2);
+			expect(signals[1]?.on?.[0]).toHaveProperty('events', '@bar0:mouseover');
+			expect(signals[1]?.on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscSeriesId');
+			expect(signals[1]?.on?.[1]).toHaveProperty('events', '@bar0:mouseout');
+			expect(signals[1]?.on?.[1]).toHaveProperty('update', 'null');
+			expect(signals[2].on).toBeUndefined();
+			expect(signals[3].on).toBeUndefined();
 		});
 	});
 });

--- a/src/specBuilder/signal/signalSpecBuilder.test.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.test.ts
@@ -43,12 +43,12 @@ describe('signalSpecBuilder', () => {
 			expect(signals).toEqual(signalsCopy);
 		});
 		test('should include update condition if excludeDataKey is provided', () => {
-			addHighlightedItemSignalEvents(signals, 'bar0', 1, 'excludeFromTooltip');
+			addHighlightedItemSignalEvents(signals, 'bar0', 1, ['excludeFromTooltip']);
 			expect(signals).toHaveLength(4);
 			expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
 			expect(signals[0].on).toHaveLength(2);
 			expect(signals[0]?.on?.[0]).toHaveProperty('events', '@bar0:mouseover');
-			expect(signals[0]?.on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscMarkId');
+			expect(signals[0]?.on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum.rscMarkId');
 			expect(signals[1].on).toBeUndefined();
 			expect(signals[2].on).toBeUndefined();
 			expect(signals[3].on).toBeUndefined();
@@ -74,13 +74,13 @@ describe('signalSpecBuilder', () => {
 			expect(signals).toEqual(signalsCopy);
 		});
 		test('should include update condition if excludeDataKey is provided', () => {
-			addHighlightedSeriesSignalEvents(signals, 'bar0', 1, 'excludeFromTooltip');
+			addHighlightedSeriesSignalEvents(signals, 'bar0', 1, ['excludeFromTooltip']);
 			expect(signals).toHaveLength(4);
 			expect(signals[0].on).toBeUndefined();
 			expect(signals[1]).toHaveProperty('name', HIGHLIGHTED_SERIES);
 			expect(signals[1].on).toHaveLength(2);
 			expect(signals[1]?.on?.[0]).toHaveProperty('events', '@bar0:mouseover');
-			expect(signals[1]?.on?.[0]).toHaveProperty('update', 'datum.excludeFromTooltip ? null : datum.rscSeriesId');
+			expect(signals[1]?.on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum.rscSeriesId');
 			expect(signals[1]?.on?.[1]).toHaveProperty('events', '@bar0:mouseout');
 			expect(signals[1]?.on?.[1]).toHaveProperty('update', 'null');
 			expect(signals[2].on).toBeUndefined();

--- a/src/specBuilder/signal/signalSpecBuilder.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.ts
@@ -81,18 +81,20 @@ export const getGenericSignal = (name: string, value: unknown = null): Signal =>
  * @param datumOrder how deep the datum is nested (i.e. 1 becomes datum.rscMarkId, 2 becomes datum.datum.rscMarkId, etc.)
  * @param excludeDataKey data items with a truthy value for this key will be excluded from the signal
  */
-export const addHighlightedItemSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKey = '') => {
+export const addHighlightedItemSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKeys?: string[]) => {
 	const highlightedItemSignal = signals.find((signal) => signal.name === HIGHLIGHTED_ITEM);
 	if (highlightedItemSignal) {
 		if (highlightedItemSignal.on === undefined) {
 			highlightedItemSignal.on = [];
 		}
 		const datum = new Array(datumOrder).fill('datum.').join('');
+
+		const excludeDataKeysCondition = excludeDataKeys?.map((excludeDataKey) => `${datum}${excludeDataKey}`).join(' || ');
 		highlightedItemSignal.on.push(
 			...[
 				{
 					events: `@${markName}:mouseover`,
-					update: excludeDataKey ? `${datum}${excludeDataKey} ? null : ${datum}${MARK_ID}` : `${datum}${MARK_ID}`,
+					update: excludeDataKeys?.length ? `(${excludeDataKeysCondition}) ? null : ${datum}${MARK_ID}` : `${datum}${MARK_ID}`,
 				},
 				{ events: `@${markName}:mouseout`, update: 'null' },
 			]
@@ -107,18 +109,20 @@ export const addHighlightedItemSignalEvents = (signals: Signal[], markName: stri
  * @param datumOrder how deep the datum is nested (i.e. 1 becomes datum.rscMarkId, 2 becomes datum.datum.rscMarkId, etc.)
  * @param excludeDataKey data items with a truthy value for this key will be excluded from the signal
  */
-export const addHighlightedSeriesSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKey = '') => {
+export const addHighlightedSeriesSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKeys?: string[]) => {
 	const highlightedSeriesSignal = signals.find((signal) => signal.name === HIGHLIGHTED_SERIES);
 	if (highlightedSeriesSignal) {
 		if (highlightedSeriesSignal.on === undefined) {
 			highlightedSeriesSignal.on = [];
 		}
 		const datum = new Array(datumOrder).fill('datum.').join('');
+
+		const excludeDataKeysCondition = excludeDataKeys?.map((excludeDataKey) => `${datum}${excludeDataKey}`).join(' || ');
 		highlightedSeriesSignal.on.push(
 			...[
 				{
 					events: `@${markName}:mouseover`,
-					update: excludeDataKey ? `${datum}${excludeDataKey} ? null : ${datum}${SERIES_ID}` : `${datum}${SERIES_ID}`,
+					update: excludeDataKeys?.length ? `(${excludeDataKeysCondition}) ? null : ${datum}${SERIES_ID}` : `${datum}${SERIES_ID}`,
 				},
 				{ events: `@${markName}:mouseout`, update: 'null' },
 			]

--- a/src/specBuilder/signal/signalSpecBuilder.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.ts
@@ -79,18 +79,20 @@ export const getGenericSignal = (name: string, value: unknown = null): Signal =>
  * @param signals
  * @param markName
  * @param datumOrder how deep the datum is nested (i.e. 1 becomes datum.rscMarkId, 2 becomes datum.datum.rscMarkId, etc.)
+ * @param excludeDataKey data items with a truthy value for this key will be excluded from the signal
  */
-export const addHighlightedItemSignalEvents = (signals: Signal[], markName: string, datumOrder = 1) => {
+export const addHighlightedItemSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKey = '') => {
 	const highlightedItemSignal = signals.find((signal) => signal.name === HIGHLIGHTED_ITEM);
 	if (highlightedItemSignal) {
 		if (highlightedItemSignal.on === undefined) {
 			highlightedItemSignal.on = [];
 		}
+		const datum = new Array(datumOrder).fill('datum.').join('');
 		highlightedItemSignal.on.push(
 			...[
 				{
 					events: `@${markName}:mouseover`,
-					update: `${new Array(datumOrder).fill('datum.').join('')}${MARK_ID}`,
+					update: excludeDataKey ? `${datum}${excludeDataKey} ? null : ${datum}${MARK_ID}` : `${datum}${MARK_ID}`,
 				},
 				{ events: `@${markName}:mouseout`, update: 'null' },
 			]
@@ -103,18 +105,20 @@ export const addHighlightedItemSignalEvents = (signals: Signal[], markName: stri
  * @param signals
  * @param markName
  * @param datumOrder how deep the datum is nested (i.e. 1 becomes datum.rscMarkId, 2 becomes datum.datum.rscMarkId, etc.)
+ * @param excludeDataKey data items with a truthy value for this key will be excluded from the signal
  */
-export const addHighlightedSeriesSignalEvents = (signals: Signal[], markName: string, datumOrder = 1) => {
+export const addHighlightedSeriesSignalEvents = (signals: Signal[], markName: string, datumOrder = 1, excludeDataKey = '') => {
 	const highlightedSeriesSignal = signals.find((signal) => signal.name === HIGHLIGHTED_SERIES);
 	if (highlightedSeriesSignal) {
 		if (highlightedSeriesSignal.on === undefined) {
 			highlightedSeriesSignal.on = [];
 		}
+		const datum = new Array(datumOrder).fill('datum.').join('');
 		highlightedSeriesSignal.on.push(
 			...[
 				{
 					events: `@${markName}:mouseover`,
-					update: `${new Array(datumOrder).fill('datum.').join('')}${SERIES_ID}`,
+					update: excludeDataKey ? `${datum}${excludeDataKey} ? null : ${datum}${SERIES_ID}` : `${datum}${SERIES_ID}`,
 				},
 				{ events: `@${markName}:mouseout`, update: 'null' },
 			]

--- a/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
+++ b/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
@@ -14,7 +14,7 @@ import React, { ReactElement } from 'react';
 import { ChartTooltip } from '@components/ChartTooltip/ChartTooltip';
 import useChartProps from '@hooks/useChartProps';
 import { Area, Bar, categorical12, Chart, Datum, Line } from '@rsc';
-import { browserData as data } from '@stories/data/data';
+import { browserData } from '@stories/data/data';
 import { formatTimestamp } from '@stories/storyUtils';
 import { StoryFn } from '@storybook/react';
 import { bindWithProps } from '@test-utils';
@@ -32,8 +32,10 @@ export default {
 	},
 };
 
+const barData = browserData.map(datum => datum.category === 'Chrome' ? ({ ...datum, excludeFromTooltip: true }) : datum);
+
 const StackedBarTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
-	const chartProps = useChartProps({ data, width: 600 });
+	const chartProps = useChartProps({ data: barData, width: 600 });
 	return (
 		<Chart {...chartProps}>
 			<Bar color="series">
@@ -43,7 +45,7 @@ const StackedBarTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElemen
 	);
 };
 const DodgedBarTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
-	const chartProps = useChartProps({ data, width: 600 });
+	const chartProps = useChartProps({ data: barData, width: 600 });
 	return (
 		<Chart {...chartProps}>
 			<Bar type="dodged" color="series">
@@ -85,7 +87,7 @@ const LineTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
 
 
 const DisabledSeriesLineTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
-	const chartProps = useChartProps({ data: disabledLineData, width: 600, colors: ['gray-500', ...categorical12]});
+	const chartProps = useChartProps({ data: disabledLineData, width: 600, colors: ['gray-300', ...categorical12]});
 	return (
 		<Chart {...chartProps}>
 			<Line color="series">
@@ -105,9 +107,9 @@ interface LineData extends Datum {
 }
 
 const AreaTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
-	const chartProps = useChartProps({ data: lineData, width: 600 });
+	const chartProps = useChartProps({ data: disabledLineData, width: 600 });
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Area>
 				<ChartTooltip {...args} />
 			</Area>
@@ -124,6 +126,7 @@ StackedBarChart.args = {
 			<div>Users: {datum.value}</div>
 		</div>
 	),
+	excludeDataKey: '',
 };
 
 const DodgedBarChart = DodgedBarTooltipStory.bind({});
@@ -135,6 +138,7 @@ DodgedBarChart.args = {
 			<div>Users: {datum.value}</div>
 		</div>
 	),
+	excludeDataKey: '',
 };
 
 const LineChart = bindWithProps(LineTooltipStory);
@@ -147,6 +151,7 @@ LineChart.args = {
 			<div>Users: {Number(datum.users).toLocaleString()}</div>
 		</div>
 	),
+	excludeDataKey: '',
 };
 
 const AreaChart = bindWithProps(AreaTooltipStory);
@@ -159,6 +164,7 @@ AreaChart.args = {
 			<div>Users: {Number(datum.users).toLocaleString()}</div>
 		</div>
 	),
+	excludeDataKey: '',
 };
 
 const DisabledSeriesLineChart = bindWithProps(DisabledSeriesLineTooltipStory);

--- a/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
+++ b/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
@@ -109,7 +109,7 @@ interface LineData extends Datum {
 const AreaTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: disabledLineData, width: 600 });
 	return (
-		<Chart {...chartProps} debug>
+		<Chart {...chartProps}>
 			<Area>
 				<ChartTooltip {...args} />
 			</Area>

--- a/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
+++ b/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
@@ -13,7 +13,7 @@ import React, { ReactElement } from 'react';
 
 import { ChartTooltip } from '@components/ChartTooltip/ChartTooltip';
 import useChartProps from '@hooks/useChartProps';
-import { Area, Bar, Chart, Datum, Line } from '@rsc';
+import { Area, Bar, categorical12, Chart, Datum, Line } from '@rsc';
 import { browserData as data } from '@stories/data/data';
 import { formatTimestamp } from '@stories/storyUtils';
 import { StoryFn } from '@storybook/react';
@@ -70,8 +70,22 @@ const lineData = [
 	{ datetime: 1668409200000, point: 25, value: 10932, users: 4913, series: 'Add Freeform table' },
 ];
 
+const disabledLineData = lineData.map(datum => datum.series === 'Add Fallout' ? { ...datum, excludeFromTooltip: true } : datum);
+
 const LineTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
 	const chartProps = useChartProps({ data: lineData, width: 600 });
+	return (
+		<Chart {...chartProps}>
+			<Line color="series">
+				<ChartTooltip {...args} />
+			</Line>
+		</Chart>
+	);
+};
+
+
+const DisabledSeriesLineTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElement => {
+	const chartProps = useChartProps({ data: disabledLineData, width: 600, colors: ['gray-500', ...categorical12]});
 	return (
 		<Chart {...chartProps}>
 			<Line color="series">
@@ -147,4 +161,17 @@ AreaChart.args = {
 	),
 };
 
-export { AreaChart, DodgedBarChart, LineChart, StackedBarChart };
+const DisabledSeriesLineChart = bindWithProps(DisabledSeriesLineTooltipStory);
+DisabledSeriesLineChart.args = {
+	children: (datum: LineData) => (
+		<div className="bar-tooltip">
+			<div>{formatTimestamp(datum.datetime as number)}</div>
+			<div>Event: {datum.series}</div>
+			<div>Count: {Number(datum.value).toLocaleString()}</div>
+			<div>Users: {Number(datum.users).toLocaleString()}</div>
+		</div>
+	),
+	excludeDataKey: 'excludeFromTooltip',
+};
+
+export { AreaChart, DodgedBarChart, LineChart, StackedBarChart, DisabledSeriesLineChart };

--- a/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
+++ b/src/stories/components/ChartTooltip/ChartTooltip.story.tsx
@@ -126,7 +126,7 @@ StackedBarChart.args = {
 			<div>Users: {datum.value}</div>
 		</div>
 	),
-	excludeDataKey: '',
+	excludeDataKeys: [],
 };
 
 const DodgedBarChart = DodgedBarTooltipStory.bind({});
@@ -138,7 +138,7 @@ DodgedBarChart.args = {
 			<div>Users: {datum.value}</div>
 		</div>
 	),
-	excludeDataKey: '',
+	excludeDataKeys: [],
 };
 
 const LineChart = bindWithProps(LineTooltipStory);
@@ -151,7 +151,7 @@ LineChart.args = {
 			<div>Users: {Number(datum.users).toLocaleString()}</div>
 		</div>
 	),
-	excludeDataKey: '',
+	excludeDataKeys: [],
 };
 
 const AreaChart = bindWithProps(AreaTooltipStory);
@@ -164,7 +164,7 @@ AreaChart.args = {
 			<div>Users: {Number(datum.users).toLocaleString()}</div>
 		</div>
 	),
-	excludeDataKey: '',
+	excludeDataKeys: [],
 };
 
 const DisabledSeriesLineChart = bindWithProps(DisabledSeriesLineTooltipStory);
@@ -177,7 +177,7 @@ DisabledSeriesLineChart.args = {
 			<div>Users: {Number(datum.users).toLocaleString()}</div>
 		</div>
 	),
-	excludeDataKey: 'excludeFromTooltip',
+	excludeDataKeys: ['excludeFromTooltip'],
 };
 
 export { AreaChart, DodgedBarChart, LineChart, StackedBarChart, DisabledSeriesLineChart };

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -531,6 +531,8 @@ export type DialogProps = ChartTooltipProps | ChartPopoverProps;
 
 export interface ChartTooltipProps {
 	children?: TooltipHandler;
+	/** The key in the data which indicates whether or not the datum should display an associated tooltip */
+	excludeDataKey?: string;
 }
 export interface ChartPopoverProps {
 	children?: PopoverHandler;

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -531,8 +531,8 @@ export type DialogProps = ChartTooltipProps | ChartPopoverProps;
 
 export interface ChartTooltipProps {
 	children?: TooltipHandler;
-	/** The key in the data which indicates whether or not the datum should display an associated tooltip */
-	excludeDataKey?: string;
+	/** The keys in the data that will disable the tooltip if they have truthy values */
+	excludeDataKeys?: string[];
 }
 export interface ChartPopoverProps {
 	children?: PopoverHandler;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `excludeDataKey` prop added to `ChartTooltip`
-  Story demonstrating `excludeDataKey` use
-  Disable interaction, voronoi calculation, and tooltip display for data points where `excludeDataKey` is truthy

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
[AN-344693](https://jira.corp.adobe.com/browse/AN-344693) (Internal)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
