### PR TITLE
Support line type on ReferenceLine

### DIFF
--- a/packages/react-spectrum-charts/src/stories/components/Bar/ReferenceLineBar.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Bar/ReferenceLineBar.story.tsx
@@ -113,4 +113,10 @@ HorizontalSupreme.args = {
   position: 'center',
 };
 
-export { Basic, Icon, Label, Supreme, Horizontal, HorizontalIcon, HorizontalLabel, HorizontalSupreme };
+const ReferenceLineDashed = bindWithProps(ReferenceLineStory);
+ReferenceLineDashed.args = {
+  value: 3,
+  lineType: 'dashed',
+};
+
+export { Basic, Icon, Label, Supreme, Horizontal, HorizontalIcon, HorizontalLabel, HorizontalSupreme,  ReferenceLineDashed};

--- a/packages/react-spectrum-charts/src/stories/components/Bar/ReferenceLineBar.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Bar/ReferenceLineBar.test.tsx
@@ -19,6 +19,7 @@ import {
   HorizontalSupreme,
   Icon,
   Label,
+  ReferenceLineDashed,
   Supreme,
 } from './ReferenceLineBar.story';
 
@@ -37,8 +38,36 @@ describe('AxisReferenceLine', () => {
       const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
       expect(axisReferenceLine).toBeInTheDocument();
       expect(axisReferenceLine).toHaveAttribute('transform', 'translate(298,0)');
+      
+      // Check that the line is solid by verifying stroke-dasharray is not set or is 'none'
+      // because the default line type is solid and for this lineType as in specUtils.ts strokeDash is empty array
+      const strokeDasharray = axisReferenceLine.getAttribute('stroke-dasharray');
+      if (strokeDasharray) {
+        expect(strokeDasharray).toBe('none');
+      }
     });
 
+    test('Reference line renders with dashed line type', async () => {
+      render(<ReferenceLineDashed {...ReferenceLineDashed.args}  />);
+
+      const chart = await findChart();
+      expect(chart).toBeInTheDocument();
+
+      const axisReferenceLine = await findMarksByGroupName(chart, 'axis0ReferenceLine0', 'line');
+      expect(axisReferenceLine).toBeInTheDocument();
+      
+      // Check that the line is dotted by verifying stroke-dasharray attribute
+      expect(axisReferenceLine).toHaveAttribute('stroke-dasharray');
+      
+        // For dotted lines, stroke-dasharray should have a value (e.g., "7,4" or similar)
+      const strokeDasharray = axisReferenceLine.getAttribute('stroke-dasharray');
+      expect(strokeDasharray).toBeTruthy();
+      
+      // Check for specific stroke-dasharray pattern [7,4] as it is dashed line type
+      expect(strokeDasharray).toBe('7,4');
+    });
+
+    
     test('Icon renders', async () => {
       render(<Icon {...Icon.args} />);
 

--- a/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.test.ts
@@ -42,6 +42,7 @@ const defaultReferenceLineOptions: ReferenceLineSpecOptions = {
   labelFontWeight: DEFAULT_LABEL_FONT_WEIGHT,
   layer: 'front',
   name: 'axis0ReferenceLine0',
+  lineType: 'solid',
 };
 
 const defaultAxisOptions: AxisSpecOptions = {
@@ -165,7 +166,7 @@ describe('getReferenceLineRuleMark()', () => {
     const rule = getReferenceLineRuleMark(defaultAxisOptions, defaultReferenceLineOptions, defaultXPositionEncoding);
     expect(rule).toStrictEqual({
       encode: {
-        enter: { stroke: { value: spectrumColors.light['gray-900'] } },
+        enter: { stroke: { value: spectrumColors.light['gray-900'] }, strokeDash: { value: [] } },
         update: { x: defaultXPositionEncoding, y: { value: 0 }, y2: { signal: 'height + 0' } },
       },
       interactive: false,

--- a/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.ts
@@ -26,7 +26,7 @@ import {
 import { DEFAULT_FONT_COLOR, DEFAULT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
-import { getPathFromIcon } from '../specUtils';
+import { getPathFromIcon, getStrokeDashFromLineType } from '../specUtils';
 import { AxisSpecOptions, Position, ReferenceLineOptions, ReferenceLineSpecOptions } from '../types';
 import { isVerticalAxis } from './axisUtils';
 
@@ -49,6 +49,7 @@ const applyReferenceLineOptionDefaults = (
   labelFontWeight: options.labelFontWeight ?? DEFAULT_LABEL_FONT_WEIGHT,
   layer: options.layer ?? 'front',
   name: `${axisOptions.name}ReferenceLine${index}`,
+  lineType: options.lineType ?? 'solid',
 });
 
 export const scaleTypeSupportsReferenceLines = (scaleType: ScaleType | undefined): boolean => {
@@ -97,7 +98,7 @@ export const getPositionEncoding = (
 
 export const getReferenceLineRuleMark = (
   { position, ticks }: AxisSpecOptions,
-  { color, colorScheme, name }: ReferenceLineSpecOptions,
+  { color, colorScheme, name, lineType }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): RuleMark => {
   const startOffset = ticks ? 9 : 0;
@@ -132,6 +133,7 @@ export const getReferenceLineRuleMark = (
     encode: {
       enter: {
         stroke: { value: getColorValue(color, colorScheme) },
+        strokeDash: { value: getStrokeDashFromLineType(lineType ?? 'solid') },
       },
       update: {
         ...positionOptions[position],

--- a/packages/vega-spec-builder/src/types/axis/referenceLineSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/axis/referenceLineSpec.types.ts
@@ -12,7 +12,7 @@
 import { FontWeight } from 'vega';
 
 import { ColorScheme } from '../chartSpec.types';
-import { PartiallyRequired } from '../specUtil.types';
+import { LineType, PartiallyRequired } from '../specUtil.types';
 import { SpectrumColor } from '../spectrumVizColor.types';
 
 export type Icon = 'date' | 'sentimentNegative' | 'sentimentNeutral' | 'sentimentPositive';
@@ -36,9 +36,11 @@ export interface ReferenceLineOptions {
   labelColor?: SpectrumColor | string;
   /** Font weight of the label. */
   labelFontWeight?: FontWeight;
+  /** Line type of the reference line. */
+  lineType?: LineType;
 }
 
-type ReferenceLineOptionsWithDefaults = 'color' | 'iconColor' | 'labelColor' | 'layer' | 'labelFontWeight';
+type ReferenceLineOptionsWithDefaults = 'color' | 'iconColor' | 'labelColor' | 'layer' | 'labelFontWeight' | 'lineType';
 
 export interface ReferenceLineSpecOptions
   extends PartiallyRequired<ReferenceLineOptions, ReferenceLineOptionsWithDefaults> {


### PR DESCRIPTION
Support line type on the ReferenceLine component

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for different line types on ReferenceLine components. Users can now specify various line styles (solid, dashed, dotted, etc.) for reference lines to improve visual distinction and customization options.

## Related Issue
AN-389085

## Motivation and Context

Reference lines are commonly used to highlight important thresholds or benchmarks in charts. Currently, all reference lines render as solid lines, which limits visual customization and can make it difficult to distinguish between multiple reference lines or different types of reference lines (e.g., target vs. average). Adding line type support allows users to:

- Use different patterns to distinguish multiple reference lines
- Improve overall chart readability and visual hierarchy


## How Has This Been Tested?

Unit Tests

- Added comprehensive tests in ReferenceLineBar.test.tsx to verify:
- Solid lines render correctly without stroke-dasharray or with 'none'
- Dashed lines render with correct stroke-dasharray pattern ('7,4')
- Reference line positioning remains accurate
- All existing functionality continues to work

Manual Testing

- Created new story ReferenceLineDashed in Storybook to demonstrate dashed line functionality
- Verified line type rendering in different chart contexts
- Tested backward compatibility with existing reference line implementations

## Screenshots (if appropriate):

<img width="690" height="369" alt="Screenshot 2025-07-24 at 3 19 29 PM" src="https://github.com/user-attachments/assets/ae0ad324-beee-47b2-a293-6696d22c79c9" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
