### PR TITLE
feat: support multi-line axis titles

### DIFF
--- a/src/stories/components/Axis/Axis.story.tsx
+++ b/src/stories/components/Axis/Axis.story.tsx
@@ -147,6 +147,16 @@ Basic.args = {
 	title: 'Conversion Rate',
 };
 
+const MultilineTitle = bindWithProps(AxisStory);
+MultilineTitle.args = {
+	position: 'left',
+	baseline: true,
+	grid: true,
+	labelFormat: 'percentage',
+	ticks: true,
+	title: ['Conversion Rate', '(converted users / total active users)'],
+};
+
 const DurationLabelFormat = bindWithProps(DurationStory);
 DurationLabelFormat.args = {
 	position: 'left',
@@ -239,6 +249,7 @@ export {
 	ControlledLabels,
 	CustomXRange,
 	DurationLabelFormat,
+	MultilineTitle,
 	NonLinearAxis,
 	NumberFormat,
 	SubLabels,

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -17,6 +17,7 @@ import {
 	Basic,
 	ControlledLabels,
 	DurationLabelFormat,
+	MultilineTitle,
 	NonLinearAxis,
 	NumberFormat,
 	SubLabels,
@@ -25,6 +26,11 @@ import {
 } from './Axis.story';
 
 describe('Axis', () => {
+	// Axis is not a real React component. This is test just provides test coverage for sonarqube
+	test('Render pseudo element', () => {
+		render(<Axis position="left" />);
+	});
+
 	test('Renders properly', async () => {
 		render(<Basic {...Basic.args} />);
 		const axes = await screen.findAllByRole('graphics-symbol');
@@ -32,9 +38,16 @@ describe('Axis', () => {
 		expect(axes.length).toEqual(2);
 	});
 
-	// Axis is not a real React component. This is test just provides test coverage for sonarqube
-	test('Render pseudo element', () => {
-		render(<Axis position="left" />);
+	describe('MultilineTitle', () => {
+		test('should render title on two lines', async () => {
+			render(<MultilineTitle {...MultilineTitle.args} />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+			// first line
+			expect(screen.getByText('Conversion Rate')).toBeInTheDocument();
+			// second line
+			expect(screen.getByText('(converted users / total active users)')).toBeInTheDocument();
+		});
 	});
 
 	describe('percentage', () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -239,7 +239,7 @@ export interface AxisProps extends BaseProps {
 	 */
 	tickMinStep?: number;
 	/** Sets the axis title */
-	title?: string;
+	title?: string | string[];
 	/** If the text is wider than the bandwidth that is labels, it will be truncated so that it stays within that bandwidth. */
 	truncateLabels?: boolean;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow multi-line axis titles by supplying and array of strings. Each string in the array will render on a new line.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/269

## Story

Axis > MultilineTitle

## Screenshots (if appropriate):

![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/90f14709-5d64-4062-98a1-7b6dcadc8d36)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
