### PR TITLE
feat: axis tickCountLimit

### DIFF
--- a/packages/react-spectrum-charts/src/stories/components/Axis/Axis.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Axis/Axis.story.tsx
@@ -337,6 +337,14 @@ CurrencyFormatSpecifier.args = {
 	title: 'Conversion Rate',
 };
 
+const TickCountLimit = bindWithProps(TimeAxisBarStory);
+TickCountLimit.args = {
+	position: 'right',
+	tickCountLimit: 5,
+	ticks: true,
+	title: 'Y-Axis with Limited Ticks',
+};
+
 const VerticalSecondGranularity = bindWithProps(VerticalTimeAxisStory);
 VerticalSecondGranularity.args = {
 	granularity: 'second',
@@ -366,4 +374,5 @@ export {
 	TruncateLabels,
 	CurrencyLocale,
 	CurrencyFormatSpecifier,
+	TickCountLimit,
 };

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
@@ -44,12 +44,12 @@ import { encodeAxisTitle, getTrellisAxisOptions, isTrellisedChart } from './axis
 import {
 	getBaselineRule,
 	getDefaultAxis,
+	getIsMetricAxis,
 	getOpposingScaleType,
 	getScale,
 	getSubLabelAxis,
 	getTimeAxes,
 	hasSubLabels,
-	isVerticalAxis,
 } from './axisUtils';
 
 export const addAxis = produce<ScSpec, [AxisOptions & { colorScheme?: ColorScheme; index?: number }]>(
@@ -285,19 +285,6 @@ export function applyPrimaryMetricAxisEncodings(axis: Axis, colorScheme: ColorSc
 	} else {
 		axis.encode = deepmerge(axis.encode, encodings);
 	}
-}
-
-/**
- * Determines if an axis is a metric axis based on its position and chart orientation
- * @param position The position of the axis
- * @param chartOrientation The orientation of the chart
- * @returns Whether the axis is a metric axis
- */
-export function getIsMetricAxis(position: Position, chartOrientation: Orientation): boolean {
-	if (chartOrientation === 'vertical') {
-		return isVerticalAxis(position);
-	}
-	return !isVerticalAxis(position);
 }
 
 /**

--- a/packages/vega-spec-builder/src/axis/axisUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.test.ts
@@ -11,7 +11,7 @@
  */
 import { SubLabel } from '../types';
 import { defaultAxisOptions, defaultXBaselineMark, defaultYBaselineMark } from './axisTestUtils';
-import { getBaselineRule, getDefaultAxis, getSubLabelAxis } from './axisUtils';
+import { getBaselineRule, getDefaultAxis, getSubLabelAxis, getTickCount } from './axisUtils';
 
 describe('getBaselineRule', () => {
 	describe('initial state', () => {
@@ -182,5 +182,30 @@ describe('getSubLabelAxis()', () => {
 			'values',
 			undefined
 		);
+	});
+});
+
+describe('getTickCount()', () => {
+	test('when maxTicks is provided, it should use maxTicks as the max value', () => {
+		expect(getTickCount('left', 5)).toEqual({
+			signal: 'clamp(ceil(height/100), 2, 5)'
+		});
+		expect(getTickCount('bottom', 15)).toEqual({
+			signal: 'clamp(ceil(width/100), 2, 15)'
+		});
+	});
+
+	test('when grid is true and maxTicks is not provided, it should use 10 as the max value', () => {
+		expect(getTickCount('left', undefined, true)).toEqual({
+			signal: 'clamp(ceil(height/100), 2, 10)'
+		});
+		expect(getTickCount('bottom', undefined, true)).toEqual({
+			signal: 'clamp(ceil(width/100), 2, 10)'
+		});
+	});
+
+	test('when neither maxTicks nor grid is provided, it should return undefined', () => {
+		expect(getTickCount('left')).toBeUndefined();
+		expect(getTickCount('bottom')).toBeUndefined();
 	});
 });

--- a/packages/vega-spec-builder/src/types/axis/axisSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/axis/axisSpec.types.ts
@@ -80,6 +80,11 @@ export interface AxisOptions {
 	labelOrientation?: Orientation;
 	/** Explicityly sets the axis labels (controlled). Providing a Label object allows for more control over the label display. */
 	labels?: (Label | string | number)[];
+	/** Sets the upper limit on the number of axis ticks.
+	 *  Base tick, typically 0, is not included in the count. e.g. 0, 1, 2, 3 is considered 3 ticks.
+	 *  Note: The final tick count may vary based on Vega's automatic calculations to create visually pleasing values. 
+	 */
+	tickCountLimit?: number;
 	/** d3 number format specifier. Only valid if labelFormat is linear or undefined.
 	 *
 	 * see {@link https://d3js.org/d3-format#locale_format}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Currently, the only ways to control the upper limit of the tick count on an axis are:
1. Set the `tickMinStep` based on data values
2. Add grid lines to the axis, which uses a limit of 10. 

It's common to need a limit when there are no gridlines, with a different upper limit than 10. Particularly with smaller sized charts. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
