### PR TITLE
Data-navigator: Enabling navigable chart elements with alt text

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
 	},
 	"dependencies": {
 		"d3-format": "^3.1.0",
-		"data-navigator": "^2.0.2",
+		"data-navigator": "^2.1.0",
 		"immer": ">= 9.0.0",
 		"uuid": ">= 9.0.0",
 		"vega-embed": ">= 6.27.0",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
 	},
 	"dependencies": {
 		"d3-format": "^3.1.0",
+		"data-navigator": "^2.0.2",
 		"immer": ">= 9.0.0",
 		"uuid": ">= 9.0.0",
 		"vega-embed": ">= 6.27.0",

--- a/src/Chart.css
+++ b/src/Chart.css
@@ -60,3 +60,33 @@ this removes transitions in the vega tooltip
 	width: auto;
 	height: 100%;
 }
+
+/* navigation elements */
+.dn-root {
+    position: relative;
+}
+.dn-wrapper {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+}
+.dn-node {
+    position: absolute;
+    padding: 0px;
+    margin: 0px;
+    overflow: visible;
+}
+.dn-node-svg {
+    position: absolute;
+    pointer-events: none;
+}
+.dn-node-path {
+    fill: none;
+    stroke: #000000;
+    stroke-width: 4px;
+    transform: translateY(2px);
+}
+.dn-entry-button {
+    position: relative;
+    top: -21px;
+}

--- a/src/Navigator.tsx
+++ b/src/Navigator.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FC, useEffect, useRef, useState, MutableRefObject } from 'react'
+import { DimensionList } from '../node_modules/data-navigator/dist/src/data-navigator'
+import { buildNavigationStructure, buildStructureHandler } from '@specBuilder/chartSpecBuilder';
+import { Navigation, CurrentNodeDetails, ChartData} from './types'
+import { View } from 'vega';
+
+export interface NavigationProps {
+    data: ChartData;
+    chartView: MutableRefObject<View | undefined>;
+    chartLayers: DimensionList;
+}
+
+export const Navigator: FC<NavigationProps> = ({data, chartView, chartLayers}) => {
+    const focusedElement = useRef({
+        id: ""
+    } as CurrentNodeDetails)
+    const willFocusAfterRender = useRef(false);
+    const firstRef = useRef<HTMLElement>(null);
+    const secondRef = useRef<HTMLElement>(null);
+
+    const navigationStructure = buildNavigationStructure(data, {}, chartLayers)
+    const structureNavigationHandler = buildStructureHandler(
+        {
+            nodes: navigationStructure.nodes,
+            edges: navigationStructure.edges,
+        },
+        navigationStructure.navigationRules || {}, 
+        navigationStructure.dimensions || {}
+    )
+
+    const entryPoint = structureNavigationHandler.enter()
+    const [navigation, setNavigation] = useState<Navigation>({
+        transform: "",
+        buttonTransform: "",
+        current: {
+            id: entryPoint.id,
+            figureRole: "figure",
+            imageRole: "image",
+            hasInteractivity: true,
+            spatialProperties: {
+                width: "",
+                height: "",
+                left: "",
+                top: ""
+            },
+            semantics: {
+                label: entryPoint.semantics?.label || "initial element test"
+            }
+        }
+    })
+
+    const setNavigationElement = (target) => {
+        console.log("changing to new target",target.id)
+        // console.log("navigationStructure.navigationRules",navigationStructure.navigationRules)
+        setSpatialProperties()
+        setNavigation({
+            transform: "",
+            buttonTransform: "",
+            current: {
+                id: target.id,
+                figureRole: "figure",
+                imageRole: "image",
+                hasInteractivity: true,
+                spatialProperties: {
+                    width: "",
+                    height: "",
+                    left: "",
+                    top: ""
+                },
+                semantics: {
+                    label: "testing semantics!"
+                }
+            }
+        })
+    }
+    // setNavigationElement(entryPoint)
+    
+    useEffect(()=>{
+        if (willFocusAfterRender.current && focusedElement.current.id !== navigation.current.id) {
+            focusedElement.current = {id: navigation.current.id}
+            willFocusAfterRender.current = false
+            console.log("firstRef",firstRef)
+            console.log("secondRef",secondRef)
+            // console.log("navigation.current.id",navigation)
+            // console.log("focusedElement",focusedElement)
+            if (firstRef.current?.id === navigation.current.id) {
+                firstRef.current.focus()
+            } else if (secondRef.current?.id === navigation.current.id) {
+                secondRef.current.focus()
+            }
+        }
+    }, [navigation])
+
+    const handleFocus = (e) => {
+        console.log("focused",e)
+        focusedElement.current = {id: e.target.id}
+    }
+    const handleBlur = (e) => {
+        console.log("bluring at parent",e)
+        focusedElement.current = {id: ""}
+    }
+    const handleKeydown = (e) => {
+        // console.log("keydown",e)
+        const direction = structureNavigationHandler.keydownValidator(e);
+        console.log("direction",direction)
+        if (direction) {
+            e.preventDefault();
+            const nextNode = structureNavigationHandler.move(e.target.id, direction);
+            if (nextNode) {
+                setNavigationElement(nextNode);
+                willFocusAfterRender.current = true
+            }
+        }
+    }
+    const setSpatialProperties = () => {
+        console.log(chartView?.current)
+    }
+
+    const dummySpecs: Navigation = {
+        ...navigation
+    }
+    dummySpecs.current = { id : "old" + navigation.current.id }
+    dummySpecs.current.semantics = { label: ""}
+    dummySpecs.current.spatialProperties = { ...navigation.current.spatialProperties }
+    const firstProps = !firstRef.current || focusedElement.current.id !== firstRef.current.id ? navigation : dummySpecs
+    const secondProps = firstProps.current.id === navigation.current.id ? dummySpecs : navigation
+
+	return (
+        <>
+            <div id="dn-wrapper-data-navigator-schema" role="application" aria-label="Data navigation structure" aria-activedescendant={focusedElement.current ? focusedElement.current.id : ""} className="dn-wrapper" style={{width: "100%", transform: navigation.transform}} onBlur={handleBlur}>
+                    {/* <button id="dn-entry-button-data-navigator-schema" className="dn-entry-button" style={{transform: navigation.buttonTransform}}>Enter navigation area</button> */}
+                    <figure ref={firstRef} role={firstProps.current.figureRole || "presentation"} id={firstProps.current.id} className="dn-node dn-test-class" tabIndex={firstProps.current.hasInteractivity ? 0 : undefined} style={firstProps.current.spatialProperties} onFocus={firstProps.current.hasInteractivity ? handleFocus : undefined} onKeyDown={firstProps.current.hasInteractivity ? handleKeydown : undefined}>
+                        <div role={firstProps.current.imageRole || "presentation"} className="dn-node-text" aria-label={firstProps.current.semantics?.label || undefined}></div>
+                    </figure>
+                    <figure ref={secondRef} role={secondProps.current.figureRole || "presentation"} id={secondProps.current.id} className="dn-node dn-test-class" tabIndex={secondProps.current.hasInteractivity ? 0 : undefined} style={secondProps.current.spatialProperties} onFocus={secondProps.current.hasInteractivity ? handleFocus : undefined} onKeyDown={secondProps.current.hasInteractivity ? handleKeydown : undefined}>
+                        <div role={secondProps.current.imageRole || "presentation"} className="dn-node-text" aria-label={secondProps.current.semantics?.label || undefined}></div>
+                    </figure>
+            </div>
+        </>
+    )
+}

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -19,6 +19,7 @@ import {
 	SELECTED_ITEM,
 	SELECTED_SERIES,
 	SERIES_ID,
+	NAVIGATION_ID_KEY
 } from '@constants';
 import useChartImperativeHandle from '@hooks/useChartImperativeHandle';
 import useLegend from '@hooks/useLegend';
@@ -40,6 +41,7 @@ import {
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Item } from 'vega';
 import { Handler, Position, Options as TooltipOptions } from 'vega-tooltip';
+import { addSimpleDataIDs as addNavigationIds } from '../node_modules/data-navigator/dist/structure.js'
 
 import { ActionButton, Dialog, DialogTrigger, View as SpectrumView } from '@adobe/react-spectrum';
 
@@ -113,7 +115,19 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 		const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false); // tracks the open/close state of the popover
 
 		const sanitizedChildren = sanitizeRscChartChildren(props.children);
+
+		/* 
+			chartLayers and addNavigationIds ensure that our Navigator can correctly build and use both data 
+			and vega's view (rendered) properties for each datum, adding NAVIGATION_ID_KEY allows us to link
+			the data in our navigation structure to the rendering data vega creates from the spec
+			Note: chartLayers is mutated/populated by useSpec and addNavigationIds mutates the input data
+		*/
 		const chartLayers = [];
+		addNavigationIds({
+			idKey: NAVIGATION_ID_KEY,
+			data,
+			addIds:true
+		})
 		// THE MAGIC, builds our spec
 		const spec = useSpec({
 			backgroundColor,

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -45,6 +45,8 @@ import { ActionButton, Dialog, DialogTrigger, View as SpectrumView } from '@adob
 
 import './Chart.css';
 import { VegaChart } from './VegaChart';
+import { Navigator } from 'Navigator';
+
 import {
 	ChartHandle,
 	ColorScheme,
@@ -53,7 +55,7 @@ import {
 	MarkBounds,
 	RscChartProps,
 	TooltipAnchor,
-	TooltipPlacement,
+	TooltipPlacement
 } from './types';
 
 interface ChartDialogProps {
@@ -111,7 +113,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 		const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false); // tracks the open/close state of the popover
 
 		const sanitizedChildren = sanitizeRscChartChildren(props.children);
-
+		const chartLayers = [];
 		// THE MAGIC, builds our spec
 		const spec = useSpec({
 			backgroundColor,
@@ -130,6 +132,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 			opacities,
 			colorScheme,
 			title,
+			chartLayers,
 			UNSAFE_vegaSpec,
 		});
 
@@ -149,7 +152,7 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 		}, [isPopoverOpen]);
 
 		useChartImperativeHandle(forwardedRef, { chartView, title });
-
+		
 		const {
 			legendHiddenSeries,
 			setLegendHiddenSeries,
@@ -309,6 +312,14 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 						popover={popover}
 					/>
 				))}
+				<Navigator
+					// navigation={navigation}
+					data={data}
+					chartView={chartView}
+					chartLayers={chartLayers}
+					// setNavigationElement={setNavigationElement}
+					// structureNavigationHandler={structureNavigationHandler}
+				></Navigator>
 			</>
 		);
 	}

--- a/src/RscChart.tsx
+++ b/src/RscChart.tsx
@@ -313,12 +313,9 @@ export const RscChart = forwardRef<ChartHandle, RscChartProps>(
 					/>
 				))}
 				<Navigator
-					// navigation={navigation}
 					data={data}
 					chartView={chartView}
 					chartLayers={chartLayers}
-					// setNavigationElement={setNavigationElement}
-					// structureNavigationHandler={structureNavigationHandler}
 				></Navigator>
 			</>
 		);

--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -103,44 +103,6 @@ export const VegaChart: FC<VegaChartProps> = ({
 				tooltip,
 				width,
 			}).then(({ view }) => {
-				// c/onsole.log("~~~~")
-				// c/onsole.log("~~~~")
-				// c/onsole.log("view!", view)
-				// c/onsole.log("specCopy!", specCopy)
-				// c/onsole.log("tableData!", tableData)
-				// c/onsole.log("config!", config)
-				// c/onsole.log("containerRef.current",containerRef.current)
-				// view._scenegraph.root.items[0].items[3].source.value[0].datum //
-				// items[0] of 0 // not sure what this level is
-					// items[2] of 4 // role === "mark", name === "bar0_background"
-					// items[3] of 4 // role === "mark", name === "bar0"
-						// source.value // this is an array of the bars in a bar chart now
-						// value[i].datum // this contains the data used to render the bar
-						// value[i].x // & y, width, & height are the rendered mark's info
-						/*
-							browser: "Chrome"
-							downloads: 27000
-							downloads0: 0
-							downloads1: 27000
-							percentLabel: "53.1%"
-							rscMarkId: 1 // this is the id
-							rscStackId: "Chrome" // this id is used for x axis grouping (if stacking?)
-							Symbol(vega_id): 13367
-						*/
-				/* 
-					goals:
-						- use tableData to construct dimensions: dimension, metric, and color are all used as encoding props. Note: dimension can sometimes be numerical or categorical
-						- figure out how to intercept which dimensions are used to encode the chart, use only those
-						- create structure: grouped or list based on encoding type, include rendered info
-							- view._scenegraph.root.items[0].items[3].source.value[0].datum is where x/y/width/eight are stored
-							- what about other mark types?
-						- create semantics for axes, legends, groups, elements, etc
-						- export the structure and semantics to ghost element renderer
-						- add alt text to root chart element
-						- on user input:
-							- render ghost element
-							- show signal in chart
-				*/
 				chartView.current = view;
 				onNewView(view);
 				view.resize();

--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -103,6 +103,44 @@ export const VegaChart: FC<VegaChartProps> = ({
 				tooltip,
 				width,
 			}).then(({ view }) => {
+				// c/onsole.log("~~~~")
+				// c/onsole.log("~~~~")
+				// c/onsole.log("view!", view)
+				// c/onsole.log("specCopy!", specCopy)
+				// c/onsole.log("tableData!", tableData)
+				// c/onsole.log("config!", config)
+				// c/onsole.log("containerRef.current",containerRef.current)
+				// view._scenegraph.root.items[0].items[3].source.value[0].datum //
+				// items[0] of 0 // not sure what this level is
+					// items[2] of 4 // role === "mark", name === "bar0_background"
+					// items[3] of 4 // role === "mark", name === "bar0"
+						// source.value // this is an array of the bars in a bar chart now
+						// value[i].datum // this contains the data used to render the bar
+						// value[i].x // & y, width, & height are the rendered mark's info
+						/*
+							browser: "Chrome"
+							downloads: 27000
+							downloads0: 0
+							downloads1: 27000
+							percentLabel: "53.1%"
+							rscMarkId: 1 // this is the id
+							rscStackId: "Chrome" // this id is used for x axis grouping (if stacking?)
+							Symbol(vega_id): 13367
+						*/
+				/* 
+					goals:
+						- use tableData to construct dimensions: dimension, metric, and color are all used as encoding props. Note: dimension can sometimes be numerical or categorical
+						- figure out how to intercept which dimensions are used to encode the chart, use only those
+						- create structure: grouped or list based on encoding type, include rendered info
+							- view._scenegraph.root.items[0].items[3].source.value[0].datum is where x/y/width/eight are stored
+							- what about other mark types?
+						- create semantics for axes, legends, groups, elements, etc
+						- export the structure and semantics to ghost element renderer
+						- add alt text to root chart element
+						- on user input:
+							- render ghost element
+							- show signal in chart
+				*/
 				chartView.current = view;
 				onNewView(view);
 				view.resize();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -119,3 +119,92 @@ export const HOVER_SHAPE = 'diamond';
 
 // navigation
 export const NAVIGATION_ID_KEY = "dnNodeId"
+export const NAVIGATION_SEMANTICS = {
+	BAR: {
+		CHILD: "Bar",
+		DIVISION: "Division",
+		CHART: "Bar chart"
+	},
+	LINE: {
+		CHILD: "Line",
+		DIVISION: "Division",
+		CHART: "Line chart"
+	},
+	AREA: {
+		CHILD: "Area",
+		DIVISION: "Division",
+		CHART: "Area chart"
+	},
+	PIE: {
+		CHILD: "Slice",
+		DIVISION: "Division",
+		CHART: "Pie chart"
+	},
+	STACK: {
+		CHILD: "Stack",
+		DIVISION: "Division",
+		CHART: "Stacked bar chart"
+	},
+	SCATTER: {
+		CHILD: "Data point",
+		DIVISION: "Division",
+		CHART: "Scatter plot"
+	},
+	DODGE: {
+		CHILD: "Group",
+		DIVISION: "Division",
+		CHART: "Dodged bar chart"
+	},
+	COMBO: {
+		CHILD: "Group",
+		DIVISION: "Division",
+		CHART: "Combo chart"
+	}
+}
+export const NAVIGATION_RULES = {
+	// utility keybinds
+	"exit": {key: 'Escape', direction: 'target'},
+	"help": {key: 'Quote', direction: 'target'},
+	"undo": {key: 'SemiColon', direction: 'target'},
+	// generics
+	"left": {key: 'Period', direction: 'source'},
+	"right": {key: 'Comma', direction: 'target'},
+	"child": {key: 'Enter', direction: 'target'},
+	// dimension
+	"previous-dimension": {direction: 'source', key: 'ArrowLeft'},
+	"next-dimension": {direction: 'target', key: 'ArrowRight'},
+	"parent-dimension": {direction: 'source', key: 'Backspace'},
+	// metric
+	"previous-metric": {direction: 'source', key: 'ArrowUp'},
+	"next-metric": {direction: 'target', key: 'ArrowDown'},
+	"parent-metric": {direction: 'source', key: 'Slash'},
+	// color
+	"previous-color": {direction: 'source', key: 'BracketLeft'},
+	"next-color": {direction: 'target', key: 'BracketRight'},
+	"parent-color": {direction: 'source', key: 'BackSlash'}
+}
+export const NAVIGATION_PAIRS = {
+	DIMENSION: {
+		parent_child: ["parent-dimension","child"],
+		sibling_sibling: ["previous-dimension","next-dimension"],
+	},
+	METRIC: {
+		parent_child: ["parent-metric","child"],
+		sibling_sibling: ["previous-metric","next-metric"],
+	},
+	COLOR: {
+		parent_child: ["parent-color","child"],
+		sibling_sibling: ["previous-color","next-color"],
+	}
+}
+/*
+	child : {key: 'Enter', direction: 'target'}
+	left : {key: 'ArrowLeft', direction: 'source'}
+	next-browser : {direction: 'target', key: 'RightBracket'}
+	next-downloads : {direction: 'target', key: 'Backslash'}
+	parent-browser : {direction: 'source', key: 'KeyW'}
+	parent-downloads : {direction: 'source', key: 'KeyJ'}
+	previous-browser : {direction: 'source', key: 'LeftBracket'}
+	previous-downloads : {direction: 'source', key: 'Slash'}
+	right : {key: 'ArrowRight', direction: 'target'}
+*/

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,3 +116,6 @@ export enum INTERACTION_MODE {
 export const HOVER_SIZE = 3000;
 export const HOVER_SHAPE_COUNT = 3;
 export const HOVER_SHAPE = 'diamond';
+
+// navigation
+export const NAVIGATION_ID_KEY = "dnNodeId"

--- a/src/hooks/useSpec.tsx
+++ b/src/hooks/useSpec.tsx
@@ -34,6 +34,7 @@ export default function useSpec({
 	symbolShapes,
 	symbolSizes,
 	title,
+	chartLayers,
 	UNSAFE_vegaSpec,
 }: SanitizedSpecProps): Spec {
 	return useMemo(() => {
@@ -70,6 +71,7 @@ export default function useSpec({
 					opacities,
 					symbolShapes,
 					symbolSizes,
+					chartLayers,
 					title,
 				})
 			)

--- a/src/specBuilder/chartSpecBuilder.test.ts
+++ b/src/specBuilder/chartSpecBuilder.test.ts
@@ -75,6 +75,7 @@ const defaultSpecProps: SanitizedSpecProps = {
 	symbolShapes: ['rounded-square'],
 	symbolSizes: ['XS', 'XL'],
 	title: '',
+	chartLayers: [],
 	UNSAFE_vegaSpec: undefined,
 };
 

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -27,6 +27,7 @@ import {
 	SYMBOL_SHAPE_SCALE,
 	SYMBOL_SIZE_SCALE,
 	TABLE,
+	NAVIGATION_ID_KEY
 } from '@constants';
 import { Area, Axis, Bar, Legend, Line, Scatter, Title } from '@rsc';
 import { Combo } from '@rsc/alpha';
@@ -275,17 +276,12 @@ export const buildNavigationStructure = (data, props, chartLayers) : Structure =
 		// append element after <VegaChart> in RscChart for navigation (the rendered thing)
 		// append an exit element within the appended parent element for our navigation stuff
 	const layers = props.list ? "" : chartLayers
+
 	const structureOptions : StructureOptions = {
 		data,
-		idKey: "dnNodeId"/*(d) => {
-			console.log("trying to find Id",d)
-			if (d && d.rscMarkId) {
-				return "rscMarkId"
-			}
-			return "rscStackId"
-		}*/,
-		addIds: true,
-		keysForIdGeneration: [],
+		idKey: NAVIGATION_ID_KEY,
+		// addIds: true,
+		// keysForIdGeneration: [],
 		dimensions: {
 			values: layers
 		}

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -34,6 +34,8 @@ import { BigNumber, Donut } from '@rsc/rc';
 import colorSchemes from '@themes/colorSchemes';
 import { produce } from 'immer';
 import { Data, LinearScale, OrdinalScale, PointScale, Scale, Signal, Spec } from 'vega';
+import {default as DataNavigator} from 'data-navigator'
+import {StructureOptions, DimensionList, DimensionDatum, Structure, NavigationRules, Dimensions} from '../../node_modules/data-navigator/dist/src/data-navigator'
 
 import {
 	AreaElement,
@@ -98,6 +100,7 @@ export function buildSpec(props: SanitizedSpecProps) {
 		opacities,
 		symbolShapes,
 		symbolSizes,
+		chartLayers,
 		title,
 	} = props;
 	let spec = initializeSpec(null, { backgroundColor, colorScheme, description, title });
@@ -119,6 +122,7 @@ export function buildSpec(props: SanitizedSpecProps) {
 	let { areaCount, axisCount, barCount, comboCount, donutCount, legendCount, lineCount, scatterCount } =
 		initializeComponentCounts();
 	const specProps = { colorScheme, idKey, highlightedItem };
+	// const chartLayers: DimensionList = []
 	spec = [...children]
 		.sort((a, b) => buildOrder.get(a.type) - buildOrder.get(b.type))
 		.reduce((acc: Spec, cur) => {
@@ -134,18 +138,25 @@ export function buildSpec(props: SanitizedSpecProps) {
 			switch (cur.type.displayName) {
 				case Area.displayName:
 					areaCount++;
+					addLayer(chartLayers, {acc,cur,index:areaCount})
 					return addArea(acc, { ...(cur as AreaElement).props, ...specProps, index: areaCount });
 				case Axis.displayName:
 					axisCount++;
+					// console.log("AXIS! What do we do here?")
+					// addLayer(chartLayers, {acc,cur,index:axisCount})
 					return addAxis(acc, { ...(cur as AxisElement).props, ...specProps, index: axisCount });
 				case Bar.displayName:
 					barCount++;
+					addLayer(chartLayers, {acc,cur,index:barCount})
 					return addBar(acc, { ...(cur as BarElement).props, ...specProps, index: barCount });
 				case Donut.displayName:
 					donutCount++;
+					addLayer(chartLayers, {acc,cur,index:donutCount})
 					return addDonut(acc, { ...(cur as DonutElement).props, ...specProps, index: donutCount });
 				case Legend.displayName:
 					legendCount++;
+					// console.log("LEGEND! What do we do here?")
+					// addLayer(chartLayers, {acc,cur,index:legendCount})
 					return addLegend(acc, {
 						...(cur as LegendElement).props,
 						...specProps,
@@ -155,18 +166,24 @@ export function buildSpec(props: SanitizedSpecProps) {
 					});
 				case Line.displayName:
 					lineCount++;
+					addLayer(chartLayers, {acc,cur,index:lineCount})
 					return addLine(acc, { ...(cur as LineElement).props, ...specProps, index: lineCount });
 				case Scatter.displayName:
 					scatterCount++;
+					addLayer(chartLayers, {acc,cur,index:scatterCount})
 					return addScatter(acc, { ...(cur as ScatterElement).props, ...specProps, index: scatterCount });
 				case Title.displayName:
 					// No title count. There can only be one title.
+					// console.log("TITLE! What do we do here?")
+					// addLayer(chartLayers, {acc,cur,index:0})
 					return addTitle(acc, { ...(cur as TitleElement).props });
 				case BigNumber.displayName:
 					// Do nothing and do not throw an error
 					return acc;
 				case Combo.displayName:
 					comboCount++;
+					// console.log("COMBO! What do we do here?")
+					// addLayer(chartLayers, {acc,cur,index:comboCount})
 					return addCombo(acc, { ...(cur as ComboElement).props, ...specProps, index: comboCount });
 				default:
 					console.error(`Invalid component type: ${cur.type.displayName} is not a supported <Chart> child`);
@@ -187,6 +204,104 @@ export function buildSpec(props: SanitizedSpecProps) {
 	spec = removeUnusedScales(spec);
 
 	return spec;
+}
+
+export const addLayer = (chartLayers: DimensionList, newLayer) => {
+	if (newLayer.cur.type.displayName === Line.displayName) {
+		// console.log("we have a line! how do we want to deal with this??")
+	}
+	const dimensions: Record<string, DimensionDatum> = {
+		dimension: {
+			dimensionKey: "",
+			operations: {
+				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1
+			},
+			behavior: {
+				extents: "circular"
+			}
+		},
+		metric: {
+			dimensionKey: "",
+			operations: {
+				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1
+			},
+			type: "numerical",
+			behavior: {
+				extents: "terminal"
+			}
+		},
+		color: {
+			dimensionKey: "",
+			type: "categorical",
+			behavior: {
+				extents: "circular"
+			}
+		}
+	}
+	if (newLayer.cur?.props) {
+		const dimensionKeys = Object.keys(dimensions)
+		if (newLayer.cur.props.metric_start || newLayer.cur.props.metric_end) {
+			// console.log("uh oh! a range!")
+		}
+		dimensionKeys.forEach(k => {
+			const dimensionKey = newLayer.cur.props[k]
+			if (dimensionKey) {
+				const newDimension: DimensionDatum = {
+					...dimensions[k],
+					dimensionKey, 
+					navigationRules: {
+						parent_child: ["parent-"+dimensionKey,"child"],
+						sibling_sibling: ["previous-"+dimensionKey,"next-"+dimensionKey]
+					},
+					divisionOptions: {
+						// sortFunction: , // no idea if we want to sort or not
+						divisionNodeIds: (dimensionKey, keyValue, i) => dimensionKey + keyValue + i
+					}
+				};
+				chartLayers.push(newDimension)
+			}
+		})
+	}
+}
+
+export const buildNavigationStructure = (data, props, chartLayers) : Structure => {
+	// to do:
+		// if "props.list" then we create a new dimension here
+		// figure out keysForIdGeneration
+		// set dimensions options (below)
+		// use data + vega lite view to finalize structure and render info
+		// generate descriptions
+		// build structure+input in RscChart
+		// append element after <VegaChart> in RscChart for navigation (the rendered thing)
+		// append an exit element within the appended parent element for our navigation stuff
+	const layers = props.list ? "" : chartLayers
+	const structureOptions : StructureOptions = {
+		data,
+		idKey: "dnNodeId"/*(d) => {
+			console.log("trying to find Id",d)
+			if (d && d.rscMarkId) {
+				return "rscMarkId"
+			}
+			return "rscStackId"
+		}*/,
+		addIds: true,
+		keysForIdGeneration: [],
+		dimensions: {
+			values: layers
+		}
+	}
+
+	// now we build with data navigator:
+	return DataNavigator.structure(structureOptions)
+}
+
+export const buildStructureHandler = (structure: Structure, navigationRules: NavigationRules, dimensions: Dimensions) => {
+	return DataNavigator.input({
+		structure,
+		navigationRules,
+		entryPoint: dimensions[Object.keys(dimensions)[0]].nodeId,
+		// exitPoint
+	})
 }
 
 export const removeUnusedScales = produce<Spec>((spec) => {

--- a/src/specBuilder/chartSpecBuilder.ts
+++ b/src/specBuilder/chartSpecBuilder.ts
@@ -27,7 +27,8 @@ import {
 	SYMBOL_SHAPE_SCALE,
 	SYMBOL_SIZE_SCALE,
 	TABLE,
-	NAVIGATION_ID_KEY
+	NAVIGATION_ID_KEY,
+	NAVIGATION_PAIRS
 } from '@constants';
 import { Area, Axis, Bar, Legend, Line, Scatter, Title } from '@rsc';
 import { Combo } from '@rsc/alpha';
@@ -36,7 +37,7 @@ import colorSchemes from '@themes/colorSchemes';
 import { produce } from 'immer';
 import { Data, LinearScale, OrdinalScale, PointScale, Scale, Signal, Spec } from 'vega';
 import {default as DataNavigator} from 'data-navigator'
-import {StructureOptions, DimensionList, DimensionDatum, Structure, NavigationRules, Dimensions} from '../../node_modules/data-navigator/dist/src/data-navigator'
+import {StructureOptions, DimensionList, DimensionDatum, Structure, NavigationRules, Dimensions, DimensionNavigationRules} from '../../node_modules/data-navigator/dist/src/data-navigator'
 
 import {
 	AreaElement,
@@ -215,28 +216,36 @@ export const addLayer = (chartLayers: DimensionList, newLayer) => {
 		dimension: {
 			dimensionKey: "",
 			operations: {
-				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1
+				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1,
+				compressSparseDivisions: true
 			},
 			behavior: {
 				extents: "circular"
-			}
+			},
+			navigationRules: NAVIGATION_PAIRS.DIMENSION as DimensionNavigationRules
 		},
 		metric: {
 			dimensionKey: "",
 			operations: {
-				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1
+				createNumericalSubdivisions: newLayer.cur.type.displayName === Scatter.displayName ? 4 : 1,
+				compressSparseDivisions: true
 			},
 			type: "numerical",
 			behavior: {
 				extents: "terminal"
-			}
+			},
+			navigationRules: NAVIGATION_PAIRS.METRIC as DimensionNavigationRules
 		},
 		color: {
 			dimensionKey: "",
 			type: "categorical",
 			behavior: {
 				extents: "circular"
-			}
+			},
+			operations: {
+				compressSparseDivisions: true
+			},
+			navigationRules: NAVIGATION_PAIRS.COLOR as DimensionNavigationRules
 		}
 	}
 	if (newLayer.cur?.props) {
@@ -249,11 +258,7 @@ export const addLayer = (chartLayers: DimensionList, newLayer) => {
 			if (dimensionKey) {
 				const newDimension: DimensionDatum = {
 					...dimensions[k],
-					dimensionKey, 
-					navigationRules: {
-						parent_child: ["parent-"+dimensionKey,"child"],
-						sibling_sibling: ["previous-"+dimensionKey,"next-"+dimensionKey]
-					},
+					dimensionKey,
 					divisionOptions: {
 						// sortFunction: , // no idea if we want to sort or not
 						divisionNodeIds: (dimensionKey, keyValue, i) => dimensionKey + keyValue + i
@@ -266,15 +271,6 @@ export const addLayer = (chartLayers: DimensionList, newLayer) => {
 }
 
 export const buildNavigationStructure = (data, props, chartLayers) : Structure => {
-	// to do:
-		// if "props.list" then we create a new dimension here
-		// figure out keysForIdGeneration
-		// set dimensions options (below)
-		// use data + vega lite view to finalize structure and render info
-		// generate descriptions
-		// build structure+input in RscChart
-		// append element after <VegaChart> in RscChart for navigation (the rendered thing)
-		// append an exit element within the appended parent element for our navigation stuff
 	const layers = props.list ? "" : chartLayers
 
 	const structureOptions : StructureOptions = {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -13,6 +13,7 @@ import { JSXElementConstructor, MutableRefObject, ReactElement, ReactNode } from
 
 import { GROUP_DATA, INTERACTION_MODE, MARK_ID, SERIES_ID, TRENDLINE_VALUE } from '@constants';
 import { Config, Data, FontWeight, Locale, NumberLocale, Padding, Spec, SymbolShape, TimeLocale, View } from 'vega';
+import { DimensionList } from '../../node_modules/data-navigator/dist/src/data-navigator'
 
 import { Icon, IconProps } from '@adobe/react-spectrum';
 import { IconPropsWithoutChildren } from '@react-spectrum/icon';
@@ -93,6 +94,7 @@ export interface SpecProps {
 	highlightedSeries?: string | number;
 	/** Data key that contains a unique ID for each data point in the array. */
 	idKey?: string;
+
 }
 
 type SpecPropsWithDefaults =
@@ -109,6 +111,7 @@ type SpecPropsWithDefaults =
 export interface SanitizedSpecProps extends PartiallyRequired<SpecProps, SpecPropsWithDefaults> {
 	/** Children with all non-RSC components removed */
 	children: ChartChildElement[];
+	chartLayers: DimensionList;
 	data?: ChartData[];
 }
 

--- a/src/types/navigationTypes.ts
+++ b/src/types/navigationTypes.ts
@@ -9,10 +9,24 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+export type Navigation = {
+    transform: string;
+    buttonTransform: string;
+    current: CurrentNodeDetails;
+}
 
-export * from './Chart';
-export * from './specBuilderTypes';
-export * from './SpectrumVizColors';
-export * from './supplementalVegaTypes';
-export * from './navigationTypes';
-export * from './locales';
+export type CurrentNodeDetails = {
+    id: string;
+    figureRole?: "figure";
+    imageRole?: "image";
+    hasInteractivity?: boolean;
+    spatialProperties?: {
+        height?: string;
+        width?: string;
+        left?: string;
+        top?: string;
+    };
+    semantics?: {
+        label: string
+    };
+}

--- a/src/types/navigationTypes.ts
+++ b/src/types/navigationTypes.ts
@@ -15,17 +15,19 @@ export type Navigation = {
     current: CurrentNodeDetails;
 }
 
+export type SpatialProperties = {
+    height?: string;
+    width?: string;
+    left?: string;
+    top?: string;
+}
+
 export type CurrentNodeDetails = {
     id: string;
     figureRole?: "figure";
     imageRole?: "image";
     hasInteractivity?: boolean;
-    spatialProperties?: {
-        height?: string;
-        width?: string;
-        left?: string;
-        top?: string;
-    };
+    spatialProperties?: SpatialProperties;
     semantics?: {
         label: string
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6269,6 +6269,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+data-navigator@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/data-navigator/-/data-navigator-2.0.2.tgz#082d65166bf950e9634340346aa0ca7cae96570a"
+  integrity sha512-K9OleAyYZpPSuYnFLdZG8VueI8PY1HxhhmS43hKYdfW0fjbarfBmeqxra1TqhFtG4TYAURY7w4pWzWSzjs8Tcg==
+
 data-urls@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6269,10 +6269,10 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-data-navigator@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/data-navigator/-/data-navigator-2.0.2.tgz#082d65166bf950e9634340346aa0ca7cae96570a"
-  integrity sha512-K9OleAyYZpPSuYnFLdZG8VueI8PY1HxhhmS43hKYdfW0fjbarfBmeqxra1TqhFtG4TYAURY7w4pWzWSzjs8Tcg==
+data-navigator@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/data-navigator/-/data-navigator-2.1.0.tgz#b80816ae659891e177a45f70ec39218102edf291"
+  integrity sha512-yDCoZxWu31qn0M6nEj19ucdcnzbeF9os0xsrENXKrqzSe5o/PmqmeA3qX0mvxwaVL8E1maA/eoYbr0G01g6XzA==
 
 data-urls@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
```
This PR is demonstrating a prototype of in-progress functionality and is subject to change.
```
<!--- Provide a general summary of your changes in the Title above -->

## Description
This work is part of an active consultation on the accessibility of React Spectrum Charts. Under the hood we want to enable accessible interaction and navigation of every chart in RSC, regardless of whether canvas or svg are used. In addition, we want to provide an API that enables core RSC developers to have opinionated design control over the navigation and interaction experience of each visualization type.

We are targeting smart defaults that make it easy for downstream developers to get accessible, rich, interactive data visualizations out of the box. But we also want to enable overrides for complex or advanced (but valid) use cases.

In general, this is a PR that is intended to demonstrate a working prototype (at minimum) and at best actually contribute working code into RSC across the ecosystem.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#482 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
If a chart can be hovered, clicked: a user should be able to do this with just a keyboard.
If a chart can't easily be summarized in just a couple of sentences: a screen reader user should be able to navigate the data and hear alt text for each element.
If a chart is being used for important decisions or is in an exploratory context: a user should be able to navigate and explore the data in a meaningful, structured way without requiring the use of a mouse or eyesight.

Presently, these experiences are not possible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

###Element-level navigation
![React spectrum's Storybook app is open showing a bar chart with a focus indication on one of the bars. Dev tools are open and show that this is a new element being rendered in HTML.](https://github.com/user-attachments/assets/4d89719a-db0c-49ca-b58e-24e0ed2da2ef)

### Alt text at the element-level
![A screen reader is announcing data about the bar element: browser: Firefox. downloads: 8000. Bar. Figure.](https://github.com/user-attachments/assets/93b12fe8-8794-4e7c-ba2a-76112b866f53)

### Group-level navigation
![A focus indicator on the bar chart is encompassing all of the bars](https://github.com/user-attachments/assets/ee96f9ce-794f-4ca7-9bd2-36c2a027f588)

![A focus indicator is on a stack of bars in a stacked bar chart](https://github.com/user-attachments/assets/cd598073-2bc3-426a-adb5-9ebf26c7f5f8)

The goal will be to use Vega's `signals` to actually show the focus indication, while my new `Navigator` component will handle actually making accessible navigation possible (even if the visualization is rendered using canvas).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
