### PR TITLE
feat: Add transparentPoints prop to Scatter component

### DIFF
--- a/packages/react-spectrum-charts/src/components/Scatter/Scatter.tsx
+++ b/packages/react-spectrum-charts/src/components/Scatter/Scatter.tsx
@@ -35,6 +35,7 @@ const Scatter: FC<ScatterProps> = ({
   opacity = { value: 1 },
   size = { value: DEFAULT_SYMBOL_SIZE },
   stroke,
+  transparentPoints,
 }) => {
   return null;
 };

--- a/packages/react-spectrum-charts/src/stories/components/Scatter/Scatter.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Scatter/Scatter.story.tsx
@@ -295,4 +295,13 @@ StrokeWithOverlappingPoints.args = {
   lineWidth: { value: 2 },
 };
 
-export { Basic, Color, ColorScaleType, LineType, OnMouseInputs, Opacity, Popover, Size, Stroke, StrokeWithOverlappingPoints, Tooltip };
+const OverlappingPoints = bindWithProps(OverlappingPointsStory);
+OverlappingPoints.args = {
+  dimension: 'speedNormal',
+  metric: 'handlingNormal',
+  color: 'weightClass',
+  transparentPoints: true,
+  size: { value: 80 },
+};
+
+export { Basic, Color, ColorScaleType, LineType, OnMouseInputs, Opacity, OverlappingPoints, Popover, Size, Stroke, StrokeWithOverlappingPoints, Tooltip };

--- a/packages/vega-spec-builder/src/scatter/scatterMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterMarkUtils.test.ts
@@ -154,3 +154,35 @@ describe('getScatterMark() stroke', () => {
     expect(mark.encode?.enter?.fill).not.toEqual(mark.encode?.enter?.stroke);
   });
 });
+
+describe('getScatterMark() transparentPoints', () => {
+  test('should use default opacity (1) when transparentPoints is not set', () => {
+    const mark = getScatterMark({ ...defaultScatterOptions });
+    expect(mark.encode?.enter?.fillOpacity).toEqual({ value: 1 });
+  });
+
+  test('should use semi-transparent opacity (0.7) when transparentPoints is true', () => {
+    const mark = getScatterMark({ ...defaultScatterOptions, transparentPoints: true });
+    expect(mark.encode?.enter?.fillOpacity).toEqual({ value: 0.7 });
+  });
+
+  test('should use semi-transparent opacity even with custom opacity when transparentPoints is true', () => {
+    const mark = getScatterMark({
+      ...defaultScatterOptions,
+      transparentPoints: true,
+      opacity: { value: 0.5 },
+    });
+    // transparentPoints takes precedence
+    expect(mark.encode?.enter?.fillOpacity).toEqual({ value: 0.7 });
+  });
+
+  test('should use default opacity when transparentPoints is false', () => {
+    const mark = getScatterMark({
+      ...defaultScatterOptions,
+      transparentPoints: false,
+      opacity: { value: 0.5 },
+    });
+    // explicit opacity is used
+    expect(mark.encode?.enter?.fillOpacity).toEqual({ value: 0.5 });
+  });
+});

--- a/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
@@ -56,6 +56,8 @@ export const addScatterMarks = produce<Mark[], [ScatterSpecOptions]>((marks, opt
  * @param scatterOptions scatterSpecOptions
  * @returns SymbolMark
  */
+const TRANSPARENT_POINTS_OPACITY = 0.7;
+
 export const getScatterMark = (options: ScatterSpecOptions): SymbolMark => {
   const {
     color,
@@ -70,7 +72,13 @@ export const getScatterMark = (options: ScatterSpecOptions): SymbolMark => {
     opacity,
     size,
     stroke,
+    transparentPoints,
   } = options;
+
+  // Use semi-transparent opacity when transparentPoints is enabled
+  // User can still override by explicitly setting opacity
+  const effectiveOpacity = transparentPoints ? { value: TRANSPARENT_POINTS_OPACITY } : opacity;
+
   return {
     name,
     description: name,
@@ -87,7 +95,7 @@ export const getScatterMark = (options: ScatterSpecOptions): SymbolMark => {
          */
         blend: { value: colorScheme === 'light' ? 'multiply' : 'screen' },
         fill: getColorProductionRule(color, colorScheme, colorScaleType),
-        fillOpacity: getOpacityProductionRule(opacity),
+        fillOpacity: getOpacityProductionRule(effectiveOpacity),
         shape: { value: 'circle' },
         size: getSymbolSizeProductionRule(size),
         strokeDash: getStrokeDashProductionRule(lineType),

--- a/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.ts
@@ -69,6 +69,7 @@ export const addScatter = produce<
       size = { value: 'M' },
       trendlines = [],
       stroke,
+      transparentPoints,
       ...options
     }
   ) => {
@@ -97,6 +98,7 @@ export const addScatter = produce<
       scatterAnnotations,
       scatterPaths,
       size,
+      transparentPoints,
       trendlines,
       ...options,
     };

--- a/packages/vega-spec-builder/src/types/marks/scatterSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/scatterSpec.types.ts
@@ -25,6 +25,7 @@ import { ScatterAnnotationOptions } from './supplemental';
 import { ScatterPathOptions } from './supplemental/scatterPathSpec.types';
 import { TrendlineOptions } from './supplemental/trendlineSpec.types';
 
+
 export interface ScatterOptions {
   markType: 'scatter';
 
@@ -84,6 +85,12 @@ export interface ScatterOptions {
    * defaults to `color` if not provided
    */
   stroke?: ColorFacet;
+  /**
+   * when true, points are rendered semi-transparent (opacity 0.7) to show overlapping points
+   * this is useful for dense scatter plots where points may overlap
+   * takes precedence over `opacity` when set to true
+   */
+  transparentPoints?: boolean;
 }
 
 type ScatterOptionsWithDefaults =


### PR DESCRIPTION
Add transparentPoints prop to Scatter component

## Description

Adds a new transparentPoints prop to the Scatter component that renders points with semi-transparent opacity (0.7) to improve visibility of overlapping data points.

Changes

- Added transparentPoints?: boolean prop to ScatterOptions interface
- When true, points render at 0.7 opacity instead of the default 1
- Added OverlappingPoints story demonstrating the feature
- Added 4 unit tests for the new prop

Usage
```
// Default behavior (unchanged)
<Scatter dimension="x" metric="y" color="category" />

// Semi-transparent points for dense scatter plots
<Scatter dimension="x" metric="y" color="category" transparentPoints />
```

Backward Compatibility
✅ Fully backward compatible - existing charts are unaffected. The prop is optional and defaults to false.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
