### PR TITLE
feat: center donut summary without label

### DIFF
--- a/src/specBuilder/donut/donutSummaryUtils.test.tsx
+++ b/src/specBuilder/donut/donutSummaryUtils.test.tsx
@@ -18,6 +18,8 @@ import {
 	getDonutSummaryGroupMark,
 	getDonutSummaryScales,
 	getDonutSummarySignals,
+	getSummaryValueBaseline,
+	getSummaryValueLimit,
 	getSummaryValueText,
 } from './donutSummaryUtils';
 import { defaultDonutProps } from './donutTestUtils';
@@ -122,5 +124,31 @@ describe('getSummaryValueText()', () => {
 			},
 			{ field: 'sum' },
 		]);
+	});
+});
+
+describe('getSummaryValueBaseline()', () => {
+	test('should return alphabetic if label is truthy', () => {
+		const baseline = getSummaryValueBaseline('Visitors');
+		expect(baseline).toHaveProperty('value', 'alphabetic');
+	});
+
+	test('should return middle if label is falsey', () => {
+		const baseline = getSummaryValueBaseline(undefined);
+		expect(baseline).toHaveProperty('value', 'middle');
+	});
+});
+
+describe('getSummaryValueLimit()', () => {
+	test('should use full font size in signal if label is truthy', () => {
+		expect(getSummaryValueLimit({ ...defaultDonutSummaryProps, label: 'Visitors' })).toEqual({
+			signal: '2 * sqrt(pow((min(width, height) / 2 - 2) * 0.85, 2) - pow(testName_summaryFontSize, 2))',
+		});
+	});
+
+	test('should use 1/2 font size in signal if label is falsey', () => {
+		expect(getSummaryValueLimit({ ...defaultDonutSummaryProps, label: '' })).toEqual({
+			signal: '2 * sqrt(pow((min(width, height) / 2 - 2) * 0.85, 2) - pow(testName_summaryFontSize * 0.5, 2))',
+		});
 	});
 });

--- a/src/stories/components/DonutSummary/DonutSummary.story.tsx
+++ b/src/stories/components/DonutSummary/DonutSummary.story.tsx
@@ -74,10 +74,8 @@ Basic.args = {
 	numberFormat: 'shortNumber',
 };
 
-const Responsive = bindWithProps(ResponsiveStory);
-Responsive.args = {
-	label: 'Visitors',
-};
+const NoLabel = bindWithProps(DonutStory);
+NoLabel.args = {};
 
 const NumberFormat = bindWithProps(DonutStory);
 NumberFormat.args = {
@@ -85,4 +83,9 @@ NumberFormat.args = {
 	label: 'Visitors',
 };
 
-export { Basic, NumberFormat, Responsive };
+const Responsive = bindWithProps(ResponsiveStory);
+Responsive.args = {
+	label: 'Visitors',
+};
+
+export { Basic, NoLabel, NumberFormat, Responsive };

--- a/src/stories/components/DonutSummary/DonutSummary.test.tsx
+++ b/src/stories/components/DonutSummary/DonutSummary.test.tsx
@@ -13,21 +13,26 @@ import { DONUT_SUMMARY_MIN_RADIUS } from '@constants';
 import { DonutSummary } from '@rsc/alpha';
 import { render, screen } from '@test-utils';
 
-import { Basic, NumberFormat } from './DonutSummary.story';
+import { Basic, NoLabel, NumberFormat } from './DonutSummary.story';
 
-describe('should render the correct number format', () => {
+describe('DonutSummary renders properly', () => {
 	// Donut is not a real React component. This is test just provides test coverage for sonarqube
 	test('Donut pseudo element', () => {
 		render(<DonutSummary />);
 	});
 
-	test('shortCurrency', async () => {
-		render(<NumberFormat {...NumberFormat.args} numberFormat="shortCurrency" />);
-		expect(await screen.findByText('$40.4K')).toBeInTheDocument();
+	test('metric value should be centered if there is not a label', async () => {
+		render(<NoLabel {...NoLabel.args} />);
+		const metricValue = await screen.findByText('40.4K');
+		screen.debug(metricValue);
+		expect(metricValue).toHaveAttribute('transform', 'translate(175,190)');
 	});
-	test('standardNumber', async () => {
-		render(<NumberFormat {...NumberFormat.args} numberFormat="standardNumber" />);
-		expect(await screen.findByText('40,365')).toBeInTheDocument();
+
+	test('metric value should be above center if there is a label', async () => {
+		render(<Basic {...Basic.args} />);
+		const metricValue = await screen.findByText('40.4K');
+		screen.debug(metricValue);
+		expect(metricValue).toHaveAttribute('transform', 'translate(175,175)');
 	});
 
 	test('metric label text should be 1/2 the size of the metric value text', async () => {
@@ -36,6 +41,17 @@ describe('should render the correct number format', () => {
 		expect(metricValue).toHaveAttribute('font-size', '28px');
 		const metricLabel = await screen.findByText('Visitors');
 		expect(metricLabel).toHaveAttribute('font-size', '14px');
+	});
+});
+
+describe('NumberFormat ', () => {
+	test('shortCurrency', async () => {
+		render(<NumberFormat {...NumberFormat.args} numberFormat="shortCurrency" />);
+		expect(await screen.findByText('$40.4K')).toBeInTheDocument();
+	});
+	test('standardNumber', async () => {
+		render(<NumberFormat {...NumberFormat.args} numberFormat="standardNumber" />);
+		expect(await screen.findByText('40,365')).toBeInTheDocument();
 	});
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Center the donut summary value when there isn't a label.

## Related Issue

#218 

## Story:

Donut > DonutSummary > NoLabel

## Screenshots (if appropriate):

Was:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/59a0689f-ffd3-406d-8259-60a2656416c9)

Is:
![image](https://github.com/adobe/react-spectrum-charts/assets/40001449/4b4450e7-f8e2-4326-a5cb-3d82c5a5e13e)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
