### PR TITLE
fix: resize vega view without recreating it to fix axis image flickering

### DIFF
--- a/packages/react-spectrum-charts/src/VegaChart.test.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { View } from 'vega';
+
+import { resizeView } from './VegaChart';
+
+const mockRunAsync = jest.fn().mockResolvedValue(undefined);
+const mockResize = jest.fn().mockReturnThis();
+const mockHeight = jest.fn().mockReturnThis();
+const mockWidth = jest.fn().mockReturnThis();
+
+const createMockView = (): View =>
+	({
+		runAsync: mockRunAsync,
+		resize: mockResize,
+		height: mockHeight,
+		width: mockWidth,
+	}) as unknown as View;
+
+describe('resizeView', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('calls width, height, resize, and runAsync when view exists and dimensions are valid', () => {
+		const mockView = createMockView();
+
+		resizeView(mockView, 800, 600);
+
+		expect(mockWidth).toHaveBeenCalledWith(800);
+		expect(mockHeight).toHaveBeenCalledWith(600);
+		expect(mockResize).toHaveBeenCalled();
+		expect(mockRunAsync).toHaveBeenCalled();
+	});
+
+	test('does not call view methods when view is undefined', () => {
+		resizeView(undefined, 800, 600);
+
+		expect(mockWidth).not.toHaveBeenCalled();
+		expect(mockHeight).not.toHaveBeenCalled();
+		expect(mockResize).not.toHaveBeenCalled();
+		expect(mockRunAsync).not.toHaveBeenCalled();
+	});
+
+	test('does not call view methods when width is 0', () => {
+		const mockView = createMockView();
+
+		resizeView(mockView, 0, 600);
+
+		expect(mockWidth).not.toHaveBeenCalled();
+	});
+
+	test('does not call view methods when height is 0', () => {
+		const mockView = createMockView();
+
+		resizeView(mockView, 800, 0);
+
+		expect(mockWidth).not.toHaveBeenCalled();
+	});
+});

--- a/packages/react-spectrum-charts/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.tsx
@@ -23,6 +23,15 @@ import { useDebugSpec } from './hooks/useDebugSpec';
 import { extractValues, isVegaData } from './hooks/useSpec';
 import { ChartProps } from './types';
 
+/**
+ * Resizes an existing Vega view without recreating it.
+ */
+export const resizeView = (view: View | undefined, width: number, height: number): void => {
+  if (view && width && height) {
+    view.width(width).height(height).resize().runAsync();
+  }
+};
+
 export interface VegaChartProps {
   config: Config;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -75,6 +84,11 @@ export const VegaChart: FC<VegaChartProps> = ({
 
   useDebugSpec(debug, spec, chartData, width, height, config);
 
+  // Handle resize without recreating the view (prevents axis image flickering)
+  useEffect(() => {
+    resizeView(chartView.current, width, height);
+  }, [width, height]);
+
   useEffect(() => {
     if (width && height && containerRef.current) {
       const specCopy = JSON.parse(JSON.stringify(spec)) as Spec;
@@ -117,11 +131,11 @@ export const VegaChart: FC<VegaChartProps> = ({
         chartView.current = undefined;
       }
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     chartData.table,
     config,
     data,
-    height,
     numberLocale,
     timeLocale,
     onNewView,
@@ -130,8 +144,8 @@ export const VegaChart: FC<VegaChartProps> = ({
     signals,
     spec,
     tooltip,
-    width,
     locale,
+    s2,
   ]);
 
   return <div ref={containerRef} className="rsc"></div>;

--- a/packages/react-spectrum-charts/src/stories/components/Axis/AxisThumbnail.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Axis/AxisThumbnail.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../test-utils';
 import '../../../test-utils/__mocks__/matchMedia.mock.js';
 import { Basic, Popover, YAxis } from './AxisThumbnail.story';
+import { Resizable } from './AxisThumbnailResize.story';
 
 describe('AxisThumbnail', () => {
   // AxisThumbnail is not a real React component. This is test just provides test coverage for sonarqube
@@ -58,6 +59,15 @@ describe('AxisThumbnail', () => {
     expect(chart).toBeInTheDocument();
 
     // Check that thumbnail icons are drawn to the chart
+    const thumbnailMarks = await findAllMarksByGroupName(chart, 'axis0AxisThumbnail0', 'image');
+    expect(thumbnailMarks).toHaveLength(5);
+  });
+
+  test('Resizable renders properly', async () => {
+    render(<Resizable {...Resizable.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
     const thumbnailMarks = await findAllMarksByGroupName(chart, 'axis0AxisThumbnail0', 'image');
     expect(thumbnailMarks).toHaveLength(5);
   });

--- a/packages/react-spectrum-charts/src/stories/components/Axis/AxisThumbnailResize.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Axis/AxisThumbnailResize.story.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { View } from '@adobe/react-spectrum';
+
+import { Chart } from '../../../Chart';
+import { Axis, AxisThumbnail, Bar } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { AxisThumbnailProps } from '../../../types';
+import { barData } from '../Bar/data';
+
+export default {
+	title: 'RSC/Axis/AxisThumbnail',
+	component: AxisThumbnail,
+};
+
+const thumbnails = ['/chrome.png', '/firefox.png', '/safari.png', '/edge.png', '/explorer.png'];
+
+const data = barData.map((datum, index) => ({
+	...datum,
+	thumbnail: thumbnails[index],
+}));
+
+const ResizableStory: StoryFn<AxisThumbnailProps> = (args): ReactElement => {
+	const chartProps = useChartProps({ data, width: 'auto', height: '100%', padding: 2 });
+
+	return (
+		<View
+			backgroundColor="gray-50"
+			overflow="hidden"
+			width={800}
+			minWidth={200}
+			maxWidth={1400}
+			height={400}
+			minHeight={200}
+			maxHeight={800}
+			borderColor="gray-400"
+			borderWidth="thick"
+			padding={16}
+			UNSAFE_style={{ resize: 'both' }}
+		>
+			<Chart {...chartProps}>
+				<Bar dimension="browser" metric="downloads" />
+				<Axis position="bottom" baseline>
+					<AxisThumbnail {...args} />
+				</Axis>
+			</Chart>
+		</View>
+	);
+};
+
+const Resizable = bindWithProps(ResizableStory);
+Resizable.args = {
+	urlKey: 'thumbnail',
+};
+
+export { Resizable };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Height and width being in the vega view dependencies was causing a full redraw on the chart whenever resizing. This fix address this issue for automatic Chart sizing. Height and width that are set to fill the outer container will no longer trigger a full re-draw when the container size changes.

This does not address the same issue when the height and width props themselves change. For instance, if changing the height from a pixel value of 600, to 400. This second case will be addressed in a later change. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Full redraw of the chart is unnecessary and causes noticeable visual rendering issues for some elements on charts, like images. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing is limited until we can implement an additional change that will resolve this for specific height/width values. Simple unit test for now, with more to come. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
