### PR TITLE
Adding a missing quotstion mark to vega rules within LegendUtils

### DIFF
--- a/packages/react-spectrum-charts/src/stories/Chart.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.story.tsx
@@ -14,7 +14,7 @@ import { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import useChartProps from '../hooks/useChartProps';
-import { Axis, Bar, Chart, ChartTooltip, Line } from '../index';
+import { Axis, Bar, Chart, ChartTooltip, Legend, Line } from '../index';
 import { bindWithProps } from '../test-utils';
 import './Chart.story.css';
 import { ChartBarStory } from './ChartBarStory';
@@ -64,6 +64,7 @@ const ChartBarTooltipStory: StoryFn<typeof Chart> = (args): ReactElement => {
           )}
         </ChartTooltip>
       </Bar>
+      <Legend />
     </Chart>
   );
 };

--- a/packages/react-spectrum-charts/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.test.tsx
@@ -377,7 +377,7 @@ describe('Chart', () => {
       expect(tooltip).toBeInTheDocument();
       if (!tooltip) return;
 
-      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(239);
+      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(176);
       expect(getPxValue(tooltip.style.getPropertyValue('left'))).toBe(35);
     });
 
@@ -392,7 +392,7 @@ describe('Chart', () => {
       expect(tooltip).toBeInTheDocument();
       if (!tooltip) return;
 
-      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(284);
+      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(213);
       expect(getPxValue(tooltip.style.getPropertyValue('left'))).toBe(35);
     });
   });

--- a/packages/react-spectrum-charts/src/stories/components/ChartTooltip/HighlightBy.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/ChartTooltip/HighlightBy.story.tsx
@@ -17,7 +17,7 @@ import { View } from '@adobe/react-spectrum';
 import { Datum } from '@spectrum-charts/vega-spec-builder';
 
 import { Chart } from '../../../Chart';
-import { Area, Bar, Line, Scatter } from '../../../components';
+import { Area, Bar, Line, Scatter, Legend } from '../../../components';
 import { ChartTooltip } from '../../../components/ChartTooltip';
 import useChartProps from '../../../hooks/useChartProps';
 import { browserData } from '../../../stories/data/data';
@@ -56,6 +56,7 @@ const StackedBarTooltipStory: StoryFn<typeof ChartTooltip> = (args): ReactElemen
     <Chart {...chartProps}>
       <Bar color="series">
         <ChartTooltip {...args} />
+        <Legend />
       </Bar>
     </Chart>
   );

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -218,7 +218,7 @@ export const getOpacityEncoding = (
   }
   if (highlightedItem) {
     rules.push({
-      test: `length(data('${CONTROLLED_HIGHLIGHTED_TABLE}))`,
+      test: `length(data('${CONTROLLED_HIGHLIGHTED_TABLE}'))`,
       signal: `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'), '${SERIES_ID}'), datum.${SERIES_ID}) > -1 ? 1 : ${FADE_FACTOR}`,
     });
   }


### PR DESCRIPTION

## Description

Multiple issues were occuring when the prop highlightedItem was being used in Chart. Chart would fail to load when highlightedItem was anything but undefined and the chart contained a legend

## Related Issue


## Motivation and Context

When using react-spectrum-charts in outside code repos, we would get a blank chart returned and a vega error when highlighedItem was being used. Stories within react-spectrum-charts, however, were not having errors. 

## How Has This Been Tested?

We added <Legend> to highlight related stories and adjusted tests accordingly. Now stories will access the same vega rules that were adjusted

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
