### PR TITLE
feat: add prop for ChartPopover

### DIFF
--- a/packages/react-spectrum-charts/src/RscChart.tsx
+++ b/packages/react-spectrum-charts/src/RscChart.tsx
@@ -145,7 +145,7 @@ RscChart.displayName = 'RscChart';
 
 const ChartDialog = ({ datum, popover, setIsPopoverOpen, targetElement }: ChartDialogProps) => {
   const { chartPopoverProps, name } = popover;
-  const { children, onOpenChange, containerPadding, containerMargin, rightClick, ...dialogProps } = chartPopoverProps;
+  const { children, onOpenChange, containerPadding, contentMargin, rightClick, ...dialogProps } = chartPopoverProps;
   const minWidth = dialogProps.minWidth ?? 0;
 
   return (
@@ -170,7 +170,7 @@ const ChartDialog = ({ datum, popover, setIsPopoverOpen, targetElement }: ChartD
             data-testid="rsc-popover-content"
             gridColumn="1/-1"
             gridRow="1/-1"
-            margin={containerMargin ?? 12}
+            margin={contentMargin ?? 12}
           >
             {datum && datum[COMPONENT_NAME] === name && children?.(datum, close)}
           </SpectrumView>

--- a/packages/react-spectrum-charts/src/rscToSbAdapter/chartPopoverAdapter.test.ts
+++ b/packages/react-spectrum-charts/src/rscToSbAdapter/chartPopoverAdapter.test.ts
@@ -24,8 +24,8 @@ describe('getChartPopoverOptions()', () => {
     const options = getChartPopoverOptions({});
     expect(options).not.toHaveProperty('height');
   });
-  it('should pass through containerMargin prop', () => {
-    const options = getChartPopoverOptions({ containerMargin: 24 });
-    expect(options).toHaveProperty('containerMargin', 24);
+  it('should pass through contentMargin prop', () => {
+    const options = getChartPopoverOptions({ contentMargin: 24 });
+    expect(options).toHaveProperty('contentMargin', 24);
   });
 });

--- a/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.story.tsx
@@ -170,13 +170,13 @@ StackedBarChart.args = { children: dialogContent, width: 'auto' };
 const Svg = bindWithProps(ChartPopoverSvgStory);
 Svg.args = { children: dialogContent, width: 'auto' };
 
-const ContainerMargin = bindWithProps(ChartPopoverSvgStory);
-ContainerMargin.args = { children: dialogContent, width: 'auto', containerMargin: 24 };
+const ContentMargin = bindWithProps(ChartPopoverSvgStory);
+ContentMargin.args = { children: dialogContent, width: 'auto', contentMargin: 24 };
 
 export {
   AreaChart,
   Canvas,
-  ContainerMargin,
+  ContentMargin,
   DodgedBarChart,
   DonutChart,
   LineChart,

--- a/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -32,7 +32,7 @@ import {
 import '../../../test-utils/__mocks__/matchMedia.mock.js';
 import {
   Canvas,
-  ContainerMargin,
+  ContentMargin,
   DodgedBarChart,
   DonutChart,
   LineChart,
@@ -148,8 +148,8 @@ describe('ChartPopover', () => {
     expect(popover).toHaveStyle('width: auto; min-width: 250px;');
   });
 
-  test('should honor containerMargin', async () => {
-    render(<ContainerMargin {...ContainerMargin.args} />);
+  test('should honor contentMargin', async () => {
+    render(<ContentMargin {...ContentMargin.args} />);
 
     const chart = await findChart();
     expect(chart).toBeInTheDocument();
@@ -171,7 +171,7 @@ describe('ChartPopover', () => {
     });
   });
 
-  test('should use default containerMargin when not provided', async () => {
+  test('should use default contentMargin when not provided', async () => {
     render(<StackedBarChart {...StackedBarChart.args} />);
 
     const chart = await findChart();

--- a/packages/vega-spec-builder/src/types/dialogs/chartPopoverSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/dialogs/chartPopoverSpec.types.ts
@@ -33,7 +33,7 @@ export interface ChartPopoverOptions {
   /** Sets which marks should be highlighted when a popover is visible.  This feature is incomplete. */
   UNSAFE_highlightBy?: 'series' | 'dimension' | 'item' | string[];
   /** The margin that should be applied between the popover and its surrounding container */
-  containerMargin?: number;
+  contentMargin?: number;
 }
 
 type ChartPopoverOptionsWithDefaults = 'UNSAFE_highlightBy';


### PR DESCRIPTION
Feature Addition: containerMargin Prop for ChartPopover


<!--- Provide a general summary of your changes in the Title above -->

## Description
Purpose: Added support for customizable margin on the popover content container, allowing developers to control the spacing between the popover content and its border.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Component Tests (packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.test.tsx)
Added test: "should honor containerMargin" - verifies custom containerMargin value (24px) is applied correctly
Added test: "should use default containerMargin when not provided" - verifies default value (12px) is used when prop is omitted

Adapter Tests (packages/react-spectrum-charts/src/rscToSbAdapter/chartPopoverAdapter.test.ts)
Added test: "should pass through containerMargin prop" - ensures the adapter correctly forwards the containerMargin property

Story Addition (packages/react-spectrum-charts/src/stories/components/ChartPopover/ChartPopover.story.tsx)
Added ContainerMargin story with containerMargin: 24 to demonstrate the feature in Storybook
Exported the new story for use in tests and documentation

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
