### PR TITLE
Is339/metric summary number format

### DIFF
--- a/src/alpha/components/Donut/Donut.tsx
+++ b/src/alpha/components/Donut/Donut.tsx
@@ -29,6 +29,7 @@ const Donut: FC<DonutProps> = ({
 	name,
 	segment,
 	startAngle = 0,
+	metricSummaryNumberFormat = 'shortNumber',
 }) => {
 	return null;
 };

--- a/src/specBuilder/axis/axisLabelUtils.test.ts
+++ b/src/specBuilder/axis/axisLabelUtils.test.ts
@@ -15,7 +15,6 @@ import {
 	getLabelAnchorValues,
 	getLabelAngle,
 	getLabelFormat,
-	getLabelNumberFormat,
 	getLabelOffset,
 	getLabelValue,
 	labelIsParallelToAxis,
@@ -187,24 +186,5 @@ describe('getLabelFormat()', () => {
 			'signal',
 			'formatTimeDurationLabels(datum)'
 		);
-	});
-});
-
-describe('getLabelNumberFormat()', () => {
-	test('should return correct signal for shortNumber', () => {
-		const format = getLabelNumberFormat('shortNumber');
-		expect(format).toHaveLength(1);
-		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))");
-	});
-	test('should return correct signal for shortCurrency', () => {
-		const format = getLabelNumberFormat('shortCurrency');
-		expect(format).toHaveLength(2);
-		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))");
-	});
-	test('should return correct signal for string specifier', () => {
-		const numberFormat = '.2f';
-		const format = getLabelNumberFormat(numberFormat);
-		expect(format).toHaveLength(1);
-		expect(format[0]).toHaveProperty('signal', `format(datum.value, '${numberFormat}')`);
 	});
 });

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { getD3FormatSpecifierFromNumberFormat } from '@specBuilder/specUtils';
+import { getTextNumberFormat } from '@specBuilder/textUtils';
 import {
 	Align,
 	Baseline,
@@ -23,7 +23,7 @@ import {
 	TickCount,
 } from 'vega';
 
-import { AxisSpecProps, Granularity, Label, LabelAlign, NumberFormat, Orientation, Position } from '../../types';
+import { AxisSpecProps, Granularity, Label, LabelAlign, Orientation, Position } from '../../types';
 import { isVerticalAxis } from './axisUtils';
 
 /**
@@ -243,46 +243,11 @@ export const getLabelFormat = (
 	}
 
 	return [
-		...getLabelNumberFormat(numberFormat),
+		...getTextNumberFormat(numberFormat),
 		...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
 			? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
 			: [{ signal: 'datum.value' }]),
 	];
-};
-
-/**
- * gets the number format tests and signals based on the numberFormat
- * @param numberFormat
- * @returns
- */
-export const getLabelNumberFormat = (
-	numberFormat: NumberFormat | string
-): ({
-	test?: string;
-} & TextValueRef)[] => {
-	const test = 'isNumber(datum.value)';
-	if (numberFormat === 'shortNumber') {
-		return [
-			{
-				test: `${test} && abs(datum.value) >= 1000`,
-				signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
-			},
-		];
-	}
-	if (numberFormat === 'shortCurrency') {
-		return [
-			{
-				test: `${test} && abs(datum.value) >= 1000`,
-				signal: "upper(replace(format(datum.value, '$.3~s'), /(\\d+)G/, '$1B'))",
-			},
-			{
-				test,
-				signal: "format(datum.value, '$')",
-			},
-		];
-	}
-	const d3FormatSpecifier = getD3FormatSpecifierFromNumberFormat(numberFormat);
-	return [{ test, signal: `format(datum.value, '${d3FormatSpecifier}')` }];
 };
 
 /**

--- a/src/specBuilder/axis/axisSpecBuilder.test.ts
+++ b/src/specBuilder/axis/axisSpecBuilder.test.ts
@@ -48,8 +48,8 @@ const defaultAxis: Axis = {
 			update: {
 				text: [
 					{
-						test: 'isNumber(datum.value) && abs(datum.value) >= 1000',
-						signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
+						test: "isNumber(datum['value']) && abs(datum['value']) >= 1000",
+						signal: "upper(replace(format(datum['value'], '.3~s'), /(\\d+)G/, '$1B'))",
 					},
 					{ signal: 'datum.value' },
 				],

--- a/src/specBuilder/axis/axisUtils.test.ts
+++ b/src/specBuilder/axis/axisUtils.test.ts
@@ -80,8 +80,8 @@ describe('getDefaultAxis()', () => {
 					update: {
 						text: [
 							{
-								test: 'isNumber(datum.value) && abs(datum.value) >= 1000',
-								signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
+								test: "isNumber(datum['value']) && abs(datum['value']) >= 1000",
+								signal: "upper(replace(format(datum['value'], '.3~s'), /(\\d+)G/, '$1B'))",
 							},
 							{
 								signal: 'datum.value',
@@ -140,8 +140,8 @@ describe('getDefaultAxis()', () => {
 					update: {
 						text: [
 							{
-								test: 'isNumber(datum.value) && abs(datum.value) >= 1000',
-								signal: "upper(replace(format(datum.value, '.3~s'), /(\\d+)G/, '$1B'))",
+								test: "isNumber(datum['value']) && abs(datum['value']) >= 1000",
+								signal: "upper(replace(format(datum['value'], '.3~s'), /(\\d+)G/, '$1B'))",
 							},
 							{
 								signal: 'datum.value',

--- a/src/specBuilder/donut/donutSpecBuilder.test.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.test.ts
@@ -121,6 +121,7 @@ describe('addMarks', () => {
 			metricLabel: 'testLabel',
 			hasDirectLabels: true,
 			children: [],
+			metricSummaryNumberFormat: 'shortNumber',
 		};
 		expect(() => addMarks(marks, props)).toThrow(
 			'If a Donut chart hasDirectLabels, a segment property name must be supplied.'

--- a/src/specBuilder/donut/donutSpecBuilder.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.ts
@@ -39,6 +39,7 @@ export const addDonut = produce<Spec, [DonutProps & { colorScheme?: ColorScheme;
 			colorScheme = DEFAULT_COLOR_SCHEME,
 			index = 0,
 			metric = DEFAULT_METRIC,
+			metricSummaryNumberFormat = 'shortNumber',
 			name,
 			startAngle = 0,
 			holeRatio = 0.85,
@@ -50,16 +51,17 @@ export const addDonut = produce<Spec, [DonutProps & { colorScheme?: ColorScheme;
 		// put props back together now that all defaults are set
 		const donutProps: DonutSpecProps = {
 			children: sanitizeMarkChildren(children),
-			colorScheme,
-			index,
 			color,
+			colorScheme,
+			hasDirectLabels,
+			holeRatio,
+			index,
+			isBoolean,
 			markType: 'donut',
 			metric,
+			metricSummaryNumberFormat,
 			name: toCamelCase(name ?? `donut${index}`),
 			startAngle,
-			holeRatio,
-			hasDirectLabels,
-			isBoolean,
 			...props,
 		};
 

--- a/src/specBuilder/donut/donutTestUtils.ts
+++ b/src/specBuilder/donut/donutTestUtils.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { DonutSpecProps } from '../../types';
 
 export const defaultDonutProps: DonutSpecProps = {
@@ -26,4 +25,5 @@ export const defaultDonutProps: DonutSpecProps = {
 	metricLabel: 'testLabel',
 	hasDirectLabels: true,
 	children: [],
+	metricSummaryNumberFormat: 'shortNumber',
 };

--- a/src/specBuilder/donut/donutUtils.test.ts
+++ b/src/specBuilder/donut/donutUtils.test.ts
@@ -48,13 +48,19 @@ describe('getPercentMetricMark()', () => {
 
 describe('getMetricNumberText()', () => {
 	test('should return the correct text for boolean metric', () => {
-		const result = getMetricNumberText('exampleMetric', true);
-		expect(result).toEqual({ signal: `format(datum['exampleMetric'], '.0%')` });
+		const result = getMetricNumberText({ ...defaultDonutProps, isBoolean: true });
+		expect(result).toEqual({ signal: `format(datum['testMetric'], '.0%')` });
 	});
 
 	test('should return the correct text for non-boolean metric', () => {
-		const result = getMetricNumberText('exampleMetric', false);
-		expect(result).toEqual({ signal: "upper(replace(format(datum.sum, '.3~s'), 'G', 'B'))" });
+		const result = getMetricNumberText(defaultDonutProps);
+		expect(result).toEqual([
+			{
+				signal: "upper(replace(format(datum['sum'], '.3~s'), /(\\d+)G/, '$1B'))",
+				test: "isNumber(datum['sum']) && abs(datum['sum']) >= 1000",
+			},
+			{ field: 'sum' },
+		]);
 	});
 });
 

--- a/src/specBuilder/donut/donutUtils.ts
+++ b/src/specBuilder/donut/donutUtils.ts
@@ -11,6 +11,7 @@
  */
 import { DONUT_DIRECT_LABEL_MIN_ANGLE, DONUT_RADIUS, DONUT_SUMMARY_MIN_RADIUS, FILTERED_TABLE } from '@constants';
 import { getColorProductionRule, getMarkOpacity, getTooltip } from '@specBuilder/marks/markUtils';
+import { getTextNumberFormat } from '@specBuilder/textUtils';
 import {
 	ArcMark,
 	EncodeEntryName,
@@ -99,17 +100,13 @@ export const getPercentMetricMark = (props: DonutSpecProps): GroupMark => {
 	return groupMark;
 };
 
-export const getMetricNumberEncode = ({
-	metric,
-	holeRatio,
-	isBoolean,
-	name,
-}: DonutSpecProps): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
+export const getMetricNumberEncode = (props: DonutSpecProps): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
+	const { holeRatio, name } = props;
 	return {
 		update: {
 			x: { signal: 'width / 2' },
 			y: { signal: 'height / 2' },
-			text: getMetricNumberText(metric, isBoolean),
+			text: getMetricNumberText(props),
 			fontSize: { signal: `${name}_summaryFontSize` },
 			align: { value: 'center' },
 			baseline: { value: 'alphabetic' },
@@ -121,11 +118,15 @@ export const getMetricNumberEncode = ({
 	};
 };
 
-export const getMetricNumberText = (metric: string, isBoolean: boolean): ProductionRule<TextValueRef> => {
+export const getMetricNumberText = ({
+	metric,
+	metricSummaryNumberFormat,
+	isBoolean,
+}: DonutSpecProps): ProductionRule<TextValueRef> => {
 	if (isBoolean) {
 		return { signal: `format(datum['${metric}'], '.0%')` };
 	}
-	return { signal: "upper(replace(format(datum.sum, '.3~s'), 'G', 'B'))" };
+	return [...getTextNumberFormat(metricSummaryNumberFormat, 'sum'), { field: 'sum' }];
 };
 
 export const getMetricLabelEncode = ({

--- a/src/specBuilder/textUtils.test.ts
+++ b/src/specBuilder/textUtils.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getTextNumberFormat } from './textUtils';
+
+describe('getTextNumberFormat()', () => {
+	test('should return correct signal for shortNumber', () => {
+		const format = getTextNumberFormat('shortNumber');
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum['value'], '.3~s'), /(\\d+)G/, '$1B'))");
+	});
+	test('should return correct signal for shortCurrency', () => {
+		const format = getTextNumberFormat('shortCurrency');
+		expect(format).toHaveLength(2);
+		expect(format[0]).toHaveProperty('signal', "upper(replace(format(datum['value'], '$.3~s'), /(\\d+)G/, '$1B'))");
+	});
+	test('should return correct signal for string specifier', () => {
+		const numberFormat = '.2f';
+		const format = getTextNumberFormat(numberFormat);
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', `format(datum['value'], '${numberFormat}')`);
+	});
+});

--- a/src/specBuilder/textUtils.ts
+++ b/src/specBuilder/textUtils.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { TextValueRef } from 'vega';
+
+import { NumberFormat } from '../types';
+import { getD3FormatSpecifierFromNumberFormat } from './specUtils';
+
+/**
+ * gets the number format tests and signals based on the numberFormat
+ * @param numberFormat
+ * @returns
+ */
+export const getTextNumberFormat = (
+	numberFormat: NumberFormat | string,
+	datumProperty: string = 'value'
+): ({
+	test?: string;
+} & TextValueRef)[] => {
+	const test = `isNumber(datum['${datumProperty}'])`;
+	if (numberFormat === 'shortNumber') {
+		return [
+			{
+				test: `${test} && abs(datum['${datumProperty}']) >= 1000`,
+				signal: `upper(replace(format(datum['${datumProperty}'], '.3~s'), /(\\d+)G/, '$1B'))`,
+			},
+		];
+	}
+	if (numberFormat === 'shortCurrency') {
+		return [
+			{
+				test: `${test} && abs(datum['${datumProperty}']) >= 1000`,
+				signal: `upper(replace(format(datum['${datumProperty}'], '$.3~s'), /(\\d+)G/, '$1B'))`,
+			},
+			{
+				test,
+				signal: `format(datum['${datumProperty}'], '$')`,
+			},
+		];
+	}
+	const d3FormatSpecifier = getD3FormatSpecifierFromNumberFormat(numberFormat);
+	return [{ test, signal: `format(datum['${datumProperty}'], '${d3FormatSpecifier}')` }];
+};

--- a/src/stories/components/Donut/Donut.story.tsx
+++ b/src/stories/components/Donut/Donut.story.tsx
@@ -184,6 +184,14 @@ Responsive.args = {
 	color: 'browser',
 };
 
+const MetricSummaryNumberFormat = bindWithProps(DonutStory);
+MetricSummaryNumberFormat.args = {
+	metricSummaryNumberFormat: 'standardNumber',
+	metric: 'count',
+	metricLabel: 'Visitors',
+	color: 'browser',
+};
+
 const BooleanDonut = bindWithProps(BooleanStory);
 BooleanDonut.args = {
 	metric: 'value',
@@ -192,4 +200,14 @@ BooleanDonut.args = {
 	isBoolean: true,
 };
 
-export { Basic, WithDirectLabels, WithPopover, WithLegend, Everything, Slivers, Responsive, BooleanDonut };
+export {
+	Basic,
+	WithDirectLabels,
+	WithPopover,
+	WithLegend,
+	Everything,
+	Slivers,
+	Responsive,
+	MetricSummaryNumberFormat,
+	BooleanDonut,
+};

--- a/src/stories/components/Donut/Donut.test.tsx
+++ b/src/stories/components/Donut/Donut.test.tsx
@@ -34,26 +34,26 @@ describe('Donut', () => {
 	describe('Summary text is correct size based on donut raidus', () => {
 		test('text should be target size', async () => {
 			render(<Basic {...Basic.args} width={300} height={300} />);
-			const metricValue = await screen.findByText('39K');
+			const metricValue = await screen.findByText('40.4K');
 			expect(metricValue).toHaveAttribute('font-size', '45px');
 		});
 
 		test('small donut, text should be min size', async () => {
 			render(<Basic {...Basic.args} width={100} height={100} />);
-			const metricValue = await screen.findByText('39K');
+			const metricValue = await screen.findByText('40.4K');
 			expect(metricValue).toHaveAttribute('font-size', `${DONUT_SUMMARY_MIN_FONT_SIZE}px`);
 		});
 
 		test('large donut, text should be max size', async () => {
 			render(<Basic {...Basic.args} width={600} height={600} />);
-			const metricValue = await screen.findByText('39K');
+			const metricValue = await screen.findByText('40.4K');
 			expect(metricValue).toHaveAttribute('font-size', `${DONUT_SUMMARY_MAX_FONT_SIZE}px`);
 		});
 	});
 
 	test('metric label text should be 1/2 the size of the metric value text', async () => {
 		render(<Basic {...Basic.args} width={200} height={200} />);
-		const metricValue = await screen.findByText('39K');
+		const metricValue = await screen.findByText('40.4K');
 		expect(metricValue).toHaveAttribute('font-size', '30px');
 		const metricLabel = await screen.findByText('Visitors');
 		expect(metricLabel).toHaveAttribute('font-size', '15px');

--- a/src/stories/components/Donut/Donut.test.tsx
+++ b/src/stories/components/Donut/Donut.test.tsx
@@ -13,7 +13,7 @@ import { DONUT_SUMMARY_MAX_FONT_SIZE, DONUT_SUMMARY_MIN_FONT_SIZE } from '@const
 import { findAllMarksByGroupName, findChart, render, screen } from '@test-utils';
 import { Donut } from 'alpha/components/Donut';
 
-import { Basic } from './Donut.story';
+import { Basic, MetricSummaryNumberFormat } from './Donut.story';
 
 describe('Donut', () => {
 	// Donut is not a real React component. This is test just provides test coverage for sonarqube
@@ -57,5 +57,26 @@ describe('Donut', () => {
 		expect(metricValue).toHaveAttribute('font-size', '30px');
 		const metricLabel = await screen.findByText('Visitors');
 		expect(metricLabel).toHaveAttribute('font-size', '15px');
+	});
+
+	describe('should render the correct number format', () => {
+		test('shortCurrency', async () => {
+			render(
+				<MetricSummaryNumberFormat
+					{...MetricSummaryNumberFormat.args}
+					metricSummaryNumberFormat="shortCurrency"
+				/>
+			);
+			expect(await screen.findByText('$40.4K')).toBeInTheDocument();
+		});
+		test('standardNumber', async () => {
+			render(
+				<MetricSummaryNumberFormat
+					{...MetricSummaryNumberFormat.args}
+					metricSummaryNumberFormat="standardNumber"
+				/>
+			);
+			expect(await screen.findByText('40,365')).toBeInTheDocument();
+		});
 	});
 });

--- a/src/stories/components/Donut/data.ts
+++ b/src/stories/components/Donut/data.ts
@@ -11,13 +11,13 @@
  */
 
 export const basicDonutData = [
-	{ count: 4000, browser: 'Other' },
-	{ count: 6000, browser: 'Opera' },
-	{ count: 10000, browser: 'Chrome' },
-	{ count: 3000, browser: 'Brave' },
-	{ count: 7000, browser: 'Safari' },
-	{ count: 8000, browser: 'Firefox' },
-	{ count: 1000, browser: 'Unknown' },
+	{ count: 10390, browser: 'Chrome' },
+	{ count: 8281, browser: 'Firefox' },
+	{ count: 7045, browser: 'Safari' },
+	{ count: 6166, browser: 'Opera' },
+	{ count: 4201, browser: 'Other' },
+	{ count: 3261, browser: 'Brave' },
+	{ count: 1021, browser: 'Unknown' },
 ];
 
 export const sliveredDonutData = [

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -185,6 +185,11 @@ export interface DonutProps extends MarkProps {
 	/** Determines if the center metric should be displayed as a percent. if true, data should only be two data points, which sum to 1
 	 * Also, if true, will display the first datapoint as a percent */
 	isBoolean?: boolean;
+	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.
+	 *
+	 * see {@link https://d3js.org/d3-format#locale_format}
+	 */
+	metricSummaryNumberFormat?: NumberFormat | string;
 }
 
 export interface AxisProps extends BaseProps {

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -120,7 +120,8 @@ type DonutPropsWithDefaults =
 	| 'startAngle'
 	| 'holeRatio'
 	| 'hasDirectLabels'
-	| 'isBoolean';
+	| 'isBoolean'
+	| 'metricSummaryNumberFormat';
 
 export interface DonutSpecProps
 	extends PartiallyRequired<DonutProps & { colorScheme: ColorScheme; index: number }, DonutPropsWithDefaults> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support number formats for the metric summary value. This implementation matches formatting for axis labels.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/339

## Story

Donut > MetricSummaryNumberFormat

## Screenshots (if appropriate):

<img width="400" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/7c93a441-59b8-4871-a9c1-3de23442ec39">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
