### PR TITLE
refactor: add hovered item opacity controls to line

### DIFF
--- a/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.test.ts
+++ b/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.test.ts
@@ -186,7 +186,7 @@ describe('addHoveredItemOpacityRules()', () => {
     expect(opacityRules[0].test).toContain(HOVERED_ITEM);
     expect(opacityRules[1]).toBe(DEFAULT_OPACITY_RULE);
 
-    opacityRules = [DEFAULT_OPACITY_RULE, { description: 'Hover', test: 'this is a test' }];
+    opacityRules = [DEFAULT_OPACITY_RULE, { description: 'Hover', test: `this is a test ${HOVERED_ITEM}` }];
     addHoveredItemOpacityRules(opacityRules, getDefautltMarkOptions());
     expect(opacityRules).toHaveLength(3);
     expect(opacityRules[0]).toBe(DEFAULT_OPACITY_RULE);

--- a/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.ts
+++ b/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.ts
@@ -219,10 +219,10 @@ export const addHighlightMarkOpacityRules = (
   }
 };
 
-export const addHoveredItemOpacityRules = (opacityRules: ({ test?: string, description?: string } & NumericValueRef)[], markOptions: TooltipParentOptions) => {
+export const addHoveredItemOpacityRules = (opacityRules: ({ test?: string } & NumericValueRef)[], markOptions: TooltipParentOptions) => {
   const { name: markName } = markOptions;
   // find the index of the first hover rule
-  const startIndex = opacityRules.findIndex((rule) => rule.description?.startsWith(`Hover`)) + 1;
+  const startIndex = opacityRules.findIndex((rule) => rule.test?.includes(HOVERED_ITEM)) + 1;
 
   const hoveredItemSignal = `${markName}_${HOVERED_ITEM}`;
 

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -13,7 +13,9 @@ import {
   COLOR_SCALE,
   DEFAULT_OPACITY_RULE,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
+  HIGHLIGHT_CONTRAST_RATIO,
   HIGHLIGHTED_SERIES,
+  HOVERED_ITEM,
   SELECTED_SERIES,
   SERIES_ID,
 } from '@spectrum-charts/constants';
@@ -121,11 +123,8 @@ describe('getLineOpacity()', () => {
       chartTooltips: [{}],
     });
     expect(opacityRule).toEqual([
-      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 0.2 },
-      {
-        test: `length(data('line0_highlightedData')) > 0 && indexof(pluck(data('line0_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) === -1`,
-        value: 0.2,
-      },
+      { test: `isValid(line0_${HOVERED_ITEM})`, signal: `line0_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`},
+      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
       { value: 1 },
     ]);
   });
@@ -138,12 +137,9 @@ describe('getLineOpacity()', () => {
       chartPopovers: [{}],
     });
     expect(opacityRule).toEqual([
-      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 0.2 },
-      {
-        test: `length(data('line0_highlightedData')) > 0 && indexof(pluck(data('line0_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) === -1`,
-        value: 0.2,
-      },
-      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`, value: 0.2 },
+      { signal: `line0_hoveredItem.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`, test: 'isValid(line0_hoveredItem)' },
+      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
+      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
       { value: 1 },
     ]);
   });
@@ -164,10 +160,7 @@ describe('getLineOpacity()', () => {
       chartTooltips: [{}],
       isHighlightedByGroup: true,
     });
-    expect(opacityRule).toHaveLength(4);
-    expect(opacityRule[0]).toHaveProperty(
-      'test',
-      `indexof(pluck(data('line0_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1`
-    );
+    expect(opacityRule).toHaveLength(3);
+    expect(opacityRule[0]).toHaveProperty('test', `length(data('line0_highlightedData'))`);
   });
 });

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_OPACITY_RULE,
   HIGHLIGHTED_SERIES,
   HIGHLIGHT_CONTRAST_RATIO,
+  HOVERED_ITEM,
   SELECTED_SERIES,
   SERIES_ID,
 } from '@spectrum-charts/constants';
@@ -104,8 +105,13 @@ export const getLineOpacity = ({
 
   if (isHighlightedByGroup) {
     strokeOpacityRules.push({
-      test: `indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1`,
-      value: 1,
+      test: `length(data('${interactiveMarkName}_highlightedData'))`,
+      signal: `indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1 ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+    })
+  } else {
+    strokeOpacityRules.push({
+      test: `isValid(${interactiveMarkName}_${HOVERED_ITEM})`,
+      signal: `${interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
     });
   }
 
@@ -115,10 +121,6 @@ export const getLineOpacity = ({
       test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
       value: 1 / HIGHLIGHT_CONTRAST_RATIO,
     },
-    {
-      test: `length(data('${interactiveMarkName}_highlightedData')) > 0 && indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) === -1`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
-    }
   );
 
   if (popoverMarkName) {

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
@@ -23,6 +23,7 @@ import {
   FILTERED_TABLE,
   HIGHLIGHTED_ITEM,
   HIGHLIGHTED_SERIES,
+  HOVERED_ITEM,
   LINEAR_PADDING,
   MARK_ID,
   SERIES_ID,
@@ -557,11 +558,13 @@ describe('lineSpecBuilder', () => {
         ...defaultLineOptions,
         metricRanges: [{ metricEnd: 'end', metricStart: 'start', displayOnHover: true }],
       });
-      expect(signals).toHaveLength(defaultSignals.length);
+      expect(signals).toHaveLength(defaultSignals.length + 1);
       expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
       expect(signals[0].on).toHaveLength(2);
       expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
       expect(signals[2].on).toHaveLength(2);
+      expect(signals.at(-1)).toHaveProperty('name', `${defaultLineOptions.name}_${HOVERED_ITEM}`);
+      expect(signals.at(-1)?.on).toHaveLength(2);
     });
 
     test('adds hover signals when displayPointMark is not undefined', () => {
@@ -574,11 +577,13 @@ describe('lineSpecBuilder', () => {
         staticPoint: 'staticPoint',
         metricRanges: [{ metricEnd: 'end', metricStart: 'start', displayOnHover: true }],
       });
-      expect(signals).toHaveLength(defaultSignals.length);
+      expect(signals).toHaveLength(defaultSignals.length + 1);
       expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
       expect(signals[0].on).toHaveLength(2);
       expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
       expect(signals[2].on).toHaveLength(2);
+      expect(signals.at(-1)).toHaveProperty('name', `${defaultLineOptions.name}_${HOVERED_ITEM}`);
+      expect(signals.at(-1)?.on).toHaveLength(2);
     });
 
     test('hover signals with interactionMode item', () => {
@@ -587,11 +592,13 @@ describe('lineSpecBuilder', () => {
         interactionMode: 'item',
         chartTooltips: [{}],
       });
-      expect(signals).toHaveLength(defaultSignals.length);
+      expect(signals).toHaveLength(defaultSignals.length + 1);
       expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
       expect(signals[0].on).toHaveLength(8);
       expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
       expect(signals[2].on).toHaveLength(8);
+      expect(signals.at(-1)).toHaveProperty('name', `${defaultLineOptions.name}_${HOVERED_ITEM}`);
+      expect(signals.at(-1)?.on).toHaveLength(2);
     });
   });
 });

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -35,7 +35,7 @@ import {
   getMetricRanges,
 } from '../metricRange/metricRangeUtils';
 import { addContinuousDimensionScale, addFieldToFacetScaleDomain, addMetricScale } from '../scale/scaleSpecBuilder';
-import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents } from '../signal/signalSpecBuilder';
+import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents, addHoveredItemSignal } from '../signal/signalSpecBuilder';
 import { getFacetsFromOptions } from '../specUtils';
 import { addTrendlineData, getTrendlineMarks, getTrendlineScales, setTrendlineSignals } from '../trendline';
 import { ColorScheme, HighlightedItem, LineOptions, LineSpecOptions, ScSpec } from '../types';
@@ -141,6 +141,7 @@ export const addSignals = produce<Signal[], [LineSpecOptions]>((signals, options
   if (!isInteractive(options)) return;
   addHighlightedItemSignalEvents(signals, `${name}_voronoi`, idKey, 2);
   addHighlightedSeriesSignalEvents(signals, `${name}_voronoi`, 2);
+  addHoveredItemSignal(signals, name, `${name}_voronoi`, 2);
   addHoverSignals(signals, options);
   addTooltipSignals(signals, options);
 });

--- a/packages/vega-spec-builder/src/signal/signalSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/signal/signalSpecBuilder.test.ts
@@ -143,5 +143,12 @@ describe('signalSpecBuilder', () => {
       expect(hoveredItemSignal?.on?.[0]).toHaveProperty('events', '@line0:mouseover');
       expect(hoveredItemSignal?.on?.[1]).toHaveProperty('events', '@line0:mouseout');
     });
+    test('should despect datum order', () => {
+      signals = [];
+      addHoveredItemSignal(signals, 'line0', 'target0', 2);
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toHaveProperty('name', `line0_${HOVERED_ITEM}`);
+      expect(signals[0]?.on?.[0]).toHaveProperty('update', 'datum.datum');
+    })
   }); 
 });

--- a/packages/vega-spec-builder/src/signal/signalSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/signal/signalSpecBuilder.ts
@@ -221,7 +221,7 @@ export const addHighlightedSeriesSignalEvents = (
   }
 };
 
-export const addHoveredItemSignal = (signals: Signal[], markName: string, targetName?: string): void => {
+export const addHoveredItemSignal = (signals: Signal[], markName: string, targetName?: string, datumOrder = 1): void => {
   targetName = targetName || markName;
   const signalName = `${markName}_${HOVERED_ITEM}`;
 
@@ -240,8 +240,10 @@ export const addHoveredItemSignal = (signals: Signal[], markName: string, target
     signal.on = [];
   }
 
+  const datum = new Array(datumOrder).fill('datum').join('.');
+
   signal.on.push(
-    { events: `@${targetName}:mouseover`, update: 'datum' },
+    { events: `@${targetName}:mouseover`, update: datum },
     { events: `@${targetName}:mouseout`, update: 'null' }
   );
 };

--- a/packages/vega-spec-builder/src/trendline/trendlineSignalUtils.test.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineSignalUtils.test.ts
@@ -11,7 +11,7 @@
  */
 import { Signal } from 'vega';
 
-import { HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES } from '@spectrum-charts/constants';
+import { HIGHLIGHTED_ITEM, HIGHLIGHTED_SERIES, HOVERED_ITEM } from '@spectrum-charts/constants';
 
 import { defaultSignals } from '../specTestUtils';
 import { setTrendlineSignals } from './trendlineSignalUtils';
@@ -27,11 +27,13 @@ describe('getTrendlineSignals()', () => {
       ...defaultLineOptions,
       trendlines: [{ chartTooltips: [{}] }],
     });
-    expect(signals).toHaveLength(defaultSignals.length);
+    expect(signals).toHaveLength(defaultSignals.length + 1);
     expect(signals[0]).toHaveProperty('name', HIGHLIGHTED_ITEM);
     expect(signals[0].on).toHaveLength(2);
     expect(signals[2]).toHaveProperty('name', HIGHLIGHTED_SERIES);
     expect(signals[2].on).toHaveLength(2);
+    expect(signals.at(-1)).toHaveProperty('name', `line0Trendline_${HOVERED_ITEM}`);
+    expect(signals.at(-1)?.on).toHaveLength(2);
   });
 
   test('should not modify any signals if there is not a ChartTooltip', () => {

--- a/packages/vega-spec-builder/src/trendline/trendlineSignalUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineSignalUtils.ts
@@ -12,7 +12,7 @@
 import { Signal } from 'vega';
 
 import { hasTooltip } from '../marks/markUtils';
-import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents } from '../signal/signalSpecBuilder';
+import { addHighlightedItemSignalEvents, addHighlightedSeriesSignalEvents, addHoveredItemSignal } from '../signal/signalSpecBuilder';
 import { TrendlineParentOptions, getTrendlines } from './trendlineUtils';
 
 export const setTrendlineSignals = (signals: Signal[], markOptions: TrendlineParentOptions): void => {
@@ -21,6 +21,7 @@ export const setTrendlineSignals = (signals: Signal[], markOptions: TrendlinePar
 
   if (trendlines.some((trendline) => hasTooltip(trendline))) {
     addHighlightedItemSignalEvents(signals, `${markName}Trendline_voronoi`, idKey, 2);
+    addHoveredItemSignal(signals, `${markName}Trendline`, `${markName}Trendline_voronoi`, 2);
     addHighlightedSeriesSignalEvents(signals, `${markName}Trendline_voronoi`, 2);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the new hovered item signals and opacity rules to line/trendline

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
