### PR TITLE
Donut segment label

### DIFF
--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -106,6 +106,8 @@ export const VegaChart: FC<VegaChartProps> = ({
 				onNewView(view);
 				view.resize();
 				view.runAsync();
+				// One additional render to settle all resize calculations
+				setTimeout(() => view.runAsync(), 0);
 			});
 		}
 		return () => {

--- a/src/alpha/components/Donut/Donut.tsx
+++ b/src/alpha/components/Donut/Donut.tsx
@@ -21,12 +21,10 @@ import { DonutProps } from '../../../types';
 const Donut: FC<DonutProps> = ({
 	children,
 	color = DEFAULT_COLOR,
-	hasDirectLabels = false,
 	holeRatio = 0.85,
 	isBoolean = false,
 	metric = DEFAULT_METRIC,
 	name,
-	segment,
 	startAngle = 0,
 }) => {
 	return null;

--- a/src/alpha/components/SegmentLabel/SegmentLabel.tsx
+++ b/src/alpha/components/SegmentLabel/SegmentLabel.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { SegmentLabelProps } from '../../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const SegmentLabel: FC<SegmentLabelProps> = ({
+	labelKey,
+	percent = false,
+	value = false,
+	valueFormat = 'standardNumber',
+}) => {
+	return null;
+};
+
+// displayName is used to validate the component type in the spec builder
+SegmentLabel.displayName = 'SegmentLabel';
+
+export { SegmentLabel };

--- a/src/alpha/components/SegmentLabel/index.ts
+++ b/src/alpha/components/SegmentLabel/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from "./SegmentLabel";

--- a/src/alpha/components/index.ts
+++ b/src/alpha/components/index.ts
@@ -12,3 +12,4 @@
 
 export * from './Donut';
 export * from './DonutSummary';
+export * from './SegmentLabel';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,8 +79,8 @@ export const TRELLIS_PADDING = 0.2;
 // donut constants
 /** Calculation for donut radius, subtract 2 pixels to make room for the selection ring */
 export const DONUT_RADIUS = '(min(width, height) / 2 - 2)';
-/** Min arc angle radians to display a direct label. If the arc angle is less than this, the direct label will be hidden. */
-export const DONUT_DIRECT_LABEL_MIN_ANGLE = 0.3;
+/** Min arc angle radians to display a segment label. If the arc angle is less than this, the segment label will be hidden. */
+export const DONUT_SEGMENT_LABEL_MIN_ANGLE = 0.3;
 /** Min font size for the donut summary metric value */
 export const DONUT_SUMMARY_MIN_FONT_SIZE = 28;
 /** Max font size for the donut summary metric value */

--- a/src/specBuilder/donut/donutSpecBuilder.test.ts
+++ b/src/specBuilder/donut/donutSpecBuilder.test.ts
@@ -16,7 +16,6 @@ import { COLOR_SCALE, FILTERED_TABLE, HIGHLIGHTED_ITEM } from '@constants';
 import { defaultSignals } from '@specBuilder/specTestUtils';
 import { initializeSpec } from '@specBuilder/specUtils';
 
-import { DonutSpecProps } from '../../types';
 import { addData, addDonut, addMarks, addScales, addSignals } from './donutSpecBuilder';
 import { defaultDonutProps } from './donutTestUtils';
 
@@ -33,31 +32,11 @@ describe('addData', () => {
 	test('should add data correctly for non-boolean donut', () => {
 		const data = addData(initializeSpec().data ?? [], defaultDonutProps);
 		expect(data).toHaveLength(2);
-		expect(data[1].transform).toHaveLength(1);
+		expect(data[1].transform).toHaveLength(4);
 		expect(data[1].transform?.[0].type).toBe('pie');
-	});
-});
-
-describe('addMarks', () => {
-	test('should throw error when hasDirectLabels is true but segment is not provided', () => {
-		const marks = [];
-		const props: DonutSpecProps = {
-			index: 0,
-			colorScheme: 'light',
-			markType: 'donut',
-			metric: 'testMetric',
-			startAngle: 1.7,
-			name: 'testName',
-			isBoolean: false,
-			segment: undefined,
-			color: 'testColor',
-			holeRatio: 0.5,
-			hasDirectLabels: true,
-			children: [],
-		};
-		expect(() => addMarks(marks, props)).toThrow(
-			'If a Donut chart hasDirectLabels, a segment property name must be supplied.'
-		);
+		expect(data[1].transform?.[1]).toHaveProperty('as', 'testName_arcTheta');
+		expect(data[1].transform?.[2]).toHaveProperty('as', 'testName_arcLength');
+		expect(data[1].transform?.[3]).toHaveProperty('as', 'testName_arcPercent');
 	});
 });
 

--- a/src/specBuilder/donut/donutSummaryUtils.ts
+++ b/src/specBuilder/donut/donutSummaryUtils.ts
@@ -40,7 +40,7 @@ const getDonutSummary = (props: DonutSpecProps): DonutSummarySpecProps | undefin
 };
 
 /**
- * Applies all default props, converting donutSummaryProps into donutSummarySpecProps
+ * Applies all default props, converting DonutSummaryProps into DonutSummarySpecProps
  * @param donutSummaryProps
  * @param donutProps
  * @returns
@@ -131,9 +131,8 @@ export const getDonutSummaryMarks = (props: DonutSpecProps): GroupMark[] => {
 	if (!donutSummary) {
 		return [];
 	}
-	const { donutProps } = donutSummary;
 	const marks: GroupMark[] = [];
-	if (donutProps.isBoolean) {
+	if (props.isBoolean) {
 		marks.push(getBooleanDonutSummaryGroupMark(donutSummary));
 	} else {
 		marks.push(getDonutSummaryGroupMark(donutSummary));

--- a/src/specBuilder/donut/donutTestUtils.ts
+++ b/src/specBuilder/donut/donutTestUtils.ts
@@ -19,9 +19,7 @@ export const defaultDonutProps: DonutSpecProps = {
 	startAngle: 0,
 	name: 'testName',
 	isBoolean: false,
-	segment: 'testSegment',
 	color: 'testColor',
 	holeRatio: 0.85,
-	hasDirectLabels: true,
 	children: [],
 };

--- a/src/specBuilder/donut/segmentLabelUtils.test.tsx
+++ b/src/specBuilder/donut/segmentLabelUtils.test.tsx
@@ -1,0 +1,86 @@
+import { SegmentLabel } from '@rsc/alpha';
+
+import { DonutSpecProps, SegmentLabelSpecProps } from '../../types';
+import { defaultDonutProps } from './donutTestUtils';
+import { getSegmentLabelMarks, getSegmentLabelValueText, getSegmentLabelValueTextMark } from './segmentLabelUtils';
+
+const defaultDonutPropsWithSegmentLabel: DonutSpecProps = {
+	...defaultDonutProps,
+	children: [<SegmentLabel key={0} />],
+};
+
+const defaultSegmentLabelProps: SegmentLabelSpecProps = {
+	donutProps: defaultDonutPropsWithSegmentLabel,
+	percent: false,
+	value: false,
+	valueFormat: 'standardNumber',
+};
+
+describe('getSegmentLabelMarks()', () => {
+	test('should return empty array if isBoolean', () => {
+		const marks = getSegmentLabelMarks({
+			...defaultDonutPropsWithSegmentLabel,
+			isBoolean: true,
+		});
+		expect(marks).toEqual([]);
+	});
+	test('should return emptry array if there is not SegmentLabel on the Donut', () => {
+		const marks = getSegmentLabelMarks({
+			...defaultDonutProps,
+		});
+		expect(marks).toEqual([]);
+	});
+	test('should return segment label marks', () => {
+		const marks = getSegmentLabelMarks({
+			...defaultDonutPropsWithSegmentLabel,
+		});
+		expect(marks).toHaveLength(1);
+		expect(marks[0].type).toEqual('group');
+		expect(marks[0].marks).toHaveLength(1);
+		expect(marks[0].marks?.[0].type).toEqual('text');
+	});
+});
+
+describe('getSegmentLabelValueTextMark()', () => {
+	test('should return empty array if value and percent are false', () => {
+		expect(getSegmentLabelValueTextMark(defaultSegmentLabelProps)).toEqual([]);
+	});
+	test('should return a text mark if value is true', () => {
+		const marks = getSegmentLabelValueTextMark({ ...defaultSegmentLabelProps, value: true });
+		expect(marks).toHaveLength(1);
+		expect(marks[0].type).toEqual('text');
+	});
+	test('should return a text mark if percent is true', () => {
+		const marks = getSegmentLabelValueTextMark({ ...defaultSegmentLabelProps, percent: true });
+		expect(marks).toHaveLength(1);
+		expect(marks[0].type).toEqual('text');
+	});
+	test('should return two text marks if value and percent are true', () => {
+		const marks = getSegmentLabelValueTextMark({ ...defaultSegmentLabelProps, value: true, percent: true });
+		expect(marks).toHaveLength(1);
+		expect(marks[0].type).toEqual('text');
+	});
+});
+
+describe('getSegmentLabelValueText()', () => {
+	test('should return undefined if value and percent are false', () => {
+		expect(getSegmentLabelValueText(defaultSegmentLabelProps)).toBeUndefined();
+	});
+	test('should return a simple percentSignal if percent is true and value is false', () => {
+		expect(getSegmentLabelValueText({ ...defaultSegmentLabelProps, percent: true })).toHaveProperty(
+			'signal',
+			`format(datum['testName_arcPercent'], '.0%')`
+		);
+	});
+	test('should return an array of rules if value is true', () => {
+		const rules = getSegmentLabelValueText({ ...defaultSegmentLabelProps, value: true });
+		expect(rules).toHaveLength(1);
+		expect(rules?.[0]).toHaveProperty('signal', "format(datum['testMetric'], ',')");
+	});
+	test('should have percentSignal combined with value signal if value and percent are true', () => {
+		const rules = getSegmentLabelValueText({ ...defaultSegmentLabelProps, value: true, percent: true });
+		expect(rules).toHaveLength(1);
+		expect(rules?.[0].signal).toContain('_arcPercent');
+		expect(rules?.[0].signal).toContain('testMetric');
+	});
+});

--- a/src/specBuilder/donut/segmentLabelUtils.ts
+++ b/src/specBuilder/donut/segmentLabelUtils.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { DONUT_RADIUS, DONUT_SEGMENT_LABEL_MIN_ANGLE, FILTERED_TABLE } from '@constants';
+import { SegmentLabel } from '@rsc/alpha';
+import { getTextNumberFormat } from '@specBuilder/textUtils';
+import { GroupMark, NumericValueRef, ProductionRule, TextEncodeEntry, TextMark, TextValueRef } from 'vega';
+
+import { DonutSpecProps, SegmentLabelElement, SegmentLabelProps, SegmentLabelSpecProps } from '../../types';
+
+/**
+ * Gets the SegmentLabel component from the children if one exists
+ * @param donutProps
+ * @returns segmentLabelProps
+ */
+const getSegmentLabel = (props: DonutSpecProps): SegmentLabelSpecProps | undefined => {
+	const segmentLabel = props.children.find((child) => child.type === SegmentLabel) as SegmentLabelElement;
+	if (!segmentLabel) {
+		return;
+	}
+	return applySegmentLabelPropDefaults(segmentLabel.props, props);
+};
+
+/**
+ * Applies all default props, converting SegmentLabelProps into SegmentLabelSpecProps
+ * @param segmentLabelProps
+ * @param donutProps
+ * @returns SegmentLabelSpecProps
+ */
+const applySegmentLabelPropDefaults = (
+	{ percent = false, value = false, valueFormat = 'standardNumber', ...props }: SegmentLabelProps,
+	donutProps: DonutSpecProps
+): SegmentLabelSpecProps => ({
+	donutProps,
+	percent,
+	value,
+	valueFormat,
+	...props,
+});
+
+/**
+ * Gets the marks for the segment label. If there isn't a segment label, an empty array is returned.
+ * @param donutProps
+ * @returns GroupMark[]
+ */
+export const getSegmentLabelMarks = (donutProps: DonutSpecProps): GroupMark[] => {
+	const { isBoolean, name } = donutProps;
+	// segment labels are not supported for boolean variants
+	if (isBoolean) return [];
+
+	const segmentLabel = getSegmentLabel(donutProps);
+	// if there isn't a segment label, we don't need to do anything
+	if (!segmentLabel) return [];
+
+	return [
+		{
+			name: `${name}_segmentLabelGroup`,
+			type: 'group',
+			marks: [getSegmentLabelTextMark(segmentLabel), ...getSegmentLabelValueTextMark(segmentLabel)],
+		},
+	];
+};
+
+/**
+ * Gets the text mark for the segment label
+ * @param segmentLabelProps
+ * @returns TextMark
+ */
+const getSegmentLabelTextMark = ({ labelKey, donutProps }: SegmentLabelSpecProps): TextMark => {
+	const { name, color } = donutProps;
+	return {
+		type: 'text',
+		name: `${name}_segmentLabel`,
+		from: { data: FILTERED_TABLE },
+		encode: {
+			update: {
+				...getBaseSegmentLabelEntryEncode(name),
+				text: { field: labelKey ?? color },
+				fontWeight: { value: 'bold' },
+				baseline: { value: 'bottom' },
+			},
+		},
+	};
+};
+
+/**
+ * Gets the text mark for the segment label values (percent and/or value)
+ * @param segmentLabelProps
+ * @returns TextMark[]
+ */
+export const getSegmentLabelValueTextMark = (props: SegmentLabelSpecProps): TextMark[] => {
+	if (!props.value && !props.percent) return [];
+	const { donutProps } = props;
+
+	return [
+		{
+			type: 'text',
+			name: `${donutProps.name}_segmentLabelValue`,
+			from: { data: FILTERED_TABLE },
+			encode: {
+				enter: {
+					...getBaseSegmentLabelEntryEncode(donutProps.name),
+					text: getSegmentLabelValueText(props),
+					baseline: { value: 'top' },
+				},
+			},
+		},
+	];
+};
+
+/**
+ * Gets all the standard entry encodes for segment label text marks
+ * @param name
+ * @returns TextEncodeEntry
+ */
+const getBaseSegmentLabelEntryEncode = (name: string): TextEncodeEntry => ({
+	x: { signal: 'width / 2' },
+	y: { signal: 'height / 2' },
+	radius: { signal: `${DONUT_RADIUS} + 15` },
+	theta: { field: `${name}_arcTheta` },
+	fontSize: getSegmentLabelFontSize(name),
+	align: {
+		signal: `datum['${name}_arcTheta'] <= PI ? 'left' : 'right'`,
+	},
+});
+
+/**
+ * Gets the text value ref for the segment label values (percent and/or value)
+ * @param segmentLabelProps
+ * @returns TextValueRef
+ */
+export const getSegmentLabelValueText = ({
+	donutProps,
+	percent,
+	value,
+	valueFormat,
+}: SegmentLabelSpecProps): ProductionRule<TextValueRef> | undefined => {
+	const percentSignal = `format(datum['${donutProps.name}_arcPercent'], '.0%')`;
+	if (value) {
+		// to support `shortNumber` and `shortCurrency` we need to use the consistent logic
+		const rules = getTextNumberFormat(valueFormat, donutProps.metric) as { test?: string; signal: string }[];
+		if (percent) {
+			// rules will be an array so we need to add the percent to each signal
+			return rules.map((rule) => ({
+				...rule,
+				signal: `${percentSignal} + "\\u00a0\\u00a0" + ${rule.signal}`,
+			}));
+		}
+		return rules;
+	}
+
+	if (percent) {
+		return { signal: percentSignal };
+	}
+};
+
+/**
+ * Gets the font size for the segment label based on the arc length
+ * If the arc length is less than 0.3 radians, the font size is 0
+ * @param name
+ * @returns NumericValueRef
+ */
+const getSegmentLabelFontSize = (name: string): ProductionRule<NumericValueRef> => {
+	// need to use radians for this. 0.3 radians is about 17 degrees
+	// if we used arc length, then showing a label could shrink the overall donut size which could make the arc to small
+	// that would hide the label which would make the arc bigger which would show the label and so on
+	return [{ test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 }, { value: 14 }];
+};

--- a/src/stories/components/Donut/Donut.story.tsx
+++ b/src/stories/components/Donut/Donut.story.tsx
@@ -19,7 +19,7 @@ import { bindWithProps } from '@test-utils';
 
 import { Content } from '@adobe/react-spectrum';
 
-import { basicDonutData, booleanDonutData, sliveredDonutData } from './data';
+import { basicDonutData, booleanDonutData } from './data';
 
 export default {
 	title: 'RSC/Donut',
@@ -37,9 +37,7 @@ const DonutStory: StoryFn<DonutProps & { width?: number; height?: number }> = (a
 	const chartProps = useChartProps({ ...defaultChartProps, width: width ?? 350, height: height ?? 350 });
 	return (
 		<Chart {...chartProps}>
-			<Donut {...donutProps}>
-				<DonutSummary label="Visitors" />
-			</Donut>
+			<Donut {...donutProps} />
 		</Chart>
 	);
 };
@@ -50,15 +48,6 @@ const DonutLegendStory: StoryFn<typeof Donut> = (args): ReactElement => {
 		<Chart {...chartProps}>
 			<Donut {...args} />
 			<Legend title="Browsers" position={'right'} highlight isToggleable />
-		</Chart>
-	);
-};
-
-const SliversStory: StoryFn<typeof Donut> = (args): ReactElement => {
-	const chartProps = useChartProps({ ...defaultChartProps, data: sliveredDonutData });
-	return (
-		<Chart {...chartProps}>
-			<Donut {...args} />
 		</Chart>
 	);
 };
@@ -115,14 +104,6 @@ Basic.args = {
 	color: 'browser',
 };
 
-const WithDirectLabels = bindWithProps(DonutStory);
-WithDirectLabels.args = {
-	metric: 'count',
-	segment: 'browser',
-	color: 'browser',
-	hasDirectLabels: true,
-};
-
 const WithPopover = bindWithProps(DonutStory);
 WithPopover.args = {
 	metric: 'count',
@@ -136,15 +117,6 @@ WithLegend.args = {
 	color: 'browser',
 };
 
-const Slivers = bindWithProps(SliversStory);
-Slivers.args = {
-	metric: 'count',
-	segment: 'browser',
-	color: 'browser',
-	hasDirectLabels: true,
-	holeRatio: 0.8,
-};
-
 const BooleanDonut = bindWithProps(BooleanStory);
 BooleanDonut.args = {
 	metric: 'value',
@@ -155,11 +127,9 @@ BooleanDonut.args = {
 const Supreme = bindWithProps(DonutLegendStory);
 Supreme.args = {
 	metric: 'count',
-	segment: 'browser',
 	color: 'browser',
-	hasDirectLabels: true,
 	holeRatio: 0.8,
-	children: interactiveChildren,
+	children: [...interactiveChildren, <DonutSummary label="Visitors" key={0} />],
 };
 
-export { Basic, BooleanDonut, Slivers, Supreme, WithDirectLabels, WithLegend, WithPopover };
+export { Basic, BooleanDonut, Supreme, WithLegend, WithPopover };

--- a/src/stories/components/SegmentLabel/SegmentLabel.story.tsx
+++ b/src/stories/components/SegmentLabel/SegmentLabel.story.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React, { ReactElement } from 'react';
+
+import useChartProps from '@hooks/useChartProps';
+import { Chart, ChartProps } from '@rsc';
+import { Donut, SegmentLabel } from '@rsc/alpha';
+import { StoryFn } from '@storybook/react';
+import { bindWithProps } from '@test-utils';
+
+import { basicDonutData, sliveredDonutData } from '../Donut/data';
+
+export default {
+	title: 'RSC/Donut/SegmentLabel',
+	component: SegmentLabel,
+};
+
+const defaultChartProps: ChartProps = {
+	data: basicDonutData,
+	width: 350,
+	height: 350,
+};
+
+const SegmentLabelStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => {
+	const chartProps = useChartProps(defaultChartProps);
+
+	return (
+		<Chart {...chartProps}>
+			<Donut metric="count" color="browser">
+				<SegmentLabel {...args} />;
+			</Donut>
+		</Chart>
+	);
+};
+
+const SliverStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => {
+	const chartProps = useChartProps({ ...defaultChartProps, data: sliveredDonutData });
+
+	return (
+		<Chart {...chartProps}>
+			<Donut metric="count" color="browser">
+				<SegmentLabel {...args} />;
+			</Donut>
+		</Chart>
+	);
+};
+
+const Basic = bindWithProps(SegmentLabelStory);
+Basic.args = {};
+
+const LabelKey = bindWithProps(SegmentLabelStory);
+LabelKey.args = { labelKey: 'browser' };
+
+const Percent = bindWithProps(SegmentLabelStory);
+Percent.args = { percent: true };
+
+const Value = bindWithProps(SegmentLabelStory);
+Value.args = { value: true };
+
+const ValueFormat = bindWithProps(SegmentLabelStory);
+ValueFormat.args = { value: true, valueFormat: 'shortNumber' };
+
+const Supreme = bindWithProps(SegmentLabelStory);
+Supreme.args = { labelKey: 'browser', percent: true, value: true, valueFormat: 'shortNumber' };
+
+const Slivers = bindWithProps(SliverStory);
+Slivers.args = { percent: true, value: true };
+
+export { Basic, LabelKey, Percent, Value, ValueFormat, Supreme, Slivers };

--- a/src/stories/components/SegmentLabel/SegmentLabel.story.tsx
+++ b/src/stories/components/SegmentLabel/SegmentLabel.story.tsx
@@ -34,7 +34,7 @@ const SegmentLabelStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => 
 	const chartProps = useChartProps(defaultChartProps);
 
 	return (
-		<Chart {...chartProps}>
+		<Chart {...chartProps} debug>
 			<Donut metric="count" color="browser">
 				<SegmentLabel {...args} />;
 			</Donut>

--- a/src/stories/components/SegmentLabel/SegmentLabel.test.tsx
+++ b/src/stories/components/SegmentLabel/SegmentLabel.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React from 'react';
+
+import '@matchMediaMock';
+import { SegmentLabel } from '@rsc/alpha';
+import { findChart, render, screen } from '@test-utils';
+
+import { Basic, Percent, Value, ValueFormat } from './SegmentLabel.story';
+
+describe('SegmentLabel', () => {
+	// SegmentLabel is not a real React component. This is test just provides test coverage for sonarqube
+	test('SegmentLabel pseudo element', () => {
+		render(<SegmentLabel />);
+	});
+
+	test('Basic renders properly', async () => {
+		render(<Basic {...Basic.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const label = await screen.findByText('Chrome');
+		expect(label).toBeInTheDocument();
+		expect(label).toHaveAttribute('font-weight', 'bold');
+		expect(await screen.findByText('Safari')).toBeInTheDocument();
+		expect(await screen.findByText('Other')).toBeInTheDocument();
+	});
+
+	test('Percent renders properly', async () => {
+		render(<Percent {...Percent.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		expect(screen.getByText('26%')).toBeInTheDocument();
+		expect(screen.getByText('17%')).toBeInTheDocument();
+		expect(screen.getByText('10%')).toBeInTheDocument();
+	});
+
+	test('Value renders properly', async () => {
+		render(<Value {...Value.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		expect(screen.getByText('10,390')).toBeInTheDocument();
+		expect(screen.getByText('7,045')).toBeInTheDocument();
+		expect(screen.getByText('4,201')).toBeInTheDocument();
+	});
+
+	test('Should format segment metric values', async () => {
+		render(<ValueFormat {...ValueFormat.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		expect(screen.getByText('10.4K')).toBeInTheDocument();
+		expect(screen.getByText('7.05K')).toBeInTheDocument();
+		expect(screen.getByText('4.2K')).toBeInTheDocument();
+	});
+
+	test('Should hide labels for thin segments', async () => {
+		render(<Basic {...Basic.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		expect(screen.getByText('Safari')).toBeInTheDocument();
+		// unknown has a font size of 0 since it's segment is too thin
+		expect(screen.getByText('Unknown')).toHaveAttribute('font-size', '0px');
+	});
+});

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -28,11 +28,12 @@ export type ChartElement = ReactElement<ChartProps, JSXElementConstructor<ChartP
 export type ChartPopoverElement = ReactElement<ChartPopoverProps, JSXElementConstructor<ChartPopoverProps>>;
 export type ChartTooltipElement = ReactElement<ChartTooltipProps, JSXElementConstructor<ChartTooltipProps>>;
 export type DonutElement = ReactElement<DonutProps, JSXElementConstructor<DonutProps>>;
+export type DonutSummaryElement = ReactElement<DonutSummaryProps, JSXElementConstructor<DonutSummaryProps>>;
 export type LegendElement = ReactElement<LegendProps, JSXElementConstructor<LegendProps>>;
 export type LineElement = ReactElement<LineProps, JSXElementConstructor<LineProps>>;
 export type ScatterPathElement = ReactElement<ScatterPathProps, JSXElementConstructor<ScatterPathProps>>;
+export type SegmentLabelElement = ReactElement<SegmentLabelProps, JSXElementConstructor<SegmentLabelProps>>;
 export type MetricRangeElement = ReactElement<MetricRangeProps, JSXElementConstructor<MetricRangeProps>>;
-export type DonutSummaryElement = ReactElement<DonutSummaryProps, JSXElementConstructor<DonutSummaryProps>>;
 export type ReferenceLineElement = ReactElement<ReferenceLineProps, JSXElementConstructor<ReferenceLineProps>>;
 export type ScatterElement = ReactElement<ScatterProps, JSXElementConstructor<ScatterProps>>;
 export type TitleElement = ReactElement<TitleProps, JSXElementConstructor<TitleProps>>;
@@ -173,27 +174,41 @@ export interface AreaProps extends MarkProps {
 }
 
 export interface DonutProps extends MarkProps {
-	/** The datum property for segments of the data */
-	segment?: string;
 	/** Start angle of the donut in radians (0 is top dead center, and default) */
 	startAngle?: number;
 	/** Ratio of the donut inner radius / donut outer radius. 0 is a pie chart. 0.85 is the default. */
 	holeRatio?: number;
-	/** Determines if it should display direct labels. If true, must also supply 'segment' prop. Default is false */
-	hasDirectLabels?: boolean;
 	/** Determines if the center metric should be displayed as a percent. if true, data should only be two data points, which sum to 1
 	 * Also, if true, will display the first datapoint as a percent */
 	isBoolean?: boolean;
 }
 
 export interface DonutSummaryProps {
-	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.
+	/** d3 number format specifier.
+	 * Sets the number format for the summary value.
 	 *
 	 * see {@link https://d3js.org/d3-format#locale_format}
 	 */
 	numberFormat?: NumberFormat | string;
 	/** Label for the metric summary */
 	label?: string;
+}
+
+export interface SegmentLabelProps {
+	/** Sets the key in the data that has the segment label. Defaults to the `color` key set on the `Donut` is undefined. */
+	labelKey?: string;
+	/** Shows the donut segment percentage */
+	percent?: boolean;
+	/** Shows the donut segment metric value */
+	value?: boolean;
+	/** d3 number format specifier.
+	 * Sets the number format for the segment metric value.
+	 *
+	 * @default 'standardNumber'
+	 *
+	 * see {@link https://d3js.org/d3-format#locale_format}
+	 */
+	valueFormat?: string;
 }
 
 export interface AxisProps extends BaseProps {
@@ -752,5 +767,6 @@ export type MarkChildElement =
 	| ScatterPathElement
 	| MetricRangeElement
 	| DonutSummaryElement
+	| SegmentLabelElement
 	| TrendlineElement;
 export type RscElement = ChartChildElement | MarkChildElement;

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -32,6 +32,7 @@ import {
 	ScaleType as RscScaleType,
 	ScatterPathProps,
 	ScatterProps,
+	SegmentLabelProps,
 	TrendlineAnnotationProps,
 	TrendlineChildElement,
 	TrendlineProps,
@@ -114,14 +115,7 @@ export interface ChartTooltipSpecProps extends PartiallyRequired<ChartTooltipPro
 	markName: string;
 }
 
-type DonutPropsWithDefaults =
-	| 'color'
-	| 'metric'
-	| 'name'
-	| 'startAngle'
-	| 'holeRatio'
-	| 'hasDirectLabels'
-	| 'isBoolean';
+type DonutPropsWithDefaults = 'color' | 'metric' | 'name' | 'startAngle' | 'holeRatio' | 'isBoolean';
 
 export interface DonutSpecProps
 	extends PartiallyRequired<DonutProps & { colorScheme: ColorScheme; index: number }, DonutPropsWithDefaults> {
@@ -132,6 +126,12 @@ export interface DonutSpecProps
 type DonutSummaryPropsWithDefaults = 'numberFormat';
 
 export interface DonutSummarySpecProps extends PartiallyRequired<DonutSummaryProps, DonutSummaryPropsWithDefaults> {
+	donutProps: DonutSpecProps;
+}
+
+type SegmentLabelPropsWithDefaults = 'percent' | 'value' | 'valueFormat';
+
+export interface SegmentLabelSpecProps extends PartiallyRequired<SegmentLabelProps, SegmentLabelPropsWithDefaults> {
 	donutProps: DonutSpecProps;
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -32,7 +32,7 @@ import {
 	Trendline,
 	TrendlineAnnotation,
 } from '..';
-import { Donut, DonutSummary } from '../alpha';
+import { Donut, DonutSummary, SegmentLabel } from '../alpha';
 import {
 	AreaElement,
 	AxisAnnotationChildElement,
@@ -111,6 +111,7 @@ export const sanitizeMarkChildren = (children: unknown): MarkChildElement[] => {
 		ScatterPath.displayName,
 		MetricRange.displayName,
 		DonutSummary.displayName,
+		SegmentLabel.displayName,
 		Trendline.displayName,
 	] as string[];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the API, breaking out segment labels.

### was:
```
...
  <Donut hasDirectLabels />
...
```

### is:
```
...
  <Donut>
    <SegmentLabel percent value valueFormat="shortNumber" />
  </Donut>
...
```

New API gives far more control.

New support for:
* display or hide percent
* display or hide value
* value number format
* key in the data to use for the label

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/218

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Stories:

Donut > SegmentLabel

## Screenshots (if appropriate):

<img width="438" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/5704c6ec-4e17-442a-b485-94bcaa04a23b">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
