### PR TITLE
fix: hideShow support for legend keys

### DIFF
--- a/src/specBuilder/legend/legendSpecBuilder.test.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.test.ts
@@ -45,21 +45,13 @@ const defaultSpec: Spec = {
 };
 
 const colorEncoding = { signal: `scale('${COLOR_SCALE}', data('legend0Aggregate')[datum.index].${DEFAULT_COLOR})` };
-const hiddenSeriesEncoding = {
-	test: 'indexof(hiddenSeries, datum.value) !== -1',
-	value: 'rgb(213, 213, 213)',
-};
 
 const defaultSymbolUpdateEncodings: SymbolEncodeEntry = {
-	fill: [hiddenSeriesEncoding, colorEncoding],
-	stroke: [hiddenSeriesEncoding, colorEncoding],
+	fill: [colorEncoding],
+	stroke: [colorEncoding],
 };
 const hiddenSeriesLabelUpdateEncoding = {
 	fill: [
-		{
-			test: 'indexof(hiddenSeries, datum.value) !== -1',
-			value: 'rgb(144, 144, 144)',
-		},
 		{
 			value: 'rgb(70, 70, 70)',
 		},

--- a/src/specBuilder/signal/signalSpecBuilder.test.ts
+++ b/src/specBuilder/signal/signalSpecBuilder.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES } from '@constants';
+import { FILTERED_TABLE, HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES } from '@constants';
 import {
 	defaultHighlightedItemSignal,
 	defaultHighlightedSeriesSignal,
@@ -17,7 +17,11 @@ import {
 } from '@specBuilder/specTestUtils';
 import { Signal } from 'vega';
 
-import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents } from './signalSpecBuilder';
+import {
+	addHighlightedItemSignalEvents,
+	addHighlightedSeriesSignalEvents,
+	getHighlightSignalUpdateExpression,
+} from './signalSpecBuilder';
 
 describe('signalSpecBuilder', () => {
 	let signals: Signal[];
@@ -92,6 +96,23 @@ describe('signalSpecBuilder', () => {
 			expect(signals[2]?.on?.[1]).toHaveProperty('update', 'null');
 			expect(signals[3].on).toBeUndefined();
 			expect(signals[4].on).toBeUndefined();
+		});
+	});
+
+	describe('getHighlightSignalUpdateExpression()', () => {
+		test('should return basic rule if there is no method of hidding series', () => {
+			const update = getHighlightSignalUpdateExpression('legend0', false);
+			expect(update).toBe(`domain("legend0Entries")[datum.index]`);
+		});
+
+		test('should reference filteredTable if there are keys', () => {
+			const update = getHighlightSignalUpdateExpression('legend0', true, ['key1', 'key2']);
+			expect(update).toContain(FILTERED_TABLE);
+		});
+
+		test('should referende hiddenSeries if there are not keys', () => {
+			const update = getHighlightSignalUpdateExpression('legend0', true, []);
+			expect(update).toContain('hiddenSeries');
 		});
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

get hide/show working with legend keys

<img width="1056" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/ac3cd9c0-eaa9-4f24-a608-312938e391ea">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
