### PR TITLE
feat: minute duration axis labels

### DIFF
--- a/src/expressionFunctions.test.ts
+++ b/src/expressionFunctions.test.ts
@@ -29,24 +29,33 @@ describe('truncateText()', () => {
 });
 
 describe('formatTimeDurationLabels()', () => {
-	test('should format durations correctly', () => {
-		const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
-		const formatDurationsFrFr = formatTimeDurationLabels(numberLocales['fr-FR']);
-		const formatDurationsDeDe = formatTimeDurationLabels(numberLocales['de-DE']);
+	const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
+	const formatDurationsFrFr = formatTimeDurationLabels(numberLocales['fr-FR']);
+	const formatDurationsDeDe = formatTimeDurationLabels(numberLocales['de-DE']);
 
-		expect(formatDurationsEnUS({ index: 0, label: '0', value: 1 })).toBe('00:00:01');
-		expect(formatDurationsEnUS({ index: 0, label: '0', value: 61 })).toBe('00:01:01');
-		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3661 })).toBe('01:01:01');
-		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3603661 })).toBe('1,001:01:01');
-		expect(formatDurationsFrFr({ index: 0, label: '0', value: 3603661 })).toBe('1\u00a0001:01:01');
-		expect(formatDurationsDeDe({ index: 0, label: '0', value: 3603661 })).toBe('1.001:01:01');
+	test('should format hour durations correctly', () => {
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 1 }, 'hour')).toBe('0:00:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 61 }, 'hour')).toBe('0:01:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3661 }, 'hour')).toBe('1:01:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: -3661 }, 'hour')).toBe('-1:01:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3603661 }, 'hour')).toBe('1,001:01:01');
+		expect(formatDurationsFrFr({ index: 0, label: '0', value: 3603661 }, 'hour')).toBe('1\u00a0001:01:01');
+		expect(formatDurationsDeDe({ index: 0, label: '0', value: 3603661 }, 'hour')).toBe('1.001:01:01');
 	});
 	test('should default to using en-US', () => {
 		const formatDurations = formatTimeDurationLabels();
-		expect(formatDurations({ index: 0, label: '0', value: 3603661 })).toBe('1,001:01:01');
+		expect(formatDurations({ index: 0, label: '0', value: 3603661 }, 'hour')).toBe('1,001:01:01');
 	});
-	test('should original string if type of value is string', () => {
-		const formatDurationsEnUS = formatTimeDurationLabels(numberLocales['en-US']);
-		expect(formatDurationsEnUS({ index: 0, label: '0', value: 'hello world!' })).toBe('hello world!');
+	test('should return original string if type of value is string', () => {
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 'hello world!' }, 'hour')).toBe('hello world!');
+	});
+	test('should use minute format if granularity === minute', () => {
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 1 }, 'minute')).toBe('0:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 61 }, 'minute')).toBe('1:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3661 }, 'minute')).toBe('61:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: -3661 }, 'minute')).toBe('-61:01');
+		expect(formatDurationsEnUS({ index: 0, label: '0', value: 3603661 }, 'minute')).toBe('60,061:01');
+		expect(formatDurationsFrFr({ index: 0, label: '0', value: 3603661 }, 'minute')).toBe('60\u00a0061:01');
+		expect(formatDurationsDeDe({ index: 0, label: '0', value: 3603661 }, 'minute')).toBe('60.061:01');
 	});
 });

--- a/src/expressionFunctions.ts
+++ b/src/expressionFunctions.ts
@@ -14,6 +14,8 @@ import { ADOBE_CLEAN_FONT } from '@themes/spectrumTheme';
 import { FormatLocaleDefinition, formatLocale } from 'd3-format';
 import { FontWeight } from 'vega';
 
+import { Granularity } from './types';
+
 interface LabelDatum {
 	index: number;
 	label: string;
@@ -43,11 +45,19 @@ export const formatTimeDurationLabels = (numberLocale: FormatLocaleDefinition = 
 	const d3 = formatLocale(numberLocale);
 	// 0 padded, minimum 2 digits, thousands separator, integer format
 	const formatDuration = d3.format('02,d');
-	return ({ value }: LabelDatum) => {
+	return ({ value }: LabelDatum, granularity: Granularity) => {
 		if (typeof value === 'string') return value;
-		const seconds = formatDuration(Math.floor(value % 60));
-		const minutes = formatDuration(Math.floor((value / 60) % 60));
+
+		const absoluteValue = Math.abs(value);
+		const seconds = formatDuration(Math.floor(absoluteValue % 60));
+
+		if (granularity === 'minute') {
+			const minutes = formatDuration(Math.floor(value / 60));
+			return `${minutes}:${seconds}`;
+		}
+
 		const hours = formatDuration(Math.floor(value / 60 / 60));
+		const minutes = formatDuration(Math.floor((absoluteValue / 60) % 60));
 		return `${hours}:${minutes}:${seconds}`;
 	};
 };

--- a/src/expressionFunctions.ts
+++ b/src/expressionFunctions.ts
@@ -44,21 +44,23 @@ const formatPrimaryTimeLabels = () => {
 export const formatTimeDurationLabels = (numberLocale: FormatLocaleDefinition = numberLocales['en-US']) => {
 	const d3 = formatLocale(numberLocale);
 	// 0 padded, minimum 2 digits, thousands separator, integer format
-	const formatDuration = d3.format('02,d');
+	const zeroPaddedFormat = d3.format('02,d');
+	const format = d3.format(',d');
 	return ({ value }: LabelDatum, granularity: Granularity) => {
 		if (typeof value === 'string') return value;
 
+		const sign = value < 0 ? '-' : '';
 		const absoluteValue = Math.abs(value);
-		const seconds = formatDuration(Math.floor(absoluteValue % 60));
+		const seconds = zeroPaddedFormat(Math.floor(absoluteValue % 60));
 
 		if (granularity === 'minute') {
-			const minutes = formatDuration(Math.floor(value / 60));
-			return `${minutes}:${seconds}`;
+			const minutes = format(Math.floor(absoluteValue / 60));
+			return `${sign}${minutes}:${seconds}`;
 		}
 
-		const hours = formatDuration(Math.floor(value / 60 / 60));
-		const minutes = formatDuration(Math.floor((absoluteValue / 60) % 60));
-		return `${hours}:${minutes}:${seconds}`;
+		const hours = format(Math.floor(absoluteValue / 60 / 60));
+		const minutes = zeroPaddedFormat(Math.floor((absoluteValue / 60) % 60));
+		return `${sign}${hours}:${minutes}:${seconds}`;
 	};
 };
 

--- a/src/specBuilder/axis/axisLabelUtils.test.ts
+++ b/src/specBuilder/axis/axisLabelUtils.test.ts
@@ -184,7 +184,7 @@ describe('getLabelFormat()', () => {
 	test('should return duration formatter if labelFormat is duration', () => {
 		expect(getLabelFormat({ ...defaultAxisProps, labelFormat: 'duration' }, 'xLinear')).toHaveProperty(
 			'signal',
-			'formatTimeDurationLabels(datum)'
+			"formatTimeDurationLabels(datum, 'day')"
 		);
 	});
 });

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -232,14 +232,14 @@ export const getLabelOffset = (
  * @returns
  */
 export const getLabelFormat = (
-	{ labelFormat, labelOrientation, numberFormat, position, truncateLabels }: AxisSpecProps,
+	{ granularity, labelFormat, labelOrientation, numberFormat, position, truncateLabels }: AxisSpecProps,
 	scaleName: string
 ): ProductionRule<TextValueRef> => {
 	if (labelFormat === 'percentage') {
 		return [{ test: 'isNumber(datum.value)', signal: "format(datum.value, '~%')" }, { signal: 'datum.value' }];
 	}
 	if (labelFormat === 'duration') {
-		return { signal: 'formatTimeDurationLabels(datum)' };
+		return { signal: `formatTimeDurationLabels(datum, '${granularity}')` };
 	}
 
 	return [

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -236,9 +236,9 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			expect(screen.getByText('00:00:00')).toBeInTheDocument();
-			expect(screen.getByText('01:23:20')).toBeInTheDocument();
-			expect(screen.getByText('02:46:40')).toBeInTheDocument();
+			expect(screen.getByText('0:00:00')).toBeInTheDocument();
+			expect(screen.getByText('1:23:20')).toBeInTheDocument();
+			expect(screen.getByText('2:46:40')).toBeInTheDocument();
 		});
 
 		test('should render duration labels in mm:ss if granularity is minutes', async () => {
@@ -246,7 +246,7 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			expect(screen.getByText('00:00')).toBeInTheDocument();
+			expect(screen.getByText('0:00')).toBeInTheDocument();
 			expect(screen.getByText('83:20')).toBeInTheDocument();
 			expect(screen.getByText('166:40')).toBeInTheDocument();
 		});

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -231,7 +231,7 @@ describe('Axis', () => {
 	});
 
 	describe('DurationLabelFormat', () => {
-		test('should render duration labels correctly', async () => {
+		test('should render duration labels in HH:mm:ss', async () => {
 			render(<DurationLabelFormat {...DurationLabelFormat.args} />);
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
@@ -239,6 +239,16 @@ describe('Axis', () => {
 			expect(screen.getByText('00:00:00')).toBeInTheDocument();
 			expect(screen.getByText('01:23:20')).toBeInTheDocument();
 			expect(screen.getByText('02:46:40')).toBeInTheDocument();
+		});
+
+		test('should render duration labels in mm:ss if granularity is minutes', async () => {
+			render(<DurationLabelFormat {...DurationLabelFormat.args} granularity="minute" />);
+			const chart = await findChart();
+			expect(chart).toBeInTheDocument();
+
+			expect(screen.getByText('00:00')).toBeInTheDocument();
+			expect(screen.getByText('83:20')).toBeInTheDocument();
+			expect(screen.getByText('166:40')).toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the ability to display duration in minute format `mm:ss` (previously only hour was supported `HH:mm:ss`).

## Motivation and Context

Requested by users

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ede778ae-5811-448d-9df8-2fe852495457)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
