### PR TITLE
Fix storybook size

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,8 +13,8 @@ const decorators: Decorator[] = [
   (Story) => {
     const darkMode = useDarkMode();
     return (
-      <Provider theme={defaultTheme} colorScheme={darkMode ? 'dark' : 'light'} locale="en-US" height="100vh">
-        <View padding={24} height="calc(100% - 48px)">
+      <Provider theme={defaultTheme} colorScheme={darkMode ? 'dark' : 'light'} locale="en-US">
+        <View padding={24} backgroundColor="gray-50">
           <Story />
         </View>
       </Provider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { DocsContainer } from '@storybook/addon-docs';
 import { Decorator, Parameters, Preview } from '@storybook/react';
@@ -12,6 +12,18 @@ import './storybook.css';
 const decorators: Decorator[] = [
   (Story) => {
     const darkMode = useDarkMode();
+
+    useEffect(() => {
+      const htmlElement = document.documentElement;
+      if (darkMode) {
+        htmlElement.classList.add('dark');
+        htmlElement.classList.remove('light');
+      } else {
+        htmlElement.classList.add('light');
+        htmlElement.classList.remove('dark');
+      }
+    }, [darkMode]);
+
     return (
       <Provider theme={defaultTheme} colorScheme={darkMode ? 'dark' : 'light'} locale="en-US">
         <View padding={24} backgroundColor="gray-50">

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -1,3 +1,11 @@
+html {
+  background-color: white;
+}
+
+html.dark {
+  background-color: black;
+}
+
 .sb-show-main.sb-main-padded,
 .docs-story div[class^='css'] {
   padding: 0;

--- a/packages/react-spectrum-charts/src/stories/Chart.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.story.tsx
@@ -19,6 +19,7 @@ import { bindWithProps } from '../test-utils';
 import './Chart.story.css';
 import { ChartBarStory } from './ChartBarStory';
 import { data, workspaceTrendsData } from './data/data';
+import { ChartDynamicHeightBarStory } from './ChartDynamicHeightBarStory';
 
 export default {
   title: 'RSC/Chart',
@@ -72,7 +73,7 @@ Basic.args = { data };
 
 const BackgroundColor = bindWithProps(ChartLineStory);
 BackgroundColor.args = {
-  backgroundColor: 'gray-50',
+  backgroundColor: 'gray-100',
   padding: 32,
   data,
 };
@@ -101,7 +102,7 @@ Width.args = {
   data,
 };
 
-const Height = bindWithProps(ChartBarStory);
+const Height = bindWithProps(ChartDynamicHeightBarStory);
 Height.args = {
   height: '50%',
   minHeight: 300,

--- a/packages/react-spectrum-charts/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.test.tsx
@@ -189,10 +189,10 @@ describe('Chart', () => {
       expect(chart).toBeInTheDocument();
 
       const svg = chart.querySelector('svg');
-      expect(svg).toHaveStyle('background-color: rgb(255, 255, 255);');
+      expect(svg).toHaveStyle('background-color: rgb(248, 248, 248);');
 
       const container = document.querySelector('.rsc-container > div');
-      expect(container).toHaveStyle('background-color: rgb(255, 255, 255);');
+      expect(container).toHaveStyle('background-color: rgb(248, 248, 248);');
     });
   });
 

--- a/packages/react-spectrum-charts/src/stories/ChartDynamicHeightBarStory.tsx
+++ b/packages/react-spectrum-charts/src/stories/ChartDynamicHeightBarStory.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Adobe. All rights reserved.
+ * Copyright 2025 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/react-spectrum-charts/src/stories/ChartDynamicHeightBarStory.tsx
+++ b/packages/react-spectrum-charts/src/stories/ChartDynamicHeightBarStory.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React, { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { View } from '@adobe/react-spectrum';
+
+import { Chart } from '../Chart';
+import { Axis, Bar } from '../components';
+import useChartProps from '../hooks/useChartProps';
+
+export const ChartDynamicHeightBarStory: StoryFn<typeof Chart> = (args): ReactElement => {
+  const props = useChartProps(args);
+  return (
+    <View
+      backgroundColor="gray-50"
+      overflow="auto"
+      minHeight={100}
+      maxHeight={1200}
+      height={600}
+      borderColor="gray-200"
+      borderWidth="thin"
+      UNSAFE_style={{
+        resize: 'vertical',
+      }}
+    >
+      <Chart {...props}>
+        <Axis position="bottom" baseline />
+        <Axis position="left" grid />
+        <Bar dimension="x" metric="y" color="series" />
+      </Chart>
+    </View>
+  );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Storybook stories used to be the height of the window. This made the docs page look odd since all the stories were too tall.

Tried fixing this in the past but had issues were the storybook preview window was white regardless of light or dark mode.

1. Made the height the story be only as tall as it needs to be.
2. Made the storybook preview background match light vs dark mode.

## How Has This Been Tested?

All tests are passing

## Screenshots (if appropriate):

Before:
<img width="1093" height="1260" alt="image" src="https://github.com/user-attachments/assets/1ecc7bd4-77f3-4215-a4fd-a99c9dd15846" />


After:
<img width="855" height="1142" alt="image" src="https://github.com/user-attachments/assets/b0f82e88-57e7-4d17-9abf-c62af8bd6095" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
