### PR TITLE
Width height integers

### DIFF
--- a/src/hooks/useChartHeight.tsx
+++ b/src/hooks/useChartHeight.tsx
@@ -17,7 +17,8 @@ export default function useChartHeight(containerHeight: number, maxHeight: numbe
 	return useMemo(() => {
 		let targetHeight = minHeight;
 		if (typeof height === 'number') {
-			targetHeight = height;
+			// integers only, decimal values can cause performance issues with vega.
+			return Math.round(height);
 		} else if (/^\d+%$/.exec(height)) {
 			targetHeight = (containerHeight * Number(height.slice(0, -1))) / 100;
 		} else {
@@ -25,6 +26,7 @@ export default function useChartHeight(containerHeight: number, maxHeight: numbe
 				`height of ${height} is not a valid height. Please provide a valid number or percentage ex. 75%`
 			);
 		}
-		return targetHeight === 0 ? 0 : Math.min(maxHeight, Math.max(minHeight, targetHeight));
+		// integers only, decimal values can cause performance issues with vega.
+		return targetHeight === 0 ? 0 : Math.round(Math.min(maxHeight, Math.max(minHeight, targetHeight)));
 	}, [containerHeight, maxHeight, minHeight, height]);
 }

--- a/src/hooks/useChartWidth.tsx
+++ b/src/hooks/useChartWidth.tsx
@@ -21,7 +21,7 @@ export default function useChartWidth(
 		let targetWidth = minWidth;
 		if (typeof width === 'number') {
 			// integers only, decimal values can cause performance issues with vega.
-			targetWidth = Math.round(width);
+			return Math.round(width);
 		} else if (width === 'auto') {
 			targetWidth = containerWidth;
 		} else if (width.match(/^\d+%$/)) {

--- a/src/hooks/useChartWidth.tsx
+++ b/src/hooks/useChartWidth.tsx
@@ -20,7 +20,8 @@ export default function useChartWidth(
 	return useMemo(() => {
 		let targetWidth = minWidth;
 		if (typeof width === 'number') {
-			targetWidth = width;
+			// integers only, decimal values can cause performance issues with vega.
+			targetWidth = Math.round(width);
 		} else if (width === 'auto') {
 			targetWidth = containerWidth;
 		} else if (width.match(/^\d+%$/)) {
@@ -30,6 +31,7 @@ export default function useChartWidth(
 				`width of ${width} is not a valid width. Please provide a valid number, 'auto' or percentage ex. 75%`
 			);
 		}
-		return targetWidth === 0 ? 0 : Math.min(maxWidth, Math.max(minWidth, targetWidth));
+		// integers only, decimal values can cause performance issues with vega.
+		return targetWidth === 0 ? 0 : Math.round(Math.min(maxWidth, Math.max(minWidth, targetWidth)));
 	}, [containerWidth, maxWidth, minWidth, width]);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Vega has performance issues if height/width contain decimals. This applies a `Math.round` so we only ever use integers.

Also fixed an issue where min/max values were being applied to static widths and heights. Static widths and heights should not respect min/max values.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/288

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
