### PR TITLE
feat: expand metric range displayOnHover prop 

### DIFF
--- a/packages/docs/docs/api/analysis/MetricRange.md
+++ b/packages/docs/docs/api/analysis/MetricRange.md
@@ -40,9 +40,9 @@ The `MetricRange` component is used to add a custom area mark onto visualization
         </tr>
         <tr>
             <td>displayOnHover</td>
-            <td>boolean</td>
+            <td>boolean | 'metric' | 'range'</td>
             <td>false</td>
-            <td>Whether the metric range should only be visible when hovering over the parent line.</td>
+            <td>Controls which parts of the metric range are visible only on hover. <code>true</code>: both the metric line and range area are hidden until hover. <code>'metric'</code>: only the metric line is hidden until hover; the range area is always visible. <code>'range'</code>: only the range area is hidden until hover; the metric line is always visible. <code>false</code>: both are always visible.</td>
         </tr>
         <tr>
             <td>hoverPoint</td>

--- a/packages/vega-spec-builder/src/area/areaUtils.test.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.test.ts
@@ -12,13 +12,18 @@
 import {
   BACKGROUND_COLOR,
   COLOR_SCALE,
+  CONTROLLED_HIGHLIGHTED_SERIES,
+  CONTROLLED_HIGHLIGHTED_TABLE,
   DEFAULT_COLOR,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_OPACITY_RULE,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
+  HOVERED_ITEM,
+  SELECTED_SERIES,
+  SERIES_ID,
 } from '@spectrum-charts/constants';
 
-import { getAreaMark } from './areaUtils';
+import { AreaMarkOptions, getAreaMark, getAreaOpacity } from './areaUtils';
 
 describe('getAreaMark', () => {
   test('basic options', () => {
@@ -242,5 +247,37 @@ describe('getAreaMark', () => {
         },
       },
     });
+  });
+});
+
+describe('getAreaOpacity', () => {
+  const baseMetricRangeOptions: AreaMarkOptions = {
+    name: 'line0MetricRange0_area',
+    color: DEFAULT_COLOR,
+    colorScheme: DEFAULT_COLOR_SCHEME,
+    metricStart: 'metricStart',
+    metricEnd: 'metricEnd',
+    isStacked: false,
+    dimension: 'dimension',
+    scaleType: 'linear',
+    opacity: 0.2,
+    isMetricRange: true,
+    interactiveMarkName: 'line0',
+  };
+
+  test('returns opacity rules to hide the area when displayOnHover is "range"', () => {
+    const opacity = getAreaOpacity({ ...baseMetricRangeOptions, displayOnHover: 'range' });
+    expect(opacity).toStrictEqual([
+      { test: `isValid(line0_${HOVERED_ITEM}) && line0_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`, value: 1 },
+      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} === datum.${SERIES_ID}`, value: 1 },
+      { test: `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'),'${SERIES_ID}'), datum.${SERIES_ID}) > -1`, value: 1 },
+      { test: `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`, value: 1 },
+      { value: 0 },
+    ]);
+  });
+
+  test('returns default opacity rule when displayOnHover is false for a metric range', () => {
+    const opacity = getAreaOpacity({ ...baseMetricRangeOptions, displayOnHover: false });
+    expect(opacity).toEqual([DEFAULT_OPACITY_RULE]);
   });
 });

--- a/packages/vega-spec-builder/src/area/areaUtils.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.ts
@@ -42,7 +42,7 @@ export interface AreaMarkOptions {
   color: ColorFacet;
   colorScheme: ColorScheme;
   dimension: string;
-  displayOnHover?: boolean;
+  displayOnHover?: boolean | 'metric' | 'range';
   highlightedItem?: HighlightedItem;
   interactiveMarkName?: string;
   isHighlightedByGroup?: boolean;
@@ -113,8 +113,22 @@ export function getAreaOpacity(areaOptions: AreaMarkOptions): ProductionRule<Num
     highlightedItem,
     name,
   } = areaOptions;
+  // if the range area is hidden until hover, use opacity to show/hide it based on series highlight state
+  if (isMetricRange && displayOnHover === 'range') {
+    const hoveredSeriesTest = `isValid(${interactiveMarkName}_${HOVERED_ITEM}) && ${interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;
+    const selectedSeriesTest = `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} === datum.${SERIES_ID}`;
+    const controlledHighlightedTableTest = `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'),'${SERIES_ID}'), datum.${SERIES_ID}) > -1`;
+    const controlledHighlightedSeriesTest = `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`;
+    return [
+      { test: hoveredSeriesTest, value: 1 },
+      { test: selectedSeriesTest, value: 1 },
+      { test: controlledHighlightedTableTest, value: 1 },
+      { test: controlledHighlightedSeriesTest, value: 1 },
+      { value: 0 },
+    ];
+  }
   // if metric ranges only display when hovering, we don't need to include other hover rules for this specific area
-  if (isMetricRange && displayOnHover) {
+  if (isMetricRange && displayOnHover === true) {
     const rules: ProductionRule<NumericValueRef> = [
       {
         test: `isValid(${interactiveMarkName}_${HOVERED_ITEM})`,

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -213,6 +213,22 @@ describe('getLineOpacity()', () => {
     expect(opacityRule).toEqual([DEFAULT_OPACITY_RULE]);
   });
 
+  test('returns opacity rules when displayOnHover is "metric" to show the line on hover', () => {
+    const opacityRule = getLineOpacity({
+      ...defaultLineMarkOptions,
+      interactiveMarkName: 'line0',
+      displayOnHover: 'metric',
+    });
+    expect(opacityRule).toEqual([
+      { test: `isValid(line0_${HOVERED_ITEM}) && line0_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`, value: 1 },
+      { test: `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} === datum.${SERIES_ID}`, value: 1 },
+      { test: `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'),'${SERIES_ID}'), datum.${SERIES_ID}) > -1`, value: 1 },
+      { test: `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`, value: 1 },
+      { value: 0 },
+    ]);
+  });
+
+
   test('should add highlightedData rule for multiple series if isHighlightedByGroup is true', () => {
     const opacityRule = getLineOpacity({
       ...defaultLineMarkOptions,

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -136,10 +136,27 @@ export const getLineOpacity = ({
   isHighlightedByGroup,
   highlightedItem,
 }: LineMarkOptions): ProductionRule<NumericValueRef> => {
-  if ((!interactiveMarkName || displayOnHover) && highlightedItem === undefined) return [DEFAULT_OPACITY_RULE];
+  if ((!interactiveMarkName || displayOnHover === true) && highlightedItem === undefined) return [DEFAULT_OPACITY_RULE];
   const strokeOpacityRules: ProductionRule<NumericValueRef> = [];
 
   if (interactiveMarkName) {
+    if (displayOnHover === 'metric') {
+      const hoveredSeriesTest = `isValid(${interactiveMarkName}_${HOVERED_ITEM}) && ${interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;
+      const selectedSeriesTest = `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} === datum.${SERIES_ID}`;
+      const controlledHighlightedTableTest = `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'),'${SERIES_ID}'), datum.${SERIES_ID}) > -1`;
+      const controlledHighlightedSeriesTest = `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`;
+      
+      strokeOpacityRules.push(
+        { test: hoveredSeriesTest, value: 1 },
+        { test: selectedSeriesTest, value: 1 },
+        { test: controlledHighlightedTableTest, value: 1 },
+        { test: controlledHighlightedSeriesTest, value: 1 },
+        { value: 0 },
+      );
+
+      return strokeOpacityRules;
+    }
+    
     if (interactionMode === INTERACTION_MODE.DIMENSION) {
       const dimensionHoverSignal = `${interactiveMarkName}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`;
       strokeOpacityRules.push(

--- a/packages/vega-spec-builder/src/line/lineUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineUtils.ts
@@ -60,7 +60,7 @@ export interface LineMarkOptions {
   colorScheme: ColorScheme;
   comboSiblingNames?: string[];
   dimension: string;
-  displayOnHover?: boolean;
+  displayOnHover?: boolean | 'metric' | 'range';
   donutSummaries?: DonutSummaryOptions[];
   dualMetricAxis?: boolean;
   hasOnClick?: boolean;

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
@@ -185,6 +185,34 @@ describe('getMetricRangeMark', () => {
     });
     expect(lineMark.encode?.enter?.strokeOpacity).toEqual({ value: 0.2 });
   });
+  describe('displayOnHover translation', () => {
+    const interactiveLineOptions = { ...defaultLineOptions, interactiveMarkName: 'line0' };
+
+    test('when displayOnHover is "metric", area is always visible and line gets "metric" opacity rules', () => {
+      const [lineMark, areaMark] = getMetricRangeMark(
+        interactiveLineOptions,
+        { ...defaultMetricRangeSpecOptions, displayOnHover: 'metric' }
+      );
+      // line: hide-when-not-hovered (metric case)
+      expect(lineMark.encode?.update?.opacity).toHaveLength(5);
+      expect(lineMark.encode?.update?.opacity?.[4]).toEqual({ value: 0 });
+      // area: always visible
+      expect(areaMark.encode?.update?.opacity).toEqual([DEFAULT_OPACITY_RULE]);
+    });
+
+    test('when displayOnHover is "range", line is always visible and area gets "range" opacity rules', () => {
+      const [lineMark, areaMark] = getMetricRangeMark(
+        interactiveLineOptions,
+        { ...defaultMetricRangeSpecOptions, displayOnHover: 'range' }
+      );
+      // line: always visible — fallback rule is { value: 1 }, not hidden
+      expect(lineMark.encode?.update?.opacity).toEqual([DEFAULT_OPACITY_RULE]);
+      // area: hide-when-not-hovered (range case)
+      expect(areaMark.encode?.update?.opacity).toHaveLength(5);
+      expect(areaMark.encode?.update?.opacity?.[4]).toEqual({ value: 0 });
+    });
+  });
+
   describe('defined encoding (creates gaps when metric values are null/undefined)', () => {
     test('line and area mark have defined set in enter so null metric values creates a break', () => {
       const [lineMark, areaMark] = getMetricRangeMark(defaultLineOptions, defaultMetricRangeSpecOptions);
@@ -214,6 +242,22 @@ describe('getMetricRangeGroupMarks', () => {
         marks: basicMetricRangeMarks,
       },
     ]);
+  });
+
+  test('uses FILTERED_TABLE as data source when displayOnHover is "metric"', () => {
+    const marks = getMetricRangeGroupMarks({
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: 'metric' }],
+    });
+    expect(marks[0]).toHaveProperty('from.facet.data', FILTERED_TABLE);
+  });
+
+  test('uses FILTERED_TABLE as data source when displayOnHover is "range"', () => {
+    const marks = getMetricRangeGroupMarks({
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: 'range' }],
+    });
+    expect(marks[0]).toHaveProperty('from.facet.data', FILTERED_TABLE);
   });
 
   test('always returns only group marks (hover points are added separately via getMetricRangeAllHoverPoints)', () => {
@@ -308,6 +352,24 @@ describe('getMetricRangeData', () => {
     });
     expect(data).toHaveLength(1);
     expect(data[0]).toHaveProperty('name', 'line0MetricRange0_highlightedData');
+  });
+
+  test('does not create _highlightedData when displayOnHover is "metric"', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: 'metric' }],
+    });
+    expect(data).toHaveLength(0);
+    expect(data.find(d => d.name?.includes('highlightedData'))).toBeUndefined();
+  });
+
+  test('does not create _highlightedData when displayOnHover is "range"', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: 'range' }],
+    });
+    expect(data).toHaveLength(0);
+    expect(data.find(d => d.name?.includes('highlightedData'))).toBeUndefined();
   });
 
   test('adds filtered hoverPointData source when hoverPoint is true and line is interactive', () => {

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
@@ -79,7 +79,7 @@ export const getMetricRangeGroupMarks = (lineMarkOptions: LineSpecOptions): Grou
   for (const metricRangeOptions of metricRanges) {
     const { displayOnHover, name } = metricRangeOptions;
     // if displayOnHover is true, use the highlightedData source, otherwise use the filtered table
-    const data = displayOnHover ? `${name}_highlightedData` : FILTERED_TABLE;
+    const data = displayOnHover === true ? `${name}_highlightedData` : FILTERED_TABLE;
     marks.push({
       name: `${name}_group`,
       type: 'group',
@@ -202,18 +202,22 @@ export const getMetricRangeMark = (
     dimension: lineMarkOptions.dimension,
     isMetricRange: true,
     parentName: lineMarkOptions.name,
-    displayOnHover: metricRangeOptions.displayOnHover,
+    // 'metric' means only the line is hidden on hover — area is always visible
+    displayOnHover: metricRangeOptions.displayOnHover === 'metric' ? false : metricRangeOptions.displayOnHover,
     interactiveMarkName: lineMarkOptions.interactiveMarkName,
   };
+  const { interactiveMarkName, ...baseLineMarkOptions } = lineMarkOptions;
   const lineOptions: LineMarkOptions = {
-    ...lineMarkOptions,
+    ...baseLineMarkOptions,
     name: `${metricRangeOptions.name}_line`,
     color: metricRangeOptions.color ? { value: metricRangeOptions.color } : lineMarkOptions.color,
     metric: metricRangeOptions.metric,
     lineType: { value: metricRangeOptions.lineType },
     lineWidth: { value: metricRangeOptions.lineWidth },
-    displayOnHover: metricRangeOptions.displayOnHover,
+    // 'range' means only the area is hidden on hover — line is always visible and should not fade on hover
+    displayOnHover: metricRangeOptions.displayOnHover === 'range' ? false : metricRangeOptions.displayOnHover,
     opacity: metricRangeOptions.lineOpacity ? metricRangeOptions.lineOpacity : { value: 1 },
+    ...(metricRangeOptions.displayOnHover !== 'range' && { interactiveMarkName }),
   };
 
   const dataSource = `${metricRangeOptions.name}_facet`;
@@ -240,7 +244,7 @@ export const getMetricRangeData = (markOptions: LineSpecOptions): SourceData[] =
       data.push(getFilteredIsValidData(`${name}_hoverPointData`, `${markOptions.name}_highlightedData`, metric));
     }
     // if displayOnHover is true, add a data source for the highlighted data
-    if (displayOnHover) {
+    if (displayOnHover === true) {
       const hoveredItem = `isValid(${markOptions.interactiveMarkName}_${HOVERED_ITEM}) && ${markOptions.interactiveMarkName}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;
       const selectedSeries = `isValid(${SELECTED_SERIES}) && ${SELECTED_SERIES} === datum.${SERIES_ID}`;
       const controlledHighlightedItem = `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'),'${SERIES_ID}'), datum.${SERIES_ID}) > -1`;

--- a/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
@@ -30,8 +30,14 @@ export interface MetricRangeOptions {
   metricStart: string;
   /** The key for the metric value in the data */
   metric?: string;
-  /** Whether the metric range should only be visible when hovering over the parent line */
-  displayOnHover?: boolean;
+  /**
+   * Controls which parts of the metric range are visible only on hover.
+   * - `true`: both the metric line and range area are hidden until the series is hovered
+   * - `'metric'`: only the metric line is hidden until hovered; the range area is always visible
+   * - `'range'`: only the range area is hidden until hovered; the metric line is always visible
+   * - `false` (default): both are always visible
+   */
+  displayOnHover?: boolean | 'metric' | 'range';
   /** Whether to show a hover point on the metric range line when the parent line is interactive */
   hoverPoint?: boolean;
   /** Boolean indicating whether or not the y-axis should expand to include the entire metric range (if necessary). */


### PR DESCRIPTION
## Description

expand metric range display on hover to take 2 strings: "metric" | "range" to display either the line or area on hover and keep the other visible

## Related Issue

## Motivation and Context

Allows the user to choose whether they want only the line or area to hide and display on hover. 

## How Has This Been Tested?

Storybook and unit tests 

## Screenshots (if appropriate):

<img width="902" height="435" alt="Screenshot 2026-04-17 at 10 07 30 AM" src="https://github.com/user-attachments/assets/4f3cd752-5824-494a-9b8b-e33d316e131b" />
<img width="878" height="444" alt="Screenshot 2026-04-17 at 10 07 40 AM" src="https://github.com/user-attachments/assets/87232db1-8e91-4cbd-ba58-ce38a660d4b1" />
<img width="853" height="445" alt="Screenshot 2026-04-17 at 10 07 49 AM" src="https://github.com/user-attachments/assets/257772a7-13bf-49a2-b348-9eb78f4056dd" />
<img width="900" height="444" alt="Screenshot 2026-04-17 at 10 07 55 AM" src="https://github.com/user-attachments/assets/2c5cf9d3-e311-4371-89b1-ef7fe4582f3a" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
