### PR TITLE
feat: Add item interaction mode for line

### DIFF
--- a/src/components/Line/Line.tsx
+++ b/src/components/Line/Line.tsx
@@ -13,7 +13,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { FC } from 'react';
 
-import { DEFAULT_METRIC, DEFAULT_TIME_DIMENSION } from '@constants';
+import { DEFAULT_INTERACTION_MODE, DEFAULT_METRIC, DEFAULT_TIME_DIMENSION } from '@constants';
 
 import { LineProps } from '../../types';
 
@@ -25,6 +25,7 @@ const Line: FC<LineProps> = ({
 	scaleType = 'time',
 	lineType = { value: 'solid' },
 	padding,
+	interactionMode = DEFAULT_INTERACTION_MODE,
 }: LineProps) => {
 	return null;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -110,3 +110,6 @@ export enum INTERACTION_MODE {
 	NEAREST = 'nearest',
 	ITEM = 'item',
 }
+export const HOVER_SIZE = 3000;
+export const HOVER_SHAPE_COUNT = 3;
+export const HOVER_SHAPE = 'diamond';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export const DEFAULT_SYMBOL_STROKE_WIDTH = 2;
 export const DEFAULT_TIME_DIMENSION = 'datetime';
 export const DEFAULT_TRANSFORMED_TIME_DIMENSION = `${DEFAULT_TIME_DIMENSION}0`;
 export const DEFAULT_TITLE_FONT_WEIGHT = 'bold';
+export const DEFAULT_INTERACTION_MODE = 'nearest';
 
 // vega data table name
 export const TABLE = 'table';
@@ -103,3 +104,9 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 
 // time constants
 export const MS_PER_DAY = 86400000;
+
+// mark constants
+export enum INTERACTION_MODE {
+	NEAREST = 'nearest',
+	ITEM = 'item',
+}

--- a/src/specBuilder/chartTooltip/chartTooltipUtils.test.ts
+++ b/src/specBuilder/chartTooltip/chartTooltipUtils.test.ts
@@ -9,19 +9,19 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { createElement } from 'react';
 
 import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { HIGHLIGHTED_GROUP } from '@constants';
 import { defaultBarProps } from '@specBuilder/bar/barTestUtils';
+import { defaultLineMarkProps } from '@specBuilder/line/lineTestUtils';
 import { defaultScatterProps } from '@specBuilder/scatter/scatterTestUtils';
 import { defaultSignals } from '@specBuilder/specTestUtils';
 import { baseData } from '@specBuilder/specUtils';
 import { Data, Signal } from 'vega';
 
-import { BarSpecProps, ChartTooltipProps } from '../../types';
+import { BarSpecProps, ChartTooltipProps, LineSpecProps } from '../../types';
 import {
 	addTooltipData,
 	addTooltipMarkOpacityRules,
@@ -146,6 +146,14 @@ describe('addTooltipSignals()', () => {
 			children: [createElement(ChartTooltip, { highlightBy: 'series' })],
 		});
 		expect(highlightedGroupSignal.on?.[0].events.toString().includes('_voronoi')).toBeTruthy();
+	});
+
+	test('should add on events if highlightBy is `series` and interactionMode is `item`', () => {
+		addTooltipSignals(signals, {
+			interactionMode: 'item',
+			children: [createElement(ChartTooltip, { highlightBy: 'series' })],
+		} as LineSpecProps);
+		expect(highlightedGroupSignal.on).toHaveLength(8);
 	});
 });
 

--- a/src/specBuilder/chartTooltip/chartTooltipUtils.test.ts
+++ b/src/specBuilder/chartTooltip/chartTooltipUtils.test.ts
@@ -15,7 +15,6 @@ import { ChartPopover } from '@components/ChartPopover';
 import { ChartTooltip } from '@components/ChartTooltip';
 import { HIGHLIGHTED_GROUP } from '@constants';
 import { defaultBarProps } from '@specBuilder/bar/barTestUtils';
-import { defaultLineMarkProps } from '@specBuilder/line/lineTestUtils';
 import { defaultScatterProps } from '@specBuilder/scatter/scatterTestUtils';
 import { defaultSignals } from '@specBuilder/specTestUtils';
 import { baseData } from '@specBuilder/specUtils';

--- a/src/specBuilder/chartTooltip/chartTooltipUtils.ts
+++ b/src/specBuilder/chartTooltip/chartTooltipUtils.ts
@@ -170,7 +170,7 @@ export const addTooltipSignals = (signals: Signal[], markProps: TooltipParentPro
 	}
 };
 
-function addMouseEvents(highlightedGroupSignal: Signal, markName: string, update: string) {
+const addMouseEvents = (highlightedGroupSignal: Signal, markName: string, update: string) => {
 	if (highlightedGroupSignal.on === undefined) {
 		highlightedGroupSignal.on = [];
 	}
@@ -183,7 +183,7 @@ function addMouseEvents(highlightedGroupSignal: Signal, markName: string, update
 			{ events: `@${markName}:mouseout`, update: 'null' },
 		]
 	);
-}
+};
 
 /**
  * adds the appropriate opacity rules to the beginning of the opacityRules array

--- a/src/specBuilder/chartTooltip/chartTooltipUtils.ts
+++ b/src/specBuilder/chartTooltip/chartTooltipUtils.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 import { ChartTooltip } from '@components/ChartTooltip';
 import {
 	DEFAULT_OPACITY_RULE,
@@ -17,10 +16,12 @@ import {
 	HIGHLIGHTED_GROUP,
 	HIGHLIGHTED_ITEM,
 	HIGHLIGHT_CONTRAST_RATIO,
+	INTERACTION_MODE,
 	MARK_ID,
 	SERIES_ID,
 } from '@constants';
 import { getFilteredTableData } from '@specBuilder/data/dataUtils';
+import { getHoverMarkNames } from '@specBuilder/marks/markUtils';
 import { Data, FormulaTransform, NumericValueRef, Signal, SourceData } from 'vega';
 
 import {
@@ -150,27 +151,39 @@ export const isHighlightedByDimension = (markProps: TooltipParentProps) => {
 export const addTooltipSignals = (signals: Signal[], markProps: TooltipParentProps) => {
 	if (isHighlightedByGroup(markProps)) {
 		const highlightedGroupSignal = signals.find((signal) => signal.name === HIGHLIGHTED_GROUP) as Signal;
-		if (highlightedGroupSignal.on === undefined) {
-			highlightedGroupSignal.on = [];
-		}
 
 		let markName = markProps.name;
 		let update = `datum.${markName}_groupId`;
+
+		if ((markProps as LineSpecProps).interactionMode === INTERACTION_MODE.ITEM) {
+			getHoverMarkNames(markName).forEach((name) => {
+				addMouseEvents(highlightedGroupSignal, name, update);
+			});
+		}
+
 		if (['scatter', 'line'].includes(markProps.markType)) {
 			update = `datum.${update}`;
 			markName += '_voronoi';
 		}
-		highlightedGroupSignal.on.push(
-			...[
-				{
-					events: `@${markName}:mouseover`,
-					update,
-				},
-				{ events: `@${markName}:mouseout`, update: 'null' },
-			]
-		);
+
+		addMouseEvents(highlightedGroupSignal, markName, update);
 	}
 };
+
+function addMouseEvents(highlightedGroupSignal: Signal, markName: string, update: string) {
+	if (highlightedGroupSignal.on === undefined) {
+		highlightedGroupSignal.on = [];
+	}
+	highlightedGroupSignal.on.push(
+		...[
+			{
+				events: `@${markName}:mouseover`,
+				update,
+			},
+			{ events: `@${markName}:mouseout`, update: 'null' },
+		]
+	);
+}
 
 /**
  * adds the appropriate opacity rules to the beginning of the opacityRules array

--- a/src/specBuilder/chartTooltip/chartTooltipUtils.ts
+++ b/src/specBuilder/chartTooltip/chartTooltipUtils.ts
@@ -155,7 +155,7 @@ export const addTooltipSignals = (signals: Signal[], markProps: TooltipParentPro
 		let markName = markProps.name;
 		let update = `datum.${markName}_groupId`;
 
-		if ((markProps as LineSpecProps).interactionMode === INTERACTION_MODE.ITEM) {
+		if ('interactionMode' in markProps && markProps.interactionMode === INTERACTION_MODE.ITEM) {
 			getHoverMarkNames(markName).forEach((name) => {
 				addMouseEvents(highlightedGroupSignal, name, update);
 			});

--- a/src/specBuilder/line/lineMarkUtils.test.ts
+++ b/src/specBuilder/line/lineMarkUtils.test.ts
@@ -69,10 +69,18 @@ describe('getLineMark()', () => {
 });
 
 describe('getLineHoverMarks()', () => {
-	test('should return 4 marks', () => {
+	test('should return 4 marks by default', () => {
 		expect(
 			getLineHoverMarks({ ...defaultLineMarkProps, isHighlightedByDimension: true, children: [] }, 'line0_facet')
 		).toHaveLength(5);
+	});
+	test('should return 4 marks if interactionMode is item', () => {
+		expect(
+			getLineHoverMarks(
+				{ ...defaultLineMarkProps, isHighlightedByDimension: true, children: [], interactionMode: 'item' },
+				'line0_facet'
+			)
+		).toHaveLength(4);
 	});
 });
 

--- a/src/specBuilder/line/lineMarkUtils.ts
+++ b/src/specBuilder/line/lineMarkUtils.ts
@@ -117,7 +117,7 @@ export const getLineHoverMarks = (
 	dataSource: string,
 	secondaryHighlightedMetric?: string
 ): Mark[] => {
-	const { children, dimension, metric, name, scaleType } = lineProps;
+	const { children, dimension, name, scaleType } = lineProps;
 	return [
 		// vertical rule shown for the hovered or selected point
 		getHoverRule(dimension, name, scaleType),

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -11,6 +11,7 @@
  */
 import { createElement } from 'react';
 
+import { ChartTooltip } from '@components/ChartTooltip';
 import { MetricRange } from '@components/MetricRange';
 import { Trendline } from '@components/Trendline';
 import {
@@ -559,6 +560,19 @@ describe('lineSpecBuilder', () => {
 			expect(signals[0].on).toHaveLength(2);
 			expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
 			expect(signals[2].on).toHaveLength(2);
+		});
+
+		test('hover signals with interactionMode item', () => {
+			const signals = addSignals(defaultSignals, {
+				...defaultLineProps,
+				interactionMode: 'item',
+				children: [createElement(ChartTooltip)],
+			});
+			expect(signals).toHaveLength(defaultSignals.length);
+			expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
+			expect(signals[0].on).toHaveLength(8);
+			expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
+			expect(signals[2].on).toHaveLength(8);
 		});
 	});
 });

--- a/src/specBuilder/line/lineSpecBuilder.ts
+++ b/src/specBuilder/line/lineSpecBuilder.ts
@@ -15,11 +15,12 @@ import {
 	DEFAULT_METRIC,
 	DEFAULT_TIME_DIMENSION,
 	FILTERED_TABLE,
+	INTERACTION_MODE,
 	LINE_TYPE_SCALE,
 	OPACITY_SCALE,
 } from '@constants';
 import { addTooltipData, addTooltipSignals, isHighlightedByGroup } from '@specBuilder/chartTooltip/chartTooltipUtils';
-import { hasInteractiveChildren, hasPopover } from '@specBuilder/marks/markUtils';
+import { getHoverMarkNames, hasInteractiveChildren, hasPopover } from '@specBuilder/marks/markUtils';
 import {
 	getMetricRangeData,
 	getMetricRangeGroupMarks,
@@ -112,6 +113,7 @@ export const addSignals = produce<Signal[], [LineSpecProps]>((signals, props) =>
 	if (!hasInteractiveChildren(children)) return;
 	addHighlightedItemSignalEvents(signals, `${name}_voronoi`, 2);
 	addHighlightedSeriesSignalEvents(signals, `${name}_voronoi`, 2);
+	addHoverSignals(signals, props);
 	addTooltipSignals(signals, props);
 });
 
@@ -168,4 +170,13 @@ const getMetricKeys = (lineMetric: string, lineChildren: MarkChildElement[], lin
 	});
 
 	return metricKeys;
+};
+
+const addHoverSignals = (signals: Signal[], props: LineSpecProps) => {
+	const { interactionMode, name } = props;
+	if (interactionMode !== INTERACTION_MODE.ITEM) return;
+	getHoverMarkNames(name).forEach((hoverMarkName) => {
+		addHighlightedItemSignalEvents(signals, hoverMarkName, 1);
+		addHighlightedSeriesSignalEvents(signals, hoverMarkName, 1);
+	});
 };

--- a/src/specBuilder/line/lineUtils.ts
+++ b/src/specBuilder/line/lineUtils.ts
@@ -18,6 +18,7 @@ import { sanitizeMarkChildren } from '@utils';
 import {
 	ColorFacet,
 	ColorScheme,
+	InteractionMode,
 	LineTypeFacet,
 	LineWidthFacet,
 	MarkChildElement,
@@ -78,4 +79,5 @@ export interface LineMarkProps {
 	popoverMarkName?: string;
 	scaleType: ScaleType;
 	staticPoint?: string;
+	interactionMode?: InteractionMode;
 }

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -22,6 +22,9 @@ import {
 	DEFAULT_OPACITY_RULE,
 	DEFAULT_TRANSFORMED_TIME_DIMENSION,
 	HIGHLIGHT_CONTRAST_RATIO,
+	HOVER_SHAPE,
+	HOVER_SHAPE_COUNT,
+	HOVER_SIZE,
 	LINEAR_COLOR_SCALE,
 	LINE_TYPE_SCALE,
 	LINE_WIDTH_SCALE,
@@ -43,6 +46,7 @@ import {
 	ArrayValueRef,
 	ColorValueRef,
 	Cursor,
+	GroupMark,
 	NumericValueRef,
 	PathMark,
 	ScaledValueRef,
@@ -336,6 +340,59 @@ export const getVoronoiPath = (children: MarkChildElement[], dataSource: string,
 			size: [{ signal: 'max(width, 1)' }, { signal: 'max(height, 1)' }],
 		},
 	],
+});
+
+/**
+ * Gets the hover area for the mark
+ * @param children
+ * @param dataSource the name of the data source that will be used in the hover area calculation
+ * @param dimension the dimension for the x encoding
+ * @param metric the metric for the y encoding
+ * @param name the name of the component the hover area is associated with, i.e. `scatter0`
+ * @param scaleType the scale type for the x encoding
+ * @returns GroupMark
+ */
+export const getItemHoverArea = (
+	children: MarkChildElement[],
+	dataSource: string,
+	dimension: string,
+	metric: string,
+	name: string,
+	scaleType: ScaleType
+): GroupMark => {
+	return {
+		name: `${name}_hoverGroup`,
+		type: 'group',
+		marks: getHoverSizes().map((size, i) => ({
+			name: getHoverMarkName(name, i),
+			type: 'symbol',
+			from: { data: dataSource },
+			encode: {
+				enter: {
+					shape: { value: HOVER_SHAPE },
+					y: { scale: 'yLinear', field: metric },
+					fill: { value: 'transparent' },
+					stroke: { value: 'transparent' },
+					tooltip: getTooltip(children, name, false),
+					size: getHoverSizeSignal(size),
+				},
+				update: {
+					x: getXProductionRule(scaleType, dimension),
+				},
+			},
+		})),
+	};
+};
+
+export const getHoverMarkName = (name: string, index: number): string => `${name}_hover${index}`;
+
+export const getHoverSizes = (): number[] => [...new Array(HOVER_SHAPE_COUNT)].map((_, i) => HOVER_SIZE / 2 ** i);
+
+export const getHoverMarkNames = (markName: string): string[] =>
+	[...new Array(HOVER_SHAPE_COUNT)].map((_, i) => getHoverMarkName(markName, i));
+
+const getHoverSizeSignal = (size: number): SignalRef => ({
+	signal: `${size} * max(width, 1) / 1000`,
 });
 
 /**

--- a/src/stories/components/Line/Line.story.tsx
+++ b/src/stories/components/Line/Line.story.tsx
@@ -229,6 +229,12 @@ Tooltip.args = {
 	),
 };
 
+const ItemTooltip = bindWithProps(BasicLineStory);
+ItemTooltip.args = {
+	...Tooltip.args,
+	interactionMode: 'item',
+};
+
 const WithStaticPoints = bindWithProps(LineWithVisiblePointsStory);
 WithStaticPoints.args = {
 	color: 'series',
@@ -284,6 +290,7 @@ export {
 	LinearTrendScale,
 	Opacity,
 	Tooltip,
+	ItemTooltip,
 	TrendScale,
 	WithStaticPoints,
 	WithStaticPointsAndDialogs,

--- a/src/stories/components/Line/Line.test.tsx
+++ b/src/stories/components/Line/Line.test.tsx
@@ -32,6 +32,7 @@ import {
 import {
 	Basic,
 	HistoricalCompare,
+	ItemTooltip,
 	LineType,
 	LineWithAxisAndLegend,
 	LineWithUTCDatetimeFormat,
@@ -205,6 +206,21 @@ describe('Line', () => {
 			expect(lines[0]).toHaveAttribute('opacity', '1');
 			expect(lines[1]).toHaveAttribute('opacity', '0.2');
 		});
+	});
+
+	test('Item tooltip renders', async () => {
+		render(<ItemTooltip {...ItemTooltip.args} />);
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		// get item hover area
+		const hoverGroup = await findAllMarksByGroupName(chart, 'line0_hover0');
+
+		// hover and validate all hover components are visible
+		await hoverNthElement(hoverGroup, 0);
+		const tooltip = await screen.findByTestId('rsc-tooltip');
+		expect(tooltip).toBeInTheDocument();
+		expect(within(tooltip).getByText('Nov 8')).toBeInTheDocument();
 	});
 
 	test('Static points render', async () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -11,7 +11,7 @@
  */
 import { JSXElementConstructor, MutableRefObject, ReactElement, ReactNode } from 'react';
 
-import { GROUP_DATA, MARK_ID, SERIES_ID, TRENDLINE_VALUE } from '@constants';
+import { GROUP_DATA, INTERACTION_MODE, MARK_ID, SERIES_ID, TRENDLINE_VALUE } from '@constants';
 import { Config, Data, FontWeight, Locale, NumberLocale, Padding, Spec, SymbolShape, TimeLocale, View } from 'vega';
 
 import { Theme } from '@react-types/provider';
@@ -400,7 +400,11 @@ export interface LineProps extends Omit<MarkProps, 'color'> {
 	scaleType?: ScaleType;
 	/** Key in the data that if it exists and the value resolves to true for each data object, a point will be drawn for that data point on the line. */
 	staticPoint?: string;
+	/** Sets the interaction mode for the line */
+	interactionMode?: InteractionMode;
 }
+
+export type InteractionMode = `${INTERACTION_MODE}`;
 
 export interface ScatterProps extends Omit<MarkProps, 'color'> {
 	/**

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -24,6 +24,7 @@ import {
 	DonutProps,
 	DonutSummaryProps,
 	FacetRef,
+	InteractionMode,
 	LegendProps,
 	LineProps,
 	LineWidth,
@@ -169,6 +170,7 @@ export interface LineSpecProps extends PartiallyRequired<LineProps, LinePropsWit
 	lineWidth?: FacetRef<LineWidth>;
 	markType: 'line';
 	popoverMarkName: string | undefined;
+	interactionMode?: InteractionMode;
 }
 
 type ScatterPropsWithDefaults =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add item interaction mode for `Line` that triggers tooltip when hovering over a particular area near points on the line

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/react-spectrum-charts/issues/364

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Voronoi method for tooltips on `Line` does not allow interaction with elements behind the line. `item` interaction mode allows for more precise interactions with the points on the `Line` and allows interaction with elements behind it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed existing tests
Added tests to cover changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
