### PR TITLE
Scrum 39/refactor/bullet marks produce

### DIFF
--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -9,6 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { GroupMark } from 'vega';
+
 import {
 	addData,
 	addMarks,
@@ -25,7 +27,7 @@ import { samplePropsColumn, samplePropsRow } from './bulletSpecBuilder.test';
 
 describe('getBulletMarks', () => {
 	test('Should return the correct marks object for column mode', () => {
-		const data = addMarks(samplePropsColumn);
+		const data = addMarks([], samplePropsColumn)[0] as GroupMark;
 		expect(data).toBeDefined;
 		expect(data?.marks).toHaveLength(4);
 		expect(data?.marks?.[0]?.type).toBe('rect');
@@ -38,7 +40,7 @@ describe('getBulletMarks', () => {
 	});
 
 	test('Should return the correct marks object for row mode', () => {
-		const data = addMarks(samplePropsRow);
+		const data = addMarks([], samplePropsRow)[0] as GroupMark;
 		expect(data).toBeDefined;
 		expect(data?.marks).toHaveLength(4);
 		expect(data?.marks?.[0]?.type).toBe('rect');
@@ -50,7 +52,7 @@ describe('getBulletMarks', () => {
 
 	test('Should not include target marks when showTarget is false', () => {
 		const props = { ...samplePropsColumn, showTarget: false, showTargetValue: true };
-		const marksGroup = addMarks(props);
+		const marksGroup = addMarks([], props)[0] as GroupMark;
 		expect(marksGroup.marks).toHaveLength(3);
 		marksGroup.marks?.forEach((mark) => {
 			expect(mark.description).not.toContain('Target');
@@ -59,7 +61,7 @@ describe('getBulletMarks', () => {
 
 	test('Should include target value label when showTargetValue is true', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true };
-		const marksGroup = addMarks(props);
+		const marksGroup = addMarks([], props)[0] as GroupMark;
 		expect(marksGroup.marks).toHaveLength(5);
 		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
 		expect(targetValueMark).toBeDefined();
@@ -67,7 +69,7 @@ describe('getBulletMarks', () => {
 
 	test('Should include label marks when axis labels are enabled', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true };
-		const marksGroup = addMarks(props);
+		const marksGroup = addMarks([], props)[0] as GroupMark;
 		expect(marksGroup.marks).toHaveLength(5);
 		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
 		expect(targetValueMark).toBeDefined();
@@ -251,7 +253,7 @@ describe('getBulletMarkValueLabel', () => {
 
 	test('Should apply numberFormat specifier to metric and target values', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true, numberFormat: '$,.2f' };
-		const marksGroup = addMarks(props);
+		const marksGroup = addMarks([], props)[0] as GroupMark;
 
 		const metricValueLabel = marksGroup.marks?.find((mark) => mark.name === `${props.name}ValueLabel`);
 		expect(metricValueLabel).toBeDefined();
@@ -278,7 +280,7 @@ describe('getBulletMarkValueLabel', () => {
 describe('getBulletMarkSideLabel', () => {
 	test('Should not return label marks when side label mode is enabled', () => {
 		const props = { ...samplePropsColumn, labelPosition: 'side' as 'side' | 'top' };
-		const marks = addMarks(props);
+		const marks = addMarks([], props)[0] as GroupMark;
 		expect(marks.marks).toBeDefined();
 		expect(marks.marks).toHaveLength(2);
 	});
@@ -321,7 +323,7 @@ describe('Threshold functionality', () => {
 				thresholdConfig: undefined,
 			};
 
-			const marksGroup = addMarks(props);
+			const marksGroup = addMarks([], props)[0] as GroupMark;
 			expect(marksGroup.data).toBeDefined();
 			expect(marksGroup.data?.[0].name).toBe('thresholds');
 

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -11,6 +11,7 @@
  */
 import {
 	addData,
+	addMarks,
 	addScales,
 	addSignals,
 	getBulletLabelAxes,
@@ -19,13 +20,12 @@ import {
 	getBulletMarkTarget,
 	getBulletMarkThreshold,
 	getBulletMarkValueLabel,
-	getBulletMarks,
 } from './bulletMarkUtils';
 import { samplePropsColumn, samplePropsRow } from './bulletSpecBuilder.test';
 
 describe('getBulletMarks', () => {
 	test('Should return the correct marks object for column mode', () => {
-		const data = getBulletMarks(samplePropsColumn);
+		const data = addMarks(samplePropsColumn);
 		expect(data).toBeDefined;
 		expect(data?.marks).toHaveLength(4);
 		expect(data?.marks?.[0]?.type).toBe('rect');
@@ -38,7 +38,7 @@ describe('getBulletMarks', () => {
 	});
 
 	test('Should return the correct marks object for row mode', () => {
-		const data = getBulletMarks(samplePropsRow);
+		const data = addMarks(samplePropsRow);
 		expect(data).toBeDefined;
 		expect(data?.marks).toHaveLength(4);
 		expect(data?.marks?.[0]?.type).toBe('rect');
@@ -50,7 +50,7 @@ describe('getBulletMarks', () => {
 
 	test('Should not include target marks when showTarget is false', () => {
 		const props = { ...samplePropsColumn, showTarget: false, showTargetValue: true };
-		const marksGroup = getBulletMarks(props);
+		const marksGroup = addMarks(props);
 		expect(marksGroup.marks).toHaveLength(3);
 		marksGroup.marks?.forEach((mark) => {
 			expect(mark.description).not.toContain('Target');
@@ -59,7 +59,7 @@ describe('getBulletMarks', () => {
 
 	test('Should include target value label when showTargetValue is true', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true };
-		const marksGroup = getBulletMarks(props);
+		const marksGroup = addMarks(props);
 		expect(marksGroup.marks).toHaveLength(5);
 		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
 		expect(targetValueMark).toBeDefined();
@@ -67,7 +67,7 @@ describe('getBulletMarks', () => {
 
 	test('Should include label marks when axis labels are enabled', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true };
-		const marksGroup = getBulletMarks(props);
+		const marksGroup = addMarks(props);
 		expect(marksGroup.marks).toHaveLength(5);
 		const targetValueMark = marksGroup.marks?.find((mark) => mark.name?.includes('TargetValueLabel'));
 		expect(targetValueMark).toBeDefined();
@@ -251,7 +251,7 @@ describe('getBulletMarkValueLabel', () => {
 
 	test('Should apply numberFormat specifier to metric and target values', () => {
 		const props = { ...samplePropsColumn, showTarget: true, showTargetValue: true, numberFormat: '$,.2f' };
-		const marksGroup = getBulletMarks(props);
+		const marksGroup = addMarks(props);
 
 		const metricValueLabel = marksGroup.marks?.find((mark) => mark.name === `${props.name}ValueLabel`);
 		expect(metricValueLabel).toBeDefined();
@@ -278,7 +278,7 @@ describe('getBulletMarkValueLabel', () => {
 describe('getBulletMarkSideLabel', () => {
 	test('Should not return label marks when side label mode is enabled', () => {
 		const props = { ...samplePropsColumn, labelPosition: 'side' as 'side' | 'top' };
-		const marks = getBulletMarks(props);
+		const marks = addMarks(props);
 		expect(marks.marks).toBeDefined();
 		expect(marks.marks).toHaveLength(2);
 	});
@@ -321,7 +321,7 @@ describe('Threshold functionality', () => {
 				thresholdConfig: undefined,
 			};
 
-			const marksGroup = getBulletMarks(props);
+			const marksGroup = addMarks(props);
 			expect(marksGroup.data).toBeDefined();
 			expect(marksGroup.data?.[0].name).toBe('thresholds');
 

--- a/src/specBuilder/bullet/bulletMarkUtils.test.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.test.ts
@@ -78,7 +78,7 @@ describe('getBulletMarks', () => {
 
 	test('Should include bullet track when track is set to true and threshold is set to false.', () => {
 		const props = { ...samplePropsColumn, threshold: false, track: true };
-		const marksGroup = getBulletMarks(props);
+		const marksGroup = addMarks([], props)[0] as GroupMark;
 		expect(marksGroup.marks).toHaveLength(5);
 		const bulletTrackMark = marksGroup.marks?.find((mark) => mark.name?.includes('Track'));
 		expect(bulletTrackMark).toBeDefined();

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -98,7 +98,7 @@ export const addData = produce<Data[], [BulletSpecProps]>((data, props) => {
 	tableData.transform = getBulletTransforms(props);
 });
 
-export function getBulletMarks(props: BulletSpecProps): GroupMark {
+export const addMarks = produce<GroupMark[], [BulletSpecProps]>((marks, props) => {
 	const markGroupEncodeUpdateDirection = props.direction === 'column' ? 'y' : 'x';
 	const bulletGroupWidth = props.direction === 'column' ? 'width' : 'bulletGroupWidth';
 
@@ -144,8 +144,8 @@ export function getBulletMarks(props: BulletSpecProps): GroupMark {
 		bulletMark.marks?.push(getBulletMarkValueLabel(props));
 	}
 
-	return bulletMark;
-}
+	marks.push(bulletMark);
+});
 
 export function getBulletMarkRect(props: BulletSpecProps): Mark {
 	//The vertical positioning is calculated starting at the bulletgroupheight

--- a/src/specBuilder/bullet/bulletMarkUtils.ts
+++ b/src/specBuilder/bullet/bulletMarkUtils.ts
@@ -98,7 +98,7 @@ export const addData = produce<Data[], [BulletSpecProps]>((data, props) => {
 	tableData.transform = getBulletTransforms(props);
 });
 
-export const addMarks = produce<GroupMark[], [BulletSpecProps]>((marks, props) => {
+export const addMarks = produce<Mark[], [BulletSpecProps]>((marks, props) => {
 	const markGroupEncodeUpdateDirection = props.direction === 'column' ? 'y' : 'x';
 	const bulletGroupWidth = props.direction === 'column' ? 'width' : 'bulletGroupWidth';
 

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -19,7 +19,7 @@ import {
 import { spectrumColors } from '@themes';
 import { toCamelCase } from '@utils';
 import { produce } from 'immer';
-import { GroupMark, Spec } from 'vega';
+import { Spec } from 'vega';
 
 import { BulletProps, BulletSpecProps, ColorScheme } from '../../types';
 import { sanitizeMarkChildren } from '../../utils';

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -19,12 +19,12 @@ import {
 import { spectrumColors } from '@themes';
 import { toCamelCase } from '@utils';
 import { produce } from 'immer';
-import { Spec } from 'vega';
+import { GroupMark, Spec } from 'vega';
 
 import { BulletProps, BulletSpecProps, ColorScheme } from '../../types';
 import { sanitizeMarkChildren } from '../../utils';
 import { getColorValue } from '../specUtils';
-import { addData, addScales, addSignals, getBulletLabelAxes, getBulletMarks } from './bulletMarkUtils';
+import { addData, addMarks, addScales, addSignals, getBulletLabelAxes } from './bulletMarkUtils';
 
 const DEFAULT_COLOR = spectrumColors.light['static-blue'];
 
@@ -70,7 +70,7 @@ export const addBullet = produce<Spec, [BulletProps & { colorScheme?: ColorSchem
 		};
 
 		spec.data = addData(spec.data ?? [], bulletProps);
-		spec.marks = [getBulletMarks(bulletProps)];
+		spec.marks = addMarks(spec.marks as GroupMark[], bulletProps);
 		spec.scales = addScales(spec.scales ?? [], bulletProps);
 		spec.signals = addSignals(spec.signals ?? [], bulletProps);
 		spec.axes = getBulletLabelAxes(bulletProps);

--- a/src/specBuilder/bullet/bulletSpecBuilder.ts
+++ b/src/specBuilder/bullet/bulletSpecBuilder.ts
@@ -70,7 +70,7 @@ export const addBullet = produce<Spec, [BulletProps & { colorScheme?: ColorSchem
 		};
 
 		spec.data = addData(spec.data ?? [], bulletProps);
-		spec.marks = addMarks(spec.marks as GroupMark[], bulletProps);
+		spec.marks = addMarks(spec.marks ?? [], bulletProps);
 		spec.scales = addScales(spec.scales ?? [], bulletProps);
 		spec.signals = addSignals(spec.signals ?? [], bulletProps);
 		spec.axes = getBulletLabelAxes(bulletProps);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactors the `getBulletMarks` logic to use produce and renames it to `addMarks` to align with the naming and structural conventions used in other chart spec builders (e.g., `addScales`, `addSignals`, `addData`). The new implementation pushes a single `GroupMark` into the marks array immutably.

## Related Issue

General refactoring.

## Motivation and Context

This change is part of a broader refactor to bring the Bullet chart implementation in line with other existing charts like Bar and Axis. Using `produce`:

- Improves code clarity and immutability.
- Aligns with consistent patterns used across the project.
- Makes future mark additions easier to integrate into the Bullet chart.

## How Has This Been Tested?

- Updated and ran all existing unit tests for Bullet marks.
- Confirmed expected structure and behavior by inspecting the returned GroupMark and sub-marks.
- Verified that spec builder correctly integrates the new marks logic.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
