### PR TITLE
Enhance bullet chart with configurable number formatting and optional target labels

### DIFF
--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -26,8 +26,8 @@ describe('getBulletMarks', () => {
 		const data = getBulletMarks(sampleProps);
 		expect(data).toBeDefined();
 		expect(data?.marks).toHaveLength(5);
-		expect(data?.marks?.[0]?.type).toBe('rect');
-		expect(data?.marks?.[1]?.type).toBe('rule');
+		expect(data?.marks?.[0]?.type).toBe('rule');
+		expect(data?.marks?.[1]?.type).toBe('rect');
 		expect(data?.marks?.[2]?.type).toBe('text');
 		expect(data?.marks?.[3]?.type).toBe('text');
 	});

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -31,13 +31,22 @@ describe('getBulletMarks', () => {
 		expect(data?.marks?.[2]?.type).toBe('text');
 		expect(data?.marks?.[3]?.type).toBe('text');
 	});
+
 	test('Should not include target marks when showTarget is false', () => {
 		const props = { ...sampleProps, showTarget: false, showTargetValue: true };
 		const marksGroup = getBulletMarks(props);
 		expect(marksGroup.marks).toHaveLength(3);
 		marksGroup.marks?.forEach((mark) => {
-			expect(mark.description).not.toContain('target');
+			expect(mark.description).not.toContain('Target');
 		});
+	});
+
+	test('Should include target value label when showTargetValue is true', () => {
+		const props = { ...sampleProps, showTarget: true, showTargetValue: true };
+		const marksGroup = getBulletMarks(props);
+		expect(marksGroup.marks).toHaveLength(5);
+		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
+		expect(targetValueMark).toBeDefined();
 	});
 });
 
@@ -99,5 +108,30 @@ describe('getBulletMarkValueLabel', () => {
 		expect(data).toBeDefined();
 		expect(data.encode?.update).toBeDefined();
 		expect(Object.keys(data.encode?.update ?? {}).length).toBe(2);
+	});
+
+	test('Should apply numberFormat specifier to metric and target values', () => {
+		const props = { ...sampleProps, showTarget: true, showTargetValue: true, numberFormat: '$,.2f' };
+		const marksGroup = getBulletMarks(props);
+
+		const metricValueLabel = marksGroup.marks?.find((mark) => mark.name === `${props.name}ValueLabel`);
+		expect(metricValueLabel).toBeDefined();
+
+		if (metricValueLabel?.encode?.enter?.text) {
+			const textEncode = metricValueLabel.encode.enter.text;
+			if (typeof textEncode === 'object' && 'signal' in textEncode) {
+				expect(textEncode.signal).toContain(`format(datum.${props.metric}, '$,.2f')`);
+			}
+		}
+
+		const TargetValueLabel = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
+		expect(TargetValueLabel).toBeDefined();
+
+		if (TargetValueLabel?.encode?.enter?.text) {
+			const textEncode = TargetValueLabel.encode.enter.text;
+			if (typeof textEncode === 'object' && 'signal' in textEncode) {
+				expect(textEncode.signal).toContain(`format(datum.${props.target}, '$,.2f')`);
+			}
+		}
 	});
 });

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -9,85 +9,87 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-import { getBulletScales, getBulletData, getBulletMarks, getBulletSignals, getBulletMarkRect, getBulletMarkLabel, getBulletMarkTarget, getBulletMarkValueLabel } from "./bulletMarkUtils";
-import { sampleProps } from "./bulletSpecBuilder.test";
+import {
+	getBulletData,
+	getBulletMarkLabel,
+	getBulletMarkRect,
+	getBulletMarkTarget,
+	getBulletMarkValueLabel,
+	getBulletMarks,
+	getBulletScales,
+	getBulletSignals,
+} from './bulletMarkUtils';
+import { sampleProps } from './bulletSpecBuilder.test';
 
 describe('getBulletMarks', () => {
-    test('Should return the correct marks object', () => {
-        const data = getBulletMarks(sampleProps);
-        expect(data).toBeDefined();
-        expect(data?.marks).toHaveLength(4);
-        expect(data?.marks?.[0]?.type).toBe('rect');
-        expect(data?.marks?.[1]?.type).toBe('rule');
-        expect(data?.marks?.[2]?.type).toBe('text');
-        expect(data?.marks?.[3]?.type).toBe('text');
-    });
+	test('Should return the correct marks object', () => {
+		const data = getBulletMarks(sampleProps);
+		expect(data).toBeDefined();
+		expect(data?.marks).toHaveLength(5);
+		expect(data?.marks?.[0]?.type).toBe('rect');
+		expect(data?.marks?.[1]?.type).toBe('rule');
+		expect(data?.marks?.[2]?.type).toBe('text');
+		expect(data?.marks?.[3]?.type).toBe('text');
+	});
 });
 
 describe('getBulletData', () => {
-    test('Should return the data object', () => {
-        const data = getBulletData(sampleProps);
-        expect(data).toHaveLength(1);
-    });
+	test('Should return the data object', () => {
+		const data = getBulletData(sampleProps);
+		expect(data).toHaveLength(1);
+	});
 });
 
 describe('getBulletScales', () => {
-
-    test('Should return the correct scales object', () => {
-        const data = getBulletScales(sampleProps);
-        expect(data).toBeDefined()
-        expect(data).toHaveLength(2)
-    });
+	test('Should return the correct scales object', () => {
+		const data = getBulletScales(sampleProps);
+		expect(data).toBeDefined();
+		expect(data).toHaveLength(2);
+	});
 });
 
 describe('getBulletSignals', () => {
-
-    test('Should return the correct signals object', () => {
-        const data = getBulletSignals();
-        expect(data).toBeDefined()
-        expect(data).toHaveLength(7)
-    });
+	test('Should return the correct signals object', () => {
+		const data = getBulletSignals();
+		expect(data).toBeDefined();
+		expect(data).toHaveLength(7);
+	});
 });
 
 describe('getBulletMarkRect', () => {
+	test('Should return the correct rect mark object', () => {
+		const data = getBulletMarkRect(sampleProps);
+		expect(data).toBeDefined();
+		expect(data.encode?.update).toBeDefined();
 
-    test('Should return the correct rect mark object', () => {
-        const data = getBulletMarkRect(sampleProps);
-        expect(data).toBeDefined()
-        expect(data.encode?.update).toBeDefined();
-
-        // Expect the correct amount of fields in the update object
-        expect(Object.keys(data.encode?.update ?? {}).length).toBe(4);
-    });
+		// Expect the correct amount of fields in the update object
+		expect(Object.keys(data.encode?.update ?? {}).length).toBe(4);
+	});
 });
 
 describe('getBulletMarkTarget', () => {
-
-    test('Should return the correct target mark object', () => {
-        const data = getBulletMarkTarget(sampleProps);
-        expect(data).toBeDefined()
-        expect(data.encode?.update).toBeDefined();
-        expect(Object.keys(data.encode?.update ?? {}).length).toBe(3);
-    });
+	test('Should return the correct target mark object', () => {
+		const data = getBulletMarkTarget(sampleProps);
+		expect(data).toBeDefined();
+		expect(data.encode?.update).toBeDefined();
+		expect(Object.keys(data.encode?.update ?? {}).length).toBe(3);
+	});
 });
 
 describe('getBulletMarkLabel', () => {
-
-    test('Should return the correct label mark object', () => {
-        const data = getBulletMarkLabel(sampleProps);
-        expect(data).toBeDefined()
-        expect(data.encode?.update).toBeDefined();
-        expect(Object.keys(data.encode?.update ?? {}).length).toBe(2);
-    });
+	test('Should return the correct label mark object', () => {
+		const data = getBulletMarkLabel(sampleProps);
+		expect(data).toBeDefined();
+		expect(data.encode?.update).toBeDefined();
+		expect(Object.keys(data.encode?.update ?? {}).length).toBe(2);
+	});
 });
 
 describe('getBulletMarkValueLabel', () => {
-
-    test('Should return the correct value label mark object', () => {
-        const data = getBulletMarkValueLabel(sampleProps);
-        expect(data).toBeDefined()
-        expect(data.encode?.update).toBeDefined();
-        expect(Object.keys(data.encode?.update ?? {}).length).toBe(2);
-    });
+	test('Should return the correct value label mark object', () => {
+		const data = getBulletMarkValueLabel(sampleProps);
+		expect(data).toBeDefined();
+		expect(data.encode?.update).toBeDefined();
+		expect(Object.keys(data.encode?.update ?? {}).length).toBe(2);
+	});
 });

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -25,11 +25,19 @@ describe('getBulletMarks', () => {
 	test('Should return the correct marks object', () => {
 		const data = getBulletMarks(sampleProps);
 		expect(data).toBeDefined();
-		expect(data?.marks).toHaveLength(5);
+		expect(data?.marks).toHaveLength(4);
 		expect(data?.marks?.[0]?.type).toBe('rule');
 		expect(data?.marks?.[1]?.type).toBe('rect');
 		expect(data?.marks?.[2]?.type).toBe('text');
 		expect(data?.marks?.[3]?.type).toBe('text');
+	});
+	test('Should not include target marks when showTarget is false', () => {
+		const props = { ...sampleProps, showTarget: false, showTargetValue: true };
+		const marksGroup = getBulletMarks(props);
+		expect(marksGroup.marks).toHaveLength(3);
+		marksGroup.marks?.forEach((mark) => {
+			expect(mark.description).not.toContain('target');
+		});
 	});
 });
 

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -9,202 +9,188 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Data, GroupMark, Mark, Scale, Signal } from 'vega';
 
-import { Scale, Signal, Data, GroupMark, Mark } from 'vega'
 import { BulletSpecProps } from '../../types';
 import { getColorValue } from '../specUtils';
 
 export function getBulletScales(props: BulletSpecProps): Scale[] {
-    const bulletScale: Scale[] = [
-        {
-            "name": "yscale",
-            "type": "band",
-            "domain": { "data": "table", "field": `${props.dimension}` },
-            "range": [0, { "signal": "height" }],
-            "paddingInner": { "signal": "paddingRatio" }
-        },
-        {
-            "name": "xscale",
-            "type": "linear",
-            "domain": { "data": "table", "fields": ["xPaddingForTarget", `${props.metric}`] },
-            "range": "width",
-            "round": true,
-            "zero": true
-        }
-    ]
-  
-    return bulletScale;
+	const bulletScale: Scale[] = [
+		{
+			name: 'yscale',
+			type: 'band',
+			domain: { data: 'table', field: `${props.dimension}` },
+			range: [0, { signal: 'height' }],
+			paddingInner: { signal: 'paddingRatio' },
+		},
+		{
+			name: 'xscale',
+			type: 'linear',
+			domain: { data: 'table', fields: ['xPaddingForTarget', `${props.metric}`] },
+			range: 'width',
+			round: true,
+			zero: true,
+		},
+	];
+
+	return bulletScale;
 }
 
 export function getBulletSignals(): Signal[] {
-    const bulletSignals: Signal[] = [
-        { "name": "gap", "value": 12 },
-        { "name": "bulletHeight", "value": 8 },
-        { "name": "bulletThresholdHeight", "update": "bulletHeight * 3" },
-        { "name": "targetHeight", "update": "bulletThresholdHeight + 6" },
-        { "name": "bulletGroupHeight", "update": "bulletThresholdHeight + 24" },
-        { "name": "paddingRatio", "update": "gap / (gap + bulletGroupHeight)" },
-        {
-            "name": "height",
-            "update": "length(data('table')) * bulletGroupHeight + (length(data('table')) - 1) * gap"
-        }
-    ]
+	const bulletSignals: Signal[] = [
+		{ name: 'gap', value: 12 },
+		{ name: 'bulletHeight', value: 8 },
+		{ name: 'bulletThresholdHeight', update: 'bulletHeight * 3' },
+		{ name: 'targetHeight', update: 'bulletThresholdHeight + 6' },
+		{ name: 'bulletGroupHeight', update: 'bulletThresholdHeight + 24' },
+		{ name: 'paddingRatio', update: 'gap / (gap + bulletGroupHeight)' },
+		{
+			name: 'height',
+			update: "length(data('table')) * bulletGroupHeight + (length(data('table')) - 1) * gap",
+		},
+	];
 
-    return bulletSignals;
+	return bulletSignals;
 }
 
 export function getBulletData(props: BulletSpecProps): Data[] {
+	//We are multiplying the target by 1.05 to make sure that the target line is never at the very end of the graph
+	const bulletData: Data[] = [
+		{
+			name: 'table',
+			values: [],
+			transform: [
+				{
+					type: 'formula',
+					expr: `round(datum.${props.target} * 1.05)`,
+					as: 'xPaddingForTarget',
+				},
+			],
+		},
+	];
 
-    //We are multiplying the target by 1.05 to make sure that the target line is never at the very end of the graph
-    const bulletData: Data[] = [
-        {
-            "name": "table",
-            "values": [],
-            "transform": [
-                {
-                    "type": "formula",
-                    "expr": `round(datum.${props.target} * 1.05)`,
-                    "as": "xPaddingForTarget"
-                }
-            ]
-        }
-    ]
-  
-    return bulletData;
+	return bulletData;
 }
 
 export function getBulletMarks(props: BulletSpecProps): GroupMark {
+	const bulletMark: GroupMark = {
+		name: 'bulletGroup',
+		type: 'group',
+		from: {
+			facet: { data: 'table', name: 'bulletGroups', groupby: `${props.dimension}` },
+		},
+		encode: {
+			update: {
+				y: { scale: 'yscale', field: `${props.dimension}` },
+				height: { signal: 'bulletGroupHeight' },
+				width: { signal: 'width' },
+			},
+		},
+		marks: [],
+	};
 
-    const bulletMark: GroupMark = {
-        "name": "bulletGroup",
-        "type": "group",
-        "from": {
-            "facet": { "data": "table", "name": "bulletGroups", "groupby": `${props.dimension}` }
-        },
-        "encode": {
-            "update": {
-                "y": { "scale": "yscale", "field": `${props.dimension}` },
-                "height": { "signal": "bulletGroupHeight" },
-                "width": { "signal": "width" }
-            }
-        },
-        "marks": []
-    }
+	bulletMark.marks?.push(getBulletMarkRect(props));
+	bulletMark.marks?.push(getBulletMarkTarget(props));
+	bulletMark.marks?.push(getBulletMarkLabel(props));
+	bulletMark.marks?.push(getBulletMarkValueLabel(props));
 
-    bulletMark.marks?.push(getBulletMarkRect(props));
-    bulletMark.marks?.push(getBulletMarkTarget(props));
-    bulletMark.marks?.push(getBulletMarkLabel(props));
-    bulletMark.marks?.push(getBulletMarkValueLabel(props));
-
-    return bulletMark
+	return bulletMark;
 }
 
 export function getBulletMarkRect(props: BulletSpecProps): Mark {
+	const bulletMarkRect: Mark = {
+		name: `${props.name}Rect`,
+		description: `${props.name}Rect`,
+		type: 'rect',
+		from: { data: 'bulletGroups' },
+		encode: {
+			enter: {
+				cornerRadiusTopLeft: [{ test: 'datum.amount < 0', value: 3 }],
+				cornerRadiusBottomLeft: [{ test: 'datum.amount < 0', value: 3 }],
+				cornerRadiusTopRight: [{ test: 'datum.amount > 0', value: 3 }],
+				cornerRadiusBottomRight: [{ test: 'datum.amount > 0', value: 3 }],
+				fill: [{ value: `${props.color}` }],
+			},
+			update: {
+				x: { scale: 'xscale', value: 0 },
+				x2: { scale: 'xscale', field: `${props.metric}` },
+				height: { signal: 'bulletHeight' },
+				y: { signal: 'bulletGroupHeight - 3 - 2 * bulletHeight' },
+			},
+		},
+	};
 
-    const bulletMarkRect: Mark = {
-        "name": `${props.name}Rect`,
-        "description": `${props.name}Rect`,
-        "type": "rect",
-        "from": { "data": "bulletGroups" },
-        "encode": {
-            "enter": {
-            "cornerRadiusTopLeft": [
-                { "test": `datum.${props.metric} < 0`, "value": 3 }
-            ],
-            "cornerRadiusBottomLeft": [
-                { "test": `datum.${props.metric} < 0`, "value": 3 }
-            ],
-            "cornerRadiusTopRight": [
-                { "test": `datum.${props.metric} > 0`, "value": 3 }
-            ],
-            "cornerRadiusBottomRight": [
-                { "test": `datum.${props.metric} > 0`, "value": 3 }
-            ],
-            "fill": [{ "value": `${props.color}` }]
-            },
-            "update": {
-                "x": { "scale": "xscale", "value": 0 },
-                "x2": { "scale": "xscale", "field": `${props.metric}` },
-                "height": { "signal": "bulletHeight" },
-                "y": { "signal": "bulletGroupHeight - 3 - 2 * bulletHeight" }
-            }
-        }
-    }
-
-    return bulletMarkRect
-
+	return bulletMarkRect;
 }
 
 export function getBulletMarkTarget(props: BulletSpecProps): Mark {
+	const solidColor = getColorValue('gray-900', props.colorScheme);
 
-    const solidColor = getColorValue('gray-900', props.colorScheme);
+	const bulletMarkTarget: Mark = {
+		name: `${props.name}Target`,
+		description: `${props.name}Target`,
+		type: 'rule',
+		from: { data: 'bulletGroups' },
+		encode: {
+			enter: {
+				stroke: { value: `${solidColor}` },
+				strokeWidth: { value: 2 },
+			},
+			update: {
+				x: { scale: 'xscale', field: `${props.target}` },
+				y: { signal: 'bulletGroupHeight - targetHeight' },
+				y2: { signal: 'bulletGroupHeight' },
+			},
+		},
+	};
 
-    const bulletMarkTarget: Mark = {
-        "name": `${props.name}Target`,
-        "description": `${props.name}Target`,
-        "type": "rule",
-        "from": { "data": "bulletGroups" },
-        "encode": {
-            "enter": {
-            "stroke": { "value": `${solidColor}` },
-            "strokeWidth": { "value": 2 }
-            },
-            "update": {
-                "x": { "scale": "xscale", "field": `${props.target}` },
-                "y": { "signal": "bulletGroupHeight - targetHeight" },
-                "y2": { "signal": "bulletGroupHeight" }
-            }
-        }
-    }
-
-    return bulletMarkTarget
-
+	return bulletMarkTarget;
 }
 
 export function getBulletMarkLabel(props: BulletSpecProps): Mark {
+	const barLabelColor = getColorValue('gray-600', props.colorScheme);
 
-    const barLabelColor = getColorValue('gray-600', props.colorScheme);
+	const bulletMarkLabel: Mark = {
+		name: `${props.name}Label`,
+		description: `${props.name}Label`,
+		type: 'text',
+		from: { data: 'bulletGroups' },
+		encode: {
+			enter: {
+				text: { signal: `datum.${props.dimension}` },
+				align: { value: 'left' },
+				baseline: { value: 'top' },
+				fill: { value: `${barLabelColor}` },
+			},
+			update: { x: { value: 0 }, y: { value: 0 } },
+		},
+	};
 
-    const bulletMarkLabel: Mark = {
-        "name": `${props.name}Label`,
-        "description": `${props.name}Label`,
-        "type": "text",
-        "from": { "data": "bulletGroups" },
-        "encode": {
-            "enter": {
-            "text": { "signal": `datum.${props.dimension}` },
-            "align": { "value": "left" },
-            "baseline": { "value": "top" },
-            "fill": {"value": `${barLabelColor}`}
-            },
-            "update": { "x": { "value": 0 }, "y": { "value": 0 } }
-        }
-    }
-
-    return bulletMarkLabel
-
+	return bulletMarkLabel;
 }
 
 export function getBulletMarkValueLabel(props: BulletSpecProps): Mark {
+	const solidColor = getColorValue('gray-900', props.colorScheme);
 
-    const solidColor = getColorValue('gray-900', props.colorScheme);
+	const bulletMarkValueLabel: Mark = {
+		name: `${props.name}ValueLabel`,
+		description: `${props.name}ValueLabel`,
+		type: 'text',
+		from: { data: 'bulletGroups' },
+		encode: {
+			enter: {
+				text: {
+					signal: `datum.${props.metric} != null ? format(datum.${props.metric}, '${
+						props.numberFormat || ''
+					}') : ''`,
+				},
+				align: { value: 'right' },
+				baseline: { value: 'top' },
+				fill: { value: `${solidColor}` },
+			},
+			update: { x: { signal: 'width' }, y: { value: 0 } },
+		},
+	};
 
-    const bulletMarkValueLabel: Mark = {
-        "name": `${props.name}ValueLabel`,
-        "description": `${props.name}ValueLabel`,
-        "type": "text",
-        "from": { "data": "bulletGroups" },
-        "encode": {
-            "enter": {
-            "text": { "signal": `datum.${props.metric}` },
-            "align": { "value": "right" },
-            "baseline": { "value": "top" },
-            "fill": {"value": `${solidColor}`}
-            },
-            "update": { "x": { "signal": "width" }, "y": { "value": 0 } }
-        }
-    }
-
-    return bulletMarkValueLabel
-
+	return bulletMarkValueLabel;
 }

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -194,3 +194,29 @@ export function getBulletMarkValueLabel(props: BulletSpecProps): Mark {
 
 	return bulletMarkValueLabel;
 }
+
+export function getBulletMarkTargetValueLabel(props: BulletSpecProps): Mark {
+	const solidColor = getColorValue('gray-900', props.colorScheme);
+
+	const bulletMarkTargetValueLabel: Mark = {
+		name: `${props.name}TargetValueLabel`,
+		description: `${props.name}TargetValueLabel`,
+		type: 'text',
+		from: { data: 'bulletGroups' },
+		encode: {
+			enter: {
+				text: {
+					signal: `datum.${props.target} != null ? format(datum.${props.target}, '${
+						props.numberFormat || ''
+					}') : ''`,
+				},
+				align: { value: 'right' },
+				baseline: { value: 'top' },
+				fill: { value: `${solidColor}` },
+			},
+			update: { x: { signal: 'width' }, y: { value: 0 } },
+		},
+	};
+
+	return bulletMarkTargetValueLabel;
+}

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -89,11 +89,15 @@ export function getBulletMarks(props: BulletSpecProps): GroupMark {
 		marks: [],
 	};
 
-	bulletMark.marks?.push(getBulletMarkTarget(props));
+	if (props.target && props.showTarget !== false) {
+		bulletMark.marks?.push(getBulletMarkTarget(props));
+		if (props.showTargetValue) {
+			bulletMark.marks?.push(getBulletMarkTargetValueLabel(props));
+		}
+	}
 	bulletMark.marks?.push(getBulletMarkRect(props));
 	bulletMark.marks?.push(getBulletMarkLabel(props));
 	bulletMark.marks?.push(getBulletMarkValueLabel(props));
-	bulletMark.marks?.push(getBulletMarkTargetValueLabel(props));
 
 	return bulletMark;
 }

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -38,7 +38,7 @@ export function getBulletScales(props: BulletSpecProps): Scale[] {
 
 export function getBulletSignals(): Signal[] {
 	const bulletSignals: Signal[] = [
-		{ name: 'gap', value: 12 },
+		{ name: 'gap', value: 36 },
 		{ name: 'bulletHeight', value: 8 },
 		{ name: 'bulletThresholdHeight', update: 'bulletHeight * 3' },
 		{ name: 'targetHeight', update: 'bulletThresholdHeight + 6' },
@@ -93,6 +93,7 @@ export function getBulletMarks(props: BulletSpecProps): GroupMark {
 	bulletMark.marks?.push(getBulletMarkTarget(props));
 	bulletMark.marks?.push(getBulletMarkLabel(props));
 	bulletMark.marks?.push(getBulletMarkValueLabel(props));
+	bulletMark.marks?.push(getBulletMarkTargetValueLabel(props));
 
 	return bulletMark;
 }
@@ -210,11 +211,11 @@ export function getBulletMarkTargetValueLabel(props: BulletSpecProps): Mark {
 						props.numberFormat || ''
 					}') : ''`,
 				},
-				align: { value: 'right' },
+				align: { value: 'center' },
 				baseline: { value: 'top' },
 				fill: { value: `${solidColor}` },
 			},
-			update: { x: { signal: 'width' }, y: { value: 0 } },
+			update: { x: { scale: 'xscale', field: `${props.target}` }, y: { signal: 'bulletGroupHeight + 6' } },
 		},
 	};
 

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -89,8 +89,8 @@ export function getBulletMarks(props: BulletSpecProps): GroupMark {
 		marks: [],
 	};
 
-	bulletMark.marks?.push(getBulletMarkRect(props));
 	bulletMark.marks?.push(getBulletMarkTarget(props));
+	bulletMark.marks?.push(getBulletMarkRect(props));
 	bulletMark.marks?.push(getBulletMarkLabel(props));
 	bulletMark.marks?.push(getBulletMarkValueLabel(props));
 	bulletMark.marks?.push(getBulletMarkTargetValueLabel(props));
@@ -106,10 +106,10 @@ export function getBulletMarkRect(props: BulletSpecProps): Mark {
 		from: { data: 'bulletGroups' },
 		encode: {
 			enter: {
-				cornerRadiusTopLeft: [{ test: 'datum.amount < 0', value: 3 }],
-				cornerRadiusBottomLeft: [{ test: 'datum.amount < 0', value: 3 }],
-				cornerRadiusTopRight: [{ test: 'datum.amount > 0', value: 3 }],
-				cornerRadiusBottomRight: [{ test: 'datum.amount > 0', value: 3 }],
+				cornerRadiusTopLeft: [{ test: `datum.${props.metric} < 0`, value: 3 }],
+				cornerRadiusBottomLeft: [{ test: `datum.${props.metric} < 0`, value: 3 }],
+				cornerRadiusTopRight: [{ test: `datum.${props.metric} > 0`, value: 3 }],
+				cornerRadiusBottomRight: [{ test: `datum.${props.metric} > 0`, value: 3 }],
 				fill: [{ value: `${props.color}` }],
 			},
 			update: {

--- a/src/stories/components/Bullet/Bullet.story.tsx
+++ b/src/stories/components/Bullet/Bullet.story.tsx
@@ -43,10 +43,11 @@ const BulletStory: StoryFn<BulletProps & { width?: number; height?: number }> = 
 
 const Basic = bindWithProps(BulletStory);
 Basic.args = {
-	metric: 'currentAmount',
+    metric: 'currentAmount',
     dimension: 'graphLabel',
     target: 'target',
-    color: 'red-500'
+    color: 'red-500',
+    numberFormat: '$,.2f',
 };
 
 export { Basic };

--- a/src/stories/components/Bullet/data.ts
+++ b/src/stories/components/Bullet/data.ts
@@ -11,10 +11,10 @@
  */
 
 export const basicBulletData = [
-    {"graphLabel": "Facebook", "currentAmount": 390, "target": 50},
-    {"graphLabel": "X", "currentAmount": 275, "target": 200},
-    {"graphLabel": "LinkedIn", "currentAmount": 200, "target": 450},
-    {"graphLabel": "Snapchat", "currentAmount": 250, "target": 200},
-    {"graphLabel": "Instagram", "currentAmount": 300, "target": 250},
-    {"graphLabel": "WhatsApp", "currentAmount": 375, "target": 300},
+	{ graphLabel: 'Facebook', currentAmount: 390, target: 50 },
+	{ graphLabel: 'X', currentAmount: 275, target: 200 },
+	{ graphLabel: 'LinkedIn', currentAmount: 200, target: 250 },
+	{ graphLabel: 'Snapchat', currentAmount: 250, target: 200 },
+	{ graphLabel: 'Instagram', currentAmount: 300, target: 250 },
+	{ graphLabel: 'WhatsApp', currentAmount: 375, target: 300 },
 ];

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -235,6 +235,10 @@ export interface DonutProps extends MarkProps {
 export interface BulletProps extends MarkProps {
 	/** Target line */
 	target?: string;
+	/** Flag to control whether the target is shown */
+	showTarget?: boolean;
+	/** Flag to control whether the target value is shown. */
+	showTargetValue?: boolean;
 	/** Data field that the metric is trended against (x-axis for horizontal orientation) */
 	dimension?: string;
 	/** d3 number format specifier.

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -237,6 +237,12 @@ export interface BulletProps extends MarkProps {
 	target?: string;
 	/** Data field that the metric is trended against (x-axis for horizontal orientation) */
 	dimension?: string;
+	/** d3 number format specifier.
+	 * Sets the number format for the summary value.
+	 *
+	 * see {@link https://d3js.org/d3-format#locale_format}
+	 */
+	numberFormat?: NumberFormat;
 }
 
 export interface DonutSummaryProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces enhancements to the Bullet Chart by adding:

- Configurable number formatting (numberFormat), to specify how metric and target values are displayed using d3-format specifiers.
- Optional target and target value labels (showTarget, showTargetValue), to display the target line and its corresponding label.

These improvements provide flexibility in visualizing progress metrics while maintaining consistency with other charting components.

## Related Issue

SCRUM-18 and SCRUM-25

## Motivation and Context

This change is required to complete use case B and E.

## How Has This Been Tested?

- Added tests for numberFormat handling (e.g., $,.2f, .2s, ,.0%, etc.).
- Validated that showTarget and showTargetValue properly control visibility.
- Ensured getBulletMarks correctly generates the expected marks based on props.
- Verified UI updates in Storybook.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
