### PR TITLE
fix: remove config for axis label limit

### DIFF
--- a/src/themes/spectrumTheme.ts
+++ b/src/themes/spectrumTheme.ts
@@ -91,9 +91,6 @@ function getSpectrumVegaConfig(colorScheme: ColorScheme): Config {
 			titleFontWeight: 'bold',
 			titlePadding: 16,
 		},
-		axisY: {
-			labelLimit: 180,
-		},
 		range: {
 			category: categorical16,
 			diverging: divergentOrangeYellowSeafoam15,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We don't really want a label limit for the y axis. Causes unexpected behavior.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
