### PR TITLE
feat: add onOpenChange to popover

### DIFF
--- a/src/hooks/usePopovers.tsx
+++ b/src/hooks/usePopovers.tsx
@@ -15,14 +15,14 @@ import { getAllElements } from '@utils';
 
 import { Chart } from '../Chart';
 import { ChartPopover } from '../components/ChartPopover';
-import { ChartChildElement, ChartPopoverElement, ChartPopoverProps, PopoverHandler } from '../types';
+import { ChartChildElement, ChartPopoverElement, ChartPopoverProps } from '../types';
 
 type MappedPopover = { name: string; element: ChartPopoverElement };
 
 export type PopoverDetail = {
+	chartPopoverProps: ChartPopoverProps;
+	key: string;
 	name: string;
-	callback: PopoverHandler;
-	dialogProps: Omit<ChartPopoverProps, 'children'>;
 };
 
 export default function usePopovers(children: ChartChildElement[]): PopoverDetail[] {
@@ -35,12 +35,11 @@ export default function usePopovers(children: ChartChildElement[]): PopoverDetai
 		() =>
 			popoverElements
 				.filter((popover) => popover.element.props.children)
-				.map((popover) => {
-					const { children, ...dialogProps } = popover.element.props;
+				.map((popover, index) => {
 					return {
+						chartPopoverProps: popover.element.props,
+						key: `${popover.name}Popover${index}`,
 						name: popover.name,
-						callback: children as PopoverHandler,
-						dialogProps,
 					};
 				}),
 		[popoverElements]

--- a/src/stories/components/ChartPopover/ChartPopover.story.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.story.tsx
@@ -120,6 +120,15 @@ Size.args = { children: dialogContent, width: 200, height: 100 };
 const MinWidth = bindWithProps(ChartPopoverSvgStory);
 MinWidth.args = { children: dialogContent, width: 'auto', minWidth: 250 };
 
+const OnOpenChange = bindWithProps(ChartPopoverSvgStory);
+OnOpenChange.args = {
+	children: dialogContent,
+	width: 'auto',
+	onOpenChange: (isOpen) => {
+		console.log('isOpen', isOpen);
+	},
+};
+
 const AreaChart = bindWithProps(AreaStory);
 AreaChart.args = { children: dialogContent, width: 'auto' };
 
@@ -132,4 +141,4 @@ LineChart.args = { children: dialogContent, width: 'auto' };
 const StackedBarChart = bindWithProps(ChartPopoverSvgStory);
 StackedBarChart.args = { children: dialogContent, width: 'auto' };
 
-export { Canvas, Svg, Size, MinWidth, AreaChart, DodgedBarChart, LineChart, StackedBarChart };
+export { Canvas, Svg, Size, MinWidth, OnOpenChange, AreaChart, DodgedBarChart, LineChart, StackedBarChart };

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -28,7 +28,16 @@ import {
 } from '@test-utils';
 import userEvent from '@testing-library/user-event';
 
-import { Canvas, DodgedBarChart, LineChart, MinWidth, Size, StackedBarChart, Svg } from './ChartPopover.story';
+import {
+	Canvas,
+	DodgedBarChart,
+	LineChart,
+	MinWidth,
+	OnOpenChange,
+	Size,
+	StackedBarChart,
+	Svg,
+} from './ChartPopover.story';
 
 describe('ChartPopover', () => {
 	// ChartPopover is not a real React component. This is test just provides test coverage for sonarqube
@@ -207,5 +216,21 @@ describe('ChartPopover', () => {
 		expect(bars[4]).toHaveAttribute('opacity', '1');
 		expect(bars[4]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
 		expect(bars[4]).toHaveAttribute('stroke-width', '2');
+	});
+
+	test('should call onClick callback when selecting a legend entry', async () => {
+		const onOpenChange = jest.fn();
+		render(<OnOpenChange {...OnOpenChange.args} onOpenChange={onOpenChange} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+		const bars = getAllMarksByGroupName(chart, 'bar0');
+
+		// clicking the bar should open the popover
+		await clickNthElement(bars, 0);
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+
+		await clickNthElement(bars, 0);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
 });

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -559,6 +559,8 @@ export interface ChartPopoverProps {
 	minHeight?: number;
 	/** Maximum height of the popover */
 	maxHeight?: number;
+	/** handler that is called when the popover's open state changes */
+	onOpenChange?: (isOpen: boolean) => void;
 }
 
 export interface ReferenceLineProps {

--- a/src/utils/markClickUtils.ts
+++ b/src/utils/markClickUtils.ts
@@ -65,8 +65,9 @@ export const getOnMarkClickCallback = (
 			selectedData.current = item.datum;
 			// we need to anchor the popover to a div that we move to the same location as the selected mark
 			selectedDataBounds.current = getItemBounds(item);
-			selectedDataName.current = getItemName(item);
-			(document.querySelector(`#${chartId.current} > div > button`) as HTMLButtonElement)?.click();
+			const itemName = getItemName(item);
+			selectedDataName.current = itemName;
+			(document.querySelector(`#${chartId.current} > div > #${itemName}-button`) as HTMLButtonElement)?.click();
 		}
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:

Add `onOpenChange` to `ChartPopover`. This will allow users to trigger side effects when the chartpopover opens of closes.

## Story:
ChartPopover > OnOpenChange

## Screenshots (if appropriate):

https://github.com/adobe/react-spectrum-charts/assets/40001449/3a0b4a1c-afd6-40c8-963e-397fd6c85bf0



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
