### PR TITLE
Ability to exclude data points from trendline calculation

### DIFF
--- a/src/components/Trendline/Trendline.tsx
+++ b/src/components/Trendline/Trendline.tsx
@@ -22,6 +22,7 @@ const Trendline: FC<TrendlineProps> = ({
 	dimensionExtent,
 	dimensionRange = [null, null],
 	displayOnHover = false,
+	excludeDataKey,
 	highlightRawPoint = false,
 	lineType = 'dashed',
 	lineWidth = 'M',

--- a/src/components/Trendline/Trendline.tsx
+++ b/src/components/Trendline/Trendline.tsx
@@ -22,7 +22,7 @@ const Trendline: FC<TrendlineProps> = ({
 	dimensionExtent,
 	dimensionRange = [null, null],
 	displayOnHover = false,
-	excludeDataKey,
+	excludeDataKeys,
 	highlightRawPoint = false,
 	lineType = 'dashed',
 	lineWidth = 'M',

--- a/src/specBuilder/trendline/trendlineDataUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.test.ts
@@ -134,6 +134,87 @@ describe('addTrendlineData()', () => {
 		expect(trendlineData[2].transform?.[1]).toHaveProperty('type', 'window');
 		expect(trendlineData[2].transform?.[2]).toHaveProperty('type', 'filter');
 	});
+
+	test('should add filter transform for regression method if trendline has excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'linear', excludeDataKey: 'exclude' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform?.[0]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude',
+		});
+	});
+
+	test('should not add filter transform for regression method if trendline does not have excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'linear' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+		expect(trendlineData[2].transform).toHaveLength(2);
+		expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+	});
+
+	test('should add filter transform for aggregate method if trendline has excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'median', excludeDataKey: 'exclude' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform?.[0]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude',
+		});
+	});
+
+	test('should not add filter transform for aggregate method if trendline does not have excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'median' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+		expect(trendlineData[2].transform).toHaveLength(2);
+		expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+	});
+
+	test('should add filter transform for window method if trendline has excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'movingAverage-2', excludeDataKey: 'exclude' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
+		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform?.[0]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude',
+		});
+	});
+
+	test('should not add filter transform for window method if trendline does not have excludeDataKey', () => {
+		const trendlineData = getDefaultData();
+
+		addTrendlineData(trendlineData, {
+			...defaultLineProps,
+			children: [createElement(Trendline, { method: 'movingAverage-2' })],
+		});
+		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
+		expect(trendlineData[2].transform).toHaveLength(2);
+		expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+	});
 });
 
 describe('getAggregateTrendlineData()', () => {

--- a/src/specBuilder/trendline/trendlineDataUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.test.ts
@@ -135,18 +135,22 @@ describe('addTrendlineData()', () => {
 		expect(trendlineData[2].transform?.[2]).toHaveProperty('type', 'filter');
 	});
 
-	test('should add filter transform for regression method if trendline has excludeDataKey', () => {
+	test('should add filter transforms for regression method if trendline has excludeDataKey', () => {
 		const trendlineData = getDefaultData();
 
 		addTrendlineData(trendlineData, {
 			...defaultLineProps,
-			children: [createElement(Trendline, { method: 'linear', excludeDataKey: 'exclude' })],
+			children: [createElement(Trendline, { method: 'linear', excludeDataKeys: ['exclude1', 'exclude2'] })],
 		});
 		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform).toHaveLength(4);
 		expect(trendlineData[2].transform?.[0]).toStrictEqual({
 			type: 'filter',
-			expr: '!datum.exclude',
+			expr: '!datum.exclude1',
+		});
+		expect(trendlineData[2].transform?.[1]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude2',
 		});
 	});
 
@@ -162,18 +166,22 @@ describe('addTrendlineData()', () => {
 		expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
 	});
 
-	test('should add filter transform for aggregate method if trendline has excludeDataKey', () => {
+	test('should add filter transforms for aggregate method if trendline has excludeDataKey', () => {
 		const trendlineData = getDefaultData();
 
 		addTrendlineData(trendlineData, {
 			...defaultLineProps,
-			children: [createElement(Trendline, { method: 'median', excludeDataKey: 'exclude' })],
+			children: [createElement(Trendline, { method: 'median', excludeDataKeys: ['exclude1', 'exclude2'] })],
 		});
 		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform).toHaveLength(4);
 		expect(trendlineData[2].transform?.[0]).toStrictEqual({
 			type: 'filter',
-			expr: '!datum.exclude',
+			expr: '!datum.exclude1',
+		});
+		expect(trendlineData[2].transform?.[1]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude2',
 		});
 	});
 
@@ -194,13 +202,17 @@ describe('addTrendlineData()', () => {
 
 		addTrendlineData(trendlineData, {
 			...defaultLineProps,
-			children: [createElement(Trendline, { method: 'movingAverage-2', excludeDataKey: 'exclude' })],
+			children: [createElement(Trendline, { method: 'movingAverage-2', excludeDataKeys: ['exclude1', 'exclude2'] })],
 		});
 		expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-		expect(trendlineData[2].transform).toHaveLength(3);
+		expect(trendlineData[2].transform).toHaveLength(4);
 		expect(trendlineData[2].transform?.[0]).toStrictEqual({
 			type: 'filter',
-			expr: '!datum.exclude',
+			expr: '!datum.exclude1',
+		});
+		expect(trendlineData[2].transform?.[1]).toStrictEqual({
+			type: 'filter',
+			expr: '!datum.exclude2',
 		});
 	});
 

--- a/src/specBuilder/trendline/trendlineDataUtils.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.ts
@@ -121,6 +121,7 @@ export const getAggregateTrendlineData = (
 		name: `${name}_highResolutionData`,
 		source: FILTERED_TABLE,
 		transform: [
+			...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
 			...dimensionRangeTransforms,
 			...getTrendlineStatisticalTransforms(markProps, trendlineProps, true),
 			getSeriesIdTransform(facets),
@@ -174,6 +175,7 @@ export const getRegressionTrendlineData = (
 		name: `${name}_highResolutionData`,
 		source: FILTERED_TABLE,
 		transform: [
+			...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
 			...dimensionRangeTransforms,
 			...getTrendlineStatisticalTransforms(markProps, trendlineProps, true),
 			getSeriesIdTransform(facets),
@@ -215,6 +217,7 @@ const getWindowTrendlineData = (markProps: TrendlineParentProps, trendlineProps:
 	name: `${trendlineProps.name}_data`,
 	source: FILTERED_TABLE,
 	transform: [
+		...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
 		...getTrendlineStatisticalTransforms(markProps, trendlineProps, false),
 		...getTrendlineDimensionRangeTransforms(markProps.dimension, trendlineProps.dimensionRange),
 	],
@@ -320,3 +323,8 @@ export const getTrendlineDisplayOnHoverData = (trendlineName: string, method: Tr
 		],
 	};
 };
+
+const getExcludeDataKeyFilter = (excludeDataKey: string): Transforms => ({
+	type: 'filter',
+	expr: `!datum.${excludeDataKey}`,
+});

--- a/src/specBuilder/trendline/trendlineDataUtils.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.ts
@@ -121,7 +121,7 @@ export const getAggregateTrendlineData = (
 		name: `${name}_highResolutionData`,
 		source: FILTERED_TABLE,
 		transform: [
-			...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
+			...getExcludeDataKeyTransforms(trendlineProps.excludeDataKeys),
 			...dimensionRangeTransforms,
 			...getTrendlineStatisticalTransforms(markProps, trendlineProps, true),
 			getSeriesIdTransform(facets),
@@ -175,7 +175,7 @@ export const getRegressionTrendlineData = (
 		name: `${name}_highResolutionData`,
 		source: FILTERED_TABLE,
 		transform: [
-			...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
+			...getExcludeDataKeyTransforms(trendlineProps.excludeDataKeys),
 			...dimensionRangeTransforms,
 			...getTrendlineStatisticalTransforms(markProps, trendlineProps, true),
 			getSeriesIdTransform(facets),
@@ -217,7 +217,7 @@ const getWindowTrendlineData = (markProps: TrendlineParentProps, trendlineProps:
 	name: `${trendlineProps.name}_data`,
 	source: FILTERED_TABLE,
 	transform: [
-		...(trendlineProps.excludeDataKey ? [getExcludeDataKeyFilter(trendlineProps.excludeDataKey)] : []),
+		...getExcludeDataKeyTransforms(trendlineProps.excludeDataKeys),
 		...getTrendlineStatisticalTransforms(markProps, trendlineProps, false),
 		...getTrendlineDimensionRangeTransforms(markProps.dimension, trendlineProps.dimensionRange),
 	],
@@ -324,7 +324,7 @@ export const getTrendlineDisplayOnHoverData = (trendlineName: string, method: Tr
 	};
 };
 
-const getExcludeDataKeyFilter = (excludeDataKey: string): Transforms => ({
+const getExcludeDataKeyTransforms = (excludeDataKeys?: string[]): Transforms[] => excludeDataKeys?.map(excludeDataKey => ({
 	type: 'filter',
 	expr: `!datum.${excludeDataKey}`,
-});
+})) ?? [];

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -151,6 +151,37 @@ const ScatterStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	);
 };
 
+export const excludeSeriesData = [
+	{ datetime: 1667890800000, point: 1, value: 3738, users: 477, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1667977200000, point: 2, value: 2704, users: 481, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1668063600000, point: 3, value: 1730, users: 483, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1668150000000, point: 4, value: 465, users: 310, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1668236400000, point: 5, value: 31, users: 18, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1668322800000, point: 8, value: 108, users: 70, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1668409200000, point: 12, value: 648, users: 438, series: 'Add Fallout', excludeFromTrendline: true },
+	{ datetime: 1667890800000, point: 4, value: 12208, users: 5253, series: 'Add Freeform table' },
+	{ datetime: 1667977200000, point: 5, value: 11309, users: 5103, series: 'Add Freeform table' },
+	{ datetime: 1668063600000, point: 17, value: 11099, users: 5047, series: 'Add Freeform table' },
+	{ datetime: 1668150000000, point: 20, value: 7243, users: 3386, series: 'Add Freeform table' },
+	{ datetime: 1668236400000, point: 21, value: 395, users: 205, series: 'Add Freeform table' },
+	{ datetime: 1668322800000, point: 22, value: 1606, users: 790, series: 'Add Freeform table' },
+	{ datetime: 1668409200000, point: 25, value: 10932, users: 4913, series: 'Add Freeform table' },
+];
+
+const ExcludeSeriesTrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
+	const chartProps = useChartProps({ ...defaultChartProps, data: excludeSeriesData, colors: ['gray-300', 'seafoam-500']});
+	return (
+		<Chart {...chartProps}>
+			<Axis position="left" grid title="Users" />
+			<Axis position="bottom" labelFormat="time" baseline ticks />
+			<Line color="series">
+				<Trendline {...args} />
+			</Line>
+			<Legend lineWidth={{ value: 0 }} highlight />
+		</Chart>
+	);
+}
+
 const Basic = bindWithProps(TrendlineStory);
 Basic.args = {
 	method: 'linear',
@@ -206,6 +237,14 @@ TooltipAndPopoverOnParentLine.args = {
 	lineWidth: 'S',
 };
 
+const ExcludeSeriesFromTrendline = bindWithProps(ExcludeSeriesTrendlineStory);
+ExcludeSeriesFromTrendline.args = {
+	method: 'linear',
+	lineType: 'dashed',
+	lineWidth: 'S',
+	excludeDataKey: 'excludeFromTrendline',
+};
+
 export {
 	Basic,
 	DimensionExtent,
@@ -214,4 +253,5 @@ export {
 	Orientation,
 	TooltipAndPopover,
 	TooltipAndPopoverOnParentLine,
+	ExcludeSeriesFromTrendline,
 };

--- a/src/stories/components/Trendline/Trendline.story.tsx
+++ b/src/stories/components/Trendline/Trendline.story.tsx
@@ -151,7 +151,7 @@ const ScatterStory: StoryFn<typeof Trendline> = (args): ReactElement => {
 	);
 };
 
-export const excludeSeriesData = [
+const excludeSeriesData = [
 	{ datetime: 1667890800000, point: 1, value: 3738, users: 477, series: 'Add Fallout', excludeFromTrendline: true },
 	{ datetime: 1667977200000, point: 2, value: 2704, users: 481, series: 'Add Fallout', excludeFromTrendline: true },
 	{ datetime: 1668063600000, point: 3, value: 1730, users: 483, series: 'Add Fallout', excludeFromTrendline: true },
@@ -242,7 +242,7 @@ ExcludeSeriesFromTrendline.args = {
 	method: 'linear',
 	lineType: 'dashed',
 	lineWidth: 'S',
-	excludeDataKey: 'excludeFromTrendline',
+	excludeDataKeys: ['excludeFromTrendline'],
 };
 
 export {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -590,6 +590,8 @@ export interface TrendlineProps {
 	dimensionRange?: [number | null, number | null];
 	/** Whether the trendline should only be visible when hovering over the parent line */
 	displayOnHover?: boolean;
+	/** Data points with a truthy value for this key will not be included in the trendline calculation */
+	excludeDataKey?: string;
 	/** If there is a tooltip on this trendline, then this will highlight the raw point in addition to the hovered trendline point. */
 	highlightRawPoint?: boolean;
 	/** The line type of the trend line. */

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -590,8 +590,8 @@ export interface TrendlineProps {
 	dimensionRange?: [number | null, number | null];
 	/** Whether the trendline should only be visible when hovering over the parent line */
 	displayOnHover?: boolean;
-	/** Data points with a truthy value for this key will not be included in the trendline calculation */
-	excludeDataKey?: string;
+	/** Data points where these keys have truthy values will not be included in the trendline calculation */
+	excludeDataKeys?: string[];
 	/** If there is a tooltip on this trendline, then this will highlight the raw point in addition to the hovered trendline point. */
 	highlightRawPoint?: boolean;
 	/** The line type of the trend line. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds `excludeDataKey` prop to `Trendline` component. Any points in the chart data where the `excludeDataKey` is truthy will not be included in the trendline calculation.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[AN-344696](https://jira.corp.adobe.com/browse/AN-344696) (Internal)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests in `trendlineDataUtils.test.ts`

## Screenshots (if appropriate):
- See story `rsc-trendline--exclude-series-from-trendline`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
