### PR TITLE
chore: clean up the legend highlight logic

### DIFF
--- a/src/specBuilder/legend/legendHighlightUtils.test.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.test.ts
@@ -9,17 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import {
-	DEFAULT_COLOR,
-	DEFAULT_OPACITY_RULE,
-	HIGHLIGHTED_SERIES,
-	HIGHLIGHT_CONTRAST_RATIO,
-	OPACITY_SCALE,
-	SERIES_ID,
-} from '@constants';
+import { DEFAULT_OPACITY_RULE, HIGHLIGHTED_SERIES, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
 import { Mark } from 'vega';
 
-import { getHighlightOpacityRule, getOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
+import { getHighlightOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
 import { defaultMark } from './legendTestUtils';
 
 const defaultGroupMark: Mark = {
@@ -37,58 +30,16 @@ const defaultOpacityEncoding = {
 };
 
 describe('getHighlightOpacityRule()', () => {
-	test('scale ref should divide by highlight contrast ratio', () => {
-		expect(getHighlightOpacityRule({ scale: OPACITY_SCALE, field: DEFAULT_COLOR })).toStrictEqual({
-			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
-		});
+	test('should use HIGHLIGHTED_SERIES in test if there are not any keys', () => {
+		const opacityRule = getHighlightOpacityRule();
+		expect(opacityRule).toHaveProperty(
+			'test',
+			`${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`
+		);
 	});
-	test('signal ref should divide by highlight contrast ratio', () => {
-		expect(getHighlightOpacityRule({ signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})` })).toStrictEqual({
-			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
-		});
-	});
-	test('value ref should divide by highlight contrast ratio', () => {
-		expect(getHighlightOpacityRule({ value: 0.5 })).toStrictEqual({
-			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-			value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
-		});
-	});
-	test('empty ref should return default rule', () => {
-		expect(getHighlightOpacityRule({})).toStrictEqual({
-			test: `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-			value: 1 / HIGHLIGHT_CONTRAST_RATIO,
-		});
-	});
-	test('should use the legend name in the test if keys exist', () => {
-		const legendName = 'legend0';
-		const { test } = getHighlightOpacityRule({}, ['series'], legendName);
-		expect(test).toContain(legendName);
-	});
-	test('should use the highlighedSeries in the test if keys do not', () => {
-		const { test } = getHighlightOpacityRule({});
-		expect(test).toContain(HIGHLIGHTED_SERIES);
-	});
-});
-
-describe('getOpacityRule()', () => {
-	test('array, should return the last value', () => {
-		expect(getOpacityRule([{ value: 0.5 }])).toStrictEqual({ value: 0.5 });
-		expect(
-			getOpacityRule([{ value: 0.5 }, { signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})` }])
-		).toStrictEqual({
-			signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR})`,
-		});
-	});
-	test('empty array, should return default value', () => {
-		expect(getOpacityRule([])).toStrictEqual({ value: 1 });
-	});
-	test('object, should return object', () => {
-		expect(getOpacityRule({ value: 0.5 })).toStrictEqual({ value: 0.5 });
-	});
-	test('undefined, should return default value', () => {
-		expect(getOpacityRule(undefined)).toStrictEqual({ value: 1 });
+	test('should use keys in test if there are keys', () => {
+		const opacityRule = getHighlightOpacityRule(['key1'], 'scatter0');
+		expect(opacityRule).toHaveProperty('test', 'scatter0_highlight && scatter0_highlight !== datum.key1');
 	});
 });
 

--- a/src/specBuilder/legend/legendHighlightUtils.ts
+++ b/src/specBuilder/legend/legendHighlightUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { COLOR_SCALE, HIGHLIGHTED_SERIES, HIGHLIGHT_CONTRAST_RATIO, SERIES_ID } from '@constants';
-import { GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
+import { GroupMark, Mark, NumericValueRef } from 'vega';
 
 /**
  * Adds opacity tests for the fill and stroke of marks that use the color scale to set the fill or stroke value.
@@ -31,10 +31,8 @@ export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: s
 		const { opacity } = update;
 
 		if (opacity !== undefined) {
-			// the production rule that sets the fill opacity for this mark
-			const opacityRule = getOpacityRule(opacity);
-			// the new production rule for highlighting
-			const highlightOpacityRule = getHighlightOpacityRule(opacityRule, keys, name);
+			// // the new production rule for highlighting
+			const highlightOpacityRule = getHighlightOpacityRule(keys, name);
 
 			if (!Array.isArray(update.opacity)) {
 				update.opacity = [];
@@ -46,42 +44,10 @@ export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: s
 	});
 };
 
-export const getOpacityRule = (
-	opacityRule: ProductionRule<NumericValueRef> | undefined
-): ProductionRule<NumericValueRef> => {
-	if (opacityRule) {
-		// if it's an array and length > 0, get the last value
-		if (Array.isArray(opacityRule)) {
-			if (opacityRule.length > 0) {
-				return opacityRule[opacityRule.length - 1];
-			}
-		} else {
-			return opacityRule;
-		}
-	}
-	return { value: 1 };
-};
-
-export const getHighlightOpacityRule = (
-	opacityRule: ProductionRule<NumericValueRef>,
-	keys?: string[],
-	name?: string
-): { test?: string } & NumericValueRef => {
+export const getHighlightOpacityRule = (keys?: string[], name?: string): { test?: string } & NumericValueRef => {
 	let test = `${HIGHLIGHTED_SERIES} && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`;
 	if (keys) {
 		test = `${name}_highlight && ${name}_highlight !== datum.${keys[0]}`;
-	}
-	if ('scale' in opacityRule && 'field' in opacityRule) {
-		return {
-			test,
-			signal: `scale('${opacityRule.scale}', datum.${opacityRule.field}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
-		};
-	}
-	if ('signal' in opacityRule) {
-		return { test, signal: `${opacityRule.signal} / ${HIGHLIGHT_CONTRAST_RATIO}` };
-	}
-	if ('value' in opacityRule && typeof opacityRule.value === 'number') {
-		return { test, value: opacityRule.value / HIGHLIGHT_CONTRAST_RATIO };
 	}
 	return { test, value: 1 / HIGHLIGHT_CONTRAST_RATIO };
 };

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.story.tsx
@@ -71,8 +71,8 @@ const MultipleSegmentFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEl
 
 	return (
 		<Chart {...chartProps}>
-			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
-			<Axis position="left" ticks grid title="Average number of times per day" />
+			<Axis position="bottom" grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
+			<Axis position="left" grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment">
 				<Trendline {...trendlineProps} displayOnHover orientation="horizontal">
 					<TrendlineAnnotation prefix="Median times" numberFormat=".3" />
@@ -91,8 +91,8 @@ const TimeCompareFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactElemen
 
 	return (
 		<Chart {...chartProps}>
-			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
-			<Axis position="left" ticks grid title="Average number of times per day" />
+			<Axis position="bottom" grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
+			<Axis position="left" grid title="Average number of times per day" />
 			<Scatter
 				dimension="dauPercent"
 				metric="countAvg"
@@ -120,8 +120,8 @@ const EventOverlayFeatureMatrixStory: StoryFn<typeof Chart> = (args): ReactEleme
 
 	return (
 		<Chart {...chartProps}>
-			<Axis position="bottom" ticks grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
-			<Axis position="left" ticks grid title="Average number of times per day" />
+			<Axis position="bottom" grid title="Percentage of daily users (DAU)" labelFormat="percentage" />
+			<Axis position="left" grid title="Average number of times per day" />
 			<Scatter dimension="dauPercent" metric="countAvg" color="segment" opacity="segment">
 				<ChartTooltip excludeDataKeys={['isTopItem']} />
 				<Trendline {...trendlineProps} excludeDataKeys={['isTopItem']} displayOnHover orientation="horizontal">

--- a/src/test-utils/customQueries.ts
+++ b/src/test-utils/customQueries.ts
@@ -23,7 +23,7 @@ const [
 	getMarksByGroupName,
 	findAllMarksByGroupName,
 	findMarksByGroupName,
-] = buildQueries(queryAllMarksByGroupName, getMultipleError, getMissingError);
+] = buildQueries<[string, string?]>(queryAllMarksByGroupName, getMultipleError, getMissingError);
 
 export {
 	queryMarksByGroupName,

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -513,7 +513,7 @@ export interface LegendProps extends BaseProps {
 	keys?: string[];
 	/** labels for each of the series */
 	legendLabels?: LegendLabel[];
-	/** max characters before truncating a legend label */
+	/** max width in pixels before truncating a legend label */
 	labelLimit?: number;
 	/** line type or key in the data that is used as the line type facet for the symbols */
 	lineType?: LineTypeFacet;


### PR DESCRIPTION
A while ago we updated the highlight logic so that `opacity` is used to highlight and `stroke-opacity` and `fill-opacity` are used to set the static opacity values. This update didn't make it all the way down to legend highlight utils. This PR gets that up to date and a couple other house cleaning items.
