### PR TITLE
Fix the type error causing build failure in the destination package

### DIFF
--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -680,10 +680,16 @@ export interface MarkBounds {
 	y2: number;
 }
 
+const DatumPredefinedKey = {
+	markId: MARK_ID,
+	seriesId: SERIES_ID,
+	trendlineValue: TRENDLINE_VALUE,
+} as const;
+
 export interface Datum {
-	[MARK_ID]: number;
-	[SERIES_ID]: string;
-	[TRENDLINE_VALUE]?: number;
+	[DatumPredefinedKey.markId]: number;
+	[DatumPredefinedKey.seriesId]: string;
+	[DatumPredefinedKey.trendlineValue]?: number;
 	[key: string]: unknown;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the error `A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.` described in the issue https://github.com/adobe/react-spectrum-charts/issues/272. See "possible solution" in the issue for more details.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/272

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
