### PR TITLE
build: update dependencies to fix themes build size

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -27,6 +27,6 @@
 	"dependencies": {
 		"@spectrum-charts/constants": "1.16.0",
 		"@spectrum-charts/utils": "1.16.0",
-		"vega": ">= 5.20.2"
+		"vega": "^5.32.0"
 	}
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"@spectrum-charts/constants": "1.16.0",
-		"@spectrum-charts/utils": "1.16.0"
+		"@spectrum-charts/utils": "1.16.0",
+		"vega": ">= 5.20.2"
 	}
 }

--- a/packages/vega-spec-builder/package.json
+++ b/packages/vega-spec-builder/package.json
@@ -23,7 +23,7 @@
 		"@spectrum-charts/themes": "1.16.0",
 		"@spectrum-charts/utils": "1.16.0",
 		"immer": "^10.1.1",
-		"vega": "^5.32.0"
+		"vega": ">= 5.20.2"
 	},
 	"devDependencies": {
 		"ts-loader": "^9.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4360,6 +4360,11 @@
   resolved "https://registry.yarnpkg.com/@types/fined/-/fined-1.1.5.tgz#504b87a0de8813e06e7d226f34c1cefb70d9afb0"
   integrity sha512-2N93vadEGDFhASTIRbizbl4bNqpMOId5zZfj6hHqYZfEzEfO9onnU4Im8xvzo8uudySDveDHBOOSlTWf38ErfQ==
 
+"@types/geojson@7946.0.16":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
+
 "@types/geojson@7946.0.4":
   version "7946.0.4"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.4.tgz#4e049756383c3f055dd8f3d24e63fb543e98eb07"
@@ -6146,7 +6151,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2:
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2, d3-array@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -6158,7 +6163,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
-d3-delaunay@^6.0.2:
+d3-delaunay@^6.0.2, d3-delaunay@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
   integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
@@ -6206,6 +6211,13 @@ d3-geo-projection@^4.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
   integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-geo@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
   dependencies:
     d3-array "2.5.0 - 3"
 
@@ -6288,6 +6300,11 @@ damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 data-urls@^3.0.2:
   version "3.0.2"
@@ -7377,6 +7394,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -7574,6 +7599,13 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -9702,12 +9734,26 @@ node-abort-controller@^3.0.1:
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^1:
   version "1.3.1"
@@ -12116,6 +12162,11 @@ vega-canvas@^1.2.6, vega-canvas@^1.2.7:
   resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-1.2.7.tgz#cf62169518f5dcd91d24ad352998c2248f8974fb"
   integrity sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==
 
+vega-canvas@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-2.0.0.tgz#4709deb68f9b4fd7475957bed99f16c38dbc07b8"
+  integrity sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==
+
 vega-crossfilter@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz#3ff3ca0574883706f7a399dc6d60f4a0f065ece4"
@@ -12125,14 +12176,14 @@ vega-crossfilter@~4.1.1:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-crossfilter@~4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.1.3.tgz#2c404ddcd420605c84fb088f3e9beb671dca498e"
-  integrity sha512-nyPJAXAUABc3EocUXvAL1J/IWotZVsApIcvOeZaUdEQEtZ7bt8VtP2nj3CLbHBA8FZZVV+K6SmdwvCOaAD4wFQ==
+vega-crossfilter@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-5.0.0.tgz#f01d51298e53132610b4b693b89bc5280c7d1f89"
+  integrity sha512-9PnDXpoLY4rWBubTjtAxEmEdSLq4pg1OyyucugnGNX6HsaAuF5fXYmXdpe4UB4SMMHMnWM3ZBA2wkkycct11sQ==
   dependencies:
-    d3-array "^3.2.2"
-    vega-dataflow "^5.7.7"
-    vega-util "^1.17.3"
+    d3-array "^3.2.4"
+    vega-dataflow "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.5:
   version "5.7.5"
@@ -12143,14 +12194,14 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.5:
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
 
-vega-dataflow@^5.7.7, vega-dataflow@~5.7.7:
-  version "5.7.7"
-  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-5.7.7.tgz#d766f650aaaf27836894bdb6ee391fd43d7a22ef"
-  integrity sha512-R2NX2HvgXL+u4E6u+L5lKvvRiCtnE6N6l+umgojfi53suhhkFP+zB+2UAQo4syxuZ4763H1csfkKc4xpqLzKnw==
+vega-dataflow@^6.0.0, vega-dataflow@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-6.0.0.tgz#fcb24be81cf5e8293c7d2e1a96364f50988a1057"
+  integrity sha512-/6Cl06lqTPDiGwwRgRJ6osAy/qwgeelwK4+tZ4QS/aNJhoEAJU5xPXuWl6U0trabUT2Pe0+Qpo1+/u0oAOmmCg==
   dependencies:
-    vega-format "^1.1.3"
-    vega-loader "^4.5.3"
-    vega-util "^1.17.3"
+    vega-format "^2.0.0"
+    vega-loader "^5.0.0"
+    vega-util "^2.0.0"
 
 "vega-embed@>= 6.27.0":
   version "6.28.0"
@@ -12177,21 +12228,26 @@ vega-encode@~4.10.0:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
-vega-encode@~4.10.2:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-4.10.2.tgz#dcef19d040905f5ef43e8a730f6ec501fe4b2a73"
-  integrity sha512-fsjEY1VaBAmqwt7Jlpz0dpPtfQFiBdP9igEefvumSpy7XUxOJmDQcRDnT3Qh9ctkv3itfPfI9g8FSnGcv2b4jQ==
+vega-encode@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-5.0.0.tgz#fd16781df8ebf7dbfc30c5eae7caa766c625dbf9"
+  integrity sha512-3YdnCGDMNppicdzyaawP1fYYyJhMUMREwgQmQvF//NFRMY3bzI59Rjhq4v+tIMXXSvnTztJ1Chm9eSvZGiNs+g==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-interpolate "^3.0.1"
-    vega-dataflow "^5.7.7"
-    vega-scale "^7.4.2"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-scale "^8.0.0"
+    vega-util "^2.0.0"
 
 vega-event-selector@^3.0.1, vega-event-selector@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-3.0.1.tgz#b99e92147b338158f8079d81b28b2e7199c2e259"
   integrity sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==
+
+vega-event-selector@^4.0.0, vega-event-selector@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-4.0.0.tgz#425e9f2671e858a1a45b4b6a7fc452ca0b22abbf"
+  integrity sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==
 
 vega-expression@^5.0.1, vega-expression@^5.1.0, vega-expression@~5.1.0, vega-expression@~5.1.1:
   version "5.1.1"
@@ -12201,13 +12257,13 @@ vega-expression@^5.0.1, vega-expression@^5.1.0, vega-expression@~5.1.0, vega-exp
     "@types/estree" "^1.0.0"
     vega-util "^1.17.2"
 
-vega-expression@^5.2.0, vega-expression@~5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.2.0.tgz#a5dfa8dd79066082add1846618f3d7f0a364305f"
-  integrity sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==
+vega-expression@^6.0.0, vega-expression@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-6.0.0.tgz#4677c0f44678850c55aa704e63b31029af5654ac"
+  integrity sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==
   dependencies:
-    "@types/estree" "^1.0.0"
-    vega-util "^1.17.3"
+    "@types/estree" "^1.0.6"
+    vega-util "^2.0.0"
 
 vega-force@~4.2.0:
   version "4.2.0"
@@ -12218,14 +12274,14 @@ vega-force@~4.2.0:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-force@~4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.2.2.tgz#e70ac31cf73d3ffaed361202613809e8c516d6f0"
-  integrity sha512-cHZVaY2VNNIG2RyihhSiWniPd2W9R9kJq0znxzV602CgUVgxEfTKtx/lxnVCn8nNrdKAYrGiqIsBzIeKG1GWHw==
+vega-force@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-5.0.0.tgz#655783488a29f5f6401d3fddaacfeb2185773be9"
+  integrity sha512-j3HNCrngjuFvOmBl2gg2NNgDys5q6i+v6pliIt9grSAcgzStNNuxcVp+OjNeWP4NSa0Hc7efEGmYvmBqTP/HpQ==
   dependencies:
     d3-force "^3.0.0"
-    vega-dataflow "^5.7.7"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-format@^1.1.1, vega-format@~1.1.1:
   version "1.1.1"
@@ -12238,16 +12294,16 @@ vega-format@^1.1.1, vega-format@~1.1.1:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-format@^1.1.3, vega-format@~1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/vega-format/-/vega-format-1.1.3.tgz#66e0fd8eb0ba8d9e638b3c62a023cdab9af57bc5"
-  integrity sha512-wQhw7KR46wKJAip28FF/CicW+oiJaPAwMKdrxlnTA0Nv8Bf7bloRlc+O3kON4b4H1iALLr9KgRcYTOeXNs2MOA==
+vega-format@^2.0.0, vega-format@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-format/-/vega-format-2.0.0.tgz#0a7d845b94e5ad17b700e71613b7c5c43697215f"
+  integrity sha512-RrMI/HedVEb4PDFyiNjzbJtOLt/H7aan1Fs3sQQamOdSAj5gcq6r9IavzKy7dC4XaovEjdStJL6JSAfTW53CiQ==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-format "^3.1.0"
     d3-time-format "^4.1.0"
-    vega-time "^2.1.3"
-    vega-util "^1.17.3"
+    vega-time "^3.0.0"
+    vega-util "^2.0.0"
 
 vega-functions@^5.13.1, vega-functions@^5.14.0, vega-functions@~5.14.0:
   version "5.14.0"
@@ -12266,22 +12322,22 @@ vega-functions@^5.13.1, vega-functions@^5.14.0, vega-functions@~5.14.0:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-functions@^5.17.0, vega-functions@~5.17.0:
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.17.0.tgz#6b1477c4f5e5a4a0c58ddf667d6952f8d61333a7"
-  integrity sha512-EoGvdCtv1Y4M/hLy83Kf0HTs4qInUfrBoanrnhbguzRl00rx7orjcv+bNZFHbCe4HkfVpbOnTrYmz3K2ivaOLw==
+vega-functions@^6.0.0, vega-functions@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-6.0.0.tgz#3e97a8bfc59f26a490bc20c5ff5f26f756711169"
+  integrity sha512-1Qy7VOUIa3GzbfLXYYpTDPQMyJVV27a7U8xCqXtMPozXQo4cKQRb/OKAqMk7A/0eCTs3E08pc41kFa/tYSOIag==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-color "^3.1.0"
-    d3-geo "^3.1.0"
-    vega-dataflow "^5.7.7"
-    vega-expression "^5.2.0"
-    vega-scale "^7.4.2"
-    vega-scenegraph "^4.13.1"
-    vega-selections "^5.6.0"
-    vega-statistics "^1.9.0"
-    vega-time "^2.1.3"
-    vega-util "^1.17.3"
+    d3-geo "^3.1.1"
+    vega-dataflow "^6.0.0"
+    vega-expression "^6.0.0"
+    vega-scale "^8.0.0"
+    vega-scenegraph "^5.0.0"
+    vega-selections "^6.0.0"
+    vega-statistics "^2.0.0"
+    vega-time "^3.0.0"
+    vega-util "^2.0.0"
 
 vega-geo@~4.4.1:
   version "4.4.1"
@@ -12297,19 +12353,19 @@ vega-geo@~4.4.1:
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
 
-vega-geo@~4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-4.4.3.tgz#038dc85e1c030b2f2c8bda61fb31ff6bdfea123b"
-  integrity sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==
+vega-geo@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-5.0.0.tgz#0e3fda29a50cd6c4a5b081a5cab7eac7056e3c7b"
+  integrity sha512-cr7Tjktgq0cuYwqhz5Mak6tv7BeaRBz1HaojNLJxJzQtNw1oBdT8gXxSYN1PA61OExHP2mG8GZRF+XdjbnN3LQ==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-color "^3.1.0"
-    d3-geo "^3.1.0"
-    vega-canvas "^1.2.7"
-    vega-dataflow "^5.7.7"
-    vega-projection "^1.6.2"
-    vega-statistics "^1.9.0"
-    vega-util "^1.17.3"
+    d3-geo "^3.1.1"
+    vega-canvas "^2.0.0"
+    vega-dataflow "^6.0.0"
+    vega-projection "^2.0.0"
+    vega-statistics "^2.0.0"
+    vega-util "^2.0.0"
 
 vega-hierarchy@~4.1.1:
   version "4.1.1"
@@ -12320,14 +12376,14 @@ vega-hierarchy@~4.1.1:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-hierarchy@~4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-4.1.3.tgz#7721aec582cdf332da6a4ee8332a94e3ac064881"
-  integrity sha512-0Z+TYKRgOEo8XYXnJc2HWg1EGpcbNAhJ9Wpi9ubIbEyEHqIgjCIyFVN8d4nSfsJOcWDzsSmRqohBztxAhOCSaw==
+vega-hierarchy@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-5.0.0.tgz#8dd3647dd0423df4db414bec2fc40b5987d942db"
+  integrity sha512-W2nVICp5946eG5zf5jenHo4Q+LBcYmDQjFt7/7HyRzvZT8IIdhBEuotb2MwmgJ9GeOsmt/DRb53DNZbXMSB9ww==
   dependencies:
     d3-hierarchy "^3.1.2"
-    vega-dataflow "^5.7.7"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-interpreter@^1.0.5:
   version "1.0.5"
@@ -12344,15 +12400,15 @@ vega-label@~1.2.1:
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
 
-vega-label@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-1.3.1.tgz#2e370dac88e91615317ba5120cbfc6c43c6227dd"
-  integrity sha512-Emx4b5s7pvuRj3fBkAJ/E2snCoZACfKAwxVId7f/4kYVlAYLb5Swq6W8KZHrH4M9Qds1XJRUYW9/Y3cceqzEFA==
+vega-label@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-2.0.0.tgz#4c0b56a906427dceb889ca2870910c8874d5ffb4"
+  integrity sha512-e+JIojHNiEcI/4jFoOLhtocbqoQzJqurZwyP3lFgV7nJOQPOZSZYiEUOUhbhYuMgnhz0HDBe3GDqSAeo1yUhfw==
   dependencies:
-    vega-canvas "^1.2.7"
-    vega-dataflow "^5.7.7"
-    vega-scenegraph "^4.13.1"
-    vega-util "^1.17.3"
+    vega-canvas "^2.0.0"
+    vega-dataflow "^6.0.0"
+    vega-scenegraph "^5.0.0"
+    vega-util "^2.0.0"
 
 vega-lite@^5.18.1:
   version "5.21.0"
@@ -12377,16 +12433,16 @@ vega-loader@^4.5.1, vega-loader@~4.5.1:
     vega-format "^1.1.1"
     vega-util "^1.17.1"
 
-vega-loader@^4.5.3, vega-loader@~4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-4.5.3.tgz#f89cf4def5b2c61f65f845ec695b6e14d15c36e9"
-  integrity sha512-dUfIpxTLF2magoMaur+jXGvwMxjtdlDZaIS8lFj6N7IhUST6nIvBzuUlRM+zLYepI5GHtCLOnqdKU4XV0NggCA==
+vega-loader@^5.0.0, vega-loader@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-5.0.0.tgz#0948c74dcd1b023763fd8e5ffc7fe5de85538b84"
+  integrity sha512-THLOtcbL0gQjv3GunKWutUiELdLc74nQOfIWNL/kx2qXtM2kYhE5FcCKQNTA9aZzklY3oN8Bt4siJ22ugO0WyA==
   dependencies:
     d3-dsv "^3.0.1"
-    node-fetch "^2.6.7"
+    node-fetch "^3.3.2"
     topojson-client "^3.1.0"
-    vega-format "^1.1.3"
-    vega-util "^1.17.3"
+    vega-format "^2.0.0"
+    vega-util "^2.0.0"
 
 vega-parser@~6.3.0:
   version "6.3.0"
@@ -12399,16 +12455,16 @@ vega-parser@~6.3.0:
     vega-scale "^7.3.1"
     vega-util "^1.17.2"
 
-vega-parser@~6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.5.0.tgz#d1427b1a921fbd25b0888659bbe9c099b317522b"
-  integrity sha512-dPxFKn6IlDyWi6CgHGGv8htSPBAyLHWlJNNGD17eMXh+Kjn4hupSNOIboRcYb8gL5HYt1tYwS6oYZXK84Bc4tg==
+vega-parser@~7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-7.0.0.tgz#9bb760c0787c3286eebe576fec541770519c7fde"
+  integrity sha512-820pladvhez0SQBZ8Yohou0fpWd4Vl+AbekGG0eu+mh2BhjJmIDaNC/5j/5sZ/A+ufHO2GPCAt4DSiM/X2jWqg==
   dependencies:
-    vega-dataflow "^5.7.7"
-    vega-event-selector "^3.0.1"
-    vega-functions "^5.17.0"
-    vega-scale "^7.4.2"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-event-selector "^4.0.0"
+    vega-functions "^6.0.0"
+    vega-scale "^8.0.0"
+    vega-util "^2.0.0"
 
 vega-projection@^1.6.0, vega-projection@~1.6.0:
   version "1.6.0"
@@ -12419,14 +12475,14 @@ vega-projection@^1.6.0, vega-projection@~1.6.0:
     d3-geo-projection "^4.0.0"
     vega-scale "^7.3.0"
 
-vega-projection@^1.6.2, vega-projection@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.6.2.tgz#69ea9a2404bad12642d3ec5c4f5615b27cdcb630"
-  integrity sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==
+vega-projection@^2.0.0, vega-projection@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-2.0.0.tgz#726104d8d921bf810e62c71b9fd2360b14a65317"
+  integrity sha512-oeNTNKD5iwDImiSTjNqxGrDGACxVmF+1XWxKgplgHsnoB0k4wtcGm0Lc6cZ0rwC6zyJ/4WRVxjUeOVGKpNCpxA==
   dependencies:
-    d3-geo "^3.1.0"
+    d3-geo "^3.1.1"
     d3-geo-projection "^4.0.0"
-    vega-scale "^7.4.2"
+    vega-scale "^8.0.0"
 
 vega-regression@~1.2.0:
   version "1.2.0"
@@ -12438,15 +12494,15 @@ vega-regression@~1.2.0:
     vega-statistics "^1.9.0"
     vega-util "^1.15.2"
 
-vega-regression@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.3.1.tgz#e1de74062250da33e823897565155caefb041dbb"
-  integrity sha512-AmccF++Z9uw4HNZC/gmkQGe6JsRxTG/R4QpbcSepyMvQN1Rj5KtVqMcmVFP1r3ivM4dYGFuPlzMWvuqp0iKMkQ==
+vega-regression@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-2.0.0.tgz#3767d6d8be43f9dbba4d6adca2c87b1289551314"
+  integrity sha512-0OW2+Pp0VQJXkNxpI+a3b3kUdqJacbmHoOKl0frGYtrJzB4GsebBsdd7N2WSztrzPh5cP3oHaYJeQSHgj9P9xw==
   dependencies:
-    d3-array "^3.2.2"
-    vega-dataflow "^5.7.7"
-    vega-statistics "^1.9.0"
-    vega-util "^1.17.3"
+    d3-array "^3.2.4"
+    vega-dataflow "^6.0.0"
+    vega-statistics "^2.0.0"
+    vega-util "^2.0.0"
 
 vega-runtime@^6.1.4, vega-runtime@~6.1.4:
   version "6.1.4"
@@ -12456,13 +12512,13 @@ vega-runtime@^6.1.4, vega-runtime@~6.1.4:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-runtime@^6.2.1, vega-runtime@~6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-6.2.1.tgz#4749ea1530d822a789ae8e431bad0965ff2925ee"
-  integrity sha512-b4eot3tWKCk++INWqot+6sLn3wDTj/HE+tRSbiaf8aecuniPMlwJEK7wWuhVGeW2Ae5n8fI/8TeTViaC94bNHA==
+vega-runtime@^7.0.0, vega-runtime@~7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-7.0.0.tgz#2bc843e11df2b479d44a03cabb420cba18ccabc1"
+  integrity sha512-bFMqxaYwOYVoXIjI3GCZstgjoXI3lvjtRSKMN3n8ASVGbakiGjtUPRcpueYQqrpGFXR8UoQcGeXtIyyHRC68mw==
   dependencies:
-    vega-dataflow "^5.7.7"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-scale@^7.3.0, vega-scale@^7.3.1:
   version "7.3.1"
@@ -12475,17 +12531,17 @@ vega-scale@^7.3.0, vega-scale@^7.3.1:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-scale@^7.4.2, vega-scale@~7.4.2:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.4.2.tgz#4e4d24aa478ba475b410b0ac9acda88e52acd5fd"
-  integrity sha512-o6Hl76aU1jlCK7Q8DPYZ8OGsp4PtzLdzI6nGpLt8rxoE78QuB3GBGEwGAQJitp4IF7Lb2rL5oAXEl3ZP6xf9jg==
+vega-scale@^8.0.0, vega-scale@~8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-8.0.0.tgz#071514427fea69662c380608b64bb9e16711b40c"
+  integrity sha512-9jEVbxi7NXVYYF2l+2PB2UcvAX/RxBMzOam7afP+68w2DeGJz43AF/8NGc9tjZZAE5SYTERotxKki31PkAPOFg==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-interpolate "^3.0.1"
     d3-scale "^4.0.2"
     d3-scale-chromatic "^3.1.0"
-    vega-time "^2.1.3"
-    vega-util "^1.17.3"
+    vega-time "^3.0.0"
+    vega-util "^2.0.0"
 
 vega-scale@~7.4.0:
   version "7.4.0"
@@ -12511,17 +12567,17 @@ vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
-vega-scenegraph@^4.13.1, vega-scenegraph@~4.13.1:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.13.1.tgz#5a7ab99cc8c4ae48a2322823faab4edef2080df9"
-  integrity sha512-LFY9+sLIxRfdDI9ZTKjLoijMkIAzPLBWHpPkwv4NPYgdyx+0qFmv+puBpAUGUY9VZqAZ736Uj5NJY9zw+/M3yQ==
+vega-scenegraph@^5.0.0, vega-scenegraph@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-5.0.0.tgz#a2954a4099369b0f5321f313840788f90830c5d8"
+  integrity sha512-BkE4n+mgMpEcHF2EKo+27Sjso0x/zPqgZjoP5dngjSkeyJqKfyxi93lDEJNylWBJqcyjNEmOrAkQQi3B4RNtKA==
   dependencies:
     d3-path "^3.1.0"
     d3-shape "^3.2.0"
-    vega-canvas "^1.2.7"
-    vega-loader "^4.5.3"
-    vega-scale "^7.4.2"
-    vega-util "^1.17.3"
+    vega-canvas "^2.0.0"
+    vega-loader "^5.0.0"
+    vega-scale "^8.0.0"
+    vega-util "^2.0.0"
 
 vega-scenegraph@~4.12.0:
   version "4.12.0"
@@ -12549,14 +12605,14 @@ vega-selections@^5.4.2:
     vega-expression "^5.0.1"
     vega-util "^1.17.1"
 
-vega-selections@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.6.0.tgz#9ffa55039f2e7ad71d4926147b8d458375ce611f"
-  integrity sha512-UE2w78rUUbaV3Ph+vQbQDwh8eywIJYRxBiZdxEG/Tr/KtFMLdy2BDgNZuuDO1Nv8jImPJwONmqjNhNDYwM0VJQ==
+vega-selections@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-6.0.0.tgz#e09fbd045c8eca3d13ebf2be2001a23e1b12d9ea"
+  integrity sha512-ig2NHIV+ZWeQJAD3T+cIJ13qM583an7NvHaDkmuOPPIRvtnrO9CbXCqQ84yHhLrJSzxLwO2h8ExSGkoOmzPUaw==
   dependencies:
     d3-array "3.2.4"
-    vega-expression "^5.2.0"
-    vega-util "^1.17.3"
+    vega-expression "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-statistics@^1.8.1, vega-statistics@^1.9.0, vega-statistics@~1.9.0:
   version "1.9.0"
@@ -12564,6 +12620,13 @@ vega-statistics@^1.8.1, vega-statistics@^1.9.0, vega-statistics@~1.9.0:
   integrity sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==
   dependencies:
     d3-array "^3.2.2"
+
+vega-statistics@^2.0.0, vega-statistics@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-2.0.0.tgz#9c9636c20682ae98e8887f8fab0e82c2466a736a"
+  integrity sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==
+  dependencies:
+    d3-array "^3.2.4"
 
 vega-themes@^2.15.0:
   version "2.15.0"
@@ -12579,14 +12642,14 @@ vega-time@^2.1.1, vega-time@~2.1.1:
     d3-time "^3.1.0"
     vega-util "^1.17.1"
 
-vega-time@^2.1.3, vega-time@~2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-2.1.3.tgz#507e3b0af61ebcd6a9c56de89fe1213924c2c1f2"
-  integrity sha512-hFcWPdTV844IiY0m97+WUoMLADCp+8yUQR1NStWhzBzwDDA7QEGGwYGxALhdMOaDTwkyoNj3V/nox2rQAJD/vQ==
+vega-time@^3.0.0, vega-time@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-3.0.0.tgz#8ff42168133a76e1d129533a0b0e0b55f6675336"
+  integrity sha512-Ifs95YXaQ6/3NCJ7l9jdda74uovwLodUHFYQqqXPanjUtF9e5juw4/VurbgIPYnB76w4ye6/q19OdlUeUdVQuw==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-time "^3.1.0"
-    vega-util "^1.17.3"
+    vega-util "^2.0.0"
 
 "vega-tooltip@>= 0.35.2":
   version "0.35.2"
@@ -12617,16 +12680,16 @@ vega-transforms@~4.11.1:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
-vega-transforms@~4.12.1:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.12.1.tgz#81a5c5505a2844542f99ab966b094c7b29d7d9f8"
-  integrity sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==
+vega-transforms@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-5.0.0.tgz#80b3d2d4efe84c4f55f02213a1d4b8f01f9e61f4"
+  integrity sha512-a4fo0tlfZFE1C/aV+IpEEl/SAyz9JnVqYCxcEeuQm6byglCz+PnjZmnqFyKFBnmVHDjQ/GP82DkqGBx52Cr0Kg==
   dependencies:
-    d3-array "^3.2.2"
-    vega-dataflow "^5.7.7"
-    vega-statistics "^1.9.0"
-    vega-time "^2.1.3"
-    vega-util "^1.17.3"
+    d3-array "^3.2.4"
+    vega-dataflow "^6.0.0"
+    vega-statistics "^2.0.0"
+    vega-time "^3.0.0"
+    vega-util "^2.0.0"
 
 vega-typings@~1.1.0:
   version "1.1.0"
@@ -12638,25 +12701,25 @@ vega-typings@~1.1.0:
     vega-expression "^5.1.0"
     vega-util "^1.17.2"
 
-vega-typings@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.5.0.tgz#f3304157b86b8bf45c983959d1530f8098cd5493"
-  integrity sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==
+vega-typings@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-2.0.1.tgz#1feff54731c3bb289ebde8ad658ffdf91df90c30"
+  integrity sha512-Jfw2zeAv4rQ8YqfgBae3QauK0T9FUpQ+0q3NNLW24Z6nyjf8H2ucnyLhw6pIqfVytne6VB4WkvazTOgJPuv5vw==
   dependencies:
-    "@types/geojson" "7946.0.4"
-    vega-event-selector "^3.0.1"
-    vega-expression "^5.2.0"
-    vega-util "^1.17.3"
+    "@types/geojson" "7946.0.16"
+    vega-event-selector "^4.0.0"
+    vega-expression "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-util@^1.15.2, vega-util@^1.17.1, vega-util@^1.17.2, vega-util@~1.17.2:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.2.tgz#f69aa09fd5d6110c19c4a0f0af9e35945b99987d"
   integrity sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==
 
-vega-util@^1.17.3:
-  version "1.17.3"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.3.tgz#8f24d867daae69580874dcf75de10c65ac9ede5d"
-  integrity sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==
+vega-util@^2.0.0, vega-util@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-2.0.0.tgz#6ecb6e3e2fe017921e36d0aa9abf15dc4e4f0a99"
+  integrity sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==
 
 vega-view-transforms@~4.5.9:
   version "4.5.9"
@@ -12667,14 +12730,14 @@ vega-view-transforms@~4.5.9:
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
 
-vega-view-transforms@~4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-4.6.1.tgz#423a1e2dae14c1506876272281e4835778fa6914"
-  integrity sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==
+vega-view-transforms@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-5.0.0.tgz#6790655f188caa0b2298352c05ee369d2b5f1a01"
+  integrity sha512-AqQStHIYZtjsm84rx43z6P18DdR4/l20q/mfWXJ2Ifts1T2gPshC24/0xUfGrnwpqM5m3X1HwkJUiyEJxzVQrQ==
   dependencies:
-    vega-dataflow "^5.7.7"
-    vega-scenegraph "^4.13.1"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-scenegraph "^5.0.0"
+    vega-util "^2.0.0"
 
 vega-view@~5.12.1:
   version "5.12.1"
@@ -12690,19 +12753,19 @@ vega-view@~5.12.1:
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
 
-vega-view@~5.15.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.15.0.tgz#f21023438ffc4574a22e3a84f7e73f9a50ede531"
-  integrity sha512-bm8STHPsI8BjVu2gYlWU8KEVOA2JyTzdtb9cJj8NW6HpN72UxTYsg5y22u9vfcLYjzjmolrlr0756VXR0uI1Cg==
+vega-view@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-6.0.0.tgz#626f91c84516de13fcffaad43c6279f9da2b704d"
+  integrity sha512-Q4bS6eEt+d8N1ZKGg/jueEFboR1CGO8olye7vz3gS/iyg4fPDwMx0sh4pDiX077OPD3UW/0NbplIiHwzQyabEg==
   dependencies:
-    d3-array "^3.2.2"
+    d3-array "^3.2.4"
     d3-timer "^3.0.1"
-    vega-dataflow "^5.7.7"
-    vega-format "^1.1.3"
-    vega-functions "^5.17.0"
-    vega-runtime "^6.2.1"
-    vega-scenegraph "^4.13.1"
-    vega-util "^1.17.3"
+    vega-dataflow "^6.0.0"
+    vega-format "^2.0.0"
+    vega-functions "^6.0.0"
+    vega-runtime "^7.0.0"
+    vega-scenegraph "^5.0.0"
+    vega-util "^2.0.0"
 
 vega-voronoi@~4.2.2:
   version "4.2.2"
@@ -12713,14 +12776,14 @@ vega-voronoi@~4.2.2:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
-vega-voronoi@~4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.2.4.tgz#f45addec69e7b40598106f221014300a58d061ef"
-  integrity sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==
+vega-voronoi@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-5.0.0.tgz#df12649b92b803f87434fc7908664f02901b5505"
+  integrity sha512-mmsQFo7Aj8WM/QS8Ta79QWxADU3WpvEQ0OIR20WFgY/QLJ+42FEcJkBlaSQQ+DFl2Ci5PdbpZtRFMPJoRokFMw==
   dependencies:
-    d3-delaunay "^6.0.2"
-    vega-dataflow "^5.7.7"
-    vega-util "^1.17.3"
+    d3-delaunay "^6.0.4"
+    vega-dataflow "^6.0.0"
+    vega-util "^2.0.0"
 
 vega-wordcloud@~4.1.4:
   version "4.1.4"
@@ -12733,16 +12796,49 @@ vega-wordcloud@~4.1.4:
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
 
-vega-wordcloud@~4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-4.1.6.tgz#a428e8e7b2f83eca454631057d6864c226b41a14"
-  integrity sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==
+vega-wordcloud@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-5.0.0.tgz#c4224ecf42823f7cc3cb53ec24ab8998e05d08db"
+  integrity sha512-Rm46D1ginGdunWLtsiymllU5RvJTEtpKRaWcc/pABpFiz7QHGGrZ9FhOczxW1o3n89h07gzc9n8xlWYco06Fdw==
   dependencies:
-    vega-canvas "^1.2.7"
-    vega-dataflow "^5.7.7"
-    vega-scale "^7.4.2"
-    vega-statistics "^1.9.0"
-    vega-util "^1.17.3"
+    vega-canvas "^2.0.0"
+    vega-dataflow "^6.0.0"
+    vega-scale "^8.0.0"
+    vega-statistics "^2.0.0"
+    vega-util "^2.0.0"
+
+"vega@>= 5.20.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-6.1.2.tgz#24158ff977ba164f3fa0f5485e53871dff276c77"
+  integrity sha512-d5GT7wRoRnK+bsQWgauOHyPFY4td52PTuX5IzMXr9PXHkz2OKXpVti7LeK5evAoyhNxVenkT1ptpRQKU2MRJdw==
+  dependencies:
+    vega-crossfilter "~5.0.0"
+    vega-dataflow "~6.0.0"
+    vega-encode "~5.0.0"
+    vega-event-selector "~4.0.0"
+    vega-expression "~6.0.0"
+    vega-force "~5.0.0"
+    vega-format "~2.0.0"
+    vega-functions "~6.0.0"
+    vega-geo "~5.0.0"
+    vega-hierarchy "~5.0.0"
+    vega-label "~2.0.0"
+    vega-loader "~5.0.0"
+    vega-parser "~7.0.0"
+    vega-projection "~2.0.0"
+    vega-regression "~2.0.0"
+    vega-runtime "~7.0.0"
+    vega-scale "~8.0.0"
+    vega-scenegraph "~5.0.0"
+    vega-statistics "~2.0.0"
+    vega-time "~3.0.0"
+    vega-transforms "~5.0.0"
+    vega-typings "~2.0.0"
+    vega-util "~2.0.0"
+    vega-view "~6.0.0"
+    vega-view-transforms "~5.0.0"
+    vega-voronoi "~5.0.0"
+    vega-wordcloud "~5.0.0"
 
 vega@^5.29.0:
   version "5.29.0"
@@ -12776,39 +12872,6 @@ vega@^5.29.0:
     vega-view-transforms "~4.5.9"
     vega-voronoi "~4.2.2"
     vega-wordcloud "~4.1.4"
-
-vega@^5.32.0:
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.32.0.tgz#a826eb0a8d429e5b715d3e69c565a73d747a02ed"
-  integrity sha512-jANt/5+SpV7b7owB5u8+M1TZ/TrF1fK6WlcvKDW38tH3Gb6hM1nzIhv10E41w3GBmwF29BU/qH2ruNkaYKjI5g==
-  dependencies:
-    vega-crossfilter "~4.1.3"
-    vega-dataflow "~5.7.7"
-    vega-encode "~4.10.2"
-    vega-event-selector "~3.0.1"
-    vega-expression "~5.2.0"
-    vega-force "~4.2.2"
-    vega-format "~1.1.3"
-    vega-functions "~5.17.0"
-    vega-geo "~4.4.3"
-    vega-hierarchy "~4.1.3"
-    vega-label "~1.3.1"
-    vega-loader "~4.5.3"
-    vega-parser "~6.5.0"
-    vega-projection "~1.6.2"
-    vega-regression "~1.3.1"
-    vega-runtime "~6.2.1"
-    vega-scale "~7.4.2"
-    vega-scenegraph "~4.13.1"
-    vega-statistics "~1.9.0"
-    vega-time "~2.1.3"
-    vega-transforms "~4.12.1"
-    vega-typings "~1.5.0"
-    vega-util "~1.17.2"
-    vega-view "~5.15.0"
-    vega-view-transforms "~4.6.1"
-    vega-voronoi "~4.2.4"
-    vega-wordcloud "~4.1.6"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"
@@ -12845,6 +12908,11 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12176,6 +12176,15 @@ vega-crossfilter@~4.1.1:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
+vega-crossfilter@~4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.1.3.tgz#2c404ddcd420605c84fb088f3e9beb671dca498e"
+  integrity sha512-nyPJAXAUABc3EocUXvAL1J/IWotZVsApIcvOeZaUdEQEtZ7bt8VtP2nj3CLbHBA8FZZVV+K6SmdwvCOaAD4wFQ==
+  dependencies:
+    d3-array "^3.2.2"
+    vega-dataflow "^5.7.7"
+    vega-util "^1.17.3"
+
 vega-crossfilter@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-5.0.0.tgz#f01d51298e53132610b4b693b89bc5280c7d1f89"
@@ -12193,6 +12202,15 @@ vega-dataflow@^5.7.3, vega-dataflow@^5.7.5, vega-dataflow@~5.7.5:
     vega-format "^1.1.1"
     vega-loader "^4.5.1"
     vega-util "^1.17.1"
+
+vega-dataflow@^5.7.7, vega-dataflow@~5.7.7:
+  version "5.7.7"
+  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-5.7.7.tgz#d766f650aaaf27836894bdb6ee391fd43d7a22ef"
+  integrity sha512-R2NX2HvgXL+u4E6u+L5lKvvRiCtnE6N6l+umgojfi53suhhkFP+zB+2UAQo4syxuZ4763H1csfkKc4xpqLzKnw==
+  dependencies:
+    vega-format "^1.1.3"
+    vega-loader "^4.5.3"
+    vega-util "^1.17.3"
 
 vega-dataflow@^6.0.0, vega-dataflow@~6.0.0:
   version "6.0.0"
@@ -12228,6 +12246,17 @@ vega-encode@~4.10.0:
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
 
+vega-encode@~4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-4.10.2.tgz#dcef19d040905f5ef43e8a730f6ec501fe4b2a73"
+  integrity sha512-fsjEY1VaBAmqwt7Jlpz0dpPtfQFiBdP9igEefvumSpy7XUxOJmDQcRDnT3Qh9ctkv3itfPfI9g8FSnGcv2b4jQ==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-interpolate "^3.0.1"
+    vega-dataflow "^5.7.7"
+    vega-scale "^7.4.2"
+    vega-util "^1.17.3"
+
 vega-encode@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-5.0.0.tgz#fd16781df8ebf7dbfc30c5eae7caa766c625dbf9"
@@ -12257,6 +12286,14 @@ vega-expression@^5.0.1, vega-expression@^5.1.0, vega-expression@~5.1.0, vega-exp
     "@types/estree" "^1.0.0"
     vega-util "^1.17.2"
 
+vega-expression@^5.2.0, vega-expression@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.2.0.tgz#a5dfa8dd79066082add1846618f3d7f0a364305f"
+  integrity sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    vega-util "^1.17.3"
+
 vega-expression@^6.0.0, vega-expression@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-6.0.0.tgz#4677c0f44678850c55aa704e63b31029af5654ac"
@@ -12273,6 +12310,15 @@ vega-force@~4.2.0:
     d3-force "^3.0.0"
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
+
+vega-force@~4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.2.2.tgz#e70ac31cf73d3ffaed361202613809e8c516d6f0"
+  integrity sha512-cHZVaY2VNNIG2RyihhSiWniPd2W9R9kJq0znxzV602CgUVgxEfTKtx/lxnVCn8nNrdKAYrGiqIsBzIeKG1GWHw==
+  dependencies:
+    d3-force "^3.0.0"
+    vega-dataflow "^5.7.7"
+    vega-util "^1.17.3"
 
 vega-force@~5.0.0:
   version "5.0.0"
@@ -12293,6 +12339,17 @@ vega-format@^1.1.1, vega-format@~1.1.1:
     d3-time-format "^4.1.0"
     vega-time "^2.1.1"
     vega-util "^1.17.1"
+
+vega-format@^1.1.3, vega-format@~1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/vega-format/-/vega-format-1.1.3.tgz#66e0fd8eb0ba8d9e638b3c62a023cdab9af57bc5"
+  integrity sha512-wQhw7KR46wKJAip28FF/CicW+oiJaPAwMKdrxlnTA0Nv8Bf7bloRlc+O3kON4b4H1iALLr9KgRcYTOeXNs2MOA==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-format "^3.1.0"
+    d3-time-format "^4.1.0"
+    vega-time "^2.1.3"
+    vega-util "^1.17.3"
 
 vega-format@^2.0.0, vega-format@~2.0.0:
   version "2.0.0"
@@ -12321,6 +12378,23 @@ vega-functions@^5.13.1, vega-functions@^5.14.0, vega-functions@~5.14.0:
     vega-statistics "^1.8.1"
     vega-time "^2.1.1"
     vega-util "^1.17.1"
+
+vega-functions@^5.18.0, vega-functions@~5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.18.0.tgz#297fbb982492622bf57ca8148447ad88cdee859c"
+  integrity sha512-+D+ey4bDAhZA2CChh7bRZrcqRUDevv05kd2z8xH+il7PbYQLrhi6g1zwvf8z3KpgGInFf5O13WuFK5DQGkz5lQ==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-color "^3.1.0"
+    d3-geo "^3.1.0"
+    vega-dataflow "^5.7.7"
+    vega-expression "^5.2.0"
+    vega-scale "^7.4.2"
+    vega-scenegraph "^4.13.1"
+    vega-selections "^5.6.0"
+    vega-statistics "^1.9.0"
+    vega-time "^2.1.3"
+    vega-util "^1.17.3"
 
 vega-functions@^6.0.0, vega-functions@~6.0.0:
   version "6.0.0"
@@ -12353,6 +12427,20 @@ vega-geo@~4.4.1:
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
 
+vega-geo@~4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-4.4.3.tgz#038dc85e1c030b2f2c8bda61fb31ff6bdfea123b"
+  integrity sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-color "^3.1.0"
+    d3-geo "^3.1.0"
+    vega-canvas "^1.2.7"
+    vega-dataflow "^5.7.7"
+    vega-projection "^1.6.2"
+    vega-statistics "^1.9.0"
+    vega-util "^1.17.3"
+
 vega-geo@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-5.0.0.tgz#0e3fda29a50cd6c4a5b081a5cab7eac7056e3c7b"
@@ -12375,6 +12463,15 @@ vega-hierarchy@~4.1.1:
     d3-hierarchy "^3.1.2"
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
+
+vega-hierarchy@~4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-4.1.3.tgz#7721aec582cdf332da6a4ee8332a94e3ac064881"
+  integrity sha512-0Z+TYKRgOEo8XYXnJc2HWg1EGpcbNAhJ9Wpi9ubIbEyEHqIgjCIyFVN8d4nSfsJOcWDzsSmRqohBztxAhOCSaw==
+  dependencies:
+    d3-hierarchy "^3.1.2"
+    vega-dataflow "^5.7.7"
+    vega-util "^1.17.3"
 
 vega-hierarchy@~5.0.0:
   version "5.0.0"
@@ -12399,6 +12496,16 @@ vega-label@~1.2.1:
     vega-dataflow "^5.7.3"
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
+
+vega-label@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/vega-label/-/vega-label-1.3.1.tgz#2e370dac88e91615317ba5120cbfc6c43c6227dd"
+  integrity sha512-Emx4b5s7pvuRj3fBkAJ/E2snCoZACfKAwxVId7f/4kYVlAYLb5Swq6W8KZHrH4M9Qds1XJRUYW9/Y3cceqzEFA==
+  dependencies:
+    vega-canvas "^1.2.7"
+    vega-dataflow "^5.7.7"
+    vega-scenegraph "^4.13.1"
+    vega-util "^1.17.3"
 
 vega-label@~2.0.0:
   version "2.0.0"
@@ -12433,6 +12540,17 @@ vega-loader@^4.5.1, vega-loader@~4.5.1:
     vega-format "^1.1.1"
     vega-util "^1.17.1"
 
+vega-loader@^4.5.3, vega-loader@~4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-4.5.3.tgz#f89cf4def5b2c61f65f845ec695b6e14d15c36e9"
+  integrity sha512-dUfIpxTLF2magoMaur+jXGvwMxjtdlDZaIS8lFj6N7IhUST6nIvBzuUlRM+zLYepI5GHtCLOnqdKU4XV0NggCA==
+  dependencies:
+    d3-dsv "^3.0.1"
+    node-fetch "^2.6.7"
+    topojson-client "^3.1.0"
+    vega-format "^1.1.3"
+    vega-util "^1.17.3"
+
 vega-loader@^5.0.0, vega-loader@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-5.0.0.tgz#0948c74dcd1b023763fd8e5ffc7fe5de85538b84"
@@ -12455,6 +12573,17 @@ vega-parser@~6.3.0:
     vega-scale "^7.3.1"
     vega-util "^1.17.2"
 
+vega-parser@~6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.6.0.tgz#f6aa6fc07c89f83196a1951ed9cf832436a429ab"
+  integrity sha512-jltyrwCTtWeidi/6VotLCybhIl+ehwnzvFWYOdWNUP0z/EskdB64YmawNwjCjzTBMemeiQtY6sJPPbewYqe3Vg==
+  dependencies:
+    vega-dataflow "^5.7.7"
+    vega-event-selector "^3.0.1"
+    vega-functions "^5.18.0"
+    vega-scale "^7.4.2"
+    vega-util "^1.17.3"
+
 vega-parser@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-7.0.0.tgz#9bb760c0787c3286eebe576fec541770519c7fde"
@@ -12475,6 +12604,15 @@ vega-projection@^1.6.0, vega-projection@~1.6.0:
     d3-geo-projection "^4.0.0"
     vega-scale "^7.3.0"
 
+vega-projection@^1.6.2, vega-projection@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.6.2.tgz#69ea9a2404bad12642d3ec5c4f5615b27cdcb630"
+  integrity sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==
+  dependencies:
+    d3-geo "^3.1.0"
+    d3-geo-projection "^4.0.0"
+    vega-scale "^7.4.2"
+
 vega-projection@^2.0.0, vega-projection@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-2.0.0.tgz#726104d8d921bf810e62c71b9fd2360b14a65317"
@@ -12494,6 +12632,16 @@ vega-regression@~1.2.0:
     vega-statistics "^1.9.0"
     vega-util "^1.15.2"
 
+vega-regression@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.3.1.tgz#e1de74062250da33e823897565155caefb041dbb"
+  integrity sha512-AmccF++Z9uw4HNZC/gmkQGe6JsRxTG/R4QpbcSepyMvQN1Rj5KtVqMcmVFP1r3ivM4dYGFuPlzMWvuqp0iKMkQ==
+  dependencies:
+    d3-array "^3.2.2"
+    vega-dataflow "^5.7.7"
+    vega-statistics "^1.9.0"
+    vega-util "^1.17.3"
+
 vega-regression@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-2.0.0.tgz#3767d6d8be43f9dbba4d6adca2c87b1289551314"
@@ -12511,6 +12659,14 @@ vega-runtime@^6.1.4, vega-runtime@~6.1.4:
   dependencies:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
+
+vega-runtime@^6.2.1, vega-runtime@~6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-6.2.1.tgz#4749ea1530d822a789ae8e431bad0965ff2925ee"
+  integrity sha512-b4eot3tWKCk++INWqot+6sLn3wDTj/HE+tRSbiaf8aecuniPMlwJEK7wWuhVGeW2Ae5n8fI/8TeTViaC94bNHA==
+  dependencies:
+    vega-dataflow "^5.7.7"
+    vega-util "^1.17.3"
 
 vega-runtime@^7.0.0, vega-runtime@~7.0.0:
   version "7.0.0"
@@ -12530,6 +12686,18 @@ vega-scale@^7.3.0, vega-scale@^7.3.1:
     d3-scale "^4.0.2"
     vega-time "^2.1.1"
     vega-util "^1.17.1"
+
+vega-scale@^7.4.2, vega-scale@~7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.4.2.tgz#4e4d24aa478ba475b410b0ac9acda88e52acd5fd"
+  integrity sha512-o6Hl76aU1jlCK7Q8DPYZ8OGsp4PtzLdzI6nGpLt8rxoE78QuB3GBGEwGAQJitp4IF7Lb2rL5oAXEl3ZP6xf9jg==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-scale-chromatic "^3.1.0"
+    vega-time "^2.1.3"
+    vega-util "^1.17.3"
 
 vega-scale@^8.0.0, vega-scale@~8.0.0:
   version "8.0.0"
@@ -12566,6 +12734,18 @@ vega-scenegraph@^4.10.2, vega-scenegraph@^4.9.2:
     vega-loader "^4.5.1"
     vega-scale "^7.3.0"
     vega-util "^1.17.1"
+
+vega-scenegraph@^4.13.1, vega-scenegraph@~4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.13.1.tgz#5a7ab99cc8c4ae48a2322823faab4edef2080df9"
+  integrity sha512-LFY9+sLIxRfdDI9ZTKjLoijMkIAzPLBWHpPkwv4NPYgdyx+0qFmv+puBpAUGUY9VZqAZ736Uj5NJY9zw+/M3yQ==
+  dependencies:
+    d3-path "^3.1.0"
+    d3-shape "^3.2.0"
+    vega-canvas "^1.2.7"
+    vega-loader "^4.5.3"
+    vega-scale "^7.4.2"
+    vega-util "^1.17.3"
 
 vega-scenegraph@^5.0.0, vega-scenegraph@~5.0.0:
   version "5.0.0"
@@ -12605,6 +12785,15 @@ vega-selections@^5.4.2:
     vega-expression "^5.0.1"
     vega-util "^1.17.1"
 
+vega-selections@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.6.0.tgz#9ffa55039f2e7ad71d4926147b8d458375ce611f"
+  integrity sha512-UE2w78rUUbaV3Ph+vQbQDwh8eywIJYRxBiZdxEG/Tr/KtFMLdy2BDgNZuuDO1Nv8jImPJwONmqjNhNDYwM0VJQ==
+  dependencies:
+    d3-array "3.2.4"
+    vega-expression "^5.2.0"
+    vega-util "^1.17.3"
+
 vega-selections@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-6.0.0.tgz#e09fbd045c8eca3d13ebf2be2001a23e1b12d9ea"
@@ -12641,6 +12830,15 @@ vega-time@^2.1.1, vega-time@~2.1.1:
     d3-array "^3.2.2"
     d3-time "^3.1.0"
     vega-util "^1.17.1"
+
+vega-time@^2.1.3, vega-time@~2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-2.1.3.tgz#507e3b0af61ebcd6a9c56de89fe1213924c2c1f2"
+  integrity sha512-hFcWPdTV844IiY0m97+WUoMLADCp+8yUQR1NStWhzBzwDDA7QEGGwYGxALhdMOaDTwkyoNj3V/nox2rQAJD/vQ==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-time "^3.1.0"
+    vega-util "^1.17.3"
 
 vega-time@^3.0.0, vega-time@~3.0.0:
   version "3.0.0"
@@ -12680,6 +12878,17 @@ vega-transforms@~4.11.1:
     vega-time "^2.1.1"
     vega-util "^1.17.1"
 
+vega-transforms@~4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.12.1.tgz#81a5c5505a2844542f99ab966b094c7b29d7d9f8"
+  integrity sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==
+  dependencies:
+    d3-array "^3.2.2"
+    vega-dataflow "^5.7.7"
+    vega-statistics "^1.9.0"
+    vega-time "^2.1.3"
+    vega-util "^1.17.3"
+
 vega-transforms@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-5.0.0.tgz#80b3d2d4efe84c4f55f02213a1d4b8f01f9e61f4"
@@ -12701,6 +12910,16 @@ vega-typings@~1.1.0:
     vega-expression "^5.1.0"
     vega-util "^1.17.2"
 
+vega-typings@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.5.0.tgz#f3304157b86b8bf45c983959d1530f8098cd5493"
+  integrity sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==
+  dependencies:
+    "@types/geojson" "7946.0.4"
+    vega-event-selector "^3.0.1"
+    vega-expression "^5.2.0"
+    vega-util "^1.17.3"
+
 vega-typings@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-2.0.1.tgz#1feff54731c3bb289ebde8ad658ffdf91df90c30"
@@ -12716,6 +12935,11 @@ vega-util@^1.15.2, vega-util@^1.17.1, vega-util@^1.17.2, vega-util@~1.17.2:
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.2.tgz#f69aa09fd5d6110c19c4a0f0af9e35945b99987d"
   integrity sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==
 
+vega-util@^1.17.3:
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.17.3.tgz#8f24d867daae69580874dcf75de10c65ac9ede5d"
+  integrity sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==
+
 vega-util@^2.0.0, vega-util@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-2.0.0.tgz#6ecb6e3e2fe017921e36d0aa9abf15dc4e4f0a99"
@@ -12729,6 +12953,15 @@ vega-view-transforms@~4.5.9:
     vega-dataflow "^5.7.5"
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
+
+vega-view-transforms@~4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-4.6.1.tgz#423a1e2dae14c1506876272281e4835778fa6914"
+  integrity sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==
+  dependencies:
+    vega-dataflow "^5.7.7"
+    vega-scenegraph "^4.13.1"
+    vega-util "^1.17.3"
 
 vega-view-transforms@~5.0.0:
   version "5.0.0"
@@ -12753,6 +12986,20 @@ vega-view@~5.12.1:
     vega-scenegraph "^4.10.2"
     vega-util "^1.17.1"
 
+vega-view@~5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.16.0.tgz#e3882f9dcb9368322a255224e5e54db864b3c226"
+  integrity sha512-Nxp1MEAY+8bphIm+7BeGFzWPoJnX9+hgvze6wqCAPoM69YiyVR0o0VK8M2EESIL+22+Owr0Fdy94hWHnmon5tQ==
+  dependencies:
+    d3-array "^3.2.2"
+    d3-timer "^3.0.1"
+    vega-dataflow "^5.7.7"
+    vega-format "^1.1.3"
+    vega-functions "^5.18.0"
+    vega-runtime "^6.2.1"
+    vega-scenegraph "^4.13.1"
+    vega-util "^1.17.3"
+
 vega-view@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-6.0.0.tgz#626f91c84516de13fcffaad43c6279f9da2b704d"
@@ -12776,6 +13023,15 @@ vega-voronoi@~4.2.2:
     vega-dataflow "^5.7.5"
     vega-util "^1.17.1"
 
+vega-voronoi@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.2.4.tgz#f45addec69e7b40598106f221014300a58d061ef"
+  integrity sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==
+  dependencies:
+    d3-delaunay "^6.0.2"
+    vega-dataflow "^5.7.7"
+    vega-util "^1.17.3"
+
 vega-voronoi@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-5.0.0.tgz#df12649b92b803f87434fc7908664f02901b5505"
@@ -12795,6 +13051,17 @@ vega-wordcloud@~4.1.4:
     vega-scale "^7.3.0"
     vega-statistics "^1.8.1"
     vega-util "^1.17.1"
+
+vega-wordcloud@~4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-4.1.6.tgz#a428e8e7b2f83eca454631057d6864c226b41a14"
+  integrity sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==
+  dependencies:
+    vega-canvas "^1.2.7"
+    vega-dataflow "^5.7.7"
+    vega-scale "^7.4.2"
+    vega-statistics "^1.9.0"
+    vega-util "^1.17.3"
 
 vega-wordcloud@~5.0.0:
   version "5.0.0"
@@ -12872,6 +13139,39 @@ vega@^5.29.0:
     vega-view-transforms "~4.5.9"
     vega-voronoi "~4.2.2"
     vega-wordcloud "~4.1.4"
+
+vega@^5.32.0:
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-5.33.0.tgz#15e5eb9a4a42aaac0564257795daea3acc0d1b21"
+  integrity sha512-jNAGa7TxLojOpMMMrKMXXBos4K6AaLJbCgGDOw1YEkLRjUkh12pcf65J2lMSdEHjcEK47XXjKiOUVZ8L+MniBA==
+  dependencies:
+    vega-crossfilter "~4.1.3"
+    vega-dataflow "~5.7.7"
+    vega-encode "~4.10.2"
+    vega-event-selector "~3.0.1"
+    vega-expression "~5.2.0"
+    vega-force "~4.2.2"
+    vega-format "~1.1.3"
+    vega-functions "~5.18.0"
+    vega-geo "~4.4.3"
+    vega-hierarchy "~4.1.3"
+    vega-label "~1.3.1"
+    vega-loader "~4.5.3"
+    vega-parser "~6.6.0"
+    vega-projection "~1.6.2"
+    vega-regression "~1.3.1"
+    vega-runtime "~6.2.1"
+    vega-scale "~7.4.2"
+    vega-scenegraph "~4.13.1"
+    vega-statistics "~1.9.0"
+    vega-time "~2.1.3"
+    vega-transforms "~4.12.1"
+    vega-typings "~1.5.0"
+    vega-util "~1.17.2"
+    vega-view "~5.16.0"
+    vega-view-transforms "~4.6.1"
+    vega-voronoi "~4.2.4"
+    vega-wordcloud "~4.1.6"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Adding vega as a dependency of themes. Build was 4+MB since it was including vega in the final build.