### PR TITLE
feat: add hoverPoint prop to MetricRange

### DIFF
--- a/packages/docs/docs/api/analysis/MetricRange.md
+++ b/packages/docs/docs/api/analysis/MetricRange.md
@@ -45,6 +45,12 @@ The `MetricRange` component is used to add a custom area mark onto visualization
             <td>Whether the metric range should only be visible when hovering over the parent line.</td>
         </tr>
         <tr>
+            <td>hoverPoint</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Whether to show a hover point on the metric line when the parent line is interactive.</td>
+        </tr>
+        <tr>
             <td>lineType</td>
             <td>'solid' | 'dashed' | 'dotted' | 'dotDash' | 'shortDash' | 'longDash' | 'twoDash' | number[]</td>
             <td>'dashed'</td>

--- a/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
@@ -20,7 +20,7 @@ import { Axis, ChartPopover, ChartTooltip, Legend, Line, MetricRange } from '../
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
-import { workspaceTrendsDataWithAnomalies, workspaceTrendsDataWithExtremeMetricRange, workspaceTrendsDataWithNullsInMetricRange } from '../../data/data';
+import { workspaceTrendsDataWithAnomalies, workspaceTrendsDataWithExtremeMetricRange, workspaceTrendsDataWithForecast, workspaceTrendsDataWithNullsInMetricRange } from '../../data/data';
 
 export default {
   title: 'RSC/MetricRange',
@@ -72,6 +72,21 @@ const MetricRangeWithPopoverStory: StoryFn<typeof MetricRange> = (args): ReactEl
         <MetricRange {...args} />
         <ChartTooltip>{dialogContent}</ChartTooltip>
         <ChartPopover width={200}>{dialogContent}</ChartPopover>
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
+const MetricRangeWithHoverPointsStory: StoryFn<typeof MetricRange> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithForecast });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <MetricRange {...args} />
+        <ChartTooltip>{dialogContent}</ChartTooltip>
       </Line>
       <Legend lineWidth={{ value: 0 }} highlight />
     </Chart>
@@ -224,6 +239,17 @@ WithBreaks.args = {
   metric: 'metric',
 };
 
+const WithHoverPoints = bindWithProps(MetricRangeWithHoverPointsStory);
+WithHoverPoints.args = {
+  lineType: 'shortDash',
+  lineWidth: 'S',
+  rangeOpacity: 0.2,
+  metricEnd: 'metricEnd',
+  metricStart: 'metricStart',
+  metric: 'metric',
+  hoverPoint: true,
+};
+
 export {
   Basic,
   DisplayOnHover,
@@ -233,4 +259,5 @@ export {
   LineOpacity,
   LineOpacityByKey,
   WithBreaks,
+  WithHoverPoints,
 };

--- a/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
@@ -148,8 +148,8 @@ const MetricRangeWithBreaksStory: StoryFn<typeof MetricRange> = (args): ReactEle
 const dialogContent = (datum) => (
   <Content>
     <div>Operating system: {datum.series}</div>
-    <div>Browser: {datum.category}</div>
-    <div>Users: {datum.value}</div>
+    {datum.category && <div>Browser: {datum.category}</div>}
+    <div>Users: {datum.value ?? datum.metric}</div>
   </Content>
 );
 

--- a/packages/react-spectrum-charts/src/stories/data/data.ts
+++ b/packages/react-spectrum-charts/src/stories/data/data.ts
@@ -970,6 +970,29 @@ export const workspaceTrendsDataWithAnomalies = [
   },
 ];
 
+export const workspaceTrendsDataWithForecast = [
+  // Historical data — solid line visible, no metric range fields
+  { datetime: 1667890800000, value: 3738, series: 'Add Fallout' },
+  { datetime: 1667977200000, value: 2704, series: 'Add Fallout' },
+  { datetime: 1668063600000, value: 1730, series: 'Add Fallout' },
+  { datetime: 1668150000000, value: 465, series: 'Add Fallout' },
+  { datetime: 1668236400000, value: 200, series: 'Add Fallout', staticPoint: true },
+  // Forecast data — solid line absent (value null), metric range visible
+  { datetime: 1668322800000, value: null, metric: 350, metricStart: 150, metricEnd: 550, series: 'Add Fallout' },
+  { datetime: 1668409200000, value: null, metric: 550, metricStart: 250, metricEnd: 850, series: 'Add Fallout' },
+  { datetime: 1668495600000, value: null, metric: 800, metricStart: 400, metricEnd: 1200, series: 'Add Fallout' },
+  // Historical data — solid line visible, no metric range fields
+  { datetime: 1667890800000, value: 12208, series: 'Add Freeform table' },
+  { datetime: 1667977200000, value: 11309, series: 'Add Freeform table' },
+  { datetime: 1668063600000, value: 11099, series: 'Add Freeform table' },
+  { datetime: 1668150000000, value: 7243, series: 'Add Freeform table' },
+  { datetime: 1668236400000, value: 5000, series: 'Add Freeform table', staticPoint: true },
+  // Forecast data — solid line absent (value null), metric range visible
+  { datetime: 1668322800000, value: null, metric: 6000, metricStart: 4500, metricEnd: 7500, series: 'Add Freeform table' },
+  { datetime: 1668409200000, value: null, metric: 7500, metricStart: 5500, metricEnd: 9500, series: 'Add Freeform table' },
+  { datetime: 1668495600000, value: null, metric: 9500, metricStart: 7000, metricEnd: 12000, series: 'Add Freeform table' },
+];
+
 export const workspaceTrendsDataWithExtremeMetricRange = [
   {
     datetime: 1667890800000,

--- a/packages/vega-spec-builder/src/data/dataUtils.ts
+++ b/packages/vega-spec-builder/src/data/dataUtils.ts
@@ -119,19 +119,31 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform[] => {
  * @param validNumericKeys Optional list of keys that must be valid finite numbers in the data.
  *                         Rows where any of these are NaN, null, or undefined are excluded
  *                         so voronoi path marks do not receive invalid path parameters.
+ * @param metricRangeHoverableMetrics Optional list of metric fields from MetricRange children with
+ *                                hoverPoint enabled. When provided, rows are also included if any
+ *                                of these metrics is valid — allowing forecast rows (where the line
+ *                                metric is null) to receive voronoi cells.
  * @returns spec data that filters out items where the `excludeDataKey` is true and invalid numeric values
  */
 export const getFilteredTooltipData = (
   chartTooltips: ChartTooltipOptions[],
-  validNumericKeys?: string[]
+  validNumericKeys?: string[],
+  metricRangeHoverableMetrics?: string[]
 ): { name: string; source: string; transform?: { type: 'filter'; expr: string }[] } => {
   const transforms: { type: 'filter'; expr: string }[] = [];
 
   if (validNumericKeys?.length) {
+    // looping through metricRangeHoverableMetrics because there could be multiple metric ranges within a Line chart
+    let metricValidExprs: string[] = [];
+    if (metricRangeHoverableMetrics && metricRangeHoverableMetrics.length > 0) { 
+      metricValidExprs = metricRangeHoverableMetrics.map((m) => `isValid(datum["${m}"])`);
+    }
+    const orClause = metricValidExprs.length ? ` || ${metricValidExprs.join(' || ')}` : '';
     validNumericKeys.forEach((key) => {
+      const baseExpr = `isValid(datum["${key}"]) && isFinite(datum["${key}"])`;
       transforms.push({
         type: 'filter',
-        expr: `isValid(datum["${key}"]) && isFinite(datum["${key}"])`,
+        expr: orClause ? `(${baseExpr})${orClause}` : baseExpr,
       });
     });
   }

--- a/packages/vega-spec-builder/src/line/lineDataUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineDataUtils.ts
@@ -62,6 +62,19 @@ export const getLineHighlightedData = (options: LineSpecOptions): SourceData => 
 };
 
 /**
+ * Gets a data source filtered to rows where the given metric is valid.
+ * Used to prevent hover marks from being created at NaN y positions when a metric is null.
+ * @param outputName - name of the output data source
+ * @param sourceName - name of the upstream data source to filter
+ * @param metric - data field to validate
+ */
+export const getFilteredIsValidData = (outputName: string, sourceName: string, metric: string): SourceData => ({
+  name: outputName,
+  source: sourceName,
+  transform: [{ type: 'filter', expr: `isValid(datum["${metric}"])` }],
+});
+
+/**
  * gets the data used for displaying points
  * @param name
  * @param staticPoint

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -21,7 +21,7 @@ import {
   SERIES_ID,
 } from '@spectrum-charts/constants';
 
-import { getLineHoverMarks, getLineMark, getLineOpacity } from './lineMarkUtils';
+import { getLineHoverMarks, getLineMark, getLineOpacity, getVoronoiYEncoding } from './lineMarkUtils';
 import { defaultLineMarkOptions } from './lineTestUtils';
 
 describe('getLineMark()', () => {
@@ -109,6 +109,33 @@ describe('getLineHoverMarks()', () => {
       'line0_facet'
     );
     expect(marks[0].encode?.update?.opacity).toEqual({ signal: "length(data('line0_selectedData')) > 0 ? 0 : 1" });
+  });
+});
+
+describe('getVoronoiYEncoding()', () => {
+  test('returns standard line y encoding when no MetricRange hover points', () => {
+    const encoding = getVoronoiYEncoding({ ...defaultLineMarkOptions, metricRanges: [] }, 'value');
+    expect(encoding).toEqual([{ scale: 'yLinear', field: 'value' }]);
+  });
+
+  test('returns conditional y encoding with MetricRange fallback when hoverPoint is true', () => {
+    const encoding = getVoronoiYEncoding(
+      { ...defaultLineMarkOptions, metricRanges: [{ metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'metric', hoverPoint: true }] },
+      'value'
+    );
+    expect(encoding).toEqual([
+      { test: 'isValid(datum["value"])', scale: 'yLinear', field: 'value' },
+      { test: 'isValid(datum["metric"])', scale: 'yLinear', field: 'metric' },
+      { scale: 'yLinear', field: 'value' },
+    ]);
+  });
+
+  test('excludes MetricRange metrics where hoverPoint is false', () => {
+    const encoding = getVoronoiYEncoding(
+      { ...defaultLineMarkOptions, metricRanges: [{ metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'metric', hoverPoint: false }] },
+      'value'
+    );
+    expect(encoding).toEqual([{ scale: 'yLinear', field: 'value' }]);
   });
 });
 

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -253,6 +253,38 @@ const getVoronoiMarks = (lineOptions: LineMarkOptions, dataSource: string): Mark
 };
 
 /**
+ * Gets the Y encoding for voronoi points, extending the standard line Y encoding with
+ * conditional fallbacks for MetricRange hover point metrics. This allows voronoi cells
+ * to be generated for rows where the line metric is null but a MetricRange metric is valid
+ * (e.g. forecast rows).
+ * @param lineOptions - Line options
+ * @param metric - The line metric field name
+ * @returns Y encoding for voronoi points
+ */
+export const getVoronoiYEncoding = (lineOptions: LineMarkOptions, metric: string): ProductionRule<NumericValueRef> => {
+  const { metricAxis, metricRanges = [] } = lineOptions;
+
+  if (isDualMetricAxis(lineOptions)) {
+    return getLineYEncoding(lineOptions, metric);
+  }
+
+  const hoverPointMetrics = metricRanges
+    .filter(mr => mr.hoverPoint && mr.metric)
+    .map(mr => mr.metric as string);
+
+  if (hoverPointMetrics.length === 0) {
+    return getLineYEncoding(lineOptions, metric);
+  }
+
+  const yScale = metricAxis || 'yLinear';
+  return [
+    { test: `isValid(datum["${metric}"])`, scale: yScale, field: metric },
+    ...hoverPointMetrics.map(mrMetric => ({ test: `isValid(datum["${mrMetric}"])`, scale: yScale, field: mrMetric })),
+    { scale: yScale, field: metric },
+  ];
+};
+
+/**
  * Gets the points used for the voronoi calculation for line charts with dual metric axis support
  * @param lineOptions - Line options including dual metric axis settings
  * @param dataSource - the name of the data source that will be used in the voronoi calculation
@@ -260,7 +292,7 @@ const getVoronoiMarks = (lineOptions: LineMarkOptions, dataSource: string): Mark
  */
 const getLinePointsForVoronoi = (lineOptions: LineMarkOptions, dataSource: string): Mark => {
   const { dimension, metric, name, scaleType } = lineOptions;
-  
+
   return {
     name: `${name}_pointsForVoronoi`,
     description: `${name}_pointsForVoronoi`,
@@ -269,7 +301,7 @@ const getLinePointsForVoronoi = (lineOptions: LineMarkOptions, dataSource: strin
     interactive: false,
     encode: {
       enter: {
-        y: getLineYEncoding(lineOptions, metric),
+        y: getVoronoiYEncoding(lineOptions, metric),
         fill: { value: 'transparent' },
         stroke: { value: 'transparent' },
       },

--- a/packages/vega-spec-builder/src/line/linePointUtils.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.ts
@@ -106,18 +106,24 @@ export const getLineStaticPoint = (lineOptions: LineSpecOptions): SymbolMark => 
   };
 };
 
+const getHighlightedDataSource = (name: string, metricRanges: LineMarkOptions['metricRanges']): string => {
+  const hasMetricRangeHoverPoints = metricRanges?.some((mr) => mr.hoverPoint);
+  return hasMetricRangeHoverPoints ? `${name}_filteredHighlightedData` : `${name}_highlightedData`;
+};
+
 /**
  * Gets a background to points to prevent opacity from displaying elements behind the point.
  * @param lineMarkOptions
  * @returns SymbolMark
  */
 export const getHighlightBackgroundPoint = (lineOptions: LineMarkOptions): SymbolMark => {
-  const { dimension, metric, name, scaleType } = lineOptions;
+  const { dimension, metric, metricRanges, name, scaleType } = lineOptions;
+  const dataSource = getHighlightedDataSource(name, metricRanges);
   return {
     name: `${name}_pointBackground`,
     description: `${name}_pointBackground`,
     type: 'symbol',
-    from: { data: `${name}_highlightedData` },
+    from: { data: dataSource },
     interactive: false,
     encode: {
       enter: {
@@ -135,12 +141,13 @@ export const getHighlightBackgroundPoint = (lineOptions: LineMarkOptions): Symbo
 };
 
 const getHighlightOrSelectionPoint = (lineOptions: LineMarkOptions, useHighlightedData = true): SymbolMark => {
-  const { color, colorScheme, dimension, metric, name, scaleType } = lineOptions;
+  const { color, colorScheme, dimension, metric, metricRanges, name, scaleType } = lineOptions;
+  const dataSource = useHighlightedData ? getHighlightedDataSource(name, metricRanges) : `${name}_selectedData`;
   return {
     name: `${name}_point_${useHighlightedData ? 'highlight' : 'select'}`,
     description: `${name}_point_${useHighlightedData ? 'highlight' : 'select'}`,
     type: 'symbol',
-    from: { data: `${name}${useHighlightedData ? '_highlightedData' : '_selectedData'}` },
+    from: { data: dataSource },
     interactive: false,
     encode: {
       enter: {

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -30,14 +30,14 @@ import { addPopoverData } from '../chartPopover/chartPopoverUtils';
 import { addTooltipData, addTooltipSignals, isHighlightedByGroup } from '../chartTooltip/chartTooltipUtils';
 import { addTimeTransform, getFilteredTooltipData, getTableData } from '../data/dataUtils';
 import { getHoverMarkNames, getInteractiveMarkName, isInteractive } from '../marks/markUtils';
-import { getMetricRangeData, getMetricRangeGroupMarks, getMetricRanges } from '../metricRange/metricRangeUtils';
+import { getMetricRangeAllHoverPoints, getMetricRangeData, getMetricRangeGroupMarks, getMetricRanges } from '../metricRange/metricRangeUtils';
 import { addContinuousDimensionScale, addFieldToFacetScaleDomain, addMetricScale } from '../scale/scaleSpecBuilder';
 import { getDualAxisScaleNames } from '../scale/scaleUtils';
 import { addHoveredItemSignal, getFirstRscSeriesIdSignal, getLastRscSeriesIdSignal } from '../signal/signalSpecBuilder';
 import { addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
 import { addTrendlineData, getTrendlineMarks, getTrendlineScales, setTrendlineSignals } from '../trendline';
 import { ColorScheme, Granularity, HighlightedItem, LineOptions, LineSpecOptions, ScSpec } from '../types';
-import { getLineHighlightedData, getLineStaticPointData } from './lineDataUtils';
+import { getFilteredIsValidData, getLineHighlightedData, getLineStaticPointData } from './lineDataUtils';
 import { getLineHoverMarks, getLineMark } from './lineMarkUtils';
 import { getLinePointAnnotationMarks } from './linePointAnnotation';
 import { getLineStaticPoint } from './linePointUtils';
@@ -146,7 +146,17 @@ export const addData = produce<Data[], [LineSpecOptions, { timeGranularity?: Gra
     }
     if (isInteractive(options) || highlightedItem !== undefined) {
       const validNumericKeys = scaleType === 'linear' ? [dimension, metric] : [metric];
-      data.push(getLineHighlightedData(options), getFilteredTooltipData(chartTooltips, validNumericKeys));
+      // Only include MetricRange metrics that are explicitly set for the voronoi OR clause.
+      // metric defaults to 'value' after applyMetricRangeOptionDefaults but may be absent in raw options.
+      const hasHoverableMetricRanges = options.metricRanges.some((mr) => mr.hoverPoint);
+      const metricRangeHoverableMetrics = options.metricRanges
+        .filter((mr) => mr.hoverPoint && mr.metric)
+        .map((mr) => mr.metric as string);
+      data.push(getLineHighlightedData(options), getFilteredTooltipData(chartTooltips, validNumericKeys, metricRangeHoverableMetrics));
+      if (hasHoverableMetricRanges) {
+        const filteredHighlightData = getFilteredIsValidData(`${name}_filteredHighlightedData`, `${name}_highlightedData`, metric);
+        data.push(filteredHighlightData);
+      }
     }
     if (staticPoint || isSparkline)
       data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE, isSparkline, isMethodLast));
@@ -255,6 +265,7 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
     marks.push(...getLineHoverMarks(options, `${FILTERED_TABLE}ForTooltip`));
   }
   marks.push(...getTrendlineMarks(options));
+  marks.push(...getMetricRangeAllHoverPoints(options));
 });
 
 const getMetricKeys = (lineOptions: LineSpecOptions) => {

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -264,8 +264,7 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
   if (isInteractive(options) || highlightedItem !== undefined) {
     marks.push(...getLineHoverMarks(options, `${FILTERED_TABLE}ForTooltip`));
   }
-  marks.push(...getTrendlineMarks(options));
-  marks.push(...getMetricRangeAllHoverPoints(options));
+  marks.push(...getTrendlineMarks(options), ...getMetricRangeAllHoverPoints(options));
 });
 
 const getMetricKeys = (lineOptions: LineSpecOptions) => {

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+  BACKGROUND_COLOR,
   COLOR_SCALE,
   DEFAULT_COLOR,
   DEFAULT_COLOR_SCHEME,
@@ -24,8 +25,10 @@ import {
 import { LineSpecOptions, MetricRangeOptions, MetricRangeSpecOptions } from '../types';
 import {
   applyMetricRangeOptionDefaults,
+  getMetricRangeAllHoverPoints,
   getMetricRangeData,
   getMetricRangeGroupMarks,
+  getMetricRangeHoverPoints,
   getMetricRangeMark,
 } from './metricRangeUtils';
 
@@ -40,6 +43,7 @@ const defaultMetricRangeOptions: MetricRangeOptions = {
 
 const defaultMetricRangeSpecOptions: MetricRangeSpecOptions = {
   chartTooltips: [],
+  hoverPoint: false,
   lineType: 'shortDash',
   lineWidth: 'S',
   rangeOpacity: 0.2,
@@ -129,6 +133,7 @@ describe('applyMetricRangePropDefaults', () => {
     expect(applyMetricRangeOptionDefaults({ metricEnd: 'metricStart', metricStart: 'metricEnd' }, 'line0', 0)).toEqual({
       chartTooltips: [],
       displayOnHover: false,
+      hoverPoint: false,
       lineType: 'dashed',
       lineWidth: 'S',
       name: 'line0MetricRange0',
@@ -149,6 +154,7 @@ describe('applyMetricRangePropDefaults', () => {
           metric: 'testMetric',
           rangeOpacity: 0.5,
           displayOnHover: true,
+          hoverPoint: true,
         },
         'line0',
         0
@@ -156,6 +162,7 @@ describe('applyMetricRangePropDefaults', () => {
     ).toEqual({
       chartTooltips: [],
       displayOnHover: true,
+      hoverPoint: true,
       lineType: 'solid',
       lineWidth: 'L',
       name: 'line0MetricRange0',
@@ -208,6 +215,89 @@ describe('getMetricRangeGroupMarks', () => {
       },
     ]);
   });
+
+  test('always returns only group marks (hover points are added separately via getMetricRangeAllHoverPoints)', () => {
+    const interactiveLineOptions = {
+      ...defaultLineOptions,
+      interactiveMarkName: 'line0',
+      metricRanges: [{ ...defaultMetricRangeOptions, hoverPoint: true }],
+    };
+    const marks = getMetricRangeGroupMarks(interactiveLineOptions);
+    expect(marks).toHaveLength(1);
+    expect(marks[0].type).toBe('group');
+  });
+});
+
+describe('getMetricRangeAllHoverPoints', () => {
+  test('returns empty array when hoverPoint is false', () => {
+    const interactiveLineOptions = { ...defaultLineOptions, interactiveMarkName: 'line0' };
+    expect(getMetricRangeAllHoverPoints(interactiveLineOptions)).toHaveLength(0);
+  });
+
+  test('returns two symbol marks when hoverPoint is true and interactiveMarkName is set', () => {
+    const interactiveLineOptions = {
+      ...defaultLineOptions,
+      interactiveMarkName: 'line0',
+      metricRanges: [{ ...defaultMetricRangeOptions, hoverPoint: true }],
+    };
+    const marks = getMetricRangeAllHoverPoints(interactiveLineOptions);
+    expect(marks).toHaveLength(2);
+    expect(marks[0].name).toBe('line0MetricRange0_pointBackground');
+    expect(marks[1].name).toBe('line0MetricRange0_point_highlight');
+  });
+
+  test('returns empty array when interactiveMarkName is undefined', () => {
+    const lineOptions = {
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, hoverPoint: true }],
+    };
+    expect(getMetricRangeAllHoverPoints(lineOptions)).toHaveLength(0);
+  });
+});
+
+describe('getMetricRangeHoverPoints', () => {
+  const interactiveLineOptions = { ...defaultLineOptions, interactiveMarkName: 'line0' };
+
+  test('returns two symbol marks: background and highlight', () => {
+    const marks = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    expect(marks).toHaveLength(2);
+    expect(marks[0].type).toBe('symbol');
+    expect(marks[1].type).toBe('symbol');
+  });
+
+  test('both marks source from the MetricRange hoverPointData', () => {
+    const marks = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    expect(marks[0].from?.data).toBe('line0MetricRange0_hoverPointData');
+    expect(marks[1].from?.data).toBe('line0MetricRange0_hoverPointData');
+  });
+
+  test('both marks are non-interactive', () => {
+    const marks = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    expect(marks[0].interactive).toBe(false);
+    expect(marks[1].interactive).toBe(false);
+  });
+
+  test('background mark uses background color for fill and stroke', () => {
+    const [bg] = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    expect(bg.encode?.enter?.fill).toHaveProperty('signal', BACKGROUND_COLOR);
+    expect(bg.encode?.enter?.stroke).toHaveProperty('signal', BACKGROUND_COLOR);
+  });
+
+  test('highlight mark uses background color for fill and series color for stroke', () => {
+    const [, highlight] = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    expect(highlight.encode?.update?.fill).toHaveProperty('signal', BACKGROUND_COLOR);
+    expect(highlight.encode?.enter?.stroke).toBeDefined();
+    expect(highlight.encode?.enter?.stroke).not.toHaveProperty('signal', BACKGROUND_COLOR);
+    expect(highlight.encode?.update?.stroke).toBeDefined();
+    expect(highlight.encode?.update?.strokeOpacity).toBeDefined();
+  });
+
+  test('both marks have opacity rule that hides them when metric is not valid', () => {
+    const [bg, highlight] = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    const expectedOpacity = [{ test: `isValid(datum["${defaultMetricRangeSpecOptions.metric}"])`, value: 1 }, { value: 0 }];
+    expect(bg.encode?.update?.opacity).toEqual(expectedOpacity);
+    expect(highlight.encode?.update?.opacity).toEqual(expectedOpacity);
+  });
 });
 
 describe('getMetricRangeData', () => {
@@ -218,5 +308,25 @@ describe('getMetricRangeData', () => {
     });
     expect(data).toHaveLength(1);
     expect(data[0]).toHaveProperty('name', 'line0MetricRange0_highlightedData');
+  });
+
+  test('adds filtered hoverPointData source when hoverPoint is true and line is interactive', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      interactiveMarkName: 'line0',
+      metricRanges: [{ ...defaultMetricRangeOptions, hoverPoint: true }],
+    });
+    expect(data).toHaveLength(1);
+    expect(data[0]).toHaveProperty('name', 'line0MetricRange0_hoverPointData');
+    expect(data[0]).toHaveProperty('source', 'line0_highlightedData');
+    expect(data[0].transform).toEqual([{ type: 'filter', expr: `isValid(datum["${defaultMetricRangeOptions.metric}"])` }]);
+  });
+
+  test('does not add filtered highlightedData source when hoverPoint is true but line is not interactive', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, hoverPoint: true }],
+    });
+    expect(data).toHaveLength(0);
   });
 });

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
@@ -9,12 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { AreaMark, GroupMark, LineMark, SourceData } from 'vega';
+import { AreaMark, GroupMark, LineMark, SourceData, SymbolMark } from 'vega';
 
 import {
+  BACKGROUND_COLOR,
   CONTROLLED_HIGHLIGHTED_SERIES,
   CONTROLLED_HIGHLIGHTED_TABLE,
   DEFAULT_METRIC,
+  DEFAULT_SYMBOL_SIZE,
+  DEFAULT_SYMBOL_STROKE_WIDTH,
   FILTERED_TABLE,
   HOVERED_ITEM,
   SELECTED_SERIES,
@@ -22,8 +25,10 @@ import {
 } from '@spectrum-charts/constants';
 
 import { AreaMarkOptions, getAreaMark } from '../area/areaUtils';
-import { getLineMark } from '../line/lineMarkUtils';
+import { getFilteredIsValidData } from '../line/lineDataUtils';
+import { getLineMark, getLineYEncoding } from '../line/lineMarkUtils';
 import { LineMarkOptions } from '../line/lineUtils';
+import { getColorProductionRule, getOpacityProductionRule, getXProductionRule } from '../marks/markUtils';
 import { getFacetsFromOptions } from '../specUtils';
 import { LineSpecOptions, MetricRangeOptions, MetricRangeSpecOptions } from '../types';
 
@@ -38,6 +43,7 @@ export const getMetricRanges = (markOptions: MetricRangeParentOptions): MetricRa
 export const applyMetricRangeOptionDefaults = (
   {
     chartTooltips = [],
+    hoverPoint = false,
     lineType = 'dashed',
     lineWidth = 'S',
     rangeOpacity = 0.2,
@@ -49,6 +55,7 @@ export const applyMetricRangeOptionDefaults = (
   index: number
 ): MetricRangeSpecOptions => ({
   chartTooltips,
+  hoverPoint,
   lineType,
   lineWidth,
   name: `${markName}MetricRange${index}`,
@@ -59,7 +66,7 @@ export const applyMetricRangeOptionDefaults = (
 });
 
 /**
- * gets the metric range group mark including the metric range line and area marks.
+  * gets the metric range group mark including the metric range line and area marks.
  * @param lineMarkOptions
  */
 export const getMetricRangeGroupMarks = (lineMarkOptions: LineSpecOptions): GroupMark[] => {
@@ -89,6 +96,89 @@ export const getMetricRangeGroupMarks = (lineMarkOptions: LineSpecOptions): Grou
   }
 
   return marks;
+};
+
+/**
+ * Gets all hover point marks for all metric ranges on a line.
+ * These must be pushed after all other marks (including line hover marks) so they render
+ * on top of the clipped metric range group layers.
+ * @param lineMarkOptions
+ */
+export const getMetricRangeAllHoverPoints = (lineMarkOptions: LineSpecOptions): SymbolMark[] => {
+  const marks: SymbolMark[] = [];
+  const metricRanges = getMetricRanges(lineMarkOptions);
+
+  for (const metricRangeOptions of metricRanges) {
+    if (metricRangeOptions.hoverPoint && lineMarkOptions.interactiveMarkName) {
+      marks.push(...getMetricRangeHoverPoints(lineMarkOptions, metricRangeOptions));
+    }
+  }
+
+  return marks;
+};
+
+/**
+ * Gets the background and highlight point marks for a metric range, displayed at the hovered position.
+ * Sources from the parent line's highlightedData so points appear when hovering the parent line.
+ * @param lineMarkOptions
+ * @param metricRangeOptions
+ */
+export const getMetricRangeHoverPoints = (
+  lineMarkOptions: LineSpecOptions,
+  metricRangeOptions: MetricRangeSpecOptions
+): SymbolMark[] => {
+  const { color: lineColor, colorScheme, dimension, scaleType } = lineMarkOptions;
+  const { color: rangeColor, metric, name } = metricRangeOptions;
+  const highlightedData = `${name}_hoverPointData`;
+  const color = rangeColor ? { value: rangeColor } : lineColor;
+
+  const validMetricTest = `isValid(datum["${metric}"])`;
+
+  const backgroundPoint: SymbolMark = {
+    name: `${name}_pointBackground`,
+    description: `${name}_pointBackground`,
+    type: 'symbol',
+    from: { data: highlightedData },
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { signal: BACKGROUND_COLOR },
+        stroke: { signal: BACKGROUND_COLOR },
+        y: getLineYEncoding(lineMarkOptions, metric),
+      },
+      update: {
+        size: { value: DEFAULT_SYMBOL_SIZE },
+        strokeWidth: { value: DEFAULT_SYMBOL_STROKE_WIDTH },
+        x: getXProductionRule(scaleType, dimension),
+        opacity: [{ test: validMetricTest, value: 1 }, { value: 0 }],
+      },
+    },
+  };
+
+  const highlightPoint: SymbolMark = {
+    name: `${name}_point_highlight`,
+    description: `${name}_point_highlight`,
+    type: 'symbol',
+    from: { data: highlightedData },
+    interactive: false,
+    encode: {
+      enter: {
+        y: getLineYEncoding(lineMarkOptions, metric),
+        stroke: getColorProductionRule(color, colorScheme),
+      },
+      update: {
+        fill: { signal: BACKGROUND_COLOR },
+        size: { value: DEFAULT_SYMBOL_SIZE },
+        stroke: getColorProductionRule(color, colorScheme),
+        strokeOpacity: getOpacityProductionRule(lineMarkOptions.opacity),
+        strokeWidth: { value: DEFAULT_SYMBOL_STROKE_WIDTH },
+        x: getXProductionRule(scaleType, dimension),
+        opacity: [{ test: validMetricTest, value: 1 }, { value: 0 }],
+      },
+    },
+  };
+
+  return [backgroundPoint, highlightPoint];
 };
 
 /**
@@ -142,7 +232,13 @@ export const getMetricRangeData = (markOptions: LineSpecOptions): SourceData[] =
   const metricRanges = getMetricRanges(markOptions);
 
   for (const metricRangeOptions of metricRanges) {
-    const { displayOnHover, name } = metricRangeOptions;
+    const { displayOnHover, hoverPoint, metric, name } = metricRangeOptions;
+    // if hoverPoint is true and the line is interactive, add a filtered data source to rows where the
+    // MetricRange metric is valid. This prevents hover marks from being created at NaN y positions
+    // for rows where the metric is null.
+    if (hoverPoint && markOptions.interactiveMarkName) {
+      data.push(getFilteredIsValidData(`${name}_hoverPointData`, `${markOptions.name}_highlightedData`, metric));
+    }
     // if displayOnHover is true, add a data source for the highlighted data
     if (displayOnHover) {
       const hoveredItem = `isValid(${markOptions.interactiveMarkName}_${HOVERED_ITEM}) && ${markOptions.interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;

--- a/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
@@ -72,6 +72,18 @@ describe('addData()', () => {
         { type: 'filter', expr: 'isValid(datum["value"]) && isFinite(datum["value"])' },
       ]);
     });
+    test('ORs metricRangeHoverMetrics into each validNumericKeys filter', () => {
+      const result = getFilteredTooltipData([{}], ['value'], ['metric']);
+      expect(result.transform).toStrictEqual([
+        { type: 'filter', expr: '(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metric"])' },
+      ]);
+    });
+    test('supports multiple metricRangeHoverMetrics joined with OR', () => {
+      const result = getFilteredTooltipData([{}], ['value'], ['metricA', 'metricB']);
+      expect(result.transform).toStrictEqual([
+        { type: 'filter', expr: '(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metricA"]) || isValid(datum["metricB"])' },
+      ]);
+    });
     test('adds validNumericKeys filters then excludeDataKeys filter', () => {
       const data = addData(initializeSpec().data ?? [], {
         ...defaultScatterOptions,

--- a/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
@@ -32,6 +32,8 @@ export interface MetricRangeOptions {
   metric?: string;
   /** Whether the metric range should only be visible when hovering over the parent line */
   displayOnHover?: boolean;
+  /** Whether to show a hover point on the metric range line when the parent line is interactive */
+  hoverPoint?: boolean;
   /** Boolean indicating whether or not the y-axis should expand to include the entire metric range (if necessary). */
   scaleAxisToFit?: boolean;
 
@@ -41,6 +43,7 @@ export interface MetricRangeOptions {
 
 type MetricRangeOptionsWithDefaults =
   | 'chartTooltips'
+  | 'hoverPoint'
   | 'lineType'
   | 'lineWidth'
   | 'metric'


### PR DESCRIPTION
## Description

add hoverPoint prop to Metric Range. 

## Related Issue

## Motivation and Context

Allows for points on metric range line to be interactive. 

## How Has This Been Tested?

Storybook and unit tests 

## Screenshots (if appropriate):

<img width="968" height="462" alt="Screenshot 2026-04-10 at 11 25 42 AM" src="https://github.com/user-attachments/assets/987d501d-0ada-482d-b049-2d597b8fc1fb" />
<img width="897" height="458" alt="Screenshot 2026-04-10 at 11 27 33 AM" src="https://github.com/user-attachments/assets/9a5522ff-45f7-407b-b15d-9ebae37a21f7" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
