### PR TITLE
feat: set reference line color

### DIFF
--- a/src/specBuilder/axis/axisReferenceLineUtils.test.ts
+++ b/src/specBuilder/axis/axisReferenceLineUtils.test.ts
@@ -239,7 +239,7 @@ describe('getReferenceLineSymbolMark()', () => {
 						y: { signal: 'height + 24' },
 					},
 				},
-				name: 'axis0ReferenceLine0_icon',
+				name: 'axis0ReferenceLine0_symbol',
 				type: 'symbol',
 			},
 		]);

--- a/src/specBuilder/axis/axisReferenceLineUtils.ts
+++ b/src/specBuilder/axis/axisReferenceLineUtils.ts
@@ -45,7 +45,7 @@ const applyReferenceLinePropDefaults = (
 	index: number
 ): ReferenceLineSpecProps => ({
 	...props,
-	color: props.color || 'gray-900',
+	color: props.color ?? 'gray-900',
 	colorScheme: axisProps.colorScheme,
 	name: `${axisProps.name}ReferenceLine${index}`,
 });

--- a/src/specBuilder/axis/axisReferenceLineUtils.ts
+++ b/src/specBuilder/axis/axisReferenceLineUtils.ts
@@ -186,7 +186,7 @@ export const getReferenceLineSymbolMark = (
 
 	return [
 		{
-			name: `${name}_icon`,
+			name: `${name}_symbol`,
 			type: 'symbol',
 			encode: {
 				enter: {

--- a/src/specBuilder/axis/axisReferenceLineUtils.ts
+++ b/src/specBuilder/axis/axisReferenceLineUtils.ts
@@ -12,7 +12,6 @@
 import { ReferenceLine } from '@components/ReferenceLine';
 import { DEFAULT_LABEL_FONT_WEIGHT } from '@constants';
 import { getColorValue, getPathFromIcon } from '@specBuilder/specUtils';
-import { toArray } from '@utils';
 import {
 	EncodeEntry,
 	FontWeight,
@@ -28,48 +27,54 @@ import {
 	TextMark,
 } from 'vega';
 
-import {
-	AxisChildElement,
-	AxisSpecProps,
-	Children,
-	Position,
-	ReferenceLineElement,
-	ReferenceLineProps,
-} from '../../types';
+import { AxisSpecProps, Position, ReferenceLineElement, ReferenceLineProps, ReferenceLineSpecProps } from '../../types';
 import { isVerticalAxis } from './axisUtils';
 
-export const getReferenceLinesFromChildren = (
-	children: Children<AxisChildElement> | undefined
-): ReferenceLineProps[] => {
-	const childrenArray = toArray(children);
-	const referenceLines = childrenArray.filter(
-		(child) => typeof child === 'object' && 'type' in child && child.type === ReferenceLine
+export const getReferenceLines = (axisProps: AxisSpecProps): ReferenceLineSpecProps[] => {
+	const referenceLineElements = axisProps.children.filter(
+		(child) => child.type === ReferenceLine
 	) as ReferenceLineElement[];
-	return referenceLines.map((referenceLineElement) => referenceLineElement.props);
+	return referenceLineElements.map((referenceLineElement, index) =>
+		applyReferenceLinePropDefaults(referenceLineElement.props, axisProps, index)
+	);
 };
+
+const applyReferenceLinePropDefaults = (
+	props: ReferenceLineProps,
+	axisProps: AxisSpecProps,
+	index: number
+): ReferenceLineSpecProps => ({
+	...props,
+	color: props.color || 'gray-900',
+	colorScheme: axisProps.colorScheme,
+	name: `${axisProps.name}ReferenceLine${index}`,
+});
 
 export const scaleTypeSupportsReferenceLines = (scaleType: ScaleType | undefined): boolean => {
 	const supportedScaleTypes: ScaleType[] = ['band', 'linear', 'point', 'time', 'utc'];
 	return Boolean(scaleType && supportedScaleTypes.includes(scaleType));
 };
 
-export const getReferenceLineMarks = (
-	axisProps: AxisSpecProps,
-	referenceLineProps: ReferenceLineProps,
-	referenceLineIndex: number,
-	scaleName: string
-): Mark[] => {
-	const positionRule = getPositionRule(axisProps, referenceLineProps, scaleName);
-	return [
-		getReferenceLineRuleMark(axisProps, referenceLineIndex, positionRule),
-		...getReferenceLineSymbolMark(axisProps, referenceLineProps, referenceLineIndex, positionRule),
-		...getReferenceLineTextMark(axisProps, referenceLineProps, referenceLineIndex, positionRule),
-	];
+export const getReferenceLineMarks = (axisProps: AxisSpecProps, scaleName: string): Mark[] => {
+	const referenceLineMarks: Mark[] = [];
+	const referenceLines = getReferenceLines(axisProps);
+
+	for (const referenceLine of referenceLines) {
+		const positionEncoding = getPositionEncoding(axisProps, referenceLine, scaleName);
+		referenceLineMarks.push(
+			...[
+				getReferenceLineRuleMark(axisProps, referenceLine, positionEncoding),
+				...getReferenceLineSymbolMark(axisProps, referenceLine, positionEncoding),
+				...getReferenceLineTextMark(axisProps, referenceLine, positionEncoding),
+			]
+		);
+	}
+	return referenceLineMarks;
 };
 
-export const getPositionRule = (
+export const getPositionEncoding = (
 	{ scaleType }: AxisSpecProps,
-	{ value, position }: ReferenceLineProps,
+	{ value, position }: ReferenceLineSpecProps,
 	scaleName: string
 ): ProductionRule<NumericValueRef> | SignalRef => {
 	const signalValue = typeof value === 'string' ? `'${value}'` : value;
@@ -85,47 +90,44 @@ export const getPositionRule = (
 	return { scale: scaleName, value };
 };
 
-const getOrientation = (position: Position): 'y' | 'x' => {
-	return isVerticalAxis(position) ? 'y' : 'x';
-};
-
 export const getReferenceLineRuleMark = (
-	{ name, position, ticks }: AxisSpecProps,
-	referenceLineIndex: number,
-	positionRule: ProductionRule<NumericValueRef> | SignalRef
+	{ position, ticks }: AxisSpecProps,
+	{ color, colorScheme, name }: ReferenceLineSpecProps,
+	positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): RuleMark => {
-	const orientation = getOrientation(position);
-
 	const startOffset = ticks ? 9 : 0;
 
 	const positionProps: { [key in Position]: Partial<EncodeEntry> } = {
 		top: {
-			x: positionRule,
+			x: positionEncoding,
 			y: { value: -startOffset },
 			y2: { signal: 'height' },
 		},
 		bottom: {
-			x: positionRule,
+			x: positionEncoding,
 			y: { value: 0 },
 			y2: { signal: `height + ${startOffset}` },
 		},
 		left: {
 			x: { value: -startOffset },
 			x2: { signal: 'width' },
-			y: positionRule,
+			y: positionEncoding,
 		},
 		right: {
 			x: { value: 0 },
 			x2: { signal: `width + ${startOffset}` },
-			y: positionRule,
+			y: positionEncoding,
 		},
 	};
 
 	return {
-		name: `${name}_${orientation}ReferenceLineRule${referenceLineIndex}`,
+		name,
 		type: 'rule',
 		interactive: false,
 		encode: {
+			enter: {
+				stroke: { value: getColorValue(color, colorScheme) },
+			},
 			update: {
 				...positionProps[position],
 			},
@@ -136,57 +138,55 @@ export const getReferenceLineRuleMark = (
 /**
  * Gets position values for additional marks for the reference line.
  * @param offset
- * @param positionRule
+ * @param positionEncoding
  * @param horizontalOffset
  * @returns SymbolMark
  */
 const getAdditiveMarkPositionProps = (
 	offset: number,
-	positionRule: ProductionRule<NumericValueRef> | SignalRef,
+	positionEncoding: ProductionRule<NumericValueRef> | SignalRef,
 	horizontalOffset?: number
 ) => ({
 	top: {
-		x: positionRule,
+		x: positionEncoding,
 		y: { value: -offset },
 	},
 	bottom: {
-		x: positionRule,
+		x: positionEncoding,
 		y: { signal: `height + ${offset}` },
 	},
 	left: {
 		x: { value: -offset },
-		y: { ...positionRule, offset: horizontalOffset },
+		y: { ...positionEncoding, offset: horizontalOffset },
 	},
 	right: {
 		x: { signal: `width + ${offset}` },
-		y: { ...positionRule, offset: horizontalOffset },
+		y: { ...positionEncoding, offset: horizontalOffset },
 	},
 });
 
 /**
  * Gets the reference line symbol mark
  * @param AxisSpecProps
- * @param ReferenceLineProps
+ * @param ReferenceLineSpecProps
  * @param referenceLineIndex
- * @param positionRule
+ * @param positionEncoding
  * @returns SymbolMark
  */
 export const getReferenceLineSymbolMark = (
-	{ colorScheme, name, position }: AxisSpecProps,
-	{ icon }: ReferenceLineProps,
-	referenceLineIndex: number,
-	positionRule: ProductionRule<NumericValueRef> | SignalRef
+	{ colorScheme, position }: AxisSpecProps,
+	{ icon, name }: ReferenceLineSpecProps,
+	positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): SymbolMark[] => {
 	if (!icon) return [];
-	const orientation = getOrientation(position);
 
 	// offset the icon from the edge of the chart area
 	const OFFSET = 24;
-	const positionProps = getAdditiveMarkPositionProps(OFFSET, positionRule);
+	const positionProps = getAdditiveMarkPositionProps(OFFSET, positionEncoding);
 
 	return [
 		{
-			name: `${name}_${orientation}ReferenceLineSymbol${referenceLineIndex}`,
+			name: `${name}_icon`,
 			type: 'symbol',
 			encode: {
 				enter: {
@@ -207,25 +207,23 @@ export const getReferenceLineSymbolMark = (
 /**
  * Gets the reference line text mark
  * @param AxisSpecProps
- * @param ReferenceLineProps
+ * @param ReferenceLineSpecProps
  * @param referenceLineIndex
- * @param positionRule
+ * @param positionEncoding
  * @returns TextMark
  */
 export const getReferenceLineTextMark = (
-	{ name, position }: AxisSpecProps,
-	{ label, icon, labelFontWeight }: ReferenceLineProps,
-	referenceLineIndex: number,
-	positionRule: ProductionRule<NumericValueRef> | SignalRef
+	{ position }: AxisSpecProps,
+	{ label, icon, labelFontWeight, name }: ReferenceLineSpecProps,
+	positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): TextMark[] => {
 	if (!label) return [];
-	const orientation = getOrientation(position);
 
 	return [
 		{
-			name: `${name}_${orientation}ReferenceLineLabel${referenceLineIndex}`,
+			name: `${name}_label`,
 			type: 'text',
-			encode: { ...getReferenceLineLabelsEncoding(labelFontWeight, label, position, positionRule, icon) },
+			encode: { ...getReferenceLineLabelsEncoding(labelFontWeight, label, position, positionEncoding, icon) },
 		},
 	];
 };
@@ -235,7 +233,7 @@ export const getReferenceLineTextMark = (
  * @param labelFontWeight
  * @param label
  * @param position
- * @param positionRule
+ * @param positionEncoding
  * @param icon
  * @returns updateEncoding
  */
@@ -243,12 +241,12 @@ export const getReferenceLineLabelsEncoding = (
 	labelFontWeight: FontWeight | undefined,
 	label: string,
 	position: Position,
-	positionRule: ProductionRule<NumericValueRef> | SignalRef,
+	positionEncoding: ProductionRule<NumericValueRef> | SignalRef,
 	icon: string | undefined
 ): GuideEncodeEntry<TextEncodeEntry> => {
 	const VERTICAL_OFFSET = icon ? 48 : 26; // Position label outside of icon.
 	const HORIZONTAL_OFFSET = isVerticalAxis(position) && icon ? 24 : 12; // Position label outside of icon for horizontal orientation.
-	const positionProps = getAdditiveMarkPositionProps(VERTICAL_OFFSET, positionRule, HORIZONTAL_OFFSET);
+	const positionProps = getAdditiveMarkPositionProps(VERTICAL_OFFSET, positionEncoding, HORIZONTAL_OFFSET);
 
 	return {
 		update: {

--- a/src/specBuilder/axis/axisSpecBuilder.test.ts
+++ b/src/specBuilder/axis/axisSpecBuilder.test.ts
@@ -271,7 +271,7 @@ describe('Spec builder, Axis', () => {
 		test('should add test to hide labels if they would overlap the reference line icon', () => {
 			const labelTextEncoding = addAxes([], {
 				...defaultAxisProps,
-				children: createElement(ReferenceLine, { value: 10, icon: 'date' }),
+				children: [createElement(ReferenceLine, { value: 10, icon: 'date' })],
 				scaleName: 'xLinear',
 				scaleType: 'linear',
 			})[0].encode?.labels?.update?.text as ProductionRule<TextValueRef>;

--- a/src/specBuilder/axis/axisSpecBuilder.ts
+++ b/src/specBuilder/axis/axisSpecBuilder.ts
@@ -30,11 +30,7 @@ import { Axis, Data, GroupMark, Mark, ScaleType, Signal, Spec } from 'vega';
 
 import { AxisProps, AxisSpecProps, ColorScheme, Label, Orientation, Position } from '../../types';
 import { getAxisLabelsEncoding, getControlledLabelAnchorValues, getLabelValue } from './axisLabelUtils';
-import {
-	getReferenceLineMarks,
-	getReferenceLinesFromChildren,
-	scaleTypeSupportsReferenceLines,
-} from './axisReferenceLineUtils';
+import { getReferenceLineMarks, getReferenceLines, scaleTypeSupportsReferenceLines } from './axisReferenceLineUtils';
 import { encodeAxisTitle, getTrellisAxisProps, isTrellisedChart } from './axisTrellisUtils';
 import {
 	getBaselineRule,
@@ -233,7 +229,7 @@ export const addAxes = produce<Axis[], [AxisSpecProps & { scaleName: string; opp
 
 		if (scaleTypeSupportsReferenceLines(axisProps.scaleType)) {
 			// encode axis to hide labels that overlap reference line icons
-			const referenceLines = getReferenceLinesFromChildren(axisProps.children);
+			const referenceLines = getReferenceLines(axisProps);
 			referenceLines.forEach((referenceLineProps) => {
 				const { label: referenceLineLabel, icon, value, position: linePosition } = referenceLineProps;
 				const text = newAxes[0].encode?.labels?.update?.text;
@@ -265,15 +261,11 @@ export const addAxesMarks = produce<
 	Mark[],
 	[AxisSpecProps & { scaleName: string; scaleType?: ScaleType; opposingScaleType?: string }]
 >((marks, props) => {
-	const { baseline, baselineOffset, children, opposingScaleType, position, scaleName, scaleType } = props;
+	const { baseline, baselineOffset, opposingScaleType, position, scaleName, scaleType } = props;
 
 	// only add reference lines to linear or time scales
 	if (scaleTypeSupportsReferenceLines(scaleType)) {
-		const referenceLines = getReferenceLinesFromChildren(children);
-		referenceLines.forEach((referenceLineProps, referenceLineIndex) => {
-			const referenceLineMarks = getReferenceLineMarks(props, referenceLineProps, referenceLineIndex, scaleName);
-			marks.push(...referenceLineMarks);
-		});
+		marks.push(...getReferenceLineMarks(props, scaleName));
 	}
 
 	const trellisGroupMark = marks.find((mark) => mark.name?.includes('Trellis')) as GroupMark;

--- a/src/specBuilder/axis/axisTestUtils.ts
+++ b/src/specBuilder/axis/axisTestUtils.ts
@@ -50,6 +50,7 @@ export const defaultAxisProps: AxisSpecProps = {
 	name: 'axis0',
 	baseline: false,
 	baselineOffset: 0,
+	children: [],
 	colorScheme: DEFAULT_COLOR_SCHEME,
 	granularity: DEFAULT_GRANULARITY,
 	grid: false,

--- a/src/specBuilder/axis/axisUtils.test.ts
+++ b/src/specBuilder/axis/axisUtils.test.ts
@@ -38,6 +38,7 @@ describe('getDefaultAxis()', () => {
 				{
 					baseline: false,
 					baselineOffset: 0,
+					children: [],
 					colorScheme: 'light',
 					granularity: 'day',
 					grid: true,
@@ -99,6 +100,7 @@ describe('getDefaultAxis()', () => {
 					baseline: false,
 					baselineOffset: 0,
 					colorScheme: 'light',
+					children: [],
 					granularity: 'day',
 					grid: true,
 					hideDefaultLabels: false,

--- a/src/stories/ChartExamples.test.tsx
+++ b/src/stories/ChartExamples.test.tsx
@@ -246,10 +246,10 @@ describe('Time comparison stories', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const releaseLine = getMarksByGroupName(chart, 'axis0_xReferenceLineRule0', 'line');
+			const releaseLine = getMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
 			expect(releaseLine).toBeInTheDocument();
 
-			const releaseIcon = getMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const releaseIcon = getMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(releaseIcon).toBeInTheDocument();
 		});
 

--- a/src/stories/components/Axis/AxisReferenceLine.story.tsx
+++ b/src/stories/components/Axis/AxisReferenceLine.story.tsx
@@ -43,10 +43,16 @@ Basic.args = {
 	value: 0.5,
 };
 
-const Icon = bindWithProps(ReferenceLineStory);
-Icon.args = {
+const Color = bindWithProps(ReferenceLineStory);
+Color.args = {
+	color: 'blue-500',
 	value: 0.5,
-	icon: 'date',
 };
 
-export { Basic, Icon };
+const Icon = bindWithProps(ReferenceLineStory);
+Icon.args = {
+	icon: 'date',
+	value: 0.5,
+};
+
+export { Basic, Color, Icon };

--- a/src/stories/components/Axis/AxisReferenceLine.test.tsx
+++ b/src/stories/components/Axis/AxisReferenceLine.test.tsx
@@ -13,8 +13,9 @@ import React from 'react';
 
 import { ReferenceLine } from '@components/ReferenceLine';
 import { findChart, findMarksByGroupName, render } from '@test-utils';
+import { spectrumColors } from '@themes';
 
-import { Basic, Icon } from './AxisReferenceLine.story';
+import { Basic, Color, Icon } from './AxisReferenceLine.story';
 
 describe('AxisReferenceLine', () => {
 	// Axis is not a real React component. This is test just provides test coverage for sonarqube
@@ -28,8 +29,19 @@ describe('AxisReferenceLine', () => {
 		const chart = await findChart();
 		expect(chart).toBeInTheDocument();
 
-		const axisReferenceLine = await findMarksByGroupName(chart, 'axis0_xReferenceLineRule0', 'line');
+		const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
 		expect(axisReferenceLine).toBeInTheDocument();
+	});
+
+	test('Color renders', async () => {
+		render(<Color {...Color.args} />);
+
+		const chart = await findChart();
+		expect(chart).toBeInTheDocument();
+
+		const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
+		expect(axisReferenceLine).toBeInTheDocument();
+		expect(axisReferenceLine).toHaveAttribute('stroke', spectrumColors.light['blue-500']);
 	});
 
 	test('Icon renders', async () => {
@@ -38,7 +50,7 @@ describe('AxisReferenceLine', () => {
 		const chart = await findChart();
 		expect(chart).toBeInTheDocument();
 
-		const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+		const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_icon');
 		expect(axisReferenceLineIcon).toBeInTheDocument();
 	});
 });

--- a/src/stories/components/Axis/AxisReferenceLine.test.tsx
+++ b/src/stories/components/Axis/AxisReferenceLine.test.tsx
@@ -50,7 +50,7 @@ describe('AxisReferenceLine', () => {
 		const chart = await findChart();
 		expect(chart).toBeInTheDocument();
 
-		const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_icon');
+		const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 		expect(axisReferenceLineIcon).toBeInTheDocument();
 	});
 });

--- a/src/stories/components/Bar/ReferenceLineBar.test.tsx
+++ b/src/stories/components/Bar/ReferenceLineBar.test.tsx
@@ -35,7 +35,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0_xReferenceLineRule0', 'line');
+			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
 			expect(axisReferenceLine).toBeInTheDocument();
 			expect(axisReferenceLine).toHaveAttribute('transform', 'translate(298,0)');
 		});
@@ -50,7 +50,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(298,290)');
 		});
@@ -65,7 +65,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(298,294)');
 		});
 
@@ -86,7 +86,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(298,271)');
 		});
@@ -97,7 +97,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(298,295)');
 		});
 	});
@@ -113,7 +113,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0_xReferenceLineRule0', 'line');
+			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
 			expect(axisReferenceLine).toBeInTheDocument();
 			expect(axisReferenceLine).toHaveAttribute('transform', 'translate(238.4,0)');
 		});
@@ -128,7 +128,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(238.4,290)');
 		});
@@ -143,7 +143,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(238.4,294)');
 		});
 
@@ -164,7 +164,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(238.4,271)');
 		});
@@ -175,7 +175,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(238.4,295)');
 		});
 	});
@@ -191,7 +191,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0_xReferenceLineRule0', 'line');
+			const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
 			expect(axisReferenceLine).toBeInTheDocument();
 			expect(axisReferenceLine).toHaveAttribute('transform', 'translate(357.59999999999997,0)');
 		});
@@ -206,7 +206,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(357.59999999999997,290)');
 		});
@@ -221,7 +221,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(357.59999999999997,294)');
 		});
 
@@ -242,7 +242,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_xReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(357.59999999999997,271)');
 		});
@@ -253,7 +253,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(357.59999999999997,295)');
 		});
 	});
@@ -269,7 +269,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_yReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(-26,119.60000000000001)');
 		});
 
@@ -283,7 +283,7 @@ describe('AxisReferenceLine', () => {
 			const bars = await findAllMarksByGroupName(chart, 'bar0');
 			expect(bars.length).toEqual(5);
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_yReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(-24,107.60000000000001)');
 		});
@@ -305,7 +305,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0_yReferenceLineSymbol0');
+			const axisReferenceLineIcon = await findMarksByGroupName(chart, 'axis0ReferenceLine0_symbol');
 			expect(axisReferenceLineIcon).toBeInTheDocument();
 			expect(axisReferenceLineIcon).toHaveAttribute('transform', 'translate(-24,107.60000000000001)');
 		});
@@ -316,7 +316,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_yReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('transform', 'translate(-48,131.60000000000002)');
 		});
 	});
@@ -328,7 +328,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('font-weight', 'normal');
 		});
 
@@ -338,7 +338,7 @@ describe('AxisReferenceLine', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0_xReferenceLineLabel0', 'text');
+			const axisReferenceLineLabel = await findMarksByGroupName(chart, 'axis0ReferenceLine0_label', 'text');
 			expect(axisReferenceLineLabel).toHaveAttribute('font-weight', 'bold');
 		});
 	});

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -602,11 +602,17 @@ export interface ChartPopoverProps {
 }
 
 export interface ReferenceLineProps {
+	/** The color of the reference line. */
+	color?: SpectrumColor | string;
+	/** The value on the axis where the reference line should be drawn. */
 	value: number | string;
+	/** Adds an icon as the reference line label on the axis */
 	icon?: Icon | string;
 	/** Position the line on the value, or between the previous/next value. Only supported in Bar visualizations. */
 	position?: 'before' | 'after' | 'center';
+	/** Axis text label. If not provided, the default label will be displayed. */
 	label?: string;
+	/** Font weight of the label. */
 	labelFontWeight?: FontWeight;
 }
 

--- a/src/types/specBuilderTypes.ts
+++ b/src/types/specBuilderTypes.ts
@@ -16,6 +16,7 @@ import {
 	AreaProps,
 	AxisAnnotationChildElement,
 	AxisAnnotationProps,
+	AxisChildElement,
 	AxisProps,
 	BarProps,
 	ChartPopoverProps,
@@ -32,6 +33,7 @@ import {
 	MarkChildElement,
 	MetricRangeProps,
 	Orientation,
+	ReferenceLineProps,
 	ScaleType as RscScaleType,
 	ScatterPathProps,
 	ScatterProps,
@@ -54,7 +56,6 @@ export interface AreaSpecProps
 type AxisPropsWithDefaults =
 	| 'baseline'
 	| 'baselineOffset'
-	| 'colorScheme'
 	| 'granularity'
 	| 'grid'
 	| 'hideDefaultLabels'
@@ -66,20 +67,17 @@ type AxisPropsWithDefaults =
 	| 'subLabels'
 	| 'ticks';
 
-/**
- * these are props that are used interally to control the axis spec
- */
-export interface InternalAxisProps {
+export interface AxisSpecProps extends PartiallyRequired<AxisProps, AxisPropsWithDefaults> {
+	name: string;
+	colorScheme: ColorScheme;
+	index: number;
+	scaleType: ScaleType;
+	children: AxisChildElement[];
 	vegaLabelAlign?: Align;
 	vegaLabelBaseline?: Baseline;
 	vegaLabelOffset?: NumberValue;
 	vegaLabelPadding?: number;
 }
-
-export type AxisSpecProps = PartiallyRequired<
-	AxisProps & { name: string; colorScheme: ColorScheme; index: number; scaleType: ScaleType } & InternalAxisProps,
-	AxisPropsWithDefaults
->;
 
 type AxisAnnotationPropsWithDefaults = 'name' | 'offset' | 'dataKey' | 'color' | 'options' | 'format';
 
@@ -256,4 +254,10 @@ export interface TrendlineAnnotationSpecProps
 	trendlineName: string;
 	trendlineOrientation: Orientation;
 	trendlineWidth: number;
+}
+type ReferenceLinePropsWithDefaults = 'color';
+
+export interface ReferenceLineSpecProps extends PartiallyRequired<ReferenceLineProps, ReferenceLinePropsWithDefaults> {
+	colorScheme: ColorScheme;
+	name: string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add prop to control the color of the reference line.

## Screenshots (if appropriate):
<img width="634" alt="image" src="https://github.com/user-attachments/assets/0a2db05f-8baa-46fb-aa5e-a543d270bedd">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
