### PR TITLE
Scrum 18/label values

### DIFF
--- a/src/specBuilder/bullet/bulletSpecBuilder.test.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.test.ts
@@ -9,73 +9,125 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-import { getBulletScales, getBulletData, getBulletMarks, addBullet } from './bulletSpecBuilder';
-import { BulletSpecProps, BulletProps } from '../../types';
 import { Spec } from 'vega';
 
+import { BulletProps, BulletSpecProps } from '../../types';
+import { addBullet, getBulletData, getBulletMarks, getBulletScales } from './bulletSpecBuilder';
+
 const sampleProps: BulletSpecProps = {
-    "children": [],
-    "colorScheme": "light",
-    "index": 0,
-    "color": "green",
-    "metric": "currentAmount",
-    "dimension": "graphLabel",
-    "target": "target",
-    "name": "bullet0",
-    "idKey": "rscMarkId"
-}
+	children: [],
+	colorScheme: 'light',
+	index: 0,
+	color: 'green',
+	metric: 'currentAmount',
+	dimension: 'graphLabel',
+	target: 'target',
+	name: 'bullet0',
+	idKey: 'rscMarkId',
+};
 
 describe('addBullet', () => {
-    let spec: Spec;
+	let spec: Spec;
 
-    beforeEach(() => {
-        spec = { data: [], marks: [], scales: [] };
-    });
+	beforeEach(() => {
+		spec = { data: [], marks: [], scales: [] };
+	});
 
-    test('should modify spec with bullet chart properties', () => {
-        const bulletProps: BulletProps & { idKey: string } = {
-            children: [],
-            name: 'testBullet',
-            metric: 'revenue',
-            dimension: 'region',
-            target: 'goal',
-            idKey: 'rscMarkId',
-        };
+	test('should modify spec with bullet chart properties', () => {
+		const bulletProps: BulletProps & { idKey: string } = {
+			children: [],
+			name: 'testBullet',
+			metric: 'revenue',
+			dimension: 'region',
+			target: 'goal',
+			idKey: 'rscMarkId',
+		};
 
-        const newSpec = addBullet(spec, bulletProps);
+		const newSpec = addBullet(spec, bulletProps);
 
-        const expectedScale = [{"domain": [0, {"signal": "data('max_values')[0].maxOverall"}], "name": "xscale", "range": [0, {"signal": "width"}], "type": "linear"}]
+		const expectedScale = [
+			{
+				domain: [0, { signal: "data('max_values')[0].maxOverall" }],
+				name: 'xscale',
+				range: [0, { signal: 'width' }],
+				type: 'linear',
+			},
+		];
 
-        expect(newSpec.data).toHaveLength(2);
-        expect(newSpec.marks).toHaveLength(4);
-        expect(newSpec.scales).toEqual(expectedScale);
-    });
+		expect(newSpec.data).toHaveLength(2);
+		expect(newSpec.marks).toHaveLength(4);
+		expect(newSpec.scales).toEqual(expectedScale);
+	});
 });
 
 describe('getBulletData', () => {
-    test('should return the data object with max value being set', () => {
-        const data = getBulletData(sampleProps);
-        expect(data).toHaveLength(2);
-    });
+	test('should return the data object with max value being set', () => {
+		const data = getBulletData(sampleProps);
+		expect(data).toHaveLength(2);
+	});
 });
 
 describe('getBulletScales', () => {
-
-    //Not much here right now because the function only returns a single const
-    test('should return the correct scales object', () => {
-        const data = getBulletScales();
-        expect(data).toBeDefined()
-    });
+	//Not much here right now because the function only returns a single const
+	test('should return the correct scales object', () => {
+		const data = getBulletScales();
+		expect(data).toBeDefined();
+	});
 });
 
 describe('getBulletMarks', () => {
-    test('should return the correct marks object', () => {
-        const data = getBulletMarks(sampleProps);
-        expect(data).toHaveLength(4);
-        expect(data[0].type).toBe('rect');
-        expect(data[1].type).toBe('text');
-        expect(data[2].type).toBe('text');
-        expect(data[3].type).toBe('rule');
-    });
+	test('should return the correct marks object', () => {
+		const data = getBulletMarks(sampleProps);
+		expect(data).toHaveLength(4);
+		expect(data[0].type).toBe('rect');
+		expect(data[1].type).toBe('text');
+		expect(data[2].type).toBe('text');
+		expect(data[3].type).toBe('rule');
+	});
+	test('should add target label mark when targetPrefix is provided', () => {
+		const propsWithPrefix: BulletSpecProps = {
+			...sampleProps,
+			targetPrefix: '$',
+		};
+		const marks = getBulletMarks(propsWithPrefix);
+		// When targetPrefix is provided, we expect 5 marks instead of 4.
+		expect(marks).toHaveLength(5);
+		// Verify the last mark is the target label mark.
+		expect(marks[4].name).toContain('targetlabel');
+	});
+
+	test('should not add target label mark when no targetPrefix or targetSuffix is provided', () => {
+		const propsWithoutPrefix: BulletSpecProps = { ...sampleProps };
+		const marks = getBulletMarks(propsWithoutPrefix);
+		// With no target prefix/suffix, there should be only 4 marks.
+		expect(marks).toHaveLength(4);
+	});
+	test('should include metricPrefix, numberFormat, and metricSuffix in the metric label signal', () => {
+		const propsWithFormatting: BulletSpecProps = {
+			...sampleProps,
+			metricPrefix: '$',
+			metricSuffix: 'M',
+			numberFormat: '.2f',
+		};
+
+		const marks = getBulletMarks(propsWithFormatting);
+
+		// Ensure the metric text mark exists
+		expect(marks[2]).toBeDefined();
+
+		// Ensure the encode object and text property exist
+		const textEncode = marks[2]?.encode?.enter?.text;
+		expect(textEncode).toBeDefined();
+
+		// Check if textEncode is a signal reference
+		if (typeof textEncode === 'object' && 'signal' in textEncode) {
+			const metricMarkSignal = textEncode.signal;
+
+			expect(metricMarkSignal).toContain("'$'");
+			expect(metricMarkSignal).toContain("'.2f'");
+			expect(metricMarkSignal).toContain("'M'");
+		} else {
+			fail('Metric label text encoding does not contain a signal reference.');
+		}
+	});
 });

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -103,8 +103,10 @@ export function getBulletMarks(props: BulletSpecProps): Mark[] {
 					y: { field: 'index', mult: 60, offset: -60 },
 					text: {
 						signal: `
-							datum.${props.metric} != null 
-								? '${props.metricPrefix || ''}' + datum.${props.metric} + '${props.metricSuffix || ''}' 
+							datum.${props.metric} != null
+								? '${props.metricPrefix || ''}' + format(datum.${props.metric}, '${props.numberFormat || ''}') + '${
+							props.metricSuffix || ''
+						}'
 								: ''
 						`,
 					},

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -9,183 +9,209 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-import { toCamelCase } from '@utils';
 import { DEFAULT_COLOR_SCHEME } from '@constants';
-import { Spec, Data, Mark, Scale } from 'vega';
-import { ColorScheme, BulletProps, BulletSpecProps } from '../../types';
+import { spectrumColors } from '@themes';
+import { toCamelCase } from '@utils';
+import { Data, Mark, Scale, Spec } from 'vega';
+
+import { BulletProps, BulletSpecProps, ColorScheme } from '../../types';
 import { sanitizeMarkChildren } from '../../utils';
 import { getColorValue } from '../specUtils';
-import { spectrumColors } from '@themes';
 
-const DEFAULT_COLOR = spectrumColors.light['static-blue']
+const DEFAULT_COLOR = spectrumColors.light['static-blue'];
 
 export const addBullet = (
-    spec: Spec,
-    {
-        children,
-        colorScheme = DEFAULT_COLOR_SCHEME,
-        index = 0,
-        name,
-        metric,
-        dimension,
-        target,
-        color = DEFAULT_COLOR,
-        ...props
-    }: BulletProps & { colorScheme?: ColorScheme; index?: number; idKey: string }
+	spec: Spec,
+	{
+		children,
+		colorScheme = DEFAULT_COLOR_SCHEME,
+		index = 0,
+		name,
+		metric,
+		dimension,
+		target,
+		color = DEFAULT_COLOR,
+		...props
+	}: BulletProps & { colorScheme?: ColorScheme; index?: number; idKey: string }
 ): Spec => {
-    const bulletProps: BulletSpecProps = {
-        children: sanitizeMarkChildren(children),
-        colorScheme: colorScheme,
-        index,
-        color: getColorValue(color, colorScheme),
-        metric: metric ?? 'currentAmount',
-        dimension: dimension ?? 'graphLabel',
-        target: target ?? 'target',
-        name: toCamelCase(name ?? `bullet${index}`),
-        ...props,
-    };
-    return {
-        ...spec,
-        data: getBulletData(bulletProps),
-        marks: getBulletMarks(bulletProps),
-        scales: getBulletScales(),
-    };
+	const bulletProps: BulletSpecProps = {
+		children: sanitizeMarkChildren(children),
+		colorScheme: colorScheme,
+		index,
+		color: getColorValue(color, colorScheme),
+		metric: metric ?? 'currentAmount',
+		dimension: dimension ?? 'graphLabel',
+		target: target ?? 'target',
+		name: toCamelCase(name ?? `bullet${index}`),
+		...props,
+	};
+	return {
+		...spec,
+		data: getBulletData(bulletProps),
+		marks: getBulletMarks(bulletProps),
+		scales: getBulletScales(),
+	};
 };
 
 export function getBulletMarks(props: BulletSpecProps): Mark[] {
+	const solidColor = getColorValue('gray-900', props.colorScheme);
+	const barLabelColor = getColorValue('gray-600', props.colorScheme);
 
-  const solidColor = getColorValue('gray-900', props.colorScheme);
-  const barLabelColor = getColorValue('gray-600', props.colorScheme);
-  
-  return [
-    {
-      "type": "rect",
-      "name": `${props.name}rect`,
-      "from": {"data": "table"},
-      "description": `${props.name}`,
-      "encode": {
-        "enter": {
-          "x": {"value": 0},
-          "y": {"field": "index", "mult": 60, "offset": -44},
-          "width": {"scale": "xscale", "field": `${props.metric}`},
-          "height": {"value": 6},
-          "fill": {"value": `${props.color}`},
-          "cornerRadiusTopRight": {"value": 2},
-          "cornerRadiusBottomRight": {"value": 2}
-        }
-      }
-    },
-    {
-      "type": "text",
-      "name": `${props.name}barlabel`,
-      "from": {"data": "table"},
-      "description": "graphLabel",
-      "encode": {
-        "enter": {
-          "x": {"value": 0},
-          "y": {"field": "index", "mult": 60, "offset": -60},
-          "text": {"field": `${props.dimension}`},
-          "align": {"value": "left"},
-          "baseline": {"value": "bottom"},
-          "fontSize": {"value": 11.5},
-          "fill": {"value": `${barLabelColor}`}
-        }
-      }
-    },
-    {
-      "type": "text",
-      "from": {"data": "table"},
-      "name": `${props.name}amountlabel`,
-      "description": "currentAmount",
-      "encode": {
-        "enter": {
-          "x": {"signal": "width"},
-          "y": {"field": "index", "mult": 60, "offset": -60},
-          "text": {"field": `${props.metric}`},
-          "align": {"value": "right"},
-          "baseline": {"value": "bottom"},
-          "fontSize": {"value": 11.5},
-          "fill": {"value": `${solidColor}`}
-        }
-      }
-    },
-    {
-      "type": "rule",
-      "from": {"data": "table"},
-      "name": `${props.name}rule`,
-      "description": `${props.name}`,
-      "encode": {
-        "enter": {
-          "x": {"scale": "xscale", "field": `${props.target}`},
-          "y": {"field": "index", "mult": 60, "offset": -53},
-          "y2": {"field": "index", "mult": 60, "offset": -29},
-          "stroke": {"value": `${solidColor}`},
-          "strokeWidth": {"value": 2},
-        }
-      }
-    }
-  ]
+	const marks: Mark[] = [
+		{
+			type: 'rect',
+			name: `${props.name}rect`,
+			from: { data: 'table' },
+			description: `${props.name}`,
+			encode: {
+				enter: {
+					x: { value: 0 },
+					y: { field: 'index', mult: 60, offset: -44 },
+					width: { scale: 'xscale', field: `${props.metric}` },
+					height: { value: 6 },
+					fill: { value: `${props.color}` },
+					cornerRadiusTopRight: { value: 2 },
+					cornerRadiusBottomRight: { value: 2 },
+				},
+			},
+		},
+		{
+			type: 'text',
+			name: `${props.name}barlabel`,
+			from: { data: 'table' },
+			description: 'graphLabel',
+			encode: {
+				enter: {
+					x: { value: 0 },
+					y: { field: 'index', mult: 60, offset: -60 },
+					text: { field: `${props.dimension}` },
+					align: { value: 'left' },
+					baseline: { value: 'bottom' },
+					fontSize: { value: 11.5 },
+					fill: { value: `${barLabelColor}` },
+				},
+			},
+		},
+		{
+			type: 'text',
+			from: { data: 'table' },
+			name: `${props.name}amountlabel`,
+			description: 'currentAmount',
+			encode: {
+				enter: {
+					x: { signal: 'width' },
+					y: { field: 'index', mult: 60, offset: -60 },
+					text: { field: `${props.metric}` },
+					align: { value: 'right' },
+					baseline: { value: 'bottom' },
+					fontSize: { value: 11.5 },
+					fill: { value: `${solidColor}` },
+				},
+			},
+		},
+		{
+			type: 'rule',
+			from: { data: 'table' },
+			name: `${props.name}rule`,
+			description: `${props.name}`,
+			encode: {
+				enter: {
+					x: { scale: 'xscale', field: `${props.target}` },
+					y: { field: 'index', mult: 60, offset: -53 },
+					y2: { field: 'index', mult: 60, offset: -29 },
+					stroke: { value: `${solidColor}` },
+					strokeWidth: { value: 2 },
+				},
+			},
+		},
+	];
+
+	if (props.targetPrefix || props.targetSuffix) {
+		marks.push({
+			type: 'text',
+			name: `${props.name}targetlabel`,
+			from: { data: 'table' },
+			description: 'targetValue',
+			encode: {
+				enter: {
+					// Position it near the target rule. Adjust offsets as needed.
+					x: { scale: 'xscale', field: `${props.target}`, offset: 5 },
+					y: { field: 'index', mult: 60, offset: -41 },
+					// Here we use a signal to build the string: if the target value is available, add the prefix/suffix.
+					text: {
+						signal: `datum.${props.target} != null 
+              ? '${props.targetPrefix || ''}' + datum.${props.target} + '${props.targetSuffix || ''}' 
+              : ''`,
+					},
+					align: { value: 'left' },
+					baseline: { value: 'middle' },
+					fontSize: { value: 11.5 },
+					fill: { value: `${solidColor}` },
+				},
+			},
+		});
+	}
+
+	return marks;
 }
 
 export function getBulletData(props: BulletSpecProps): Data[] {
+	//We are multiplying the target by 1.1 to make sure that the target line is never at the very end of the graph
+	const maxValue = `max(datum.${props.metric}, datum.${props.target} * 1.1)`;
+	const filter = `isValid(datum.${props.dimension}) && datum.${props.dimension} !== null && datum.${props.dimension} !== ''`;
 
-  //We are multiplying the target by 1.1 to make sure that the target line is never at the very end of the graph
-  const maxValue = `max(datum.${props.metric}, datum.${props.target} * 1.1)`
-  const filter = `isValid(datum.${props.dimension}) && datum.${props.dimension} !== null && datum.${props.dimension} !== ''`
+	const bulletData: Data[] = [
+		{
+			name: 'table',
+			values: [],
+			transform: [
+				{
+					type: 'filter',
+					expr: filter,
+				},
+				{
+					type: 'formula',
+					as: 'maxValue',
+					expr: maxValue,
+				},
+				{
+					type: 'window',
+					ops: ['row_number'],
+					as: ['index'],
+				},
+			],
+		},
+		{
+			name: 'max_values',
+			source: 'table',
+			transform: [
+				{
+					type: 'aggregate',
+					ops: ['max'],
+					fields: ['maxValue'],
+					as: ['maxOverall'],
+				},
+			],
+		},
+	];
 
-  const bulletData: Data[] = [
-    {
-      "name": "table",
-      "values": [],
-      "transform": [
-        {
-          "type": "filter",
-          "expr": filter
-        },
-        {
-          "type": "formula",
-          "as": "maxValue",
-          "expr": maxValue
-        },
-        {
-          "type": "window",
-          "ops": ["row_number"],
-          "as": ["index"]
-        }
-      ]
-    },
-    {
-      "name": "max_values",
-      "source": "table",
-      "transform": [
-        {
-          "type": "aggregate",
-          "ops": ["max"],
-          "fields": ["maxValue"],
-          "as": ["maxOverall"]
-        }
-      ]
-    }
-  ]
-
-  return bulletData;
+	return bulletData;
 }
 
 export function getBulletScales(): Scale[] {
-  const bulletScale: Scale[] = [
-    {
-      "name": "xscale",
-      "type": "linear",
-      "domain": [
-              0,
-              {
-                "signal": "data('max_values')[0].maxOverall"
-              }
-            ],
-      "range": [0, {"signal": "width"}]
-    }
-  ]
+	const bulletScale: Scale[] = [
+		{
+			name: 'xscale',
+			type: 'linear',
+			domain: [
+				0,
+				{
+					signal: "data('max_values')[0].maxOverall",
+				},
+			],
+			range: [0, { signal: 'width' }],
+		},
+	];
 
-  return bulletScale;
+	return bulletScale;
 }

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -101,7 +101,13 @@ export function getBulletMarks(props: BulletSpecProps): Mark[] {
 				enter: {
 					x: { signal: 'width' },
 					y: { field: 'index', mult: 60, offset: -60 },
-					text: { field: `${props.metric}` },
+					text: {
+						signal: `
+							datum.${props.metric} != null 
+								? '${props.metricPrefix || ''}' + datum.${props.metric} + '${props.metricSuffix || ''}' 
+								: ''
+						`,
+					},
 					align: { value: 'right' },
 					baseline: { value: 'bottom' },
 					fontSize: { value: 11.5 },

--- a/src/stories/components/Bullet/Bullet.story.tsx
+++ b/src/stories/components/Bullet/Bullet.story.tsx
@@ -43,10 +43,11 @@ const BulletStory: StoryFn<BulletProps & { width?: number; height?: number }> = 
 
 const Basic = bindWithProps(BulletStory);
 Basic.args = {
-	metric: 'currentAmount',
+    metric: 'currentAmount',
     dimension: 'graphLabel',
     target: 'target',
-    color: 'red-500'
+    color: 'red-500',
+    targetPrefix: '$',
 };
 
 export { Basic };

--- a/src/stories/components/Bullet/Bullet.story.tsx
+++ b/src/stories/components/Bullet/Bullet.story.tsx
@@ -47,7 +47,9 @@ Basic.args = {
     dimension: 'graphLabel',
     target: 'target',
     color: 'red-500',
-    targetPrefix: '$',
+    //targetPrefix: '$',
+    metricPrefix: '$',
+    metricSuffix: 'M',
 };
 
 export { Basic };

--- a/src/stories/components/Bullet/Bullet.story.tsx
+++ b/src/stories/components/Bullet/Bullet.story.tsx
@@ -35,7 +35,7 @@ const BulletStory: StoryFn<BulletProps & { width?: number; height?: number }> = 
     const { width, height, ...bulletProps } = args;
     const chartProps = useChartProps({ ...defaultChartProps, width: width ?? 350, height: height ?? 350 });
     return (
-        <Chart {...chartProps}>
+        <Chart {...chartProps} debug>
             <Bullet {...bulletProps} />
         </Chart>
     );
@@ -49,7 +49,8 @@ Basic.args = {
     color: 'red-500',
     //targetPrefix: '$',
     metricPrefix: '$',
-    metricSuffix: 'M',
+    //metricSuffix: 'M',
+    numberFormat: '.2f'
 };
 
 export { Basic };

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -237,6 +237,10 @@ export interface BulletProps extends MarkProps {
 	target?: string;
 	/** Data field that the metric is trended against (x-axis for horizontal orientation) */
 	dimension?: string;
+	/** D3 number format specifier for the target value (e.g. ".2f", "~s", etc.) */
+	targetSuffix?: string;
+	/** Optional string to prepend to the formatted target (e.g. '$') */
+	targetPrefix?: string;
 }
 
 export interface DonutSummaryProps {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -245,6 +245,8 @@ export interface BulletProps extends MarkProps {
 	metricPrefix?: string;
 	/** Optional string to append to the progress (metric) value (e.g. '%', 'M', 'K') */
 	metricSuffix?: string;
+	/** D3 number format specifier for the metric value (e.g. ".2f", "~s", etc.) */
+	numberFormat?: NumberFormat;
 }
 
 export interface DonutSummaryProps {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -241,6 +241,10 @@ export interface BulletProps extends MarkProps {
 	targetSuffix?: string;
 	/** Optional string to prepend to the formatted target (e.g. '$') */
 	targetPrefix?: string;
+	/** Optional string to prepend to the progress (metric) value (e.g. '$') */
+	metricPrefix?: string;
+	/** Optional string to append to the progress (metric) value (e.g. '%', 'M', 'K') */
+	metricSuffix?: string;
 }
 
 export interface DonutSummaryProps {


### PR DESCRIPTION
Implemented labeling and formatting of metric and target values. 

## Description

This PR enhances the Bullet Chart component by adding support for formatting and the metric (progress bar) value. Previously, the metric value was displayed as a raw number. Now, users can specify a D3 number format, as well as optional prefixes and suffixes (e.g., $, M, %).

## Related Issue

SCRUM-18

## Motivation and Context

This change was required to improve the readability of numeric values in the Bullet Chart, especially when dealing with large numbers or currency values.

## How Has This Been Tested?

Unit tests were added and updated for:
- Ensuring that the metric text mark includes the correct formatting.
- Verifying that the prefix and suffix are applied correctly.
- Checking that the number format is respected when different formats (.2f, ~s, etc.) are provided.
- Ensuring that no formatting is applied when numberFormat is omitted.
* The Bullet Chart was manually tested in Storybook with various formatting options ($1.2M, 123.45%, €1.5K).
* All existing and new tests passed successfully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
