### PR TITLE
refactor: the start of switching to hoveredItem

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -65,12 +65,14 @@ export const FILTERED_TABLE = 'filteredTable';
 // vega data field names
 export const GROUP_DATA = 'rscGroupData';
 export const MARK_ID = 'rscMarkId';
+export const GROUP_ID = 'rscGroupId';
 export const SERIES_ID = 'rscSeriesId';
 export const STACK_ID = 'rscStackId';
 export const COMPONENT_NAME = 'rscComponentName';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';
 
 // signal names
+export const HOVERED_ITEM = 'hoveredItem'; // hovered item suffix
 export const HIGHLIGHTED_ITEM = 'highlightedItem'; // data point
 export const HIGHLIGHTED_GROUP = 'highlightedGroup'; // data point
 export const HIGHLIGHTED_SERIES = 'highlightedSeries'; // series
@@ -125,6 +127,7 @@ export const DEFAULT_VENN_METRIC = 'size';
 export const DEFAULT_VENN_LABEL = 'label';
 
 // ratio that each opacity is divded by when hovering or highlighting from legend
+// TODO: invert this ratio so we don't have to do 1 / HIGHLIGHT_CONTRAST_RATIO every time
 export const HIGHLIGHT_CONTRAST_RATIO = 5;
 
 // legend tooltips

--- a/packages/react-spectrum-charts/src/hooks/useTooltipInteractions.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useTooltipInteractions.tsx
@@ -14,7 +14,7 @@ import { FC } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Position, Options as TooltipOptions } from 'vega-tooltip';
 
-import { COMPONENT_NAME, FILTERED_TABLE, GROUP_DATA } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, FILTERED_TABLE, GROUP_DATA, GROUP_ID } from '@spectrum-charts/constants';
 import { ColorScheme, LegendDescription, TooltipAnchor, TooltipPlacement } from '@spectrum-charts/vega-spec-builder';
 
 import { useChartContext } from '../context/RscChartContext';
@@ -60,14 +60,14 @@ const useTooltipsInteractions = (props: RscChartProps, sanitizedChildren: ChartC
           chartView.current?.signal(controlledHoveredIdSignal.current.name, value?.[idKey] ?? null);
         }
         if (controlledHoveredGroupSignal.current) {
-          const key = Object.keys(value).find((k) => k.endsWith('_highlightGroupId'));
+          const key = Object.keys(value).find((k) => k.endsWith(GROUP_ID));
           if (key) {
             chartView.current?.signal(controlledHoveredGroupSignal.current.name, value[key]);
           }
         }
         if (tooltip.highlightBy && tooltip.highlightBy !== 'item') {
           const tableData = chartView.current?.data(FILTERED_TABLE);
-          const groupId = `${tooltip.name}_highlightGroupId`;
+          const groupId = `${tooltip.name}_${GROUP_ID}`;
           value[GROUP_DATA] = tableData?.filter((d) => d[groupId] === value[groupId]);
         }
         return renderToStaticMarkup(

--- a/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_METRIC,
   DEFAULT_TIME_DIMENSION,
   FILTERED_TABLE,
+  GROUP_ID,
   HIGHLIGHTED_ITEM,
   SELECTED_ITEM,
   SELECTED_SERIES,
@@ -164,7 +165,7 @@ export const getAreaHighlightedData = (
 ): SourceData => {
   let expr = '';
   if (hasGroupId) {
-    expr += `${name}_controlledHoveredGroup === datum.${name}_highlightGroupId`;
+    expr += `${name}_controlledHoveredGroup === datum.${name}_${GROUP_ID}`;
   } else {
     expr += `isArray(${HIGHLIGHTED_ITEM}) && indexof(${HIGHLIGHTED_ITEM}, datum.${idKey}) > -1  || ${HIGHLIGHTED_ITEM} === datum.${idKey}`;
     if (hasTooltip) {

--- a/packages/vega-spec-builder/src/bar/barSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/bar/barSpecBuilder.ts
@@ -45,6 +45,7 @@ import {
 import { getDualAxisScaleNames } from '../scale/scaleUtils';
 import {
   addHighlightedItemSignalEvents,
+  addHoveredItemSignal,
   getFirstRscSeriesIdSignal,
   getGenericValueSignal,
   getLastRscSeriesIdSignal,
@@ -147,6 +148,7 @@ export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options)
     barAnnotations,
     chartTooltips,
     chartPopovers,
+    hasOnClick,
     idKey,
     name,
     paddingRatio,
@@ -161,10 +163,11 @@ export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options)
     signals.push(getFirstRscSeriesIdSignal(), getLastRscSeriesIdSignal(), getMouseOverSeriesSignal(name));
   }
 
-  if (!barAnnotations.length && !chartPopovers.length && !chartTooltips.length && !trendlines.length) {
+  if (!barAnnotations.length && !chartPopovers.length && !chartTooltips.length && !trendlines.length && !hasOnClick) {
     return;
   }
   addHighlightedItemSignalEvents(signals, name, idKey, 1, chartTooltips[0]?.excludeDataKeys);
+  addHoveredItemSignal(signals, name)
   addTooltipSignals(signals, options);
   setTrendlineSignals(signals, options);
 });

--- a/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
@@ -24,6 +24,7 @@ import {
   FILTERED_TABLE,
   HIGHLIGHTED_ITEM,
   HIGHLIGHT_CONTRAST_RATIO,
+  HOVERED_ITEM,
   MARK_ID,
 } from '@spectrum-charts/constants';
 
@@ -118,6 +119,10 @@ const defaultMarkWithTooltip: Mark = {
       ...defaultDodgedXEncodings,
       ...defaultBarStrokeEncodings,
       opacity: [
+        {
+          test: `isValid(bar0_${HOVERED_ITEM})`,
+          signal: `bar0_${HOVERED_ITEM}.${MARK_ID} === datum.${MARK_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+        },
         {
           test: `isArray(${HIGHLIGHTED_ITEM}) && length(${HIGHLIGHTED_ITEM}) > 0 && indexof(${HIGHLIGHTED_ITEM}, datum.rscMarkId) === -1`,
           value: 1 / HIGHLIGHT_CONTRAST_RATIO,

--- a/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.test.ts
+++ b/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.test.ts
@@ -9,9 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Data, Signal } from 'vega';
+import { Data, NumericValueRef, Signal } from 'vega';
 
-import { HIGHLIGHTED_GROUP } from '@spectrum-charts/constants';
+import { DEFAULT_OPACITY_RULE, GROUP_ID, HIGHLIGHTED_GROUP, HOVERED_ITEM } from '@spectrum-charts/constants';
 
 import { defaultBarOptions } from '../bar/barTestUtils';
 import { defaultScatterOptions } from '../scatter/scatterTestUtils';
@@ -20,6 +20,7 @@ import { baseData } from '../specUtils';
 import { BarSpecOptions, ChartTooltipOptions, LineSpecOptions } from '../types';
 import {
   addHighlightMarkOpacityRules,
+  addHoveredItemOpacityRules,
   addTooltipData,
   addTooltipSignals,
   applyTooltipPropDefaults,
@@ -70,19 +71,19 @@ describe('addTooltipData()', () => {
     const markOptions = getDefautltMarkOptions({ highlightBy: 'dimension' });
     addTooltipData(data, markOptions);
     expect(data[1].transform?.length).toBe(1);
-    expect(data[1].transform?.[0]).toHaveProperty('as', 'bar0_highlightGroupId');
+    expect(data[1].transform?.[0]).toHaveProperty('as', `bar0_${GROUP_ID}`);
   });
   test('should add the group id transform if highlightBy is `series`', () => {
     const markOptions = getDefautltMarkOptions({ highlightBy: 'series' });
     addTooltipData(data, markOptions);
     expect(data[1].transform?.length).toBe(1);
-    expect(data[1].transform?.[0]).toHaveProperty('as', 'bar0_highlightGroupId');
+    expect(data[1].transform?.[0]).toHaveProperty('as', `bar0_${GROUP_ID}`);
   });
   test('should add the group id transform if highlightBy is a key array', () => {
     const markOptions = getDefautltMarkOptions({ highlightBy: ['operatingSystem'] });
     addTooltipData(data, markOptions);
     expect(data[1].transform?.length).toBe(1);
-    expect(data[1].transform?.[0]).toHaveProperty('as', 'bar0_highlightGroupId');
+    expect(data[1].transform?.[0]).toHaveProperty('as', `bar0_${GROUP_ID}`);
   });
   test('should not add highlightedData for the mark if false', () => {
     const dataLength = data.length;
@@ -168,5 +169,34 @@ describe('addTooltipMarkOpacityRules()', () => {
     const opacityRules = [];
     addHighlightMarkOpacityRules(opacityRules, getDefautltMarkOptions({ highlightBy: 'series' }));
     expect(opacityRules).toHaveLength(3);
+  });
+});
+
+
+describe('addHoveredItemOpacityRules()', () => {
+  test('should add hovered item opacity rules', () => {
+    const opacityRules = [];
+    addHoveredItemOpacityRules(opacityRules, getDefautltMarkOptions());
+    expect(opacityRules).toHaveLength(1);
+  });
+  test('should add hovered item opacity rule at the correct index', () => {
+    let opacityRules: ({ test?: string, description?: string } & NumericValueRef)[] = [DEFAULT_OPACITY_RULE];
+    addHoveredItemOpacityRules(opacityRules, getDefautltMarkOptions());
+    expect(opacityRules).toHaveLength(2);
+    expect(opacityRules[0].test).toContain(HOVERED_ITEM);
+    expect(opacityRules[1]).toBe(DEFAULT_OPACITY_RULE);
+
+    opacityRules = [DEFAULT_OPACITY_RULE, { description: 'Hover', test: 'this is a test' }];
+    addHoveredItemOpacityRules(opacityRules, getDefautltMarkOptions());
+    expect(opacityRules).toHaveLength(3);
+    expect(opacityRules[0]).toBe(DEFAULT_OPACITY_RULE);
+    expect(opacityRules[1]).toHaveProperty('description', 'Hover');
+    expect(opacityRules[2].test).toContain(HOVERED_ITEM);
+  });
+  test('should use group id if highlighted by group', () => {
+    const opacityRules: ({ test?: string, description?: string, signal?: string } & NumericValueRef)[] = [];
+    addHoveredItemOpacityRules(opacityRules, getDefautltMarkOptions({ highlightBy: 'dimension' }));
+    expect(opacityRules).toHaveLength(1);
+    expect(opacityRules[0].signal).toContain(GROUP_ID);
   });
 });

--- a/packages/vega-spec-builder/src/donut/donutSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/donut/donutSpecBuilder.test.ts
@@ -40,7 +40,7 @@ describe('addData', () => {
 describe('addSignals()', () => {
   test('should add hover events when tooltip is present', () => {
     const signals = addSignals(defaultSignals, { ...defaultDonutOptions, chartTooltips: [{}] });
-    expect(signals).toHaveLength(defaultSignals.length);
+    expect(signals).toHaveLength(defaultSignals.length + 1);
     expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
     expect(signals[0].on).toHaveLength(2);
     expect(signals[0].on?.[0]).toHaveProperty('events', '@testName:mouseover');
@@ -51,7 +51,7 @@ describe('addSignals()', () => {
       ...defaultDonutOptions,
       chartTooltips: [{ excludeDataKeys: ['excludeFromTooltip'] }],
     });
-    expect(signals).toHaveLength(defaultSignals.length);
+    expect(signals).toHaveLength(defaultSignals.length + 1);
     expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
     expect(signals[0].on).toHaveLength(2);
     expect(signals[0].on?.[0]).toHaveProperty('events', '@testName:mouseover');

--- a/packages/vega-spec-builder/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/donut/donutSpecBuilder.ts
@@ -23,7 +23,7 @@ import { toCamelCase } from '@spectrum-charts/utils';
 
 import { isInteractive } from '../marks/markUtils';
 import { addFieldToFacetScaleDomain } from '../scale/scaleSpecBuilder';
-import { addHighlightedItemSignalEvents } from '../signal/signalSpecBuilder';
+import { addHighlightedItemSignalEvents, addHoveredItemSignal } from '../signal/signalSpecBuilder';
 import { ColorScheme, DonutOptions, DonutSpecOptions, HighlightedItem, ScSpec } from '../types';
 import {
   getDonutSummaryData,
@@ -150,5 +150,6 @@ export const addSignals = produce<Signal[], [DonutSpecOptions]>((signals, option
   const { chartTooltips, idKey, name } = options;
   signals.push(...getDonutSummarySignals(options));
   if (!isInteractive(options)) return;
+  addHoveredItemSignal(signals, name);
   addHighlightedItemSignalEvents(signals, name, idKey, 1, chartTooltips[0]?.excludeDataKeys);
 });

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
@@ -13,6 +13,7 @@ import { Mark } from 'vega';
 
 import {
   DEFAULT_OPACITY_RULE,
+  GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
   HIGHLIGHT_CONTRAST_RATIO,
@@ -48,7 +49,7 @@ describe('getHighlightOpacityRule()', () => {
     const opacityRule = getHighlightOpacityRule(['key1'], 'legend0');
     expect(opacityRule).toHaveProperty(
       'test',
-      `isValid(${HIGHLIGHTED_GROUP}) && ${HIGHLIGHTED_GROUP} !== datum.legend0_highlightGroupId`
+      `isValid(${HIGHLIGHTED_GROUP}) && ${HIGHLIGHTED_GROUP} !== datum.legend0_${GROUP_ID}`
     );
   });
 });

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
@@ -13,6 +13,7 @@ import { GroupMark, Mark, NumericValueRef } from 'vega';
 
 import {
   COLOR_SCALE,
+  GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
   HIGHLIGHT_CONTRAST_RATIO,
@@ -54,7 +55,7 @@ export const setHoverOpacityForMarks = (marks: Mark[], keys?: string[], name?: s
 export const getHighlightOpacityRule = (keys?: string[], name?: string): { test?: string } & NumericValueRef => {
   let test = `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`;
   if (keys?.length) {
-    test = `isValid(${HIGHLIGHTED_GROUP}) && ${HIGHLIGHTED_GROUP} !== datum.${name}_highlightGroupId`;
+    test = `isValid(${HIGHLIGHTED_GROUP}) && ${HIGHLIGHTED_GROUP} !== datum.${name}_${GROUP_ID}`;
   }
   return { test, value: 1 / HIGHLIGHT_CONTRAST_RATIO };
 };

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_COLOR,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_SECONDARY_COLOR,
+  GROUP_ID,
   HIGHLIGHTED_SERIES,
   LINEAR_COLOR_SCALE,
   TABLE,
@@ -335,7 +336,7 @@ describe('addData()', () => {
   test('should add legend group Id if keys has length', () => {
     const data = addData(baseData, { ...defaultLegendOptions, facets: [DEFAULT_COLOR], keys: ['key1', 'key2'] });
     expect(data[0].transform).toHaveLength(2);
-    expect(data[0].transform?.[1]).toHaveProperty('as', 'legend0_highlightGroupId');
+    expect(data[0].transform?.[1]).toHaveProperty('as', `legend0_${GROUP_ID}`);
   });
   test('should add transform to table if they do not exist', () => {
     const data = addData([{ ...baseData[0], transform: undefined }, ...baseData], {

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
@@ -15,6 +15,7 @@ import { Data, Legend, Mark, Scale, Signal } from 'vega';
 import {
   COLOR_SCALE,
   DEFAULT_COLOR_SCHEME,
+  GROUP_ID,
   LINEAR_COLOR_SCALE,
   LINE_TYPE_SCALE,
   OPACITY_SCALE,
@@ -301,7 +302,7 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
       }
       tableData.transform.push({
         type: 'formula',
-        as: `${name}_highlightGroupId`,
+        as: `${name}_${GROUP_ID}`,
         expr: keys.map((key) => `datum.${key}`).join(' + " | " + '),
       });
     }

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_LEGEND_SYMBOL_WIDTH,
   DEFAULT_OPACITY_RULE,
   FILTERED_TABLE,
+  GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
   HIGHLIGHT_CONTRAST_RATIO,
@@ -316,7 +317,7 @@ export const getHiddenSeriesColorRule = (
   if (keys?.length) {
     return [
       {
-        test: `indexof(pluck(data('${FILTERED_TABLE}'), '${name}_highlightGroupId'), datum.value) === -1`,
+        test: `indexof(pluck(data('${FILTERED_TABLE}'), '${name}_${GROUP_ID}'), datum.value) === -1`,
         value: getColorValue(colorValue, colorScheme),
       },
     ];

--- a/packages/vega-spec-builder/src/line/lineDataUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineDataUtils.ts
@@ -11,7 +11,7 @@
  */
 import { SourceData } from 'vega';
 
-import { HIGHLIGHTED_GROUP, HIGHLIGHTED_ITEM, SELECTED_ITEM } from '@spectrum-charts/constants';
+import { GROUP_ID, HIGHLIGHTED_GROUP, HIGHLIGHTED_ITEM, SELECTED_ITEM } from '@spectrum-charts/constants';
 
 /**
  * gets the data used for highlighting hovered data points
@@ -27,7 +27,7 @@ export const getLineHighlightedData = (
   hasGroupId: boolean
 ): SourceData => {
   const highlightedExpr = hasGroupId
-    ? `${HIGHLIGHTED_GROUP} === datum.${name}_highlightGroupId`
+    ? `${HIGHLIGHTED_GROUP} === datum.${name}_${GROUP_ID}`
     : `isArray(${HIGHLIGHTED_ITEM}) && indexof(${HIGHLIGHTED_ITEM}, datum.${idKey}) > -1  || ${HIGHLIGHTED_ITEM} === datum.${idKey}`;
   const expr = hasPopover
     ? `${SELECTED_ITEM} && ${SELECTED_ITEM} === datum.${idKey} || !${SELECTED_ITEM} && ${highlightedExpr}`

--- a/packages/vega-spec-builder/src/marks/markUtils.test.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
   HIGHLIGHTED_ITEM,
   HIGHLIGHT_CONTRAST_RATIO,
+  HOVERED_ITEM,
   LINEAR_COLOR_SCALE,
   LINE_TYPE_SCALE,
   LINE_WIDTH_SCALE,
@@ -274,20 +275,22 @@ describe('getMarkOpacity()', () => {
   });
   test('Tooltip child, should return tests for hover and default to opacity', () => {
     const opacity = getMarkOpacity({ ...defaultBarOptions, chartTooltips: [{}] });
-    expect(opacity).toHaveLength(3);
-    expect(opacity[0].test).toContain(HIGHLIGHTED_ITEM);
+    expect(opacity).toHaveLength(4);
+    expect(opacity[0].test).toContain(HOVERED_ITEM);
+    expect(opacity[1].test).toContain(HIGHLIGHTED_ITEM);
     expect(opacity.at(-1)).toStrictEqual(DEFAULT_OPACITY_RULE);
   });
   test('Popover child, should return tests for hover and select and default to opacity', () => {
     const opacity = getMarkOpacity({ ...defaultBarOptions, chartPopovers: [{}] });
-    expect(opacity).toHaveLength(7);
+    expect(opacity).toHaveLength(8);
     expect(opacity[0].test).toContain(`${SELECTED_ITEM} !==`);
     expect(opacity[1].test).toContain(`${SELECTED_ITEM} ===`);
 
     expect(opacity[2].test).toContain(`${SELECTED_GROUP} ===`);
     expect(opacity[3].test).toContain(`${SELECTED_GROUP} !==`);
 
-    expect(opacity[4].test).toContain(HIGHLIGHTED_ITEM);
+    expect(opacity[4].test).toContain(HOVERED_ITEM);
+    expect(opacity[5].test).toContain(HIGHLIGHTED_ITEM);
     expect(opacity.at(-1)).toStrictEqual(DEFAULT_OPACITY_RULE);
   });
 });

--- a/packages/vega-spec-builder/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.ts
@@ -41,7 +41,7 @@ import {
 } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
-import { addHighlightMarkOpacityRules } from '../chartTooltip/chartTooltipUtils';
+import { addHighlightMarkOpacityRules, addHoveredItemOpacityRules } from '../chartTooltip/chartTooltipUtils';
 import { LineMarkOptions } from '../line/lineUtils';
 import { getScaleName } from '../scale/scaleSpecBuilder';
 import {
@@ -430,6 +430,7 @@ export const getMarkOpacity = (
   }
 
   addHighlightMarkOpacityRules(rules, options);
+  addHoveredItemOpacityRules(rules, options);
 
   // if a bar is hovered/selected, all other bars should have reduced opacity
   if (hasPopover(options)) {

--- a/packages/vega-spec-builder/src/signal/signalSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/signal/signalSpecBuilder.test.ts
@@ -11,12 +11,13 @@
  */
 import { Signal } from 'vega';
 
-import { FILTERED_TABLE, HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES, MARK_ID } from '@spectrum-charts/constants';
+import { FILTERED_TABLE, HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES, HOVERED_ITEM, MARK_ID } from '@spectrum-charts/constants';
 
 import { defaultHighlightedItemSignal, defaultHighlightedSeriesSignal, defaultSignals } from '../specTestUtils';
 import {
   addHighlightedItemSignalEvents,
   addHighlightedSeriesSignalEvents,
+  addHoveredItemSignal,
   getHighlightSignalUpdateExpression,
 } from './signalSpecBuilder';
 
@@ -109,4 +110,38 @@ describe('signalSpecBuilder', () => {
       expect(update).toContain('hiddenSeries');
     });
   });
+
+  describe('addHoveredItemSignal()', () => {
+    test('should use targetName if provided', () => {
+      signals = [];
+      addHoveredItemSignal(signals, 'line0', 'target0');
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toHaveProperty('name', `line0_${HOVERED_ITEM}`);
+      expect(signals[0]?.on?.[0]).toHaveProperty('events', '@target0:mouseover');
+      expect(signals[0]?.on?.[1]).toHaveProperty('events', '@target0:mouseout');
+    });
+    test('should use markName if targetName is not provided', () => {
+      signals = [];
+      addHoveredItemSignal(signals, 'line0');
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toHaveProperty('name', `line0_${HOVERED_ITEM}`);
+      expect(signals[0]?.on?.[0]).toHaveProperty('events', '@line0:mouseover');
+      expect(signals[0]?.on?.[1]).toHaveProperty('events', '@line0:mouseout');
+    });
+    test('should add signal if it does not exist', () => {
+      addHoveredItemSignal(signals, 'line0');
+      expect(signals).toHaveLength(defaultSignals.length + 1);
+      expect(signals.at(-1)).toHaveProperty('name', `line0_${HOVERED_ITEM}`);
+    });
+    test('should add on events to signal instead of creating a new one', () => {
+      signals.push({ name: `line0_${HOVERED_ITEM}`, value: null, on: [] });
+      addHoveredItemSignal(signals, 'line0');
+      expect(signals).toHaveLength(defaultSignals.length + 1);
+      const hoveredItemSignal = signals.at(-1);
+      expect(hoveredItemSignal).toHaveProperty('name', `line0_${HOVERED_ITEM}`);
+      expect(hoveredItemSignal?.on).toHaveLength(2);
+      expect(hoveredItemSignal?.on?.[0]).toHaveProperty('events', '@line0:mouseover');
+      expect(hoveredItemSignal?.on?.[1]).toHaveProperty('events', '@line0:mouseout');
+    });
+  }); 
 });

--- a/packages/vega-spec-builder/src/signal/signalSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/signal/signalSpecBuilder.ts
@@ -15,9 +15,11 @@ import {
   COLOR_SCALE,
   FILTERED_TABLE,
   FIRST_RSC_SERIES_ID,
+  GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_ITEM,
   HIGHLIGHTED_SERIES,
+  HOVERED_ITEM,
   LAST_RSC_SERIES_ID,
   MOUSE_OVER_SERIES,
   SERIES_ID,
@@ -89,7 +91,7 @@ export const getHighlightSignalUpdateExpression = (
   const hoveredSeriesExpression = `domain("${legendName}Entries")[datum.index]`;
   if (!includeHiddenSeries) return hoveredSeriesExpression;
   if (keys?.length) {
-    return `indexof(pluck(data("${FILTERED_TABLE}"),"${legendName}_highlightGroupId"), ${hoveredSeriesExpression}) !== -1 ? ${hoveredSeriesExpression} : null`;
+    return `indexof(pluck(data("${FILTERED_TABLE}"),"${legendName}_${GROUP_ID}"), ${hoveredSeriesExpression}) !== -1 ? ${hoveredSeriesExpression} : null`;
   }
   return `indexof(hiddenSeries, ${hoveredSeriesExpression}) === -1 ? ${hoveredSeriesExpression} : null`;
 };
@@ -217,4 +219,29 @@ export const addHighlightedSeriesSignalEvents = (
       ]
     );
   }
+};
+
+export const addHoveredItemSignal = (signals: Signal[], markName: string, targetName?: string): void => {
+  targetName = targetName || markName;
+  const signalName = `${markName}_${HOVERED_ITEM}`;
+
+  let signal = signals.find((signal) => signal.name === signalName);
+  if (!signal) {
+    signal = {
+      description: `Tracks the hovered item for ${targetName}`,
+      name: signalName,
+      value: null,
+      on: [],
+    };
+    signals.push(signal);
+  }
+
+  if (signal.on === undefined) {
+    signal.on = [];
+  }
+
+  signal.on.push(
+    { events: `@${targetName}:mouseover`, update: 'datum' },
+    { events: `@${targetName}:mouseout`, update: 'null' }
+  );
 };

--- a/packages/vega-spec-builder/src/venn/vennSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/venn/vennSpecBuilder.test.ts
@@ -60,7 +60,7 @@ describe('addSignal', () => {
       chartTooltips: [{}],
     });
 
-    expect(signals).toHaveLength(defaultSignals.length);
+    expect(signals).toHaveLength(defaultSignals.length + 1);
     expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
     expect(signals[0].on).toHaveLength(4);
     expect(signals[0].on?.[0]).toHaveProperty('events', '@venn:mouseover');

--- a/packages/vega-spec-builder/src/venn/vennSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/venn/vennSpecBuilder.ts
@@ -35,7 +35,7 @@ import { toCamelCase } from '@spectrum-charts/utils';
 
 import { isInteractive } from '../marks/markUtils';
 import { addFieldToFacetScaleDomain } from '../scale/scaleSpecBuilder';
-import { addHighlightedItemSignalEvents } from '../signal/signalSpecBuilder';
+import { addHighlightedItemSignalEvents, addHoveredItemSignal } from '../signal/signalSpecBuilder';
 import { ChartData, ColorScheme, HighlightedItem, ScSpec, VennOptions, VennSpecOptions } from '../types';
 import {
   SET_ID_DELIMITER,
@@ -192,6 +192,8 @@ export const addSignals = produce<Signal[], [VennSpecOptions]>((signals, props) 
   const { chartTooltips, name, idKey } = props;
 
   if (!isInteractive(props)) return;
+  addHoveredItemSignal(signals, name);
+  addHoveredItemSignal(signals, name, `${name}_intersections`);
   addHighlightedItemSignalEvents(signals, name, idKey, 1, chartTooltips[0]?.excludeDataKeys);
   addHighlightedItemSignalEvents(signals, `${name}_intersections`, idKey, 1, chartTooltips[0]?.excludeDataKeys);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactoring the highlight logic.

This is the first of many PRs.

Highlight logic has gotten vary complex. The purpose of this refactor is to simplify it so that it becomes easier to add highlight and interactivity logic in the future.

This PR specifically does the following:
* adds and wires up a new signal: `${markName}_hoveredItem`.
* switching `_highlightedGroupId` to a new constant `rscGroupId`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
