### PR TITLE
fix: separate venn and establish new init render cycle pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,9 @@ When adding a new mark, verify its encodings follow the same conventions as comp
 - Opacity must use `getMarkOpacity()` rather than a hardcoded value
 - Cross-check against one or two similar existing marks (e.g. `barAnnotationUtils.ts`, `linePointUtils.ts`) to catch any other conventions
 
+### 6. TypeScript
+After writing or modifying test files, run `yarn tsc --noEmit` and confirm no errors before reporting the work done. `yarn test` passing does not imply the files are type-correct.
+
 ---
 
 ## S2 Docs Pages
@@ -273,6 +276,8 @@ When adding a new page under `packages/docs/docs/spectrum2/`:
 ## S2 Variant
 
 `vega-spec-builder-s2` overrides specific functions from `vega-spec-builder` (color resolution, background signals) to use Spectrum 2 tokens. `react-spectrum-charts-s2` wraps the S2 spec builder. When working on S2 features, build with `yarn build:s2` and run Storybook with `yarn storybook:s2`.
+
+When fixing a bug or refactoring behavior in an s1 package file, always check whether the corresponding s2 file needs the same change. The packages mirror each other structurally but s2 has no Venn support, no `s2` prop, and uses s2-specific imports (`vega-spec-builder-s2`, `react-spectrum-charts-s2`). A fix in one without the other leaves the packages inconsistent.
 
 ---
 

--- a/packages/react-spectrum-charts-s2/src/VegaChart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/VegaChart.test.tsx
@@ -9,9 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { View } from 'vega';
+import { render, waitFor } from '@testing-library/react';
+import { Spec, View } from 'vega';
+import embed from 'vega-embed';
 
-import { resizeView } from './VegaChart';
+import { VegaChart, VegaChartProps, resizeView } from './VegaChart';
+
+jest.mock('vega-embed');
+
+const mockEmbed = jest.mocked(embed);
 
 const mockRunAsync = jest.fn().mockResolvedValue(undefined);
 const mockResize = jest.fn().mockReturnThis();
@@ -24,7 +30,24 @@ const createMockView = (): View =>
 		resize: mockResize,
 		height: mockHeight,
 		width: mockWidth,
+		finalize: jest.fn(),
 	}) as unknown as View;
+
+const defaultSpec: Spec = {};
+
+const defaultProps: VegaChartProps = {
+	config: {},
+	data: [],
+	debug: false,
+	height: 600,
+	locale: undefined,
+	onNewView: jest.fn(),
+	padding: 0,
+	renderer: 'svg',
+	spec: defaultSpec,
+	tooltip: {},
+	width: 800,
+};
 
 describe('resizeView', () => {
 	beforeEach(() => {
@@ -65,5 +88,34 @@ describe('resizeView', () => {
 		resizeView(mockView, 800, 0);
 
 		expect(mockWidth).not.toHaveBeenCalled();
+	});
+});
+
+// AN-445759: regression tests for the init render cycle fix
+describe('VegaChart init render cycle', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockEmbed.mockResolvedValue({ view: createMockView() } as unknown as Awaited<ReturnType<typeof embed>>);
+	});
+
+	test('calls embed on initial mount with valid dimensions', async () => {
+		render(<VegaChart {...defaultProps} />);
+
+		await waitFor(() => expect(mockEmbed).toHaveBeenCalledTimes(1));
+	});
+
+	test('does not call embed on initial mount with zero dimensions', () => {
+		render(<VegaChart {...defaultProps} width={0} height={0} />);
+
+		expect(mockEmbed).not.toHaveBeenCalled();
+	});
+
+	test('calls embed when dimensions become valid after starting at zero', async () => {
+		const { rerender } = render(<VegaChart {...defaultProps} width={0} height={0} />);
+		expect(mockEmbed).not.toHaveBeenCalled();
+
+		rerender(<VegaChart {...defaultProps} width={800} height={600} />);
+
+		await waitFor(() => expect(mockEmbed).toHaveBeenCalledTimes(1));
 	});
 });

--- a/packages/react-spectrum-charts-s2/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/VegaChart.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FC, useEffect, useMemo, useRef } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Config, Padding, Renderers, Spec, View } from 'vega';
 import embed from 'vega-embed';
@@ -64,6 +64,10 @@ export const VegaChart: FC<VegaChartProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartView = useRef<View>();
+  const hasMounted = useRef(false);
+  // AN-445759: flipped to true when dimensions become valid post-mount with no existing view,
+  // forcing the embed effect to run even though width/height are not in its deps.
+  const [needsInitEmbed, setNeedsInitEmbed] = useState(false);
 
   const { number: numberLocale, time: timeLocale } = useMemo(() => getLocale(locale), [locale]);
 
@@ -82,9 +86,19 @@ export const VegaChart: FC<VegaChartProps> = ({
 
   useDebugSpec(debug, spec, chartData, width, height, config);
 
-  // Handle resize without recreating the view (prevents axis image flickering)
+  // Handle resize without recreating the view (prevents axis image flickering).
+  // AN-445759: skip on initial mount — the embed effect handles that render. After mount, if
+  // dimensions become valid with no existing view (started at 0), trigger the embed via needsInitEmbed.
   useEffect(() => {
-    resizeView(chartView.current, width, height);
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    if (width && height && !chartView.current) {
+      setNeedsInitEmbed(true);
+    } else {
+      resizeView(chartView.current, width, height);
+    }
   }, [width, height]);
 
   useEffect(() => {
@@ -134,6 +148,7 @@ export const VegaChart: FC<VegaChartProps> = ({
     chartData.table,
     config,
     data,
+    needsInitEmbed,
     numberLocale,
     timeLocale,
     onNewView,

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { buildSpec } from '@spectrum-charts/vega-spec-builder-s2';
+
+import useSpec from './useSpec';
+
+jest.mock('@spectrum-charts/vega-spec-builder-s2', () => ({
+	buildSpec: jest.fn(() => ({ $schema: 'mocked-spec' })),
+	baseData: [],
+}));
+
+jest.mock('../rscToSbAdapter', () => ({
+	rscPropsToSpecBuilderOptions: jest.fn(() => ({})),
+}));
+
+const mockBuildSpec = jest.mocked(buildSpec);
+
+const baseProps = {
+	backgroundColor: 'gray-50',
+	children: [],
+	colors: [],
+	colorScheme: 'light',
+	hiddenSeries: [],
+	idKey: 'rscMarkId',
+	lineTypes: [],
+	lineWidths: [],
+	symbolShapes: [],
+	symbolSizes: [],
+	chartWidth: 400,
+	chartHeight: 300,
+} as unknown as Parameters<typeof useSpec>[0];
+
+// AN-445759: regression tests for spec memoization — size changes must not trigger re-embed
+describe('useSpec memoization', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockBuildSpec.mockReturnValue({} as ReturnType<typeof buildSpec>);
+	});
+
+	test('does not rebuild spec when only chartWidth changes', () => {
+		const { result, rerender } = renderHook(
+			({ chartWidth }: { chartWidth: number }) => useSpec({ ...baseProps, chartWidth }),
+			{ initialProps: { chartWidth: 400 } }
+		);
+		const initialSpec = result.current;
+
+		rerender({ chartWidth: 800 });
+
+		expect(result.current).toBe(initialSpec);
+		expect(mockBuildSpec).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not rebuild spec when only chartHeight changes', () => {
+		const { result, rerender } = renderHook(
+			({ chartHeight }: { chartHeight: number }) => useSpec({ ...baseProps, chartHeight }),
+			{ initialProps: { chartHeight: 300 } }
+		);
+		const initialSpec = result.current;
+
+		rerender({ chartHeight: 600 });
+
+		expect(result.current).toBe(initialSpec);
+		expect(mockBuildSpec).toHaveBeenCalledTimes(1);
+	});
+
+	test('rebuilds spec when a non-size prop changes', () => {
+		const { rerender } = renderHook(
+			({ description }: { description: string }) => useSpec({ ...baseProps, description }),
+			{ initialProps: { description: 'initial' } }
+		);
+
+		rerender({ description: 'updated' });
+
+		expect(mockBuildSpec).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
 import { Data, Spec, ValuesData } from 'vega';
 
@@ -40,33 +40,9 @@ export default function useSpec({
   title,
   UNSAFE_vegaSpec,
 }: SanitizedSpecProps): Spec {
-  const prevSpec = useRef<Spec | null>(null);
-
-  // invalidate cache if changes to props other than width, height change
-  useEffect(() => {
-    prevSpec.current = null;
-  }, [
-    UNSAFE_vegaSpec,
-    backgroundColor,
-    children,
-    colors,
-    colorScheme,
-    description,
-    hiddenSeries,
-    highlightedItem,
-    highlightedSeries,
-    idKey,
-    lineTypes,
-    lineWidths,
-    opacities,
-    symbolShapes,
-    symbolSizes,
-    title,
-    data,
-  ]);
-
+  // AN-445759: chartWidth/chartHeight intentionally excluded — VegaChart's resize-only effect
+  // handles size changes without re-embedding. Prop changes always trigger a rebuild here.
   return useMemo(() => {
-    // They already supplied a spec, fill it in with defaults
     if (UNSAFE_vegaSpec) {
       const vegaSpecWithDefaults = initializeSpec(UNSAFE_vegaSpec, {
         backgroundColor,
@@ -75,14 +51,9 @@ export default function useSpec({
         description,
         title,
       });
-
-      // copy the spec so we don't mutate the original
-      const spec = JSON.parse(JSON.stringify(vegaSpecWithDefaults));
-      prevSpec.current = spec;
-      return spec;
+      return structuredClone(vegaSpecWithDefaults) as Spec;
     }
 
-    // or we need to build their spec
     const chartOptions = rscPropsToSpecBuilderOptions({
       backgroundColor,
       chartHeight,
@@ -104,17 +75,14 @@ export default function useSpec({
       title,
     });
 
-    // stringify-parse so that all immer stuff gets cleared out
-    const spec = buildSpec(chartOptions);
-    prevSpec.current = spec;
-
-    return spec;
+    return buildSpec(chartOptions);
   }, [
     UNSAFE_vegaSpec,
     backgroundColor,
     children,
     colors,
     colorScheme,
+    data,
     description,
     hiddenSeries,
     highlightedItem,
@@ -126,9 +94,6 @@ export default function useSpec({
     symbolShapes,
     symbolSizes,
     title,
-    data,
-    chartHeight,
-    chartWidth,
   ]);
 }
 

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -21,8 +21,6 @@ import { SanitizedSpecProps } from '../types';
 
 export default function useSpec({
   backgroundColor,
-  chartHeight,
-  chartWidth,
   children,
   colors,
   colorScheme,
@@ -40,8 +38,6 @@ export default function useSpec({
   title,
   UNSAFE_vegaSpec,
 }: SanitizedSpecProps): Spec {
-  // AN-445759: chartWidth/chartHeight intentionally excluded — VegaChart's resize-only effect
-  // handles size changes without re-embedding. Prop changes always trigger a rebuild here.
   return useMemo(() => {
     if (UNSAFE_vegaSpec) {
       const vegaSpecWithDefaults = initializeSpec(UNSAFE_vegaSpec, {

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -56,8 +56,6 @@ export default function useSpec({
 
     const chartOptions = rscPropsToSpecBuilderOptions({
       backgroundColor,
-      chartHeight,
-      chartWidth,
       children,
       colors,
       colorScheme,

--- a/packages/react-spectrum-charts/src/VegaChart.test.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.test.tsx
@@ -9,9 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { View } from 'vega';
+import { render, waitFor } from '@testing-library/react';
+import { Spec, View } from 'vega';
+import embed from 'vega-embed';
 
-import { resizeView } from './VegaChart';
+import { VegaChart, VegaChartProps, resizeView } from './VegaChart';
+
+jest.mock('vega-embed');
+
+const mockEmbed = jest.mocked(embed);
 
 const mockRunAsync = jest.fn().mockResolvedValue(undefined);
 const mockResize = jest.fn().mockReturnThis();
@@ -24,7 +30,25 @@ const createMockView = (): View =>
 		resize: mockResize,
 		height: mockHeight,
 		width: mockWidth,
+		finalize: jest.fn(),
 	}) as unknown as View;
+
+const defaultSpec: Spec = {};
+
+const defaultProps: VegaChartProps = {
+	config: {},
+	data: [],
+	debug: false,
+	height: 600,
+	locale: undefined,
+	onNewView: jest.fn(),
+	padding: 0,
+	renderer: 'svg',
+	s2: false,
+	spec: defaultSpec,
+	tooltip: {},
+	width: 800,
+};
 
 describe('resizeView', () => {
 	beforeEach(() => {
@@ -65,5 +89,34 @@ describe('resizeView', () => {
 		resizeView(mockView, 800, 0);
 
 		expect(mockWidth).not.toHaveBeenCalled();
+	});
+});
+
+// AN-445759: regression tests for the init render cycle fix
+describe('VegaChart init render cycle', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockEmbed.mockResolvedValue({ view: createMockView() } as unknown as Awaited<ReturnType<typeof embed>>);
+	});
+
+	test('calls embed on initial mount with valid dimensions', async () => {
+		render(<VegaChart {...defaultProps} />);
+
+		await waitFor(() => expect(mockEmbed).toHaveBeenCalledTimes(1));
+	});
+
+	test('does not call embed on initial mount with zero dimensions', () => {
+		render(<VegaChart {...defaultProps} width={0} height={0} />);
+
+		expect(mockEmbed).not.toHaveBeenCalled();
+	});
+
+	test('calls embed when dimensions become valid after starting at zero', async () => {
+		const { rerender } = render(<VegaChart {...defaultProps} width={0} height={0} />);
+		expect(mockEmbed).not.toHaveBeenCalled();
+
+		rerender(<VegaChart {...defaultProps} width={800} height={600} />);
+
+		await waitFor(() => expect(mockEmbed).toHaveBeenCalledTimes(1));
 	});
 });

--- a/packages/react-spectrum-charts/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FC, useEffect, useMemo, useRef } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Config, Padding, Renderers, Spec, View } from 'vega';
 import embed from 'vega-embed';
@@ -66,6 +66,10 @@ export const VegaChart: FC<VegaChartProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartView = useRef<View>();
+  const hasMounted = useRef(false);
+  // AN-445759: flipped to true when dimensions become valid post-mount with no existing view,
+  // forcing the embed effect to run even though width/height are not in its deps.
+  const [needsInitEmbed, setNeedsInitEmbed] = useState(false);
 
   const { number: numberLocale, time: timeLocale } = useMemo(() => getLocale(locale), [locale]);
 
@@ -84,9 +88,19 @@ export const VegaChart: FC<VegaChartProps> = ({
 
   useDebugSpec(debug, spec, chartData, width, height, config);
 
-  // Handle resize without recreating the view (prevents axis image flickering)
+  // Handle resize without recreating the view (prevents axis image flickering).
+  // AN-445759: skip on initial mount — the embed effect handles that render. After mount, if
+  // dimensions become valid with no existing view (started at 0), trigger the embed via needsInitEmbed.
   useEffect(() => {
-    resizeView(chartView.current, width, height);
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    if (width && height && !chartView.current) {
+      setNeedsInitEmbed(true);
+    } else {
+      resizeView(chartView.current, width, height);
+    }
   }, [width, height]);
 
   useEffect(() => {
@@ -136,6 +150,7 @@ export const VegaChart: FC<VegaChartProps> = ({
     chartData.table,
     config,
     data,
+    needsInitEmbed,
     numberLocale,
     timeLocale,
     onNewView,

--- a/packages/react-spectrum-charts/src/hooks/useSpec.test.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useSpec.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { buildSpec } from '@spectrum-charts/vega-spec-builder';
+
+import { chartHasChild } from '../utils';
+import useSpec from './useSpec';
+
+jest.mock('@spectrum-charts/vega-spec-builder', () => ({
+	buildSpec: jest.fn(() => ({ $schema: 'mocked-spec' })),
+	baseData: [],
+}));
+
+jest.mock('../rscToSbAdapter', () => ({
+	rscPropsToSpecBuilderOptions: jest.fn(() => ({})),
+}));
+
+jest.mock('../utils', () => ({
+	chartHasChild: jest.fn(() => false),
+}));
+
+jest.mock('../alpha', () => ({
+	Venn: { displayName: 'Venn' },
+}));
+
+const mockBuildSpec = jest.mocked(buildSpec);
+
+const baseProps = {
+	backgroundColor: 'gray-50',
+	children: [],
+	colors: [],
+	colorScheme: 'light',
+	hiddenSeries: [],
+	idKey: 'rscMarkId',
+	lineTypes: [],
+	lineWidths: [],
+	s2: false,
+	symbolShapes: [],
+	symbolSizes: [],
+	chartWidth: 400,
+	chartHeight: 300,
+} as unknown as Parameters<typeof useSpec>[0];
+
+// AN-445759: regression tests for spec memoization — size changes must not trigger re-embed
+describe('useSpec memoization', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockBuildSpec.mockReturnValue({} as ReturnType<typeof buildSpec>);
+		(chartHasChild as jest.Mock).mockReturnValue(undefined);
+	});
+
+	test('does not rebuild spec when only chartWidth changes', () => {
+		const { result, rerender } = renderHook(
+			({ chartWidth }: { chartWidth: number }) => useSpec({ ...baseProps, chartWidth }),
+			{ initialProps: { chartWidth: 400 } }
+		);
+		const initialSpec = result.current;
+
+		rerender({ chartWidth: 800 });
+
+		expect(result.current).toBe(initialSpec);
+		expect(mockBuildSpec).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not rebuild spec when only chartHeight changes', () => {
+		const { result, rerender } = renderHook(
+			({ chartHeight }: { chartHeight: number }) => useSpec({ ...baseProps, chartHeight }),
+			{ initialProps: { chartHeight: 300 } }
+		);
+		const initialSpec = result.current;
+
+		rerender({ chartHeight: 600 });
+
+		expect(result.current).toBe(initialSpec);
+		expect(mockBuildSpec).toHaveBeenCalledTimes(1);
+	});
+
+	test('rebuilds spec when a non-size prop changes', () => {
+		const { rerender } = renderHook(
+			({ description }: { description: string }) => useSpec({ ...baseProps, description }),
+			{ initialProps: { description: 'initial' } }
+		);
+
+		rerender({ description: 'updated' });
+
+		expect(mockBuildSpec).toHaveBeenCalledTimes(2);
+	});
+});
+
+// Venn bakes dimensions into the spec, so it must rebuild on size changes
+describe('useSpec Venn memoization', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockBuildSpec.mockReturnValue({} as ReturnType<typeof buildSpec>);
+		(chartHasChild as jest.Mock).mockReturnValue({});
+	});
+
+	test('rebuilds spec when chartWidth changes', () => {
+		const { rerender } = renderHook(
+			({ chartWidth }: { chartWidth: number }) => useSpec({ ...baseProps, chartWidth }),
+			{ initialProps: { chartWidth: 400 } }
+		);
+
+		rerender({ chartWidth: 800 });
+
+		expect(mockBuildSpec).toHaveBeenCalledTimes(2);
+	});
+
+	test('rebuilds spec when chartHeight changes', () => {
+		const { rerender } = renderHook(
+			({ chartHeight }: { chartHeight: number }) => useSpec({ ...baseProps, chartHeight }),
+			{ initialProps: { chartHeight: 300 } }
+		);
+
+		rerender({ chartHeight: 600 });
+
+		expect(mockBuildSpec).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/react-spectrum-charts/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useSpec.tsx
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
 import { Data, Spec, ValuesData } from 'vega';
 
@@ -43,12 +43,46 @@ export default function useSpec({
   title,
   UNSAFE_vegaSpec,
 }: SanitizedSpecProps): Spec {
-  const prevSpec = useRef<Spec | null>(null);
   const hasVenn = useMemo(() => chartHasChild({ children, displayName: Venn.displayName as string }), [children]);
 
-  // invalidate cache if changes to props other than width, height change
-  useEffect(() => {
-    prevSpec.current = null;
+  // AN-445759: regular charts don't include chartWidth/chartHeight in deps — VegaChart's resize-only
+  // effect handles size changes without re-embedding. Keeping size out of deps means prop changes
+  // always trigger a rebuild without the async-effect timing bug from the previous cache approach.
+  const regularSpec = useMemo(() => {
+    if (hasVenn) return null;
+
+    if (UNSAFE_vegaSpec) {
+      const vegaSpecWithDefaults = initializeSpec(UNSAFE_vegaSpec, {
+        backgroundColor,
+        colorScheme,
+        data,
+        description,
+        title,
+      });
+      return JSON.parse(JSON.stringify(vegaSpecWithDefaults)) as Spec;
+    }
+
+    const chartOptions = rscPropsToSpecBuilderOptions({
+      backgroundColor,
+      children,
+      colors,
+      colorScheme,
+      data,
+      description,
+      hiddenSeries,
+      highlightedItem,
+      highlightedSeries,
+      idKey,
+      lineTypes,
+      lineWidths,
+      opacities,
+      s2,
+      symbolShapes,
+      symbolSizes,
+      title,
+    });
+
+    return buildSpec(chartOptions);
   }, [
     UNSAFE_vegaSpec,
     backgroundColor,
@@ -68,31 +102,14 @@ export default function useSpec({
     symbolSizes,
     title,
     data,
+    hasVenn,
   ]);
 
-  return useMemo(() => {
-    // returned cached spec if there is a cached spec and if venn is not a child element
-    if (!hasVenn && prevSpec.current !== null) {
-      return prevSpec.current;
-    }
+  // AN-445759: Venn layout is computed from chart dimensions (circle positions baked into the spec),
+  // so it must rebuild when size changes — chartWidth/chartHeight are intentionally in these deps.
+  const vennSpec = useMemo(() => {
+    if (!hasVenn) return null;
 
-    // They already supplied a spec, fill it in with defaults
-    if (UNSAFE_vegaSpec) {
-      const vegaSpecWithDefaults = initializeSpec(UNSAFE_vegaSpec, {
-        backgroundColor,
-        colorScheme,
-        data,
-        description,
-        title,
-      });
-
-      // copy the spec so we don't mutate the original
-      const spec = JSON.parse(JSON.stringify(vegaSpecWithDefaults));
-      prevSpec.current = spec;
-      return spec;
-    }
-
-    // or we need to build their spec
     const chartOptions = rscPropsToSpecBuilderOptions({
       backgroundColor,
       chartHeight,
@@ -115,17 +132,15 @@ export default function useSpec({
       title,
     });
 
-    // stringify-parse so that all immer stuff gets cleared out
-    const spec = buildSpec(chartOptions);
-    prevSpec.current = spec;
-
-    return spec;
+    return buildSpec(chartOptions);
   }, [
-    UNSAFE_vegaSpec,
     backgroundColor,
+    chartHeight,
+    chartWidth,
     children,
     colors,
     colorScheme,
+    data,
     description,
     hiddenSeries,
     highlightedItem,
@@ -138,11 +153,10 @@ export default function useSpec({
     symbolShapes,
     symbolSizes,
     title,
-    data,
-    chartHeight,
-    chartWidth,
     hasVenn,
   ]);
+
+  return (hasVenn ? vennSpec : regularSpec) as Spec;
 }
 
 const initializeSpec = (

--- a/packages/react-spectrum-charts/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useSpec.tsx
@@ -59,7 +59,7 @@ export default function useSpec({
         description,
         title,
       });
-      return JSON.parse(JSON.stringify(vegaSpecWithDefaults)) as Spec;
+      return structuredClone(vegaSpecWithDefaults) as Spec;
     }
 
     const chartOptions = rscPropsToSpecBuilderOptions({

--- a/packages/react-spectrum-charts/src/stories/components/Venn/Venn.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Venn/Venn.story.tsx
@@ -112,7 +112,35 @@ const interactiveChildren = [
   </ChartPopover>,
 ];
 
+const ResizableVennStory: StoryFn<VennProps> = (args) => {
+  return (
+    <View
+      backgroundColor="gray-50"
+      overflow="hidden"
+      width={650}
+      minWidth={200}
+      maxWidth={900}
+      height={650}
+      minHeight={200}
+      maxHeight={900}
+      borderColor="gray-400"
+      borderWidth="thick"
+      padding={16}
+      UNSAFE_style={{ resize: 'both' }}
+    >
+      <Chart data={radioData} width="auto" height="100%" config={{ autosize: { type: 'pad' } }}>
+        <Venn {...args} />
+      </Chart>
+    </View>
+  );
+};
+
 const Basic = bindWithProps(BasicVennStory);
+
+const Resizable = bindWithProps(ResizableVennStory);
+Resizable.args = {
+  children: interactiveChildren,
+};
 
 const WithLegend = bindWithProps(VennStoryWithLegend);
 
@@ -131,4 +159,4 @@ WithPopover.args = {
   children: interactiveChildren,
 };
 
-export { Basic, WithLegend, WithToolTip, WithPopover, Supreme };
+export { Basic, Resizable, WithLegend, WithToolTip, WithPopover, Supreme };


### PR DESCRIPTION
# Fix: Refactor render cycle in `useSpec` to eliminate async-effect timing bug

## Description

Venn implementation introduced a spec caching strategy in order to allow chart size dependencies to resize the Venn. This has created some ongoing maintenance challenges for other chart types that we don't want to depend on size props. Typically chart resizing is handled by vega view resizing functions. 

Refactors the render cycle in `useSpec` (s1 and s2) to remove a `useRef`-based spec cache that was gated by a `useEffect`. Replaces the cache pattern with two separate `useMemo` calls — one for regular charts (excluding `chartWidth`/`chartHeight` from deps) and one for Venn charts (including size in deps).

Also adds a resizable Venn Storybook story to make it easier to manually verify Venn layout behavior at different container sizes.

## Related Issue

## Motivation and Context

The previous implementation cached the built Vega spec in a `useRef` and cleared it via a `useEffect` whenever non-size props changed. The useMemo call triggered when size props updated, and the spec would be cached. Since the useEffect that clears the cache didn't fire on size prop change, the cache wouldn't be cleared. As a result of this, any time you resized the chart and then changed a non-size prop after, an additional re-render would have to occur before the updated spec would be used. 

The fix separates the two concerns:

- **Regular charts** — `chartWidth`/`chartHeight` are excluded from the `useMemo` deps. `VegaChart` handles resize-only updates through its own resize effect without re-embedding, so size changes don't need to trigger a full spec rebuild.
- **Venn charts** — Venn circle positions are baked into the spec from the chart dimensions, so `chartWidth`/`chartHeight` must remain in deps and the spec must rebuild on resize.

Separating these cases removes the need for the ref/effect cache entirely.

## How Has This Been Tested?

- Regression tests added to `useSpec.test.tsx` (s1 and s2) and `VegaChart.test.tsx` (s1 and s2) covering the new render cycle behaviour.
- Manual testing via Storybook: a new **Resizable** Venn story (based on the Supreme story) was used to verify that Venn charts re-layout correctly as the container is resized.
- All existing tests pass.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
