### PR TITLE
Move @adobe/react-spectrum from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"skulk": "yarn watch --silent"
 	},
 	"devDependencies": {
+		"@adobe/react-spectrum": "3.34.1",
 		"@babel/cli": "^7.19.3",
 		"@babel/core": "^7.20.5",
 		"@babel/eslint-parser": "^7.19.1",
@@ -126,7 +127,6 @@
 		"webpack-node-externals": "^3.0.0"
 	},
 	"dependencies": {
-		"@adobe/react-spectrum": ">= 3.23.0",
 		"d3-format": "^3.1.0",
 		"immer": ">= 9.0.0",
 		"uuid": ">= 9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
 
 "@adobe/react-spectrum@3.34.1":
   version "3.34.1"
-  resolved "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/react-spectrum/-/react-spectrum-3.34.1.tgz#d1b334dd1297856a1f4ca13a190d4c731c1c116a"
+  resolved "https://registry.yarnpkg.com/@adobe/react-spectrum/-/react-spectrum-3.34.1.tgz#d1b334dd1297856a1f4ca13a190d4c731c1c116a"
   integrity sha512-J1HOjntW+H8xusfc5xLnIlUXNOzllp4f7qzh3LlDOsZuH8oBH8sIYmBVp4ijVhRFUKa10qg088role1On3UGbg==
   dependencies:
     "@internationalized/string" "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,9 +27,9 @@
   resolved "https://registry.yarnpkg.com/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.4.tgz#eec7f2c2d855e72196cbb7572905413a5005c7d9"
   integrity sha512-XPLzIBl58HdLF9WIPB7RDAvVXvCE3SjG+HaWQhW2P9MnxSz1DEA9O7mlTlYblJkMbfk10T/+RFaSupc1yoN+TA==
 
-"@adobe/react-spectrum@>= 3.23.0":
+"@adobe/react-spectrum@3.34.1":
   version "3.34.1"
-  resolved "https://registry.yarnpkg.com/@adobe/react-spectrum/-/react-spectrum-3.34.1.tgz#d1b334dd1297856a1f4ca13a190d4c731c1c116a"
+  resolved "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/react-spectrum/-/react-spectrum-3.34.1.tgz#d1b334dd1297856a1f4ca13a190d4c731c1c116a"
   integrity sha512-J1HOjntW+H8xusfc5xLnIlUXNOzllp4f7qzh3LlDOsZuH8oBH8sIYmBVp4ijVhRFUKa10qg088role1On3UGbg==
   dependencies:
     "@internationalized/string" "^3.2.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Move @adobe/react-spectrum from dependencies to devDependencies

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/286

## Motivation and Context

Since `@adobe/react-spectrum` is in peerDependencies, it should not be in dependencies.
Add it to devDependencies for developing

## How Has This Been Tested?
Tested locally, story book can run as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
