### PR TITLE
feat: add size props to chartPopover

### DIFF
--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -308,7 +308,6 @@ const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers
 	const popoverDetail = popovers.find((p) => p.name === itemName);
 	const popover = popoverDetail?.callback;
 	const dialogProps = popoverDetail?.dialogProps;
-	const width = dialogProps?.width ?? 'auto';
 	const minWidth = dialogProps?.minWidth ?? 0;
 	return (
 		<DialogTrigger
@@ -321,13 +320,7 @@ const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers
 		>
 			<ActionButton UNSAFE_style={{ display: 'none' }}>launch chart popover</ActionButton>
 			{(close) => (
-				<Dialog
-					{...dialogProps}
-					data-testid="rsc-popover"
-					UNSAFE_className="rsc-popover"
-					width={width}
-					minWidth={minWidth}
-				>
+				<Dialog data-testid="rsc-popover" UNSAFE_className="rsc-popover" {...dialogProps} minWidth={minWidth}>
 					<SpectrumView gridColumn="1/-1" gridRow="1/-1" margin={12}>
 						{popover && datum && popover(datum, close)}
 					</SpectrumView>

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -307,7 +307,9 @@ const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers
 	}
 	const popoverDetail = popovers.find((p) => p.name === itemName);
 	const popover = popoverDetail?.callback;
-	const width = popoverDetail?.width;
+	const dialogProps = popoverDetail?.dialogProps;
+	const width = dialogProps?.width ?? 'auto';
+	const minWidth = dialogProps?.minWidth ?? 0;
 	return (
 		<DialogTrigger
 			type="popover"
@@ -319,7 +321,13 @@ const ChartDialog = ({ datum, itemName, targetElement, setPopoverState, popovers
 		>
 			<ActionButton UNSAFE_style={{ display: 'none' }}>launch chart popover</ActionButton>
 			{(close) => (
-				<Dialog data-testid="rsc-popover" UNSAFE_className="rsc-popover" minWidth="size-1000" width={width}>
+				<Dialog
+					{...dialogProps}
+					data-testid="rsc-popover"
+					UNSAFE_className="rsc-popover"
+					width={width}
+					minWidth={minWidth}
+				>
 					<SpectrumView gridColumn="1/-1" gridRow="1/-1" margin={12}>
 						{popover && datum && popover(datum, close)}
 					</SpectrumView>

--- a/src/hooks/usePopovers.tsx
+++ b/src/hooks/usePopovers.tsx
@@ -15,11 +15,15 @@ import { getAllElements } from '@utils';
 
 import { Chart } from '../Chart';
 import { ChartPopover } from '../components/ChartPopover';
-import { ChartChildElement, ChartPopoverElement, PopoverHandler } from '../types';
+import { ChartChildElement, ChartPopoverElement, ChartPopoverProps, PopoverHandler } from '../types';
 
 type MappedPopover = { name: string; element: ChartPopoverElement };
 
-export type PopoverDetail = { name: string; callback: PopoverHandler; width?: number };
+export type PopoverDetail = {
+	name: string;
+	callback: PopoverHandler;
+	dialogProps: Omit<ChartPopoverProps, 'children'>;
+};
 
 export default function usePopovers(children: ChartChildElement[]): PopoverDetail[] {
 	const popoverElements = useMemo(
@@ -31,11 +35,14 @@ export default function usePopovers(children: ChartChildElement[]): PopoverDetai
 		() =>
 			popoverElements
 				.filter((popover) => popover.element.props.children)
-				.map((popover) => ({
-					name: popover.name,
-					callback: popover.element.props.children,
-					width: popover.element.props.width,
-				})) as PopoverDetail[],
+				.map((popover) => {
+					const { children, ...dialogProps } = popover.element.props;
+					return {
+						name: popover.name,
+						callback: children as PopoverHandler,
+						dialogProps,
+					};
+				}),
 		[popoverElements]
 	);
 }

--- a/src/stories/components/ChartPopover/ChartPopover.story.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.story.tsx
@@ -109,24 +109,27 @@ const AreaStory: StoryFn<typeof ChartPopover> = (args): ReactElement => {
 };
 
 const Canvas = bindWithProps(ChartPopoverCanvasStory);
-Canvas.args = { children: dialogContent };
+Canvas.args = { children: dialogContent, width: 'auto' };
 
 const Svg = bindWithProps(ChartPopoverSvgStory);
-Svg.args = { children: dialogContent };
+Svg.args = { children: dialogContent, width: 'auto' };
 
 const Size = bindWithProps(ChartPopoverSvgStory);
-Size.args = { children: dialogContent, width: 200, height: 100, minWidth: 50 };
+Size.args = { children: dialogContent, width: 200, height: 100 };
+
+const MinWidth = bindWithProps(ChartPopoverSvgStory);
+MinWidth.args = { children: dialogContent, width: 'auto', minWidth: 250 };
 
 const AreaChart = bindWithProps(AreaStory);
-AreaChart.args = { children: dialogContent };
+AreaChart.args = { children: dialogContent, width: 'auto' };
 
 const DodgedBarChart = bindWithProps(ChartPopoverDodgedBarStory);
-DodgedBarChart.args = { children: dialogContent };
+DodgedBarChart.args = { children: dialogContent, width: 'auto' };
 
 const LineChart = bindWithProps(LineStory);
-LineChart.args = { children: dialogContent };
+LineChart.args = { children: dialogContent, width: 'auto' };
 
 const StackedBarChart = bindWithProps(ChartPopoverSvgStory);
-StackedBarChart.args = { children: dialogContent };
+StackedBarChart.args = { children: dialogContent, width: 'auto' };
 
-export { Canvas, Svg, Size, AreaChart, DodgedBarChart, LineChart, StackedBarChart };
+export { Canvas, Svg, Size, MinWidth, AreaChart, DodgedBarChart, LineChart, StackedBarChart };

--- a/src/stories/components/ChartPopover/ChartPopover.story.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.story.tsx
@@ -109,21 +109,24 @@ const AreaStory: StoryFn<typeof ChartPopover> = (args): ReactElement => {
 };
 
 const Canvas = bindWithProps(ChartPopoverCanvasStory);
-Canvas.args = { children: dialogContent, width: 250 };
+Canvas.args = { children: dialogContent };
 
 const Svg = bindWithProps(ChartPopoverSvgStory);
-Svg.args = { children: dialogContent, width: 250 };
+Svg.args = { children: dialogContent };
+
+const Size = bindWithProps(ChartPopoverSvgStory);
+Size.args = { children: dialogContent, width: 200, height: 100, minWidth: 50 };
 
 const AreaChart = bindWithProps(AreaStory);
 AreaChart.args = { children: dialogContent };
 
 const DodgedBarChart = bindWithProps(ChartPopoverDodgedBarStory);
-DodgedBarChart.args = { children: dialogContent, width: 250 };
+DodgedBarChart.args = { children: dialogContent };
 
 const LineChart = bindWithProps(LineStory);
 LineChart.args = { children: dialogContent };
 
 const StackedBarChart = bindWithProps(ChartPopoverSvgStory);
-StackedBarChart.args = { children: dialogContent, width: 250 };
+StackedBarChart.args = { children: dialogContent };
 
-export { Canvas, Svg, AreaChart, DodgedBarChart, LineChart, StackedBarChart };
+export { Canvas, Svg, Size, AreaChart, DodgedBarChart, LineChart, StackedBarChart };

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -28,7 +28,7 @@ import {
 } from '@test-utils';
 import userEvent from '@testing-library/user-event';
 
-import { Canvas, DodgedBarChart, LineChart, StackedBarChart, Svg } from './ChartPopover.story';
+import { Canvas, DodgedBarChart, LineChart, Size, StackedBarChart, Svg } from './ChartPopover.story';
 
 describe('ChartPopover', () => {
 	// ChartPopover is not a real React component. This is test just provides test coverage for sonarqube
@@ -102,6 +102,21 @@ describe('ChartPopover', () => {
 		expect(bars[0]).toHaveAttribute('stroke-width', '2');
 		// all other bars should be faded
 		expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+	});
+
+	test('Popover should be corrrect size', async () => {
+		render(<Size {...Size.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+		const bars = getAllMarksByGroupName(chart, 'bar0');
+
+		// clicking the bar should open the popover
+		await clickNthElement(bars, 0);
+		const popover = await screen.findByTestId('rsc-popover');
+		await waitFor(() => expect(popover).toBeInTheDocument()); // waitFor to give the popover time to make sure it doesn't close
+
+		expect(popover).toHaveStyle('width: 200px; height: 100px; min-width: 50px;');
 	});
 
 	test('Line popover opens and closes corectly when clicking on the chart', async () => {

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -28,7 +28,7 @@ import {
 } from '@test-utils';
 import userEvent from '@testing-library/user-event';
 
-import { Canvas, DodgedBarChart, LineChart, Size, StackedBarChart, Svg } from './ChartPopover.story';
+import { Canvas, DodgedBarChart, LineChart, MinWidth, Size, StackedBarChart, Svg } from './ChartPopover.story';
 
 describe('ChartPopover', () => {
 	// ChartPopover is not a real React component. This is test just provides test coverage for sonarqube
@@ -116,7 +116,22 @@ describe('ChartPopover', () => {
 		const popover = await screen.findByTestId('rsc-popover');
 		await waitFor(() => expect(popover).toBeInTheDocument()); // waitFor to give the popover time to make sure it doesn't close
 
-		expect(popover).toHaveStyle('width: 200px; height: 100px; min-width: 50px;');
+		expect(popover).toHaveStyle('width: 200px; height: 100px; min-width: 0px;');
+	});
+
+	test('should honor minWidth', async () => {
+		render(<MinWidth {...MinWidth.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+		const bars = getAllMarksByGroupName(chart, 'bar0');
+
+		// clicking the bar should open the popover
+		await clickNthElement(bars, 0);
+		const popover = await screen.findByTestId('rsc-popover');
+		await waitFor(() => expect(popover).toBeInTheDocument()); // waitFor to give the popover time to make sure it doesn't close
+
+		expect(popover).toHaveStyle('width: auto; min-width: 250px;');
 	});
 
 	test('Line popover opens and closes corectly when clicking on the chart', async () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -545,8 +545,20 @@ export interface ChartTooltipProps {
 	highlightBy?: 'series' | 'dimension' | 'item' | string[];
 }
 export interface ChartPopoverProps {
+	/** Callback used to control the content rendered in the popover */
 	children?: PopoverHandler;
-	width?: number;
+	/** Width of the popover */
+	width?: number | 'auto';
+	/** Minimum width of the popover */
+	minWidth?: number;
+	/** Maximum width of the popover */
+	maxWidth?: number;
+	/** Height of the popover */
+	height?: number | 'auto';
+	/** Minimum height of the popover */
+	minHeight?: number;
+	/** Maximum height of the popover */
+	maxHeight?: number;
 }
 
 export interface ReferenceLineProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add more props to control the size of ChartPopover.

* `minWidth`
* `maxWidth`
* `height`
* `minHeight`
* `maxHeight`

`width` now supports `'auto'`

## Motivation and Context

Better layout control of popovers

## Story:

ChartPopover > Size
ChartPopover > MinWidth

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
