### PR TITLE
Feat/axis hover tooltip

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -123,7 +123,7 @@ export const DEFAULT_VENN_LABEL = 'label';
 export const HIGHLIGHT_CONTRAST_RATIO = 5;
 
 // legend tooltips
-export const LEGEND_TOOLTIP_DELAY = 350;
+export const TOOLTIP_DELAY = 350;
 
 // signal names
 // 'backgroundColor' is an undocumented protected signal name used by vega

--- a/packages/react-spectrum-charts/src/hooks/useNewChartView.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useNewChartView.tsx
@@ -14,7 +14,7 @@ import { useCallback, useMemo } from 'react';
 import { Item, View } from 'vega';
 import { Handler, Options as TooltipOptions } from 'vega-tooltip';
 
-import { LEGEND_TOOLTIP_DELAY } from '@spectrum-charts/constants';
+import { TOOLTIP_DELAY } from '@spectrum-charts/constants';
 
 import { Legend } from '../components';
 import { useChartContext } from '../context/RscChartContext';
@@ -69,11 +69,16 @@ const useNewChartView = (
           clearTimeout(tooltipTimeout);
           tooltipTimeout = undefined;
         }
-        if (event && event.type === 'pointermove' && itemIsLegendItem(item) && 'tooltip' in item) {
+        if (
+          event &&
+          event.type === 'pointermove' &&
+          (itemIsLegendItem(item) || itemIsAxisLabel(item)) &&
+          'tooltip' in item
+        ) {
           tooltipTimeout = setTimeout(() => {
             tooltipHandler.call(viewRef, event, item, value);
             tooltipTimeout = undefined;
-          }, LEGEND_TOOLTIP_DELAY);
+          }, TOOLTIP_DELAY);
         } else {
           tooltipHandler.call(viewRef, event, item, value);
         }
@@ -158,3 +163,5 @@ export default useNewChartView;
 const itemIsLegendItem = (item: Item<unknown>): boolean => {
   return 'name' in item.mark && typeof item.mark.name === 'string' && item.mark.name.includes('legend');
 };
+
+const itemIsAxisLabel = (item: Item<unknown>): boolean => 'role' in item.mark && item.mark.role === 'axis-label';

--- a/packages/react-spectrum-charts/src/stories/components/Axis/AxisLabels.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Axis/AxisLabels.story.tsx
@@ -23,6 +23,9 @@ import { bindWithProps } from '../../../test-utils';
 export default {
   title: 'RSC/Axis/Labels',
   component: Axis,
+  argTypes: {
+    hasTooltip: { control: 'boolean' },
+  },
 };
 
 const data = [

--- a/packages/react-spectrum-charts/src/stories/components/Axis/AxisLabels.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Axis/AxisLabels.story.tsx
@@ -75,6 +75,18 @@ LabelOrientation.args = {
   baseline: true,
 };
 
+const LabelWithTooltip = bindWithProps(AxisLabelStory);
+LabelWithTooltip.args = {
+  labelAlign: 'center',
+  labelFontWeight: DEFAULT_LABEL_FONT_WEIGHT,
+  labelFormat: 'linear',
+  labelOrientation: DEFAULT_LABEL_ORIENTATION,
+  position: 'bottom',
+  ticks: true,
+  baseline: true,
+  hasTooltip: true,
+};
+
 const LabelLimitStory: StoryFn<typeof Axis> = (args): ReactElement => {
   const longLabelData = [
     { browser: 'Chrome with Very Long Browser Name That Exceeds Normal Limits', downloads: 100 },
@@ -99,4 +111,4 @@ LabelLimit.args = {
   labelLimit: 60,
 };
 
-export { Basic, LabelAlign, LabelOrientation, LabelLimit };
+export { Basic, LabelAlign, LabelOrientation, LabelLimit, LabelWithTooltip };

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import userEvent from '@testing-library/user-event';
 
-import { HIGHLIGHT_CONTRAST_RATIO, LEGEND_TOOLTIP_DELAY } from '@spectrum-charts/constants';
+import { HIGHLIGHT_CONTRAST_RATIO, TOOLTIP_DELAY } from '@spectrum-charts/constants';
 
 import { Chart } from '../../../Chart';
 import { Legend } from '../../../components';
@@ -44,7 +44,7 @@ import {
  * Wait for the the duration of the legend tooltip hover delay.
  */
 export const waitForLegendTooltip = async () => {
-  await new Promise((resolve) => setTimeout(resolve, LEGEND_TOOLTIP_DELAY));
+  await new Promise((resolve) => setTimeout(resolve, TOOLTIP_DELAY));
 };
 
 /**

--- a/packages/vega-spec-builder/src/axis/axisLabelUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisLabelUtils.ts
@@ -284,7 +284,7 @@ export const getAxisLabelsEncoding = (
   update: {
     text: [
       {
-        test: `indexof(pluck(${signalName}, 'value'), datum.value) !== -1`,
+        test: `indexof(pluck(${signalName}, 'value'), datum.value) !== -1 && ${signalName}[indexof(pluck(${signalName}, 'value'), datum.value)].${labelKey}`,
         signal: `${signalName}[indexof(pluck(${signalName}, 'value'), datum.value)].${labelKey}`,
       },
       { signal: 'datum.value' },

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
@@ -49,6 +49,7 @@ const defaultAxis: Axis = {
   labelPadding: undefined,
   encode: {
     labels: {
+      interactive: true,
       update: {
         text: [
           {
@@ -57,6 +58,7 @@ const defaultAxis: Axis = {
           },
           { signal: 'datum.value' },
         ],
+        tooltip: { signal: 'datum.value' },
       },
     },
   },
@@ -66,6 +68,7 @@ const defaultSubLabelAxis: Axis = {
   ...defaultAxis,
   encode: {
     labels: {
+      interactive: true,
       update: {
         text: [
           {
@@ -214,11 +217,13 @@ describe('Spec builder, Axis', () => {
               labelBaseline: 'middle',
               encode: {
                 labels: {
+                  interactive: true,
                   update: {
                     text: [
                       { test: 'isNumber(datum.value)', signal: "format(datum.value, '~%')" },
                       { signal: 'datum.value' },
                     ],
+                    tooltip: { signal: 'datum.value' },
                   },
                 },
               },

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
@@ -49,7 +49,7 @@ const defaultAxis: Axis = {
   labelPadding: undefined,
   encode: {
     labels: {
-      interactive: true,
+      interactive: false,
       update: {
         text: [
           {
@@ -58,7 +58,6 @@ const defaultAxis: Axis = {
           },
           { signal: 'datum.value' },
         ],
-        tooltip: { signal: 'datum.value' },
       },
     },
   },
@@ -68,12 +67,12 @@ const defaultSubLabelAxis: Axis = {
   ...defaultAxis,
   encode: {
     labels: {
-      interactive: true,
+      interactive: false,
       update: {
         text: [
           {
             signal: "axis0_subLabels[indexof(pluck(axis0_subLabels, 'value'), datum.value)].subLabel",
-            test: "indexof(pluck(axis0_subLabels, 'value'), datum.value) !== -1",
+            test: "indexof(pluck(axis0_subLabels, 'value'), datum.value) !== -1 && axis0_subLabels[indexof(pluck(axis0_subLabels, 'value'), datum.value)].subLabel",
           },
           { signal: 'datum.value' },
         ],
@@ -217,13 +216,12 @@ describe('Spec builder, Axis', () => {
               labelBaseline: 'middle',
               encode: {
                 labels: {
-                  interactive: true,
+                  interactive: false,
                   update: {
                     text: [
                       { test: 'isNumber(datum.value)', signal: "format(datum.value, '~%')" },
                       { signal: 'datum.value' },
                     ],
-                    tooltip: { signal: 'datum.value' },
                   },
                 },
               },

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
@@ -350,6 +350,7 @@ export const addAxes = produce<
     labelOrientation,
     name,
     position,
+    hasTooltip,
   } = axisOptions;
 
   if (labelFormat === 'time') {
@@ -362,10 +363,27 @@ export const addAxes = produce<
       const labels = axisOptions.labels;
       const signalName = `${name}_labels`;
       axis.values = labels.map((label) => getLabelValue(label));
+      const baseEncoding = getAxisLabelsEncoding(
+        labelAlign,
+        labelFontWeight,
+        'label',
+        labelOrientation,
+        position,
+        signalName
+      );
+      const encodingWithOptionalTooltip = hasTooltip
+        ? {
+            ...baseEncoding,
+            update: {
+              ...baseEncoding.update,
+              tooltip: { signal: 'datum.value' },
+            },
+          }
+        : baseEncoding;
       axis.encode = {
         labels: {
-          interactive: true,
-          ...getAxisLabelsEncoding(labelAlign, labelFontWeight, 'label', labelOrientation, position, signalName),
+          interactive: hasTooltip,
+          ...encodingWithOptionalTooltip,
         },
       };
     }

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
@@ -363,7 +363,10 @@ export const addAxes = produce<
       const signalName = `${name}_labels`;
       axis.values = labels.map((label) => getLabelValue(label));
       axis.encode = {
-        labels: getAxisLabelsEncoding(labelAlign, labelFontWeight, 'label', labelOrientation, position, signalName),
+        labels: {
+          interactive: true,
+          ...getAxisLabelsEncoding(labelAlign, labelFontWeight, 'label', labelOrientation, position, signalName),
+        },
       };
     }
 

--- a/packages/vega-spec-builder/src/axis/axisUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.test.ts
@@ -79,6 +79,7 @@ describe('getDefaultAxis()', () => {
       labelPadding: undefined,
       encode: {
         labels: {
+          interactive: true,
           update: {
             text: [
               {
@@ -89,6 +90,9 @@ describe('getDefaultAxis()', () => {
                 signal: 'datum.value',
               },
             ],
+            tooltip: {
+              signal: 'datum.value',
+            },
           },
         },
       },
@@ -141,6 +145,7 @@ describe('getDefaultAxis()', () => {
       labelPadding: undefined,
       encode: {
         labels: {
+          interactive: true,
           update: {
             text: [
               {
@@ -151,6 +156,9 @@ describe('getDefaultAxis()', () => {
                 signal: 'datum.value',
               },
             ],
+            tooltip: {
+              signal: 'datum.value',
+            },
           },
         },
       },
@@ -164,10 +172,7 @@ describe('getDefaultAxis()', () => {
   });
 
   test('should set labelLimit property with custom value', () => {
-    expect(getDefaultAxis({ ...defaultAxisOptions, labelLimit: 5 }, 'xLinear')).toHaveProperty(
-      'labelLimit',
-      5
-    );
+    expect(getDefaultAxis({ ...defaultAxisOptions, labelLimit: 5 }, 'xLinear')).toHaveProperty('labelLimit', 5);
   });
 
   test('should not include labelLimit property when not specified', () => {

--- a/packages/vega-spec-builder/src/axis/axisUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.test.ts
@@ -79,7 +79,7 @@ describe('getDefaultAxis()', () => {
       labelPadding: undefined,
       encode: {
         labels: {
-          interactive: true,
+          interactive: false,
           update: {
             text: [
               {
@@ -90,9 +90,6 @@ describe('getDefaultAxis()', () => {
                 signal: 'datum.value',
               },
             ],
-            tooltip: {
-              signal: 'datum.value',
-            },
           },
         },
       },
@@ -145,7 +142,7 @@ describe('getDefaultAxis()', () => {
       labelPadding: undefined,
       encode: {
         labels: {
-          interactive: true,
+          interactive: false,
           update: {
             text: [
               {
@@ -156,9 +153,6 @@ describe('getDefaultAxis()', () => {
                 signal: 'datum.value',
               },
             ],
-            tooltip: {
-              signal: 'datum.value',
-            },
           },
         },
       },

--- a/packages/vega-spec-builder/src/axis/axisUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.ts
@@ -63,8 +63,10 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
     ...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
     encode: {
       labels: {
+        interactive: true,
         update: {
           text: getLabelFormat(axisOptions, scaleName),
+          tooltip: { signal: 'datum.value' },
         },
       },
     },
@@ -128,8 +130,10 @@ const getSecondaryTimeAxisLabelFormatting = (granularity: Granularity, position:
       format: `${primaryLabelFormat}\u2000${secondaryLabelFormat}`,
       encode: {
         labels: {
+          interactive: true,
           update: {
             text: { signal: 'formatVerticalAxisTimeLabels(datum)' },
+            tooltip: { signal: 'formatVerticalAxisTimeLabels(datum)' },
           },
         },
       },
@@ -179,11 +183,13 @@ const getPrimaryTimeAxis = (
       ...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
       encode: {
         labels: {
+          interactive: true,
           enter: {
             dy: { value: (ticks ? 28 : 20) * (position === 'top' ? -1 : 1) }, // account for tick height
           },
           update: {
             text: { signal: 'formatHorizontalTimeAxisLabels(datum)' },
+            tooltip: { signal: 'formatHorizontalTimeAxisLabels(datum)' },
           },
         },
       },
@@ -215,6 +221,7 @@ export const getSubLabelAxis = (axisOptions: AxisSpecOptions, scaleName: string)
     values: subLabelValues.length ? subLabelValues : undefined,
     encode: {
       labels: {
+        interactive: true,
         ...getAxisLabelsEncoding(labelAlign, labelFontWeight, 'subLabel', labelOrientation, position, signalName),
       },
     },

--- a/packages/vega-spec-builder/src/axis/axisUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.ts
@@ -64,7 +64,7 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
     ...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
     encode: {
       labels: {
-        interactive: hasTooltip,
+        interactive: Boolean(hasTooltip),
         update: {
           text: getLabelFormat(axisOptions, scaleName),
           ...(hasTooltip ? { tooltip: { signal: 'datum.value' } } : {}),

--- a/packages/vega-spec-builder/src/axis/axisUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisUtils.ts
@@ -45,6 +45,7 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
     vegaLabelBaseline,
     vegaLabelOffset,
     vegaLabelPadding,
+    hasTooltip,
   } = axisOptions;
   return {
     scale: scaleName,
@@ -63,10 +64,10 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
     ...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
     encode: {
       labels: {
-        interactive: true,
+        interactive: hasTooltip,
         update: {
           text: getLabelFormat(axisOptions, scaleName),
-          tooltip: { signal: 'datum.value' },
+          ...(hasTooltip ? { tooltip: { signal: 'datum.value' } } : {}),
         },
       },
     },
@@ -130,10 +131,9 @@ const getSecondaryTimeAxisLabelFormatting = (granularity: Granularity, position:
       format: `${primaryLabelFormat}\u2000${secondaryLabelFormat}`,
       encode: {
         labels: {
-          interactive: true,
+          interactive: false,
           update: {
             text: { signal: 'formatVerticalAxisTimeLabels(datum)' },
-            tooltip: { signal: 'formatVerticalAxisTimeLabels(datum)' },
           },
         },
       },
@@ -183,13 +183,12 @@ const getPrimaryTimeAxis = (
       ...getLabelAnchorValues(position, labelOrientation, labelAlign, vegaLabelAlign, vegaLabelBaseline),
       encode: {
         labels: {
-          interactive: true,
+          interactive: false,
           enter: {
             dy: { value: (ticks ? 28 : 20) * (position === 'top' ? -1 : 1) }, // account for tick height
           },
           update: {
             text: { signal: 'formatHorizontalTimeAxisLabels(datum)' },
-            tooltip: { signal: 'formatHorizontalTimeAxisLabels(datum)' },
           },
         },
       },
@@ -221,7 +220,7 @@ export const getSubLabelAxis = (axisOptions: AxisSpecOptions, scaleName: string)
     values: subLabelValues.length ? subLabelValues : undefined,
     encode: {
       labels: {
-        interactive: true,
+        interactive: false,
         ...getAxisLabelsEncoding(labelAlign, labelFontWeight, 'subLabel', labelOrientation, position, signalName),
       },
     },

--- a/packages/vega-spec-builder/src/types/axis/axisSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/axis/axisSpec.types.ts
@@ -106,6 +106,8 @@ export interface AxisOptions {
   subLabels?: SubLabel[];
   /** Displays ticks at each label location */
   ticks?: boolean;
+  /** Enables hover tooltips on axis labels for this axis. */
+  hasTooltip?: boolean;
   /**
    * The minimum desired step between axis ticks, in terms of scale domain values.
    * For example, a value of 1 indicates that ticks should not be less than 1 unit apart.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a tooltip to the axis. Extended the tooltip delay from legend items to axis items. Updated the tooltip delay constant to be more generic.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

As we move towards the axis containing more lengthy strings, we are adding the tooltip functionality there so that the user can still access that data.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated the spec tests the include the two new props `Interactive` as well as `tooltip`

## Screenshots (if appropriate):

<img width="544" height="399" alt="image" src="https://github.com/user-attachments/assets/84212e4c-d43e-4a67-a10c-fcca505425d8" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
