### PR TITLE
fix: use displayName to check component type

### DIFF
--- a/src/specBuilder/donut/donutSummaryUtils.ts
+++ b/src/specBuilder/donut/donutSummaryUtils.ts
@@ -12,6 +12,7 @@
 import { DONUT_RADIUS, DONUT_SUMMARY_FONT_SIZE_RATIO, DONUT_SUMMARY_MIN_RADIUS, FILTERED_TABLE } from '@constants';
 import { DonutSummary } from '@rsc/rc';
 import { getTextNumberFormat } from '@specBuilder/textUtils';
+import { getElementDisplayName } from '@utils';
 import {
 	EncodeEntryName,
 	GroupMark,
@@ -34,7 +35,9 @@ import { DonutSpecProps, DonutSummaryElement, DonutSummaryProps, DonutSummarySpe
  * @returns
  */
 const getDonutSummary = (props: DonutSpecProps): DonutSummarySpecProps | undefined => {
-	const donutSummary = props.children.find((child) => child.type === DonutSummary) as DonutSummaryElement;
+	const donutSummary = props.children.find(
+		(child) => getElementDisplayName(child) === DonutSummary.displayName
+	) as DonutSummaryElement;
 	if (!donutSummary) {
 		return;
 	}

--- a/src/specBuilder/donut/segmentLabelUtils.ts
+++ b/src/specBuilder/donut/segmentLabelUtils.ts
@@ -12,6 +12,7 @@
 import { DONUT_RADIUS, DONUT_SEGMENT_LABEL_MIN_ANGLE, FILTERED_TABLE } from '@constants';
 import { SegmentLabel } from '@rsc/rc';
 import { getTextNumberFormat } from '@specBuilder/textUtils';
+import { getElementDisplayName } from '@utils';
 import { GroupMark, NumericValueRef, ProductionRule, TextEncodeEntry, TextMark, TextValueRef } from 'vega';
 
 import { DonutSpecProps, SegmentLabelElement, SegmentLabelProps, SegmentLabelSpecProps } from '../../types';
@@ -22,7 +23,9 @@ import { DonutSpecProps, SegmentLabelElement, SegmentLabelProps, SegmentLabelSpe
  * @returns segmentLabelProps
  */
 const getSegmentLabel = (props: DonutSpecProps): SegmentLabelSpecProps | undefined => {
-	const segmentLabel = props.children.find((child) => child.type === SegmentLabel) as SegmentLabelElement;
+	const segmentLabel = props.children.find(
+		(child) => getElementDisplayName(child) === SegmentLabel.displayName
+	) as SegmentLabelElement;
 	if (!segmentLabel) {
 		return;
 	}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -73,7 +73,7 @@ export function toArray<Child>(children: Child | Child[] | undefined): Child[] {
 	return [children];
 }
 
-const getElementDisplayName = (element: unknown): string => {
+export const getElementDisplayName = (element: unknown): string => {
 	if (
 		!element ||
 		typeof element !== 'object' ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We were using referential equality to verify that the component is our `SegmentLabel` and/or `DonutSummary` components. This doesn't work for components imported from RC because the code will be verifying the `SegmentLabel` is the exact same component as exists in the standard export but users have to import `SegmentLabel` from `rc` so they are not referentially equal.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
