### PR TITLE
fix: only show the trendline for the hovered item not the highlighted group

### DIFF
--- a/src/specBuilder/trendline/trendlineDataUtils.test.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.test.ts
@@ -22,14 +22,13 @@ import {
 	TRENDLINE_VALUE,
 } from '@constants';
 import { baseData } from '@specBuilder/specUtils';
-import { Data, FilterTransform } from 'vega';
+import { Data } from 'vega';
 
 import {
 	addTableDataTransforms,
 	addTrendlineData,
 	getAggregateTrendlineData,
 	getRegressionTrendlineData,
-	getTrendlineDisplayOnHoverData,
 	getTrendlineStatisticalTransforms,
 } from './trendlineDataUtils';
 import { defaultLineProps, defaultTrendlineProps } from './trendlineTestUtils';
@@ -343,18 +342,5 @@ describe('addTableDataTransforms()', () => {
 		});
 		expect(transforms).toHaveLength(1);
 		expect(transforms[0]).toHaveProperty('type', 'extent');
-	});
-});
-
-describe('getTrendlineDisplayOnHoverData()', () => {
-	test('should add highlighted group to expr if isHighlightedByGroup', () => {
-		const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', 'line0', true);
-		expect(
-			(data.transform?.[0] as FilterTransform).expr.includes(`indexof(pluck(data('line0_highlightedData')`)
-		).toBe(true);
-	});
-	test('should include high resolution data if not a widnow method', () => {
-		const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', 'line0', false);
-		expect(data.source).toBe('line0Trendline0_highResolutionData');
 	});
 });

--- a/src/specBuilder/trendline/trendlineDataUtils.ts
+++ b/src/specBuilder/trendline/trendlineDataUtils.ts
@@ -18,7 +18,6 @@ import {
 	SELECTED_SERIES,
 	SERIES_ID,
 } from '@constants';
-import { isHighlightedByGroup } from '@specBuilder/chartTooltip/chartTooltipUtils';
 import { getSeriesIdTransform, getTableData } from '@specBuilder/data/dataUtils';
 import { hasInteractiveChildren } from '@specBuilder/marks/markUtils';
 import { getFacetsFromProps } from '@specBuilder/specUtils';
@@ -87,7 +86,7 @@ export const getTrendlineData = (markProps: TrendlineParentProps): SourceData[] 
 			data.push(getWindowTrendlineData(markProps, trendlineProps));
 		}
 		if (displayOnHover) {
-			data.push(getTrendlineDisplayOnHoverData(name, method, markName, isHighlightedByGroup(markProps)));
+			data.push(getTrendlineDisplayOnHoverData(name, method));
 		}
 		if (hasInteractiveChildren(trendlineChildren)) {
 			concatenatedTrendlineData.source.push(`${name}_data`);
@@ -310,24 +309,15 @@ export const addTableDataTransforms = produce<Transforms[], [TrendlineParentProp
  * @param method
  * @returns SourceData
  */
-export const getTrendlineDisplayOnHoverData = (
-	trendlineName: string,
-	method: TrendlineMethod,
-	markName: string,
-	isHighlightedByGroup: boolean
-): SourceData => {
+export const getTrendlineDisplayOnHoverData = (trendlineName: string, method: TrendlineMethod): SourceData => {
 	const source = isWindowMethod(method) ? `${trendlineName}_data` : `${trendlineName}_highResolutionData`;
-	let expr = `datum.${SERIES_ID} === ${HIGHLIGHTED_SERIES} || datum.${SERIES_ID} === ${SELECTED_SERIES}`;
-	if (isHighlightedByGroup) {
-		expr += ` || indexof(pluck(data('${markName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1`;
-	}
 	return {
 		name: `${trendlineName}_highlightedData`,
 		source,
 		transform: [
 			{
 				type: 'filter',
-				expr,
+				expr: `datum.${SERIES_ID} === ${HIGHLIGHTED_SERIES} || datum.${SERIES_ID} === ${SELECTED_SERIES}`,
 			},
 		],
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`displayOnHover` trendlines should only display for the hovered item not the highlighted group (`highlightBy`)

## Screenshots (if appropriate):

<img width="886" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/4c53b6cb-9451-4ad4-9b77-43bac7a304c9">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
