### PR TITLE
fix: only render popover content if associated component matches

### DIFF
--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -12,6 +12,7 @@
 import { FC, MutableRefObject, forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
+	COMPONENT_NAME,
 	DEFAULT_BACKGROUND_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_LINE_TYPES,
@@ -165,7 +166,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 		if (tooltips.length || legendDescriptions) {
 			tooltipConfig.formatTooltip = (value) => {
 				debugLog(debug, { title: 'Tooltip datum', contents: value });
-				if (value.rscComponentName?.startsWith('legend') && legendDescriptions && 'index' in value) {
+				if (value[COMPONENT_NAME]?.startsWith('legend') && legendDescriptions && 'index' in value) {
 					debugLog(debug, {
 						title: 'Legend descriptions',
 						contents: legendDescriptions,
@@ -180,7 +181,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 					);
 				}
 				// get the correct tooltip to render based on the hovered item
-				const tooltip = tooltips.find((t) => t.name === value.rscComponentName);
+				const tooltip = tooltips.find((t) => t.name === value[COMPONENT_NAME]);
 				if (tooltip?.callback && !('index' in value)) {
 					if (controlledHoveredIdSignal) {
 						chartView.current?.signal(controlledHoveredIdSignal.name, value?.[MARK_ID] ?? null);
@@ -326,7 +327,7 @@ const ChartDialog = ({ datum, popover, setIsPopoverOpen, targetElement }: ChartD
 			{(close) => (
 				<Dialog data-testid="rsc-popover" UNSAFE_className="rsc-popover" {...dialogProps} minWidth={minWidth}>
 					<SpectrumView gridColumn="1/-1" gridRow="1/-1" margin={12}>
-						{datum && children?.(datum, close)}
+						{datum && datum[COMPONENT_NAME] === name && children?.(datum, close)}
 					</SpectrumView>
 				</Dialog>
 			)}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,7 @@ export const GROUP_DATA = 'rscGroupData';
 export const MARK_ID = 'rscMarkId';
 export const SERIES_ID = 'rscSeriesId';
 export const STACK_ID = 'rscStackId';
+export const COMPONENT_NAME = 'rscComponentName';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';
 
 // signal names

--- a/src/specBuilder/bar/dodgedBarUtils.test.ts
+++ b/src/specBuilder/bar/dodgedBarUtils.test.ts
@@ -16,6 +16,7 @@ import { ChartTooltip } from '@components/ChartTooltip';
 import {
 	BACKGROUND_COLOR,
 	COLOR_SCALE,
+	COMPONENT_NAME,
 	CORNER_RADIUS,
 	DEFAULT_CATEGORICAL_DIMENSION,
 	DEFAULT_COLOR,
@@ -114,7 +115,7 @@ const defaultMarkWithTooltip: Mark = {
 			...defaultDodgedCornerRadiusEncodings,
 			fill: { field: DEFAULT_COLOR, scale: COLOR_SCALE },
 			fillOpacity: DEFAULT_OPACITY_RULE,
-			tooltip: { signal: "merge(datum, {'rscComponentName': 'bar0'})" },
+			tooltip: { signal: `merge(datum, {'${COMPONENT_NAME}': 'bar0'})` },
 		},
 		update: {
 			...defaultDodgedXEncodings,

--- a/src/specBuilder/legend/legendSpecBuilder.test.ts
+++ b/src/specBuilder/legend/legendSpecBuilder.test.ts
@@ -11,6 +11,7 @@
  */
 import {
 	COLOR_SCALE,
+	COMPONENT_NAME,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_SECONDARY_COLOR,
@@ -61,7 +62,7 @@ const defaultTooltipLegendEncoding: LegendEncode = {
 	entries: {
 		name: 'legend0_legendEntry',
 		interactive: true,
-		enter: { tooltip: { signal: "merge(datum, {'rscComponentName': 'legend0'})" } },
+		enter: { tooltip: { signal: `merge(datum, {'${COMPONENT_NAME}': 'legend0'})` } },
 		update: { fill: { value: 'transparent' } },
 	},
 	labels: { update: { ...hiddenSeriesLabelUpdateEncoding, opacity: undefined } },

--- a/src/specBuilder/legend/legendUtils.ts
+++ b/src/specBuilder/legend/legendUtils.ts
@@ -11,6 +11,7 @@
  */
 import {
 	COLOR_SCALE,
+	COMPONENT_NAME,
 	DEFAULT_OPACITY_RULE,
 	FILTERED_TABLE,
 	HIGHLIGHTED_GROUP,
@@ -157,7 +158,7 @@ const getHoverEncodings = (facets: Facet[], props: LegendSpecProps): LegendEncod
 
 const getTooltip = (descriptions: LegendDescription[] | undefined, name: string) => {
 	if (descriptions?.length) {
-		return { signal: `merge(datum, {'rscComponentName': '${name}'})` };
+		return { signal: `merge(datum, {'${COMPONENT_NAME}': '${name}'})` };
 	}
 	return undefined;
 };

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -18,6 +18,7 @@ import { Trendline } from '@components/Trendline';
 import {
 	BACKGROUND_COLOR,
 	COLOR_SCALE,
+	COMPONENT_NAME,
 	DEFAULT_OPACITY_RULE,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
@@ -89,7 +90,7 @@ export function getTooltip(
 	// skip annotations
 	if (hasTooltip(children)) {
 		const defaultTooltip = {
-			signal: `merge(datum${nestedDatum ? '.datum' : ''}, {'rscComponentName': '${name}'})`,
+			signal: `merge(datum${nestedDatum ? '.datum' : ''}, {'${COMPONENT_NAME}': '${name}'})`,
 		};
 		// if the tooltip has an excludeDataKey prop, then disable the tooltip where that key is present
 		const excludeDataKeys = getTooltipProps(children)?.excludeDataKeys;

--- a/src/utils/markClickUtils.ts
+++ b/src/utils/markClickUtils.ts
@@ -11,6 +11,7 @@
  */
 import { MutableRefObject } from 'react';
 
+import { COMPONENT_NAME } from '@constants';
 import { toggleStringArrayValue } from '@utils';
 import { Item, Scene, SceneGroup, SceneItem, ScenegraphEvent, View } from 'vega';
 
@@ -62,10 +63,10 @@ export const getOnMarkClickCallback = (
 			// clicking the button will trigger a new view since it will cause a rerender
 			// this means we don't need to set the signal value since it would just be cleared on rerender
 			// instead, the rerender will set the value of the signal to the selectedData
-			selectedData.current = item.datum;
+			const itemName = getItemName(item);
+			selectedData.current = { [COMPONENT_NAME]: itemName, ...item.datum };
 			// we need to anchor the popover to a div that we move to the same location as the selected mark
 			selectedDataBounds.current = getItemBounds(item);
-			const itemName = getItemName(item);
 			selectedDataName.current = itemName;
 			(document.querySelector(`#${chartId.current} > div > #${itemName}-button`) as HTMLButtonElement)?.click();
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

You can have multiple popovers on a chart. When you open a popover, it computes the content of all popovers even if they aren't being displayed.

This fixes that so that we only compute the content of the popover if the associated component name matches.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
