### PR TITLE
feat: bar dimension selection ring

### DIFF
--- a/src/specBuilder/bar/barSpecBuilder.test.ts
+++ b/src/specBuilder/bar/barSpecBuilder.test.ts
@@ -36,6 +36,7 @@ import {
 	Data,
 	GroupMark,
 	Mark,
+	RectMark,
 	Scale,
 	ScaleData,
 	SourceData,
@@ -426,6 +427,18 @@ describe('barSpecBuilder', () => {
 			expect(addedMarks).toHaveLength(1);
 			expect(addedMarks[0].name).toEqual('bar0_group');
 			expect((addedMarks[0] as GroupMark).marks).toHaveLength(3);
+		});
+
+		test('should add dimension selection ring if a popover is highlighting by dimension', () => {
+			const marks = addMarks([], {
+				...defaultBarProps,
+				children: [createElement(ChartPopover, { UNSAFE_highlightBy: 'dimension' })],
+			});
+			expect(marks).toHaveLength(3);
+
+			const selectionRingMark = marks[2] as RectMark;
+			expect(selectionRingMark.type).toEqual('rect');
+			expect(selectionRingMark.name).toEqual('bar0_selectionRing');
 		});
 
 		test('should add trellis group mark if trellis prop is set', () => {

--- a/src/specBuilder/bar/barSpecBuilder.ts
+++ b/src/specBuilder/bar/barSpecBuilder.ts
@@ -21,7 +21,7 @@ import {
 	STACK_ID,
 	TRELLIS_PADDING,
 } from '@constants';
-import { addPopoverData } from '@specBuilder/chartPopover/chartPopoverUtils';
+import { addPopoverData, getPopovers } from '@specBuilder/chartPopover/chartPopoverUtils';
 import { addTooltipData, addTooltipSignals } from '@specBuilder/chartTooltip/chartTooltipUtils';
 import { getTransformSort } from '@specBuilder/data/dataUtils';
 import { getTooltipProps } from '@specBuilder/marks/markUtils';
@@ -41,7 +41,7 @@ import { produce } from 'immer';
 import { BandScale, Data, FormulaTransform, Mark, OrdinalScale, Scale, Signal, Spec } from 'vega';
 
 import { BarProps, BarSpecProps, ColorScheme } from '../../types';
-import { getBarPadding, getScaleValues, isDodgedAndStacked } from './barUtils';
+import { getBarPadding, getDimensionSelectionRing, getScaleValues, isDodgedAndStacked } from './barUtils';
 import { getDodgedMark } from './dodgedBarUtils';
 import { getDodgedAndStackedBarMark, getStackedBarMarks } from './stackedBarUtils';
 import { addTrellisScale, getTrellisGroupMark, isTrellised } from './trellisedBarUtils';
@@ -257,6 +257,11 @@ export const addMarks = produce<Mark[], [BarSpecProps]>((marks, props) => {
 		barMarks.push(...getStackedBarMarks(props));
 	} else {
 		barMarks.push(getDodgedMark(props));
+	}
+
+	const popovers = getPopovers(props);
+	if (popovers.some((popover) => popover.UNSAFE_highlightBy === 'dimension')) {
+		barMarks.push(getDimensionSelectionRing(props));
 	}
 
 	// if this is a trellis plot, we add the bars and the repeated scale to the trellis group

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -343,15 +343,14 @@ describe('barUtils', () => {
 					enter: {
 						cornerRadius: { value: 6 },
 						fill: { value: 'transparent' },
-						padding: { value: 5 },
 						stroke: { value: 'rgb(20, 115, 230)' },
 						strokeWidth: { value: 2 },
 					},
 					update: {
 						width: { signal: "bandwidth('xBand')/(1 - 0.3 / 2)" },
 						xc: { signal: "scale('xBand', datum.bar0_selectedGroupId) + bandwidth('xBand')/2" },
-						y: { value: -5 },
-						y2: { signal: 'height + 5' },
+						y: { value: 0 },
+						y2: { signal: 'height' },
 					},
 				},
 				from: {
@@ -369,13 +368,12 @@ describe('barUtils', () => {
 					enter: {
 						cornerRadius: { value: 6 },
 						fill: { value: 'transparent' },
-						padding: { value: 5 },
 						stroke: { value: 'rgb(20, 115, 230)' },
 						strokeWidth: { value: 2 },
 					},
 					update: {
-						x: { value: -5 },
-						x2: { signal: 'width + 5' },
+						x: { value: 0 },
+						x2: { signal: 'width' },
 						yc: { signal: `scale('yBand', datum.bar0_selectedGroupId) + bandwidth('yBand')/2` },
 						height: { signal: `bandwidth('yBand')/(1 - 0.3 / 2)` },
 					},

--- a/src/specBuilder/bar/barUtils.test.ts
+++ b/src/specBuilder/bar/barUtils.test.ts
@@ -25,8 +25,6 @@ import {
 	SELECTED_ITEM,
 	STACK_ID,
 } from '@constants';
-import { PaddingRatio } from '@stories/components/Bar/Bar.story';
-import colorSchemes from '@themes/colorSchemes';
 import { RectEncodeEntry } from 'vega';
 
 import { BarSpecProps } from '../../types';

--- a/src/specBuilder/bar/barUtils.ts
+++ b/src/specBuilder/bar/barUtils.ts
@@ -262,14 +262,14 @@ export const getDimensionSelectionRing = (props: BarSpecProps): RectMark => {
 	const update =
 		orientation === 'vertical'
 			? {
-					y: { value: -5 },
-					y2: { signal: 'height + 5' },
+					y: { value: 0 },
+					y2: { signal: 'height' },
 					xc: { signal: `scale('xBand', datum.${name}_selectedGroupId) + bandwidth('xBand')/2` },
 					width: { signal: `bandwidth('xBand')/(1 - ${paddingRatio} / 2)` },
 			  }
 			: {
-					x: { value: -5 },
-					x2: { signal: 'width + 5' },
+					x: { value: 0 },
+					x2: { signal: 'width' },
 					yc: { signal: `scale('yBand', datum.${name}_selectedGroupId) + bandwidth('yBand')/2` },
 					height: { signal: `bandwidth('yBand')/(1 - ${paddingRatio} / 2)` },
 			  };
@@ -287,7 +287,6 @@ export const getDimensionSelectionRing = (props: BarSpecProps): RectMark => {
 				strokeWidth: { value: 2 },
 				stroke: { value: getColorValue('static-blue', colorScheme) },
 				cornerRadius: { value: 6 },
-				padding: { value: 5 },
 			},
 			update,
 		},

--- a/src/specBuilder/bar/barUtils.ts
+++ b/src/specBuilder/bar/barUtils.ts
@@ -18,6 +18,7 @@ import {
 	SELECTED_ITEM,
 	STACK_ID,
 } from '@constants';
+import { getPopovers } from '@specBuilder/chartPopover/chartPopoverUtils';
 import {
 	getColorProductionRule,
 	getCursor,
@@ -36,6 +37,7 @@ import {
 	NumericValueRef,
 	ProductionRule,
 	RectEncodeEntry,
+	RectMark,
 } from 'vega';
 
 import { BarSpecProps, Orientation } from '../../types';
@@ -254,6 +256,44 @@ export const getStroke = ({ name, children, color, colorScheme }: BarSpecProps):
 	];
 };
 
+export const getDimensionSelectionRing = (props: BarSpecProps): RectMark => {
+	const { name, colorScheme, paddingRatio, orientation } = props;
+
+	const update =
+		orientation === 'vertical'
+			? {
+					y: { value: -5 },
+					y2: { signal: 'height + 5' },
+					xc: { signal: `scale('xBand', datum.${name}_selectedGroupId) + bandwidth('xBand')/2` },
+					width: { signal: `bandwidth('xBand')/(1 - ${paddingRatio} / 2)` },
+			  }
+			: {
+					x: { value: -5 },
+					x2: { signal: 'width + 5' },
+					yc: { signal: `scale('yBand', datum.${name}_selectedGroupId) + bandwidth('yBand')/2` },
+					height: { signal: `bandwidth('yBand')/(1 - ${paddingRatio} / 2)` },
+			  };
+
+	return {
+		name: `${name}_selectionRing`,
+		type: 'rect',
+		from: {
+			data: `${name}_selectedData`,
+		},
+		interactive: false,
+		encode: {
+			enter: {
+				fill: { value: 'transparent' },
+				strokeWidth: { value: 2 },
+				stroke: { value: getColorValue('static-blue', colorScheme) },
+				cornerRadius: { value: 6 },
+				padding: { value: 5 },
+			},
+			update,
+		},
+	};
+};
+
 export const getStrokeDash = ({ children, lineType }: BarSpecProps): ProductionRule<ArrayValueRef> => {
 	const defaultProductionRule = getStrokeDashProductionRule(lineType);
 	if (!hasPopover(children)) {
@@ -263,10 +303,16 @@ export const getStrokeDash = ({ children, lineType }: BarSpecProps): ProductionR
 	return [{ test: `${SELECTED_ITEM} && ${SELECTED_ITEM} === datum.${MARK_ID}`, value: [] }, defaultProductionRule];
 };
 
-export const getStrokeWidth = ({ name, children, lineWidth }: BarSpecProps): ProductionRule<NumericValueRef> => {
+export const getStrokeWidth = (props: BarSpecProps): ProductionRule<NumericValueRef> => {
+	const { lineWidth, name } = props;
 	const lineWidthValue = getLineWidthPixelsFromLineWidth(lineWidth);
 	const defaultProductionRule = { value: lineWidthValue };
-	if (!hasPopover(children)) {
+	const popovers = getPopovers(props);
+	const popoverWithDimensionHighlightExists = popovers.some(
+		({ UNSAFE_highlightBy }) => UNSAFE_highlightBy === 'dimension'
+	);
+
+	if (popovers.length === 0 || popoverWithDimensionHighlightExists) {
 		return [defaultProductionRule];
 	}
 

--- a/src/stories/components/ChartPopover/ChartPopover.story.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.story.tsx
@@ -63,7 +63,7 @@ const ChartPopoverSvgStory: StoryFn<typeof ChartPopover> = (args): ReactElement 
 		<Chart {...chartProps}>
 			<Bar color="series">
 				<ChartTooltip>{dialogContent}</ChartTooltip>
-				<ChartPopover UNSAFE_highlightBy="item" {...args} />
+				<ChartPopover {...args} />
 			</Bar>
 		</Chart>
 	);
@@ -75,7 +75,7 @@ const ChartPopoverDodgedBarStory: StoryFn<typeof ChartPopover> = (args): ReactEl
 		<Chart {...chartProps}>
 			<Bar color="series" type="dodged">
 				<ChartTooltip>{dialogContent}</ChartTooltip>
-				<ChartPopover UNSAFE_highlightBy="item" {...args} />
+				<ChartPopover {...args} />
 			</Bar>
 		</Chart>
 	);

--- a/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -219,6 +219,40 @@ describe('ChartPopover', () => {
 		expect(bars[4]).toHaveAttribute('stroke-width', '2');
 	});
 
+	test('Dodged bar popover opens on dimension click and closes when clicking outside', async () => {
+		render(<DodgedBarChart {...DodgedBarChart.args} UNSAFE_highlightBy="dimension" />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+		let bars = getAllMarksByGroupName(chart, 'bar0');
+
+		// clicking the bar should open the popover
+		await clickNthElement(bars, 4);
+		const popover = await screen.findByTestId('rsc-popover');
+		await waitFor(() => expect(popover).toBeInTheDocument()); // waitFor to give the popover time to make sure it doesn't close
+
+		// check the content of the popover
+		expect(within(popover).getByText('Operating system: Mac')).toBeInTheDocument();
+		expect(within(popover).getByText('Browser: Firefox')).toBeInTheDocument();
+		expect(within(popover).getByText('Users: 3')).toBeInTheDocument();
+
+		bars = getAllMarksByGroupName(chart, 'bar0');
+
+		// validate the highlight visuals are present
+		expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+		expect(bars[4]).toHaveAttribute('opacity', '1');
+
+		const selectionRingMarks = getAllMarksByGroupName(chart, 'bar0_selectionRing');
+
+		expect(selectionRingMarks).toHaveLength(3);
+		expect(selectionRingMarks[0]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
+		expect(selectionRingMarks[1]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
+		expect(selectionRingMarks[2]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
+		expect(selectionRingMarks[0]).toHaveAttribute('stroke-width', '2');
+		expect(selectionRingMarks[1]).toHaveAttribute('stroke-width', '2');
+		expect(selectionRingMarks[2]).toHaveAttribute('stroke-width', '2');
+	});
+
 	test('should call onClick callback when selecting a legend entry', async () => {
 		const onOpenChange = jest.fn();
 		render(<OnOpenChange {...OnOpenChange.args} onOpenChange={onOpenChange} />);


### PR DESCRIPTION
Adds a selection ring for bar charts when highlighting by dimension

## Description

When highlighting by dimension, instead of changing the stoke width and color for the bar that was selected, a new selection ring will appear that circles the entire dimension selected.

## Related Issue

#374 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7f07d764-d513-40ee-b3ca-6d0eda3dd302)

![image](https://github.com/user-attachments/assets/1d2c0e89-c611-4fb5-aff8-8b93152b6a62)

![image](https://github.com/user-attachments/assets/b07c89e7-766f-4030-b823-9eb57062d6de)

![image](https://github.com/user-attachments/assets/7ad91ee7-9e70-4d0c-9327-ad22cddd2a05)

![image](https://github.com/user-attachments/assets/3aa24924-a436-4208-901c-2fdc37d5f798)
![image](https://github.com/user-attachments/assets/b9cb08c9-5f9b-4718-a1a7-4e86344f2060)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
