### PR TITLE
feat: update text anchor for segment labels

### DIFF
--- a/src/specBuilder/donut/segmentLabelUtils.test.tsx
+++ b/src/specBuilder/donut/segmentLabelUtils.test.tsx
@@ -2,7 +2,12 @@ import { SegmentLabel } from '@rsc/alpha';
 
 import { DonutSpecProps, SegmentLabelSpecProps } from '../../types';
 import { defaultDonutProps } from './donutTestUtils';
-import { getSegmentLabelMarks, getSegmentLabelValueText, getSegmentLabelValueTextMark } from './segmentLabelUtils';
+import {
+	getSegmentLabelMarks,
+	getSegmentLabelTextMark,
+	getSegmentLabelValueText,
+	getSegmentLabelValueTextMark,
+} from './segmentLabelUtils';
 
 const defaultDonutPropsWithSegmentLabel: DonutSpecProps = {
 	...defaultDonutProps,
@@ -82,5 +87,16 @@ describe('getSegmentLabelValueText()', () => {
 		expect(rules).toHaveLength(1);
 		expect(rules?.[0].signal).toContain('_arcPercent');
 		expect(rules?.[0].signal).toContain('testMetric');
+	});
+});
+
+describe('getSegmentLabelTextMark()', () => {
+	test('should define dy if value or percent are true', () => {
+		const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelProps, value: true });
+		expect(mark.encode?.enter).toHaveProperty('dy');
+	});
+	test('should not define dy if value and percent are false', () => {
+		const mark = getSegmentLabelTextMark(defaultSegmentLabelProps);
+		expect(mark.encode?.enter?.dy).toBeUndefined();
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the segment label anchor position. The anchor used to be the left or right side in between the label and the value. Now it is based on the quadrant. For example: If the segment label is in the top left, it's anchor is the bottom right.

## Related Issue

https://github.com/adobe/react-spectrum-charts/issues/218

## Screenshots (if appropriate):

It's subtle but notice how the spacing between the donut and the summary label is now more consistent (always 6px)

### Was:
<img width="453" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/9b027bd8-e091-4f51-a73e-1bd5ee9a7ce0">

### Is:
<img width="436" alt="image" src="https://github.com/adobe/react-spectrum-charts/assets/40001449/a2d50e2a-d99e-4daa-a0a1-0b6b676c121a">

# Story:

Donut > SegmentLabels

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
