### PR TITLE
Update immer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 	"dependencies": {
 		"@adobe/react-spectrum": ">= 3.23.0",
 		"d3-format": "^3.1.0",
-		"immer": ">= 9.0.0",
+		"immer": "^ 9.0.0",
 		"uuid": ">= 9.0.0",
 		"vega-embed": ">= 6.24.0",
 		"vega-tooltip": ">= 0.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8908,10 +8908,10 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
-"immer@>= 9.0.0":
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.3.tgz#a8de42065e964aa3edf6afc282dfc7f7f34ae3c9"
-  integrity sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==
+"immer@^ 9.0.0":
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update `immer` from `>=9.0.0` to `^9.0.0`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently we declare `"immer": ">= 9.0.0",` so[ version "10.0.3"](https://github.com/adobe/react-spectrum-charts/pull/303/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL8912) got installed.
While integrating RSC package into quarry package, we got some conflict version error from `@ajo/decision-policy-assist` complaining:
```
src/store/addStrategy/addStrategySlice.ts(16,14): error TS2742: The inferred type of 'addStrategySlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
src/store/details/detailsSlice.ts(26,14): error TS2742: The inferred type of 'detailsSlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
src/store/dialog/dialogSlice.ts(16,14): error TS2742: The inferred type of 'dialogSlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
src/store/review/reviewSlice.ts(14,14): error TS2742: The inferred type of 'reviewSlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
src/store/selectFallback/selectFallbackSlice.ts(36,14): error TS2742: The inferred type of 'selectFallbackSlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
src/store/strategies/strategiesSlice.ts(75,14): error TS2742: The inferred type of 'strategiesSlice' cannot be named without a reference to '@reduxjs/toolkit/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.
ERROR: "build:defs" exited with 1.
npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!  in workspace: @ajo/decision-policy-assist@0.3.2 
npm ERR!  at location: /Users/nli1/Workspace/quarry/packages/@ajo/decision-policy-assist 
ERROR: "build" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This could be possible fixed by adding `immer` in resolutions or nohlist ([reference](https://git.corp.adobe.com/frontend/quarry/pull/6685#discussion_r7564180)). 
But in order to make things simple and clean, I was wondering if we could use `"immer": "^ 9.0.0",`, so [version "9.0.21"](https://github.com/adobe/react-spectrum-charts/pull/303/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR8912) will be installed, then there won't be conflict in quarry? Thanks!
## How Has This Been Tested?
Tested locally, storybook run as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
