### PR TITLE
feat: added advanced currency locale configuration

### DIFF
--- a/src/VegaChart.tsx
+++ b/src/VegaChart.tsx
@@ -18,7 +18,7 @@ import { Config, Padding, Renderers, Spec, View } from 'vega';
 import embed from 'vega-embed';
 import { Options as TooltipOptions } from 'vega-tooltip';
 
-import { expressionFunctions, formatTimeDurationLabels } from './expressionFunctions';
+import { expressionFunctions, formatLocaleCurrency, formatTimeDurationLabels } from './expressionFunctions';
 import { ChartData, ChartProps } from './types';
 import { getLocale } from './utils/locale';
 
@@ -94,6 +94,7 @@ export const VegaChart: FC<VegaChartProps> = ({
 				expressionFunctions: {
 					...expressionFunctions,
 					formatTimeDurationLabels: formatTimeDurationLabels(numberLocale),
+					formatLocaleCurrency: formatLocaleCurrency(numberLocale),
 				},
 				formatLocale: numberLocale as unknown as Record<string, unknown>, // these are poorly typed by vega-embed
 				height,

--- a/src/expressionFunctions.test.ts
+++ b/src/expressionFunctions.test.ts
@@ -15,9 +15,73 @@ import {
 	LabelDatum,
 	expressionFunctions,
 	formatHorizontalTimeAxisLabels,
+	formatLocaleCurrency,
 	formatTimeDurationLabels,
 	formatVerticalAxisTimeLabels,
 } from './expressionFunctions';
+
+describe('formatLocaleCurrency()', () => {
+	test('formats US currency correctly', () => {
+		const formatter = formatLocaleCurrency();
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.56 };
+
+		expect(formatter(datum, 'en-US', 'USD', 'currency')).toBe('$1,234.56');
+	});
+	test('formats US currency position with EUR currencyCode', () => {
+		const formatter = formatLocaleCurrency();
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.56 };
+
+		expect(formatter(datum, 'en-US', 'EUR', 'currency')).toBe('€1,234.56');
+	});
+	test('formats US currency position with JPY currencyCode and fr-FR separators', () => {
+		const formatter = formatLocaleCurrency(numberLocales['fr-FR']);
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.56 };
+
+		expect(formatter(datum, 'en-US', 'JPY', 'currency')).toBe('¥1 234,56');
+	});
+	test('formats FR currency position with JPY currencyCode and de-DE separators', () => {
+		const formatter = formatLocaleCurrency(numberLocales['de-DE']);
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.56 };
+
+		expect(formatter(datum, 'fr-FR', 'JPY', 'currency')).toBe('1.234,56 JPY');
+	});
+	test('rounds decimals to 2 places', () => {
+		const formatter = formatLocaleCurrency(numberLocales['de-DE']);
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.5678 };
+
+		expect(formatter(datum, 'fr-FR', 'JPY', 'currency')).toBe('1.234,57 JPY');
+	});
+	test('adds custom number format precision', () => {
+		const formatter = formatLocaleCurrency(numberLocales['de-DE']);
+		const datum: LabelDatum = { index: 0, label: '', value: 1234.5678 };
+
+		expect(formatter(datum, 'fr-FR', 'JPY', ',.4f')).toBe('1.234,5678 JPY');
+	});
+	test('returns value if value is a string', () => {
+		const formatter = formatLocaleCurrency(numberLocales['de-DE']);
+		const datum: LabelDatum = { index: 0, label: '', value: '1234.56' };
+
+		expect(formatter(datum, 'fr-FR', 'JPY', 'currency')).toBe('1234.56');
+	});
+
+	describe('error handling', () => {
+		beforeEach(() => {
+			jest.spyOn(console, 'error').mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		test('invalid format falls back to default value', () => {
+			const formatter = formatLocaleCurrency(numberLocales['de-DE']);
+			const datum: LabelDatum = { index: 0, label: '', value: 1234.56 };
+
+			expect(formatter(datum, 'en-US', 'JPY', '.invalidf')).toBe('1.234,56 €');
+			expect(console.error).toHaveBeenCalled();
+		});
+	});
+});
 
 describe('truncateText()', () => {
 	const longText =

--- a/src/specBuilder/axis/axisLabelUtils.ts
+++ b/src/specBuilder/axis/axisLabelUtils.ts
@@ -234,7 +234,15 @@ export const getLabelOffset = (
  * @returns
  */
 export const getLabelFormat = (
-	{ labelFormat, labelOrientation, numberFormat, position, truncateLabels }: AxisSpecProps,
+	{
+		labelFormat,
+		labelOrientation,
+		numberFormat,
+		position,
+		truncateLabels,
+		currencyLocale,
+		currencyCode,
+	}: AxisSpecProps,
 	scaleName: string
 ): ProductionRule<TextValueRef> => {
 	if (labelFormat === 'percentage') {
@@ -245,7 +253,7 @@ export const getLabelFormat = (
 	}
 
 	return [
-		...getTextNumberFormat(numberFormat),
+		...getTextNumberFormat(numberFormat, undefined, currencyLocale, currencyCode),
 		...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
 			? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
 			: [{ signal: 'datum.value' }]),

--- a/src/specBuilder/textUtils.test.ts
+++ b/src/specBuilder/textUtils.test.ts
@@ -28,4 +28,27 @@ describe('getTextNumberFormat()', () => {
 		expect(format).toHaveLength(1);
 		expect(format[0]).toHaveProperty('signal', `format(datum['value'], '${numberFormat}')`);
 	});
+	test('should return correct signal for string specifier with currencyCode and locale', () => {
+		const currencyCode = 'JPY';
+		const locale = 'fr-FR';
+		const numberFormat = '.4f';
+		const format = getTextNumberFormat(numberFormat, 'value', locale, currencyCode);
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty(
+			'signal',
+			`formatLocaleCurrency(datum, \"${locale}\", \"${currencyCode}\", \"${numberFormat}\")`
+		);
+	});
+	test('should return correct signal for string specifier if no currencyCode', () => {
+		const numberFormat = '.2f';
+		const format = getTextNumberFormat(numberFormat, 'value', 'fr-FR');
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', `format(datum['value'], '${numberFormat}')`);
+	});
+	test('should return correct signal for string specifier if no currencyLocale', () => {
+		const numberFormat = '.2f';
+		const format = getTextNumberFormat(numberFormat, 'value', undefined, 'USD');
+		expect(format).toHaveLength(1);
+		expect(format[0]).toHaveProperty('signal', `format(datum['value'], '${numberFormat}')`);
+	});
 });

--- a/src/specBuilder/textUtils.ts
+++ b/src/specBuilder/textUtils.ts
@@ -21,7 +21,9 @@ import { getD3FormatSpecifierFromNumberFormat } from './specUtils';
  */
 export const getTextNumberFormat = (
 	numberFormat: NumberFormat | string,
-	datumProperty: string = 'value'
+	datumProperty: string = 'value',
+	currencyLocale?: string,
+	currencyCode?: string
 ): ({
 	test?: string;
 } & TextValueRef)[] => {
@@ -44,6 +46,11 @@ export const getTextNumberFormat = (
 				test,
 				signal: `format(datum['${datumProperty}'], '$')`,
 			},
+		];
+	}
+	if (currencyCode && currencyLocale) {
+		return [
+			{ test, signal: `formatLocaleCurrency(datum, "${currencyLocale}", "${currencyCode}", "${numberFormat}")` },
 		];
 	}
 	const d3FormatSpecifier = getD3FormatSpecifierFromNumberFormat(numberFormat);

--- a/src/stories/components/Axis/Axis.story.tsx
+++ b/src/stories/components/Axis/Axis.story.tsx
@@ -268,6 +268,30 @@ VerticalTimeAxis.args = {
 	labelAlign: 'center',
 };
 
+const CurrencyLocale = bindWithProps(AxisStory);
+CurrencyLocale.args = {
+	position: 'left',
+	baseline: true,
+	grid: true,
+	currencyCode: 'EUR',
+	currencyLocale: 'en-US',
+	numberFormat: 'currency',
+	ticks: true,
+	title: 'Conversion Rate',
+};
+
+const CurrencyFormatSpecifier = bindWithProps(AxisStory);
+CurrencyFormatSpecifier.args = {
+	position: 'left',
+	baseline: true,
+	grid: true,
+	currencyCode: 'EUR',
+	currencyLocale: 'en-US',
+	numberFormat: ',.6f',
+	ticks: true,
+	title: 'Conversion Rate',
+};
+
 export {
 	Basic,
 	ControlledLabels,
@@ -281,4 +305,6 @@ export {
 	Time,
 	TruncateLabels,
 	VerticalTimeAxis,
+	CurrencyLocale,
+	CurrencyFormatSpecifier,
 };

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -118,7 +118,7 @@ export type LineTypes = LineType[] | LineType[][];
 export type Opacities = number[] | number[][];
 export type SymbolShapes = ChartSymbolShape[] | ChartSymbolShape[][];
 export type ChartSymbolShape = 'rounded-square' | SymbolShape;
-export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber';
+export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | string;
 export type TooltipAnchor = 'cursor' | 'mark';
 export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
 
@@ -237,7 +237,7 @@ export interface DonutSummaryProps {
 	 *
 	 * see {@link https://d3js.org/d3-format#locale_format}
 	 */
-	numberFormat?: NumberFormat | string;
+	numberFormat?: NumberFormat;
 	/** Label for the metric summary */
 	label?: string;
 }
@@ -292,7 +292,7 @@ export interface AxisProps extends BaseProps {
 	 *
 	 * see {@link https://d3js.org/d3-format#locale_format}
 	 */
-	numberFormat?: NumberFormat | string;
+	numberFormat?: NumberFormat;
 	/** The minimum and maximum values for the axis, for example: `[-10, 10]`.
 	 *
 	 * Note: This prop is only supported for axes with `linear` or `time` scale types.
@@ -314,6 +314,28 @@ export interface AxisProps extends BaseProps {
 	title?: string | string[];
 	/** If the text is wider than the bandwidth that is labels, it will be truncated so that it stays within that bandwidth. */
 	truncateLabels?: boolean;
+	/**
+	 * Set the locale for currency formatting (affects symbol position and spacing).
+	 *
+	 * ⚠️ Limited Support:
+	 * Support for and changes to this prop will be limited.
+	 * Only use this if you need to override the currency locale formatting from the chart locale.
+	 *
+	 * **Important:** This prop requires 'currencyCode' prop to take effect.
+	 *
+	 * Example: 'en-US' ($100) vs 'de-DE' (100 $)
+	 */
+	currencyLocale?: string;
+	/**
+	 * Override the currency symbol from the chart locale with a specific currency code.
+	 *
+	 * ⚠️ Limited Support:
+	 * Support for and changes to this prop will be limited.
+	 * Only use this if you need to override the currency symbol from the chart locale.
+	 *
+	 * **Important:** This prop requires 'currencyLocale' prop to take effect.
+	 */
+	currencyCode?: string;
 }
 
 export interface BigNumberProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Introduces advanced configuration options for currency formatting on the axis.

- **`currencyLocale`**:  
  Allows you to specify a locale string to determine the **positioning** and **spacing** of the currency format.  
  Example:  
  - `"en-US"`: `$100.00`  
  - `"de-DE"` (positioning based on German locale): `100.00 $`  

- **`currencyCode`**:  
  Lets you override the currency symbol from the current chart locale by specifying a currency code string.  
  Example:  
  - With currencyCode `"JPY"` using the above example:  
    - `"de-DE"`: `100.00 ¥` or `100.00 JPY` (depending on how the currency code is supported in the `currencyLocale`)  

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  Will be done after merge
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
