### PR TITLE
Scrum 35/refactor/bullet scales and signals produce

### DIFF
--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -136,13 +136,17 @@ describe('getBulletScales', () => {
 	});
 
 	test('Should return the correct scales object when a negative value is passed for maxScaleValue', () => {
-		const props = { ...samplePropsColumn, scaleType: 'fixed' as 'normal' | 'flexible' | 'fixed', maxScaleValue: -100 };
-		const data = getBulletScales(props);
+		const props = {
+			...samplePropsColumn,
+			scaleType: 'fixed' as 'normal' | 'flexible' | 'fixed',
+			maxScaleValue: -100,
+		};
+		const data = addScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
 
 		// Expect normal scale mode to be used
-		expect(data[1].domain).toStrictEqual({data: 'table',fields:['xPaddingForTarget', props.metric]});
+		expect(data[1].domain).toStrictEqual({ data: 'table', fields: ['xPaddingForTarget', props.metric] });
 	});
 });
 

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import {
-	addBulletScales,
+	addScales,
+	addSignals,
 	getBulletData,
 	getBulletLabelAxes,
 	getBulletMarkLabel,
@@ -19,7 +20,6 @@ import {
 	getBulletMarkThreshold,
 	getBulletMarkValueLabel,
 	getBulletMarks,
-	getBulletSignals,
 } from './bulletMarkUtils';
 import { samplePropsColumn, samplePropsRow } from './bulletSpecBuilder.test';
 
@@ -89,7 +89,7 @@ describe('getBulletData', () => {
 
 describe('getBulletScales', () => {
 	test('Should return the correct scales object for column mode', () => {
-		const data = addBulletScales([], samplePropsColumn);
+		const data = addScales([], samplePropsColumn);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(2);
 		expect('range' in data[0] && data[0].range && data[0].range[1]).toBeTruthy();
@@ -99,7 +99,7 @@ describe('getBulletScales', () => {
 	});
 
 	test('Should return the correct scales object for row mode', () => {
-		const data = addBulletScales([], samplePropsRow);
+		const data = addScales([], samplePropsRow);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(2);
 		expect('range' in data[0] && data[0].range && data[0].range[1]).toBeTruthy();
@@ -110,7 +110,7 @@ describe('getBulletScales', () => {
 
 	test('Should return the correct scales object for flexible scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'flexible' as 'normal' | 'flexible' | 'fixed' };
-		const data = addBulletScales([], props);
+		const data = addScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
 		expect(data[1].domain).toStrictEqual({
@@ -121,7 +121,7 @@ describe('getBulletScales', () => {
 
 	test('Should return the correct scales object for fixed scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'fixed' as 'normal' | 'flexible' | 'fixed' };
-		const data = addBulletScales([], props);
+		const data = addScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
 		expect(data[1].domain).toStrictEqual([0, `${props.maxScaleValue}`]);
@@ -129,7 +129,7 @@ describe('getBulletScales', () => {
 
 	test('Should return the correct scales object for normal scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'normal' as 'normal' | 'flexible' | 'fixed' };
-		const data = addBulletScales([], props);
+		const data = addScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
 		expect(data[1].domain).toStrictEqual({ data: 'table', fields: ['xPaddingForTarget', props.metric] });
@@ -138,20 +138,20 @@ describe('getBulletScales', () => {
 
 describe('getBulletSignals', () => {
 	test('Should return the correct signals object in column mode', () => {
-		const data = getBulletSignals(samplePropsColumn);
+		const data = addSignals([], samplePropsColumn);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(7);
 	});
 
 	test('Should return the correct signals object in row mode', () => {
-		const data = getBulletSignals(samplePropsRow);
+		const data = addSignals([], samplePropsRow);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(8);
 	});
 
 	test('Should include targetValueLabelHeight signal when showTargetValue is true', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true };
-		const signals = getBulletSignals(props);
+		const signals = addSignals([], props);
 		expect(signals.find((signal) => signal.name === 'targetValueLabelHeight')).toBeDefined();
 	});
 
@@ -162,7 +162,7 @@ describe('getBulletSignals', () => {
 			showTargetValue: true,
 			labelPosition: 'side' as 'side' | 'top',
 		};
-		const signals = getBulletSignals(props);
+		const signals = addSignals([], props);
 		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
 			name: 'bulletGroupHeight',
 			update: 'bulletThresholdHeight + targetValueLabelHeight + 10',
@@ -176,7 +176,7 @@ describe('getBulletSignals', () => {
 			showTargetValue: true,
 			labelPosition: 'top' as 'side' | 'top',
 		};
-		const signals = getBulletSignals(props);
+		const signals = addSignals([], props);
 		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
 			name: 'bulletGroupHeight',
 			update: 'bulletThresholdHeight + targetValueLabelHeight + 24',
@@ -190,7 +190,7 @@ describe('getBulletSignals', () => {
 			showTargetValue: false,
 			labelPosition: 'side' as 'side' | 'top',
 		};
-		const signals = getBulletSignals(props);
+		const signals = addSignals([], props);
 		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
 			name: 'bulletGroupHeight',
 			update: 'bulletThresholdHeight + 10',

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -10,16 +10,16 @@
  * governing permissions and limitations under the License.
  */
 import {
+	addBulletScales,
 	getBulletData,
+	getBulletLabelAxes,
 	getBulletMarkLabel,
 	getBulletMarkRect,
 	getBulletMarkTarget,
 	getBulletMarkThreshold,
 	getBulletMarkValueLabel,
 	getBulletMarks,
-	getBulletScales,
 	getBulletSignals,
-	getBulletLabelAxes
 } from './bulletMarkUtils';
 import { samplePropsColumn, samplePropsRow } from './bulletSpecBuilder.test';
 
@@ -72,7 +72,6 @@ describe('getBulletMarks', () => {
 		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
 		expect(targetValueMark).toBeDefined();
 	});
-
 });
 
 describe('getBulletData', () => {
@@ -90,7 +89,7 @@ describe('getBulletData', () => {
 
 describe('getBulletScales', () => {
 	test('Should return the correct scales object for column mode', () => {
-		const data = getBulletScales(samplePropsColumn);
+		const data = addBulletScales([], samplePropsColumn);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(2);
 		expect('range' in data[0] && data[0].range && data[0].range[1]).toBeTruthy();
@@ -100,7 +99,7 @@ describe('getBulletScales', () => {
 	});
 
 	test('Should return the correct scales object for row mode', () => {
-		const data = getBulletScales(samplePropsRow);
+		const data = addBulletScales([], samplePropsRow);
 		expect(data).toBeDefined();
 		expect(data).toHaveLength(2);
 		expect('range' in data[0] && data[0].range && data[0].range[1]).toBeTruthy();
@@ -111,29 +110,29 @@ describe('getBulletScales', () => {
 
 	test('Should return the correct scales object for flexible scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'flexible' as 'normal' | 'flexible' | 'fixed' };
-		const data = getBulletScales(props);
+		const data = addBulletScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
 		expect(data[1].domain).toStrictEqual({
 			data: 'table',
-			fields: ['xPaddingForTarget', props.metric, 'flexibleScaleValue']
+			fields: ['xPaddingForTarget', props.metric, 'flexibleScaleValue'],
 		});
 	});
 
 	test('Should return the correct scales object for fixed scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'fixed' as 'normal' | 'flexible' | 'fixed' };
-		const data = getBulletScales(props);
+		const data = addBulletScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
-		expect(data[1].domain).toStrictEqual([0,`${props.maxScaleValue}`]);
+		expect(data[1].domain).toStrictEqual([0, `${props.maxScaleValue}`]);
 	});
 
 	test('Should return the correct scales object for normal scale mode', () => {
 		const props = { ...samplePropsColumn, scaleType: 'normal' as 'normal' | 'flexible' | 'fixed' };
-		const data = getBulletScales(props);
+		const data = addBulletScales([], props);
 		expect(data).toBeDefined();
 		expect(data[1].domain).toBeDefined();
-		expect(data[1].domain).toStrictEqual({data: 'table',fields:['xPaddingForTarget', props.metric]});
+		expect(data[1].domain).toStrictEqual({ data: 'table', fields: ['xPaddingForTarget', props.metric] });
 	});
 });
 
@@ -157,21 +156,45 @@ describe('getBulletSignals', () => {
 	});
 
 	test('Should include correct targetValueLabelHeight signal when showTargetValue is true', () => {
-		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true, labelPosition: "side" as "side" | "top" };
+		const props = {
+			...samplePropsColumn,
+			showTarget: true,
+			showTargetValue: true,
+			labelPosition: 'side' as 'side' | 'top',
+		};
 		const signals = getBulletSignals(props);
-		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({"name": "bulletGroupHeight", "update": "bulletThresholdHeight + targetValueLabelHeight + 10"});
+		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
+			name: 'bulletGroupHeight',
+			update: 'bulletThresholdHeight + targetValueLabelHeight + 10',
+		});
 	});
 
 	test('Should include correct targetValueLabelHeight signal when showTargetValue is true', () => {
-		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true, labelPosition: "top" as "side" | "top" };
+		const props = {
+			...samplePropsColumn,
+			showTarget: true,
+			showTargetValue: true,
+			labelPosition: 'top' as 'side' | 'top',
+		};
 		const signals = getBulletSignals(props);
-		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({"name": "bulletGroupHeight", "update": "bulletThresholdHeight + targetValueLabelHeight + 24"});
+		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
+			name: 'bulletGroupHeight',
+			update: 'bulletThresholdHeight + targetValueLabelHeight + 24',
+		});
 	});
 
 	test('Should include correct targetValueLabelHeight signal when showTargetValue is true', () => {
-		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: false, labelPosition: "side" as "side" | "top" };
+		const props = {
+			...samplePropsColumn,
+			showTarget: true,
+			showTargetValue: false,
+			labelPosition: 'side' as 'side' | 'top',
+		};
 		const signals = getBulletSignals(props);
-		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({"name": "bulletGroupHeight", "update": "bulletThresholdHeight + 10"});
+		expect(signals.find((signal) => signal.name === 'bulletGroupHeight')).toStrictEqual({
+			name: 'bulletGroupHeight',
+			update: 'bulletThresholdHeight + 10',
+		});
 	});
 });
 
@@ -248,7 +271,6 @@ describe('getBulletMarkSideLabel', () => {
 });
 
 describe('getBulletAxes', () => {
-
 	test('Should return the correct axes object when side label mode is enabled', () => {
 		const props = { ...samplePropsColumn, labelPosition: 'side' as 'side' | 'top' };
 		const axes = getBulletLabelAxes(props);
@@ -268,8 +290,7 @@ describe('getBulletAxes', () => {
 		const axes = getBulletLabelAxes(props);
 		expect(axes).toStrictEqual([]);
 	});
-	
-})
+});
 
 describe('Threshold functionality', () => {
 	describe('Data generation', () => {

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -15,7 +15,7 @@ import { Axis, Data, GroupMark, Mark, Scale, Signal } from 'vega';
 import { BulletSpecProps } from '../../types';
 import { getColorValue } from '../specUtils';
 
-export const addBulletScales = produce<Scale[], [BulletSpecProps]>((scales, props) => {
+export const addScales = produce<Scale[], [BulletSpecProps]>((scales, props) => {
 	const groupScaleRangeSignal = props.direction === 'column' ? 'height' : 'width';
 	const xRange = props.direction === 'column' ? 'width' : [0, { signal: 'bulletGroupWidth' }];
 	let domainFields;
@@ -59,37 +59,33 @@ function getBulletGroupHeightExpression(props: BulletSpecProps): string {
 	return 'bulletThresholdHeight + 24';
 }
 
-export function getBulletSignals(props: BulletSpecProps): Signal[] {
-	const bulletSignals: Signal[] = [
-		{ name: 'gap', value: 12 },
-		{ name: 'bulletHeight', value: 8 },
-		{ name: 'bulletThresholdHeight', update: 'bulletHeight * 3' },
-		{ name: 'targetHeight', update: 'bulletThresholdHeight + 6' },
-	];
+export const addSignals = produce<Signal[], [BulletSpecProps]>((signals, props) => {
+	signals.push({ name: 'gap', value: 12 });
+	signals.push({ name: 'bulletHeight', value: 8 });
+	signals.push({ name: 'bulletThresholdHeight', update: 'bulletHeight * 3' });
+	signals.push({ name: 'targetHeight', update: 'bulletThresholdHeight + 6' });
 
 	if (props.showTargetValue && props.showTarget) {
-		bulletSignals.push({ name: 'targetValueLabelHeight', update: '20' });
+		signals.push({ name: 'targetValueLabelHeight', update: '20' });
 	}
 
-	bulletSignals.push({
+	signals.push({
 		name: 'bulletGroupHeight',
 		update: getBulletGroupHeightExpression(props),
 	});
 
 	if (props.direction === 'column') {
-		bulletSignals.push({ name: 'paddingRatio', update: 'gap / (gap + bulletGroupHeight)' });
-		bulletSignals.push({
+		signals.push({ name: 'paddingRatio', update: 'gap / (gap + bulletGroupHeight)' });
+		signals.push({
 			name: 'height',
 			update: "length(data('table')) * bulletGroupHeight + (length(data('table')) - 1) * gap",
 		});
 	} else {
-		bulletSignals.push({ name: 'bulletGroupWidth', update: "(width / length(data('table'))) - gap" });
-		bulletSignals.push({ name: 'paddingRatio', update: 'gap / (gap + bulletGroupWidth)' });
-		bulletSignals.push({ name: 'height', update: 'bulletGroupHeight' });
+		signals.push({ name: 'bulletGroupWidth', update: "(width / length(data('table'))) - gap" });
+		signals.push({ name: 'paddingRatio', update: 'gap / (gap + bulletGroupWidth)' });
+		signals.push({ name: 'height', update: 'bulletGroupHeight' });
 	}
-
-	return bulletSignals;
-}
+});
 
 export function getBulletData(props: BulletSpecProps): Data[] {
 	//We are multiplying the target by 1.05 to make sure that the target line is never at the very end of the graph

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -9,15 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { produce } from 'immer';
 import { Axis, Data, GroupMark, Mark, Scale, Signal } from 'vega';
 
 import { BulletSpecProps } from '../../types';
 import { getColorValue } from '../specUtils';
 
-export function getBulletScales(props: BulletSpecProps): Scale[] {
+export const addBulletScales = produce<Scale[], [BulletSpecProps]>((scales, props) => {
 	const groupScaleRangeSignal = props.direction === 'column' ? 'height' : 'width';
 	const xRange = props.direction === 'column' ? 'width' : [0, { signal: 'bulletGroupWidth' }];
 	let domainFields;
+
 	if (props.scaleType === 'flexible') {
 		domainFields = { data: 'table', fields: ['xPaddingForTarget', props.metric, 'flexibleScaleValue'] };
 	} else if (props.scaleType === 'fixed') {
@@ -26,7 +28,7 @@ export function getBulletScales(props: BulletSpecProps): Scale[] {
 		domainFields = { data: 'table', fields: ['xPaddingForTarget', props.metric] };
 	}
 
-	const bulletScales: Scale[] = [
+	scales.push(
 		{
 			name: 'groupScale',
 			type: 'band',
@@ -42,11 +44,9 @@ export function getBulletScales(props: BulletSpecProps): Scale[] {
 			round: true,
 			clamp: true,
 			zero: true,
-		},
-	];
-
-	return bulletScales;
-}
+		}
+	);
+});
 
 function getBulletGroupHeightExpression(props: BulletSpecProps): string {
 	if (props.showTargetValue && props.showTarget) {

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -48,17 +48,6 @@ export const addScales = produce<Scale[], [BulletSpecProps]>((scales, props) => 
 	);
 });
 
-function getBulletGroupHeightExpression(props: BulletSpecProps): string {
-	if (props.showTargetValue && props.showTarget) {
-		return props.labelPosition === 'side' && props.direction === 'column'
-			? 'bulletThresholdHeight + targetValueLabelHeight + 10'
-			: 'bulletThresholdHeight + targetValueLabelHeight + 24';
-	} else if (props.labelPosition === 'side' && props.direction === 'column') {
-		return 'bulletThresholdHeight + 10';
-	}
-	return 'bulletThresholdHeight + 24';
-}
-
 export const addSignals = produce<Signal[], [BulletSpecProps]>((signals, props) => {
 	signals.push({ name: 'gap', value: 12 });
 	signals.push({ name: 'bulletHeight', value: 8 });
@@ -86,6 +75,22 @@ export const addSignals = produce<Signal[], [BulletSpecProps]>((signals, props) 
 		signals.push({ name: 'height', update: 'bulletGroupHeight' });
 	}
 });
+
+/**
+ * Returns the height of the bullet group based on the props
+ * @param props the bullet spec props
+ * @returns the height of the bullet group
+ */
+function getBulletGroupHeightExpression(props: BulletSpecProps): string {
+	if (props.showTargetValue && props.showTarget) {
+		return props.labelPosition === 'side' && props.direction === 'column'
+			? 'bulletThresholdHeight + targetValueLabelHeight + 10'
+			: 'bulletThresholdHeight + targetValueLabelHeight + 24';
+	} else if (props.labelPosition === 'side' && props.direction === 'column') {
+		return 'bulletThresholdHeight + 10';
+	}
+	return 'bulletThresholdHeight + 24';
+}
 
 export function getBulletData(props: BulletSpecProps): Data[] {
 	//We are multiplying the target by 1.05 to make sure that the target line is never at the very end of the graph

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -25,10 +25,10 @@ import { BulletProps, BulletSpecProps, ColorScheme } from '../../types';
 import { sanitizeMarkChildren } from '../../utils';
 import { getColorValue } from '../specUtils';
 import {
+	addBulletScales,
 	getBulletData,
 	getBulletLabelAxes,
 	getBulletMarks,
-	getBulletScales,
 	getBulletSignals,
 } from './bulletMarkUtils';
 
@@ -75,13 +75,10 @@ export const addBullet = produce<Spec, [BulletProps & { colorScheme?: ColorSchem
 			...props,
 		};
 
-		return {
-			...spec,
-			data: getBulletData(bulletProps),
-			marks: [getBulletMarks(bulletProps)],
-			scales: getBulletScales(bulletProps),
-			signals: getBulletSignals(bulletProps),
-			axes: getBulletLabelAxes(bulletProps),
-		};
+		spec.data = getBulletData(bulletProps);
+		spec.marks = [getBulletMarks(bulletProps)];
+		spec.scales = addBulletScales(spec.scales ?? [], bulletProps);
+		spec.signals = getBulletSignals(bulletProps);
+		spec.axes = getBulletLabelAxes(bulletProps);
 	}
 );

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -24,13 +24,7 @@ import { Spec } from 'vega';
 import { BulletProps, BulletSpecProps, ColorScheme } from '../../types';
 import { sanitizeMarkChildren } from '../../utils';
 import { getColorValue } from '../specUtils';
-import {
-	addBulletScales,
-	getBulletData,
-	getBulletLabelAxes,
-	getBulletMarks,
-	getBulletSignals,
-} from './bulletMarkUtils';
+import { addScales, addSignals, getBulletData, getBulletLabelAxes, getBulletMarks } from './bulletMarkUtils';
 
 const DEFAULT_COLOR = spectrumColors.light['static-blue'];
 
@@ -77,8 +71,8 @@ export const addBullet = produce<Spec, [BulletProps & { colorScheme?: ColorSchem
 
 		spec.data = getBulletData(bulletProps);
 		spec.marks = [getBulletMarks(bulletProps)];
-		spec.scales = addBulletScales(spec.scales ?? [], bulletProps);
-		spec.signals = getBulletSignals(bulletProps);
+		spec.scales = addScales(spec.scales ?? [], bulletProps);
+		spec.signals = addSignals(spec.signals ?? [], bulletProps);
 		spec.axes = getBulletLabelAxes(bulletProps);
 	}
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR refactors the Bullet chart’s getBulletScales and getBulletSignals functions to use the produce pattern from Immer. The refactored versions are now named addScales and addSignals and follow the same structure as other chart components (e.g., Bar, Donut).

## Related Issue

General refactoring.

## Motivation and Context

- Aligns Bullet chart logic with the rest of the chart implementations.
- Enables a standardized, immutable update pattern via produce.

## How Has This Been Tested?

- Updated the Bullet unit tests to pass the additional parameter ([]) required by the produce functions.
- Verified that Bullet renders correctly in Storybook and behaves as expected with both default and custom props.
- Ran the full test suite to confirm no regressions across other parts of the codebase.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (non-breaking change improving code structure)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
