### PR TITLE
fix: add description for aria label to highlight points

### DIFF
--- a/packages/vega-spec-builder/src/line/linePointUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.test.ts
@@ -21,11 +21,14 @@ import {
 } from '@spectrum-charts/constants';
 
 import {
+  getHighlightPoint,
   getHighlightPointFill,
   getHighlightPointSize,
   getHighlightPointStroke,
   getHighlightPointStrokeOpacity,
   getHighlightPointStrokeWidth,
+  getSecondaryHighlightPoint,
+  getSelectionPoint,
 } from './linePointUtils';
 import { defaultLineMarkOptions } from './lineTestUtils';
 
@@ -119,5 +122,26 @@ describe('getHighlightPointStrokeWidth()', () => {
     const rules = getHighlightPointStrokeWidth({ ...defaultLineMarkOptions, staticPoint });
     expect(rules).toHaveLength(2);
     expect(rules[0]).toHaveProperty(`test`, `datum.${staticPoint} && datum.${staticPoint} === true`);
+  });
+});
+
+describe('getHighlightPoint()', () => {
+  test('should set description property', () => {
+    const mark = getHighlightPoint(defaultLineMarkOptions);
+    expect(mark.description).toBe('line0_point_highlight');
+  });
+});
+
+describe('getSelectionPoint()', () => {
+  test('should set description property', () => {
+    const mark = getSelectionPoint(defaultLineMarkOptions);
+    expect(mark.description).toBe('line0_point_select');
+  });
+});
+
+describe('getSecondaryHighlightPoint()', () => {
+  test('should set description property', () => {
+    const mark = getSecondaryHighlightPoint(defaultLineMarkOptions, 'secondaryMetric');
+    expect(mark.description).toBe('line0_secondaryPoint');
   });
 });

--- a/packages/vega-spec-builder/src/line/linePointUtils.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.ts
@@ -106,6 +106,7 @@ const getHighlightOrSelectionPoint = (lineOptions: LineMarkOptions, useHighlight
     type: 'symbol',
     from: { data: `${name}${useHighlightedData ? '_highlightedData' : '_selectedData'}` },
     interactive: false,
+    description: `${name}_point_${useHighlightedData ? 'highlight' : 'select'}`,
     encode: {
       enter: {
         y: getYProductionRule(metricAxis, metric),
@@ -154,6 +155,7 @@ export const getSecondaryHighlightPoint = (
   const { color, colorScheme, dimension, metricAxis, name, scaleType } = lineOptions;
   return {
     name: `${name}_secondaryPoint`,
+    description: `${name}_secondaryPoint`,
     type: 'symbol',
     from: { data: `${name}_highlightedData` },
     interactive: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This is a quick fix to make sure we have aria-labels generating for highlight points through Vega. We'll need to apply this to more spec elements in order to solve this error in multiple places:
js
```
Ensure <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Simple unit tests. We should consider more robust automate accessibility testing going forward.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1162" height="1242" alt="Screenshot 2025-10-28 at 10 06 44" src="https://github.com/user-attachments/assets/da33d3f3-d4b1-4798-b80b-cae7ec77d104" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
