### PR TITLE
refactor: change HILIGHT_CONTRAST_RATIO to FADE_FACTOR

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -128,7 +128,11 @@ export const DEFAULT_VENN_LABEL = 'label';
 
 // ratio that each opacity is divded by when hovering or highlighting from legend
 // TODO: invert this ratio so we don't have to do 1 / HIGHLIGHT_CONTRAST_RATIO every time
+/**
+ * @deprecated
+ */
 export const HIGHLIGHT_CONTRAST_RATIO = 5;
+export const FADE_FACTOR = 0.2;
 
 // legend tooltips
 export const TOOLTIP_DELAY = 350;

--- a/packages/react-spectrum-charts/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.test.tsx
@@ -11,7 +11,7 @@
  */
 import { createRef } from 'react';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { ChartHandle } from '@spectrum-charts/vega-spec-builder';
 
 import { Chart } from '../Chart';
@@ -357,8 +357,8 @@ describe('Chart', () => {
       const bars = getAllMarksByGroupName(chart, 'bar0');
 
       expect(bars[14]).toHaveAttribute('opacity', '1');
-      expect(bars[13]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-      expect(bars[15]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+      expect(bars[13]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[15]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     });
   });
 });

--- a/packages/react-spectrum-charts/src/stories/components/Area/Area.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Area/Area.test.tsx
@@ -9,11 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
 import userEvent from '@testing-library/user-event';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 
 import { Area } from '../../../components';
 import {
@@ -81,7 +80,7 @@ describe('Area', () => {
     const tooltip = await screen.findByTestId('rsc-tooltip');
     expect(tooltip).toBeInTheDocument();
     expect(within(tooltip).getByText('OS: Windows')).toBeInTheDocument();
-    expect(areas[1].getAttribute('opacity')).toEqual((1 / HIGHLIGHT_CONTRAST_RATIO).toString());
+    expect(areas[1].getAttribute('opacity')).toEqual(`${FADE_FACTOR}`);
 
     const highlightRule = await findMarksByGroupName(chart, 'area0_rule', 'line');
     expect(highlightRule).toBeInTheDocument();

--- a/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -9,11 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
 import userEvent from '@testing-library/user-event';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
 import { ChartPopover } from '../../../components';
@@ -115,7 +114,7 @@ describe('ChartPopover', () => {
     expect(bars[0]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
     expect(bars[0]).toHaveAttribute('stroke-width', '2');
     // all other bars should be faded
-    expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
   });
 
   test('Popover should be corrrect size', async () => {
@@ -220,7 +219,7 @@ describe('ChartPopover', () => {
 
     // validate the first line is still full opacity, but the other lines are faded
     expect(lines[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
   });
 
   test('Dodged bar popover opens on mark click and closes when clicking outside', async () => {
@@ -243,7 +242,7 @@ describe('ChartPopover', () => {
     bars = getAllMarksByGroupName(chart, 'bar0');
 
     // validate the highlight visuals are present
-    expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(bars[4]).toHaveAttribute('opacity', '1');
     expect(bars[4]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
     expect(bars[4]).toHaveAttribute('stroke-width', '2');
@@ -269,7 +268,7 @@ describe('ChartPopover', () => {
     bars = getAllMarksByGroupName(chart, 'bar0');
 
     // validate the highlight visuals are present
-    expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(bars[4]).toHaveAttribute('opacity', '1');
 
     const selectionRingMarks = getAllMarksByGroupName(chart, 'bar0_selectionRing');
@@ -319,7 +318,7 @@ describe('ChartPopover', () => {
     segments = getAllMarksByGroupName(chart, 'donut0');
 
     // validate the highlight visuals are present
-    expect(segments[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(segments[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(segments[4]).toHaveAttribute('opacity', '1');
     expect(segments[4]).toHaveAttribute('stroke', spectrumColors.light['static-blue']);
     expect(segments[4]).toHaveAttribute('stroke-width', '2');

--- a/packages/react-spectrum-charts/src/stories/components/ChartTooltip/ChartTooltip.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartTooltip/ChartTooltip.test.tsx
@@ -9,9 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 
 import { ChartTooltip } from '../../../components';
 import {
@@ -48,7 +47,7 @@ describe('ChartTooltip', () => {
     const tooltip = await screen.findByTestId('rsc-tooltip');
     expect(tooltip).toBeInTheDocument();
     expect(within(tooltip).getByText('Operating system: Windows')).toBeInTheDocument();
-    expect(bars[1].getAttribute('opacity')).toEqual(`${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[1].getAttribute('opacity')).toEqual(`${FADE_FACTOR}`);
 
     // unhover and validate the highlights go away
     await unhoverNthElement(bars, 0);
@@ -99,7 +98,7 @@ describe('ChartTooltip', () => {
     expect(within(tooltip).getByText('Users: 3')).toBeInTheDocument();
 
     // validate the highlight visuals are present
-    expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(bars[4]).toHaveAttribute('opacity', '1');
 
     await unhoverNthElement(bars, 4);

--- a/packages/react-spectrum-charts/src/stories/components/ChartTooltip/HighlightBy.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartTooltip/HighlightBy.test.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 
 import {
   allElementsHaveAttributeValue,
@@ -37,7 +37,7 @@ describe('Basic', () => {
     expect(bars[2]).toHaveAttribute('opacity', '1');
     // all other bars
     expect(
-      allElementsHaveAttributeValue([...bars.slice(0, 2), ...bars.slice(3)], 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)
+      allElementsHaveAttributeValue([...bars.slice(0, 2), ...bars.slice(3)], 'opacity', FADE_FACTOR)
     ).toBe(true);
   });
 });
@@ -56,7 +56,7 @@ describe('Dimension', () => {
     // first three bars (same dimension)
     expect(allElementsHaveAttributeValue(bars.slice(0, 2), 'opacity', '1')).toBe(true);
     // all other bars
-    expect(allElementsHaveAttributeValue(bars.slice(3), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBe(true);
+    expect(allElementsHaveAttributeValue(bars.slice(3), 'opacity', FADE_FACTOR)).toBe(true);
   });
 });
 
@@ -78,7 +78,7 @@ describe('Series', () => {
       allElementsHaveAttributeValue(
         [...bars.slice(0, 1), ...bars.slice(3, 4), ...bars.slice(6, 7)],
         'opacity',
-        1 / HIGHLIGHT_CONTRAST_RATIO
+        FADE_FACTOR
       )
     ).toBe(true);
   });
@@ -102,7 +102,7 @@ describe('Keys', () => {
       allElementsHaveAttributeValue(
         [...bars.slice(0, 1), ...bars.slice(3, 4), ...bars.slice(6, 7)],
         'opacity',
-        1 / HIGHLIGHT_CONTRAST_RATIO
+        FADE_FACTOR
       )
     ).toBe(true);
   });
@@ -147,7 +147,7 @@ describe('ScatterChart', () => {
     // highlighted points
     expect(allElementsHaveAttributeValue(points.slice(0, 6), 'opacity', '1')).toBe(true);
     // all other points
-    expect(allElementsHaveAttributeValue(points.slice(6), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBe(true);
+    expect(allElementsHaveAttributeValue(points.slice(6), 'opacity', FADE_FACTOR)).toBe(true);
   });
 });
 
@@ -194,7 +194,7 @@ describe('AreaChart', () => {
     const highlightVerticalRules = queryAllMarksByGroupName(chart, 'area0_rule', 'line');
     expect(highlightVerticalRules).toHaveLength(0);
     expect(areas[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(areas.slice(1), 'opacity', (1 / HIGHLIGHT_CONTRAST_RATIO).toString())).toBe(
+    expect(allElementsHaveAttributeValue(areas.slice(1), 'opacity', (FADE_FACTOR).toString())).toBe(
       true
     );
   });

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
@@ -9,11 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
 import userEvent from '@testing-library/user-event';
 
-import { HIGHLIGHT_CONTRAST_RATIO, TOOLTIP_DELAY } from '@spectrum-charts/constants';
+import { FADE_FACTOR, TOOLTIP_DELAY } from '@spectrum-charts/constants';
 
 import { Chart } from '../../../Chart';
 import { Legend } from '../../../components';
@@ -218,7 +217,7 @@ describe('Legend', () => {
     // first symbol should be highlighted
     let symbols = getAllLegendSymbols(chart);
     expect(symbols[0]).toHaveAttribute('opacity', '1');
-    expect(symbols[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(symbols[1]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
 
     // shouldn't close the popover
     await userEvent.click(popover);

--- a/packages/react-spectrum-charts/src/stories/components/Legend/LegendHideShow.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/LegendHideShow.test.tsx
@@ -9,9 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
 import {
@@ -114,7 +113,7 @@ test('Hidden series should not highlight any marks', async () => {
   // hovering the second entry should lower the opacity of the first series
   await hoverNthElement(entries, 1);
   let bars = await findAllMarksByGroupName(chart, 'bar0');
-  expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+  expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
 
   // hovering the third entry should not adjust the opcity of any of the bars since it is a hidden series
   await hoverNthElement(entries, 2);

--- a/packages/react-spectrum-charts/src/stories/components/Legend/LegendHighlight.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/LegendHighlight.test.tsx
@@ -9,9 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import React from 'react';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 
 import {
   allElementsHaveAttributeValue,
@@ -31,9 +30,9 @@ describe('Controlled', () => {
 
     const bars = await findAllMarksByGroupName(chart, 'bar0');
     expect(bars.length).toEqual(9);
-    expect(bars[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(bars[1]).toHaveAttribute('opacity', '1');
-    expect(bars[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
   });
 
   test('non highlighted series legend symbols should have opacity applied', async () => {
@@ -42,9 +41,9 @@ describe('Controlled', () => {
 
     const legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendSymbols.length).toEqual(3);
-    expect(legendSymbols[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(legendSymbols[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
-    expect(legendSymbols[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(legendSymbols[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
   });
 
   test('non highlighted series legend labels should have opacity applied', async () => {
@@ -53,9 +52,9 @@ describe('Controlled', () => {
 
     const legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendLabels.length).toEqual(3);
-    expect(legendLabels[0]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(legendLabels[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     expect(legendLabels[1]).toHaveAttribute('opacity', '1');
-    expect(legendLabels[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(legendLabels[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
   });
 });
 
@@ -79,8 +78,8 @@ describe('Uncontrolled', () => {
 
     bars = await findAllMarksByGroupName(chart, 'bar0');
     expect(bars[0]).toHaveAttribute('opacity', '1');
-    expect(bars[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
-    expect(bars[2]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+    expect(bars[1]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
   });
 
   test('hovering over legend items adds opacity to the non hovered legend symbols', async () => {
@@ -96,7 +95,7 @@ describe('Uncontrolled', () => {
 
     legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
   });
 
   test('hovering over legend items adds opacity to the non hovered legend labels', async () => {
@@ -113,6 +112,6 @@ describe('Uncontrolled', () => {
     legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendLabels.length).toEqual(3);
     expect(legendLabels[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(legendLabels.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(legendLabels.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
   });
 });

--- a/packages/react-spectrum-charts/src/stories/components/Line/Line.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Line/Line.test.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 
 import { Line } from '../../../components';
 import { workspaceTrendsData } from '../../../stories/data/data';
@@ -127,7 +127,6 @@ describe('Line', () => {
   });
 
   test('Hovering over the entries on HistoricalCompare should highlight hovered series', async () => {
-    const reducedOpacity = 1 / HIGHLIGHT_CONTRAST_RATIO;
     render(<HistoricalCompare {...HistoricalCompare.args} />);
     const chart = await findChart();
     expect(chart).toBeInTheDocument();
@@ -139,24 +138,24 @@ describe('Line', () => {
     // symbol opacity should be reduced for all but the first symbol
     let symbols = getAllLegendSymbols(chart);
     expect(symbols[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(symbols.slice(1), 'opacity', reducedOpacity)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(symbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
 
     // line opacity should be reduced for all but the first line
     let lines = await findAllMarksByGroupName(chart, 'line0');
     expect(lines[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', reducedOpacity)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(lines.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
 
     await unhoverNthElement(entries, 0);
     await hoverNthElement(entries, 3);
 
     // symbol opacity should be reduced for all but the last symbol
     symbols = getAllLegendSymbols(chart);
-    expect(allElementsHaveAttributeValue(symbols.slice(0, 3), 'opacity', reducedOpacity)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(symbols.slice(0, 3), 'opacity', FADE_FACTOR)).toBeTruthy();
     expect(symbols[3]).toHaveAttribute('opacity', '1');
 
     // line opacity should be reduced for all but the last line
     lines = await findAllMarksByGroupName(chart, 'line0');
-    expect(allElementsHaveAttributeValue(lines.slice(0, 3), 'opacity', reducedOpacity)).toBeTruthy();
+    expect(allElementsHaveAttributeValue(lines.slice(0, 3), 'opacity', FADE_FACTOR)).toBeTruthy();
     expect(lines[3]).toHaveAttribute('opacity', '1');
   });
 

--- a/packages/react-spectrum-charts/src/stories/components/Scatter/Scatter.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Scatter/Scatter.test.tsx
@@ -11,7 +11,7 @@
  */
 import userEvent from '@testing-library/user-event';
 
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
 import { Scatter } from '../../../components';
@@ -143,7 +143,7 @@ describe('Scatter', () => {
       expect(points[0]).toHaveAttribute('opacity', '1');
 
       // make sure all points after the first have reduced opacity
-      expect(allElementsHaveAttributeValue(points.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+      expect(allElementsHaveAttributeValue(points.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
 
       // find the select ring
       const selectRing = await findMarksByGroupName(chart, 'scatter0_selectRing');
@@ -202,7 +202,7 @@ describe('Scatter', () => {
       expect(points[0]).toHaveAttribute('opacity', '1');
 
       // make sure all points after the first have reduced opacity
-      expect(allElementsHaveAttributeValue(points.slice(1), 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)).toBeTruthy();
+      expect(allElementsHaveAttributeValue(points.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
     });
   });
 });

--- a/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.test.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { HIGHLIGHT_CONTRAST_RATIO } from '@spectrum-charts/constants';
+import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
 import { Trendline } from '../../../components';
@@ -191,7 +191,7 @@ describe('Trendline', () => {
 
       // other lines and trendlines are faded
       expect(
-        allElementsHaveAttributeValue([lines[1], trendlines[1]], 'opacity', 1 / HIGHLIGHT_CONTRAST_RATIO)
+        allElementsHaveAttributeValue([lines[1], trendlines[1]], 'opacity', FADE_FACTOR)
       ).toBeTruthy();
     });
   });
@@ -218,7 +218,7 @@ describe('Trendline', () => {
       expect(lines[0]).toHaveAttribute('opacity', '1');
 
       // other lines and trendlines are faded
-      expect(lines[1]).toHaveAttribute('opacity', `${1 / HIGHLIGHT_CONTRAST_RATIO}`);
+      expect(lines[1]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
     });
   });
 

--- a/packages/vega-spec-builder/src/area/areaUtils.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.ts
@@ -16,10 +16,10 @@ import {
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
   HIGHLIGHTED_ITEM,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVERED_ITEM,
   SELECTED_SERIES,
-  SERIES_ID,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 import {
@@ -104,7 +104,6 @@ export const getAreaMark = (
 export function getAreaOpacity(areaOptions: AreaMarkOptions): ProductionRule<NumericValueRef> | undefined {
   const { chartPopovers, displayOnHover, isHighlightedByGroup, isMetricRange, highlightedItem, name } = areaOptions;
   // if metric ranges only display when hovering, we don't need to include other hover rules for this specific area
-  const fadedOpacity = 1 / HIGHLIGHT_CONTRAST_RATIO;
   if (isMetricRange && displayOnHover) {
     return [
       { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`, value: 1 },
@@ -133,15 +132,15 @@ export function getAreaOpacity(areaOptions: AreaMarkOptions): ProductionRule<Num
       ...opacityRules,
       {
         test: `!isValid(${SELECTED_SERIES}) && isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-        value: fadedOpacity,
+        value: FADE_FACTOR,
       },
       {
         test: `!isValid(${SELECTED_SERIES}) && length(data('${name}_highlightedData')) > 0 && indexof(pluck(data('${name}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) === -1`,
-        value: fadedOpacity,
+        value: FADE_FACTOR,
       },
       {
         test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`,
-        value: fadedOpacity,
+        value: FADE_FACTOR,
       },
       DEFAULT_OPACITY_RULE,
     ];
@@ -151,15 +150,15 @@ export function getAreaOpacity(areaOptions: AreaMarkOptions): ProductionRule<Num
     ...opacityRules,
     {
       test: `isValid(${name}_${HOVERED_ITEM})`,
-      signal: `${name}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : ${fadedOpacity}`,
+      signal: `${name}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : ${FADE_FACTOR}`,
     },
     {
       test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-      value: fadedOpacity,
+      value: FADE_FACTOR,
     },
     {
       test: `length(data('${name}_highlightedData')) > 0 && indexof(pluck(data('${name}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) === -1`,
-      value: fadedOpacity,
+      value: FADE_FACTOR,
     },
     DEFAULT_OPACITY_RULE,
   ];

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.test.ts
@@ -14,9 +14,9 @@ import { Axis, ColorValueRef, GroupMark, NumericValueRef, ProductionRule, Scale,
 import {
   DEFAULT_LABEL_FONT_WEIGHT,
   FILTERED_TABLE,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   LAST_RSC_SERIES_ID,
-  MOUSE_OVER_SERIES,
+  MOUSE_OVER_SERIES
 } from '@spectrum-charts/constants';
 
 import { SubLabel } from '../types';
@@ -310,7 +310,7 @@ describe('Spec builder, Axis', () => {
         expect(labelFillOpacityEncoding).toHaveLength(1);
         expect(labelFillOpacityEncoding?.[0]).toEqual({
           test: `${MOUSE_OVER_SERIES} === ${LAST_RSC_SERIES_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         });
       });
 
@@ -343,7 +343,7 @@ describe('Spec builder, Axis', () => {
         expect(titleFillOpacityEncoding).toHaveLength(1);
         expect(titleFillOpacityEncoding?.[0]).toEqual({
           test: `${MOUSE_OVER_SERIES} === ${LAST_RSC_SERIES_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         });
       });
 
@@ -378,7 +378,7 @@ describe('Spec builder, Axis', () => {
         expect(labelFillOpacityEncoding).toHaveLength(1);
         expect(labelFillOpacityEncoding?.[0]).toEqual({
           test: `${MOUSE_OVER_SERIES} === ${LAST_RSC_SERIES_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         });
       });
 
@@ -434,7 +434,7 @@ describe('Spec builder, Axis', () => {
         expect(labelFillOpacityEncoding).toHaveLength(1);
         expect(labelFillOpacityEncoding?.[0]).toEqual({
           test: `isValid(${MOUSE_OVER_SERIES}) && ${MOUSE_OVER_SERIES} !== ${LAST_RSC_SERIES_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         });
       });
 
@@ -465,7 +465,7 @@ describe('Spec builder, Axis', () => {
         expect(labelFillOpacityEncoding).toHaveLength(1);
         expect(labelFillOpacityEncoding?.[0]).toEqual({
           test: `isValid(${MOUSE_OVER_SERIES}) && ${MOUSE_OVER_SERIES} !== ${LAST_RSC_SERIES_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         });
       });
 

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
@@ -30,7 +30,7 @@ import {
   DEFAULT_LABEL_FONT_WEIGHT,
   DEFAULT_LABEL_ORIENTATION,
   FIRST_RSC_SERIES_ID,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   LAST_RSC_SERIES_ID,
   MOUSE_OVER_SERIES
 } from '@spectrum-charts/constants';
@@ -48,7 +48,6 @@ import { getGenericValueSignal } from '../signal/signalSpecBuilder';
 import { AxisOptions, AxisSpecOptions, ColorScheme, Label, Orientation, Position, ScSpec, UserMeta } from '../types';
 import { getAxisLabelsEncoding, getControlledLabelAnchorValues, getLabelValue } from './axisLabelUtils';
 import { getReferenceLineMarks, getReferenceLines, scaleTypeSupportsReferenceLines } from './axisReferenceLineUtils';
-import { encodeAxisTitle, getTrellisAxisOptions, isTrellisedChart } from './axisTrellisUtils';
 import {
   addAxisThumbnailSignals,
   getAxisThumbnailLabelOffset,
@@ -56,6 +55,7 @@ import {
   getAxisThumbnails,
   scaleTypeSupportsThumbnails,
 } from './axisThumbnailUtils';
+import { encodeAxisTitle, getTrellisAxisOptions, isTrellisedChart } from './axisTrellisUtils';
 import {
   getBaselineRule,
   getDefaultAxis,
@@ -238,7 +238,7 @@ export function applySecondaryMetricAxisEncodings(axis: Axis): void {
   const secondaryAxisFillOpacityRules = [
     {
       test: `isValid(${MOUSE_OVER_SERIES}) && ${MOUSE_OVER_SERIES} !== ${LAST_RSC_SERIES_ID}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     },
   ];
 
@@ -287,7 +287,7 @@ export function applyPrimaryMetricAxisEncodings(axis: Axis, colorScheme: ColorSc
   const primaryAxisFillOpacityRules = [
     {
       test: `${MOUSE_OVER_SERIES} === ${LAST_RSC_SERIES_ID}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     },
   ];
 

--- a/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
@@ -23,9 +23,9 @@ import {
   DEFAULT_SECONDARY_COLOR,
   FILTERED_TABLE,
   HIGHLIGHTED_ITEM,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVERED_ITEM,
-  MARK_ID,
+  MARK_ID
 } from '@spectrum-charts/constants';
 
 import { BarSpecOptions } from '../types';
@@ -121,15 +121,15 @@ const defaultMarkWithTooltip: Mark = {
       opacity: [
         {
           test: `isValid(bar0_${HOVERED_ITEM})`,
-          signal: `bar0_${HOVERED_ITEM}.${MARK_ID} === datum.${MARK_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+          signal: `bar0_${HOVERED_ITEM}.${MARK_ID} === datum.${MARK_ID} ? 1 : ${FADE_FACTOR}`,
         },
         {
           test: `isArray(${HIGHLIGHTED_ITEM}) && length(${HIGHLIGHTED_ITEM}) > 0 && indexof(${HIGHLIGHTED_ITEM}, datum.rscMarkId) === -1`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         },
         {
           test: `!isArray(${HIGHLIGHTED_ITEM}) && isValid(${HIGHLIGHTED_ITEM}) && ${HIGHLIGHTED_ITEM} !== datum.${MARK_ID}`,
-          value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+          value: FADE_FACTOR,
         },
         DEFAULT_OPACITY_RULE,
       ],

--- a/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.ts
+++ b/packages/vega-spec-builder/src/chartTooltip/chartTooltipUtils.ts
@@ -17,10 +17,10 @@ import {
   GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_ITEM,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVERED_ITEM,
   INTERACTION_MODE,
-  SERIES_ID,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 import { getFilteredTableData } from '../data/dataUtils';
@@ -203,11 +203,11 @@ export const addHighlightMarkOpacityRules = (
   opacityRules.unshift(
     {
       test: `isArray(${HIGHLIGHTED_ITEM}) && length(${HIGHLIGHTED_ITEM}) > 0 && indexof(${HIGHLIGHTED_ITEM}, datum.${markOptions.idKey}) === -1`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     },
     {
       test: `!isArray(${HIGHLIGHTED_ITEM}) && isValid(${HIGHLIGHTED_ITEM}) && ${HIGHLIGHTED_ITEM} !== datum.${markOptions.idKey}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     }
   );
   if (isHighlightedByGroup(markOptions)) {
@@ -233,6 +233,6 @@ export const addHoveredItemOpacityRules = (opacityRules: ({ test?: string } & Nu
 
   opacityRules.splice(startIndex, 0, {
     test: `isValid(${hoveredItemSignal})`,
-    signal: `${hoveredItemSignal}.${key} === datum.${key} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+    signal: `${hoveredItemSignal}.${key} === datum.${key} ? 1 : ${FADE_FACTOR}`,
   });
 }

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
@@ -16,8 +16,8 @@ import {
   GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
-  SERIES_ID,
+  FADE_FACTOR,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 import { getHighlightOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
@@ -32,7 +32,7 @@ const defaultOpacityEncoding = {
   opacity: [
     {
       test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     },
   ],
 };

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
@@ -16,8 +16,8 @@ import {
   GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
-  SERIES_ID,
+  FADE_FACTOR,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 /**
@@ -57,7 +57,7 @@ export const getHighlightOpacityRule = (keys?: string[], name?: string): { test?
   if (keys?.length) {
     test = `isValid(${HIGHLIGHTED_GROUP}) && ${HIGHLIGHTED_GROUP} !== datum.${name}_${GROUP_ID}`;
   }
-  return { test, value: 1 / HIGHLIGHT_CONTRAST_RATIO };
+  return { test, value: FADE_FACTOR };
 };
 
 /**

--- a/packages/vega-spec-builder/src/legend/legendTestUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendTestUtils.ts
@@ -20,8 +20,8 @@ import {
   DEFAULT_OPACITY_RULE,
   FILTERED_TABLE,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
-  SELECTED_SERIES,
+  FADE_FACTOR,
+  SELECTED_SERIES
 } from '@spectrum-charts/constants';
 
 import { LegendSpecOptions } from '../types';
@@ -29,11 +29,11 @@ import { LegendSpecOptions } from '../types';
 export const opacityEncoding = [
   {
     test: `isValid(${HIGHLIGHTED_SERIES}) && datum.value !== ${HIGHLIGHTED_SERIES}`,
-    value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+    value: FADE_FACTOR,
   },
   {
     test: `isValid(${SELECTED_SERIES}) && datum.value !== ${SELECTED_SERIES}`,
-    value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+    value: FADE_FACTOR,
   },
   DEFAULT_OPACITY_RULE,
 ];

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -33,14 +33,14 @@ import {
   GROUP_ID,
   HIGHLIGHTED_GROUP,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   LINE_TYPE_SCALE,
   LINE_WIDTH_SCALE,
   OPACITY_SCALE,
   SELECTED_GROUP,
   SELECTED_SERIES,
   SYMBOL_SHAPE_SCALE,
-  SYMBOL_SIZE_SCALE,
+  SYMBOL_SIZE_SCALE
 } from '@spectrum-charts/constants';
 import { getColorValue, spectrumColors } from '@spectrum-charts/themes';
 
@@ -203,11 +203,11 @@ export const getOpacityEncoding = ({
     return [
       {
         test: `isValid(${highlightSignalName}) && datum.value !== ${highlightSignalName}`,
-        value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+        value: FADE_FACTOR,
       },
       {
         test: `isValid(${selectedSignalName}) && datum.value !== ${selectedSignalName}`,
-        value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+        value: FADE_FACTOR,
       },
       DEFAULT_OPACITY_RULE,
     ];

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -13,11 +13,11 @@ import {
   COLOR_SCALE,
   DEFAULT_OPACITY_RULE,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HIGHLIGHTED_SERIES,
   HOVERED_ITEM,
   SELECTED_SERIES,
-  SERIES_ID,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 import { getLineHoverMarks, getLineMark, getLineOpacity } from './lineMarkUtils';
@@ -123,8 +123,8 @@ describe('getLineOpacity()', () => {
       chartTooltips: [{}],
     });
     expect(opacityRule).toEqual([
-      { test: `isValid(line0_${HOVERED_ITEM})`, signal: `line0_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`},
-      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
+      { test: `isValid(line0_${HOVERED_ITEM})`, signal: `line0_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : ${FADE_FACTOR}`},
+      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: FADE_FACTOR },
       { value: 1 },
     ]);
   });
@@ -137,9 +137,9 @@ describe('getLineOpacity()', () => {
       chartPopovers: [{}],
     });
     expect(opacityRule).toEqual([
-      { signal: `line0_hoveredItem.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`, test: 'isValid(line0_hoveredItem)' },
-      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
-      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`, value: 1 / HIGHLIGHT_CONTRAST_RATIO },
+      { signal: `line0_hoveredItem.${SERIES_ID} === datum.${SERIES_ID} ? 1 : ${FADE_FACTOR}`, test: 'isValid(line0_hoveredItem)' },
+      { test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`, value: FADE_FACTOR },
+      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`, value: FADE_FACTOR },
       { value: 1 },
     ]);
   });

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -15,10 +15,10 @@ import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_OPACITY_RULE,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVERED_ITEM,
   SELECTED_SERIES,
-  SERIES_ID,
+  SERIES_ID
 } from '@spectrum-charts/constants';
 
 import { getPopovers } from '../chartPopover/chartPopoverUtils';
@@ -106,12 +106,12 @@ export const getLineOpacity = ({
   if (isHighlightedByGroup) {
     strokeOpacityRules.push({
       test: `length(data('${interactiveMarkName}_highlightedData'))`,
-      signal: `indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1 ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+      signal: `indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${SERIES_ID}'), datum.${SERIES_ID}) !== -1 ? 1 : ${FADE_FACTOR}`,
     })
   } else {
     strokeOpacityRules.push({
       test: `isValid(${interactiveMarkName}_${HOVERED_ITEM})`,
-      signal: `${interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : 1 / ${HIGHLIGHT_CONTRAST_RATIO}`,
+      signal: `${interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID} ? 1 : ${FADE_FACTOR}`,
     });
   }
 
@@ -119,14 +119,14 @@ export const getLineOpacity = ({
   strokeOpacityRules.push(
     {
       test: `isValid(${HIGHLIGHTED_SERIES}) && ${HIGHLIGHTED_SERIES} !== datum.${SERIES_ID}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     },
   );
 
   if (popoverMarkName) {
     strokeOpacityRules.push({
       test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} !== datum.${SERIES_ID}`,
-      value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+      value: FADE_FACTOR,
     });
   }
   // This allows us to only show the metric range when hovering over the parent line component.

--- a/packages/vega-spec-builder/src/marks/markUtils.test.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.test.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_TIME_DIMENSION,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
   HIGHLIGHTED_ITEM,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVERED_ITEM,
   LINEAR_COLOR_SCALE,
   LINE_TYPE_SCALE,
@@ -28,7 +28,7 @@ import {
   OPACITY_SCALE,
   SELECTED_GROUP,
   SELECTED_ITEM,
-  SYMBOL_SIZE_SCALE,
+  SYMBOL_SIZE_SCALE
 } from '@spectrum-charts/constants';
 
 import { defaultBarOptions } from '../bar/barTestUtils';
@@ -184,12 +184,12 @@ describe('getTooltip()', () => {
 describe('getHighlightOpacityValue()', () => {
   test('should divide a signal ref by the highlight contract ratio', () => {
     expect(getHighlightOpacityValue(getOpacityProductionRule(DEFAULT_COLOR))).toStrictEqual({
-      signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) / ${HIGHLIGHT_CONTRAST_RATIO}`,
+      signal: `scale('${OPACITY_SCALE}', datum.${DEFAULT_COLOR}) * ${FADE_FACTOR}`,
     });
   });
   test('shold divide a value ref by the highlight contrast ratio', () => {
     expect(getHighlightOpacityValue(getOpacityProductionRule({ value: 0.5 }))).toStrictEqual({
-      value: 0.5 / HIGHLIGHT_CONTRAST_RATIO,
+      value: 0.5 * FADE_FACTOR,
     });
   });
 });

--- a/packages/vega-spec-builder/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.ts
@@ -27,7 +27,7 @@ import {
   COMPONENT_NAME,
   DEFAULT_OPACITY_RULE,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   HOVER_SHAPE,
   HOVER_SHAPE_COUNT,
   HOVER_SIZE,
@@ -37,7 +37,7 @@ import {
   OPACITY_SCALE,
   SELECTED_GROUP,
   SELECTED_ITEM,
-  SYMBOL_SIZE_SCALE,
+  SYMBOL_SIZE_SCALE
 } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
@@ -256,9 +256,9 @@ export const getHighlightOpacityValue = (
   opacityValue: { signal: string } | { value: number } = DEFAULT_OPACITY_RULE
 ): NumericValueRef => {
   if ('signal' in opacityValue) {
-    return { signal: `${opacityValue.signal} / ${HIGHLIGHT_CONTRAST_RATIO}` };
+    return { signal: `${opacityValue.signal} * ${FADE_FACTOR}` };
   }
-  return { value: opacityValue.value / HIGHLIGHT_CONTRAST_RATIO };
+  return { value: opacityValue.value * FADE_FACTOR };
 };
 
 /**
@@ -437,7 +437,7 @@ export const getMarkOpacity = (
     return [
       {
         test: `!isValid(${SELECTED_GROUP}) && ${SELECTED_ITEM} && ${SELECTED_ITEM} !== datum.${idKey}`,
-        value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+        value: FADE_FACTOR,
       },
       { test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.${idKey}`, ...DEFAULT_OPACITY_RULE },
       {
@@ -446,7 +446,7 @@ export const getMarkOpacity = (
       },
       {
         test: `isValid(${SELECTED_GROUP}) && ${SELECTED_GROUP} !== datum.${markName}_selectedGroupId`,
-        value: 1 / HIGHLIGHT_CONTRAST_RATIO,
+        value: FADE_FACTOR,
       },
       ...rules,
     ];

--- a/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
@@ -15,8 +15,8 @@ import { GroupMark, Mark, NumericValueRef, SymbolMark } from 'vega';
 import {
   DEFAULT_OPACITY_RULE,
   FILTERED_TABLE,
-  HIGHLIGHT_CONTRAST_RATIO,
-  SELECTED_ITEM,
+  FADE_FACTOR,
+  SELECTED_ITEM
 } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
@@ -113,16 +113,13 @@ export const getOpacity = (scatterOptions: ScatterSpecOptions): ({ test?: string
   if (!isInteractive(scatterOptions) && highlightedItem === undefined) {
     return [DEFAULT_OPACITY_RULE];
   }
-  // if a point is hovered or selected, all other points should be reduced opacity
-  const fadedValue = 1 / HIGHLIGHT_CONTRAST_RATIO;
-
   const rules: ({ test?: string } & NumericValueRef)[] = [];
   addHighlightMarkOpacityRules(rules, scatterOptions);
   addHoveredItemOpacityRules(rules, scatterOptions);
   if (hasPopover(scatterOptions)) {
     rules.push({
       test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} !== datum.${idKey}`,
-      value: fadedValue,
+      value: FADE_FACTOR,
     });
   }
 

--- a/packages/vega-spec-builder/src/scatterPath/scatterPathUtils.ts
+++ b/packages/vega-spec-builder/src/scatterPath/scatterPathUtils.ts
@@ -16,10 +16,10 @@ import {
   FILTERED_TABLE,
   HIGHLIGHTED_ITEM,
   HIGHLIGHTED_SERIES,
-  HIGHLIGHT_CONTRAST_RATIO,
+  FADE_FACTOR,
   SELECTED_ITEM,
   SELECTED_SERIES,
-  SYMBOL_PATH_WIDTH_SCALE,
+  SYMBOL_PATH_WIDTH_SCALE
 } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
@@ -152,12 +152,11 @@ export const getScatterPathTrailMark = ({
  */
 export const getOpacity = (): ({ test?: string } & NumericValueRef)[] => {
   // if a point is hovered or selected, all other points should be reduced opacity
-  const fadedValue = 1 / HIGHLIGHT_CONTRAST_RATIO;
 
   return [
     {
       test: `isValid(${HIGHLIGHTED_SERIES}) || isValid(${HIGHLIGHTED_ITEM}) || isValid(${SELECTED_SERIES}) || isValid(${SELECTED_ITEM})`,
-      value: fadedValue,
+      value: FADE_FACTOR,
     },
     DEFAULT_OPACITY_RULE,
   ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Switch HIGHLIGHT_CONTRAST_RATIO to FADE_FACTOR.

Easier to use `0.2` everywhere instead of `1 / 5`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
