### PR TITLE
fix: trendline annotations should not be interactive

### DIFF
--- a/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/src/specBuilder/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -124,6 +124,7 @@ const getTrendlineAnnotationPoints = (annotationProps: TrendlineAnnotationSpecPr
 		name: `${name}_points`,
 		type: 'symbol',
 		from: { data },
+		interactive: false,
 		encode: {
 			enter: {
 				opacity: { value: 0 },
@@ -200,6 +201,7 @@ export const getTrendlineAnnotationTextMark = (annotation: TrendlineAnnotationSp
 		type: 'text',
 		from: { data: `${name}_points` },
 		zindex: 1, // this will draw the text in front of the badge
+		interactive: false,
 		encode: {
 			enter: {
 				text: { signal: `${textPrefix}format(datum.datum.${TRENDLINE_VALUE}, '${numberFormat}')` },
@@ -257,6 +259,7 @@ export const getTrendlineAnnotationBadgeMark = ({
 			name: `${name}_badge`,
 			type: 'rect',
 			from: { data: `${name}` },
+			interactive: false,
 			encode: {
 				enter: {
 					cornerRadius: { value: 2 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Trendline annotations should not be interactive. This means that hovering them should not interrupt tooltips. This fixes that.

https://github.com/adobe/react-spectrum-charts/assets/40001449/960dd7fd-2e49-48d5-94ed-f7fa7db31150

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
