### PR TITLE
a11y fix: <svg> elements with an img role must have an alternative text

### DIFF
--- a/packages/vega-spec-builder/src/line/linePointUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.test.ts
@@ -27,6 +27,7 @@ import {
   getHighlightPointStroke,
   getHighlightPointStrokeOpacity,
   getHighlightPointStrokeWidth,
+  getSecondaryHighlightPoint,
   getSelectionPoint,
 } from './linePointUtils';
 import { defaultLineMarkOptions } from './lineTestUtils';
@@ -194,5 +195,56 @@ describe('getSelectionPoint()', () => {
     expect(selectionMark.from).toEqual({ data: 'line0_selectedData' });
     expect(highlightMark.name).toContain('highlight');
     expect(selectionMark.name).toContain('select');
+  });
+});
+
+describe('getSecondaryHighlightPoint()', () => {
+  const secondaryMetric = 'trendlineValue';
+
+  test('should return symbol mark with correct name and description', () => {
+    const mark = getSecondaryHighlightPoint(defaultLineMarkOptions, secondaryMetric);
+    expect(mark.name).toBe('line0_secondaryPoint');
+    expect(mark.description).toBe('line0_secondaryPoint');
+  });
+
+  test('should return symbol mark with correct properties', () => {
+    const mark = getSecondaryHighlightPoint(defaultLineMarkOptions, secondaryMetric);
+    expect(mark.type).toBe('symbol');
+    expect(mark.interactive).toBe(false);
+    expect(mark.from).toEqual({ data: 'line0_highlightedData' });
+  });
+
+  test('should have correct encode structure with secondary metric', () => {
+    const mark = getSecondaryHighlightPoint(defaultLineMarkOptions, secondaryMetric);
+    expect(mark.encode).toBeDefined();
+    expect(mark.encode?.enter).toBeDefined();
+    expect(mark.encode?.update).toBeDefined();
+    expect(mark.encode?.enter?.y).toEqual({ field: secondaryMetric, scale: 'yLinear' });
+    expect(mark.encode?.enter?.fill).toEqual({ signal: BACKGROUND_COLOR });
+    expect(mark.encode?.enter?.stroke).toEqual({ field: DEFAULT_COLOR, scale: COLOR_SCALE });
+  });
+
+  test('should use custom name in mark name and description', () => {
+    const customOptions = { ...defaultLineMarkOptions, name: 'customLine' };
+    const mark = getSecondaryHighlightPoint(customOptions, secondaryMetric);
+    expect(mark.name).toBe('customLine_secondaryPoint');
+    expect(mark.description).toBe('customLine_secondaryPoint');
+    expect(mark.from).toEqual({ data: 'customLine_highlightedData' });
+  });
+
+  test('should use the secondary metric for y-axis encoding', () => {
+    const metric1 = 'metric1';
+    const metric2 = 'metric2';
+    const mark1 = getSecondaryHighlightPoint(defaultLineMarkOptions, metric1);
+    const mark2 = getSecondaryHighlightPoint(defaultLineMarkOptions, metric2);
+    expect(mark1.encode?.enter?.y).toEqual({ field: metric1, scale: 'yLinear' });
+    expect(mark2.encode?.enter?.y).toEqual({ field: metric2, scale: 'yLinear' });
+  });
+
+  test('should use highlightedData like the primary highlight point', () => {
+    const mark = getSecondaryHighlightPoint(defaultLineMarkOptions, secondaryMetric);
+    const highlightMark = getHighlightPoint(defaultLineMarkOptions);
+    expect(mark.from).toEqual(highlightMark.from);
+    expect(mark.from).toEqual({ data: 'line0_highlightedData' });
   });
 });

--- a/packages/vega-spec-builder/src/line/linePointUtils.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.ts
@@ -155,6 +155,7 @@ export const getSecondaryHighlightPoint = (
   const { color, colorScheme, dimension, metricAxis, name, scaleType } = lineOptions;
   return {
     name: `${name}_secondaryPoint`,
+    description: `${name}_secondaryPoint`,
     type: 'symbol',
     from: { data: `${name}_highlightedData` },
     interactive: false,


### PR DESCRIPTION
## Description
Fix accessibility issue: `<svg> elements with an img role must have an alternative text`

## Related Issue
[PLAT-241299](https://jira.corp.adobe.com/browse/PLAT-241299)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
AEP Monitoring noun is using RSC in Streaming end-to-end v2. We got accessibility ticket: https://jira.corp.adobe.com/browse/PLAT-241299, which complains `<svg> elements with an img role does not have an alternative text in "Data management" > "Monitoring" > "Streaming end-to-end" tab`

## How Has This Been Tested?
Tested on local storybook, `aria-label` is added to solve this issue. 
Also run axe DevTools on the local again, the issue is gone.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1574" height="798" alt="Screenshot 2025-10-27 at 4 27 55 PM" src="https://github.com/user-attachments/assets/fee9afc3-fdca-45a4-873f-3d79a3f66f86" />
<img width="1721" height="939" alt="Screenshot 2025-10-27 at 4 44 51 PM" src="https://github.com/user-attachments/assets/493defad-2bd2-455a-ba3b-bbd2681d7b47" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
