### PR TITLE
feat: remove 32 padding on linear dimension scales

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
 		"sonar-fork-pr": "node ./scripts/runSonarOnFork.js",
 		"start": "yarn storybook",
 		"storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider && storybook dev -p 6009",
-		"test": "cross-env BABEL_ENV=test jest",
-		"watch": "cross-env BABEL_ENV=test jest --watch",
+		"test": "cross-env TZ=UTC BABEL_ENV=test jest",
+		"watch": "cross-env TZ=UTC BABEL_ENV=test jest --watch",
 		"skulk": "yarn watch --silent"
 	},
 	"devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,7 +78,7 @@ export const CORNER_RADIUS = 6;
 // padding constants
 export const DISCRETE_PADDING = 0.5;
 export const PADDING_RATIO = 0.4;
-export const LINEAR_PADDING = 32;
+export const LINEAR_PADDING = 0;
 export const TRELLIS_PADDING = 0.2;
 
 // donut constants

--- a/src/specBuilder/area/areaSpecBuilder.test.ts
+++ b/src/specBuilder/area/areaSpecBuilder.test.ts
@@ -24,6 +24,7 @@ import {
 	FILTERED_TABLE,
 	HIGHLIGHTED_ITEM,
 	HIGHLIGHTED_SERIES,
+	LINEAR_PADDING,
 	MARK_ID,
 	SELECTED_GROUP,
 	SELECTED_ITEM,
@@ -131,7 +132,7 @@ const defaultSpec = initializeSpec({
 		{
 			domain: { data: FILTERED_TABLE, fields: [DEFAULT_TRANSFORMED_TIME_DIMENSION] },
 			name: 'xTime',
-			padding: 32,
+			padding: LINEAR_PADDING,
 			range: 'width',
 			type: 'time',
 		},
@@ -150,7 +151,7 @@ const defaultSpec = initializeSpec({
 const defaultLinearScale = {
 	domain: { data: FILTERED_TABLE, fields: [DEFAULT_TIME_DIMENSION] },
 	name: 'xLinear',
-	padding: 32,
+	padding: LINEAR_PADDING,
 	range: 'width',
 	type: 'linear',
 };

--- a/src/specBuilder/line/lineSpecBuilder.test.ts
+++ b/src/specBuilder/line/lineSpecBuilder.test.ts
@@ -26,6 +26,7 @@ import {
 	FILTERED_TABLE,
 	HIGHLIGHTED_ITEM,
 	HIGHLIGHTED_SERIES,
+	LINEAR_PADDING,
 	MARK_ID,
 	SERIES_ID,
 	TABLE,
@@ -124,7 +125,7 @@ const defaultSpec = initializeSpec({
 		{
 			domain: { data: FILTERED_TABLE, fields: [DEFAULT_TRANSFORMED_TIME_DIMENSION] },
 			name: 'xTime',
-			padding: 32,
+			padding: LINEAR_PADDING,
 			range: 'width',
 			type: 'time',
 		},
@@ -143,7 +144,7 @@ const defaultSpec = initializeSpec({
 const defaultLinearScale = {
 	domain: { data: FILTERED_TABLE, fields: [DEFAULT_TIME_DIMENSION] },
 	name: 'xLinear',
-	padding: 32,
+	padding: LINEAR_PADDING,
 	range: 'width',
 	type: 'linear',
 };

--- a/src/specBuilder/scale/scaleSpecBuilder.test.ts
+++ b/src/specBuilder/scale/scaleSpecBuilder.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { COLOR_SCALE, DEFAULT_COLOR } from '@constants';
+import { COLOR_SCALE, DEFAULT_COLOR, LINEAR_PADDING } from '@constants';
 import { OrdinalScale, Scale } from 'vega';
 
 import {
@@ -49,12 +49,12 @@ describe('addDomainFields()', () => {
 describe('getPadding()', () => {
 	test('time', () => {
 		expect(getPadding('time')).toStrictEqual({
-			padding: 32,
+			padding: LINEAR_PADDING,
 		});
 	});
 	test('linear', () => {
 		expect(getPadding('time')).toStrictEqual({
-			padding: 32,
+			padding: LINEAR_PADDING,
 		});
 	});
 	test('point', () => {

--- a/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
+++ b/src/stories/ChartExamples/FeatureMatrix/FeatureMatrix.test.tsx
@@ -45,7 +45,7 @@ describe('FeatureMatrix', () => {
 		// horizontal trendline
 		const horizontalTrendline = await findMarksByGroupName(chart, 'scatter0Trendline0', 'line');
 		expect(horizontalTrendline).toBeInTheDocument();
-		expect(horizontalTrendline).toHaveAttribute('x2', '452');
+		expect(horizontalTrendline).toHaveAttribute('x2', '448');
 		expect(horizontalTrendline).toHaveAttribute('y2', '0');
 		expect(horizontalTrendline).toHaveAttribute('stroke', colors['gray-900']);
 		expect(horizontalTrendline).toHaveAttribute('stroke-width', '1');

--- a/src/stories/components/Axis/Axis.story.tsx
+++ b/src/stories/components/Axis/Axis.story.tsx
@@ -55,7 +55,7 @@ const AxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
 };
 
 const TimeAxisStory: StoryFn<typeof Axis> = (args): ReactElement => {
-	const chartProps = useChartProps({ data: timeData[args.granularity ?? DEFAULT_GRANULARITY], width: 'auto' });
+	const chartProps = useChartProps({ data: timeData[args.granularity ?? DEFAULT_GRANULARITY], width: 600 });
 	return (
 		<Chart {...chartProps}>
 			<Axis {...args} />

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -98,6 +98,7 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
+			screen.debug(chart, Infinity);
 			// make sure labels are visible
 			expect(screen.getByText('11')).toBeInTheDocument();
 			expect(screen.getByText('Sep')).toBeInTheDocument();
@@ -108,6 +109,7 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
+			screen.debug(chart, Infinity);
 			// make sure labels are visible
 			expect(screen.getByText('Jan')).toBeInTheDocument();
 			expect(screen.getByText('2022')).toBeInTheDocument();

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -99,7 +99,7 @@ describe('Axis', () => {
 			expect(chart).toBeInTheDocument();
 
 			// make sure labels are visible
-			expect(await screen.findByText('11')).toBeInTheDocument();
+			expect(await screen.findByText('18')).toBeInTheDocument();
 			expect(await screen.findByText('Sep')).toBeInTheDocument();
 		});
 
@@ -109,7 +109,7 @@ describe('Axis', () => {
 			expect(chart).toBeInTheDocument();
 
 			// make sure labels are visible
-			expect(await screen.findByText('Jan')).toBeInTheDocument();
+			expect(await screen.findByText('Feb')).toBeInTheDocument();
 			expect(await screen.findByText('2022')).toBeInTheDocument();
 		});
 

--- a/src/stories/components/Axis/Axis.test.tsx
+++ b/src/stories/components/Axis/Axis.test.tsx
@@ -98,10 +98,9 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			screen.debug(chart, Infinity);
 			// make sure labels are visible
-			expect(screen.getByText('11')).toBeInTheDocument();
-			expect(screen.getByText('Sep')).toBeInTheDocument();
+			expect(await screen.findByText('11')).toBeInTheDocument();
+			expect(await screen.findByText('Sep')).toBeInTheDocument();
 		});
 
 		test('Month renders properly', async () => {
@@ -109,10 +108,9 @@ describe('Axis', () => {
 			const chart = await findChart();
 			expect(chart).toBeInTheDocument();
 
-			screen.debug(chart, Infinity);
 			// make sure labels are visible
-			expect(screen.getByText('Jan')).toBeInTheDocument();
-			expect(screen.getByText('2022')).toBeInTheDocument();
+			expect(await screen.findByText('Jan')).toBeInTheDocument();
+			expect(await screen.findByText('2022')).toBeInTheDocument();
 		});
 
 		test('Quarter renders properly', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Padding existed on linear dimension axes but it was misleading and identified as a design bug. This removes that padding.


## Motivation and Context

Existing padding was misleading on continuous data

## How Has This Been Tested?

Existing tests pass

## Screenshots (if appropriate):

Before:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/c7c1cedb-cee0-4bf9-9e1c-abbefc2343dd">

After:
<img width="740" alt="image" src="https://github.com/user-attachments/assets/b702d22d-4139-44ad-857c-f68b2b0586d1">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
