### PR TITLE
feat: metric range hover fixes 

### DIFF
--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -22,7 +22,9 @@ import {
   SERIES_ID,
 } from '@spectrum-charts/constants';
 
-import { getLineHoverMarks, getLineMark, getLineOpacity, getVoronoiYEncoding } from './lineMarkUtils';
+import type { Mark } from 'vega';
+
+import { getLineHoverMarks, getLineMark, getLineOpacity, getLineYEncoding, getVoronoiYEncoding } from './lineMarkUtils';
 import { defaultLineMarkOptions } from './lineTestUtils';
 
 describe('getLineMark()', () => {
@@ -120,6 +122,62 @@ describe('getLineHoverMarks()', () => {
       'line0_facet'
     );
     expect(marks[0].encode?.update?.opacity).toEqual({ signal: "length(data('line0_selectedData')) > 0 ? 0 : 1" });
+  });
+});
+
+describe('getLineHoverMarks() hover hit-area y encoding', () => {
+  const dataSource = 'line0_facet';
+
+  const getHoverGroup = (marks: Mark[], lineName: string) =>
+    marks.find((m) => m.type === 'group' && m.name === `${lineName}_hoverGroup`);
+
+  test('item mode: hover symbol y includes metric range hover points', () => {
+    const lineOptions = {
+      ...defaultLineMarkOptions,
+      isHighlightedByDimension: true,
+      interactionMode: 'item' as const,
+      metricRanges: [
+        { metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'forecastedExpectedValue', hoverPoint: true },
+      ],
+    };
+    const marks = getLineHoverMarks(lineOptions, dataSource);
+    const hoverGroup = getHoverGroup(marks, lineOptions.name);
+    expect(hoverGroup).toBeDefined();
+    const nested = (hoverGroup as { marks?: Mark[] })?.marks ?? [];
+    expect(nested.length).toBeGreaterThan(0);
+    const expectedY = getVoronoiYEncoding(lineOptions, lineOptions.metric);
+    nested.forEach((m) => {
+      expect(m.encode?.enter?.y).toEqual(expectedY);
+    });
+  });
+
+  test('item mode: when no MetricRange hover points, hover y matches getLineYEncoding (same result if interactionMode is dimension)', () => {
+    const lineOptions = {
+      ...defaultLineMarkOptions,
+      isHighlightedByDimension: true,
+      interactionMode: 'item' as const,
+      metricRanges: [],
+    };
+    const marks = getLineHoverMarks(lineOptions, dataSource);
+    const hoverGroup = getHoverGroup(marks, lineOptions.name);
+    const nested = (hoverGroup as { marks?: Mark[] })?.marks ?? [];
+    expect(nested[0]?.encode?.enter?.y).toEqual(getLineYEncoding(lineOptions, lineOptions.metric));
+  });
+
+  test('dimension mode: hover symbol y includes metric range hover points', () => {
+    const lineOptions = {
+      ...defaultLineMarkOptions,
+      isHighlightedByDimension: true,
+      interactionMode: 'dimension' as const,
+      metricRanges: [
+        { metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'forecastedExpectedValue', hoverPoint: true },
+      ],
+    };
+    const marks = getLineHoverMarks(lineOptions, dataSource);
+    const hoverGroup = getHoverGroup(marks, lineOptions.name);
+    expect(hoverGroup).toBeDefined();
+    const nested = (hoverGroup as { marks?: Mark[] })?.marks ?? [];
+    expect(nested[0]?.encode?.enter?.y).toEqual(getVoronoiYEncoding(lineOptions, lineOptions.metric));
   });
 });
 

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -352,7 +352,7 @@ const getItemHoverMarks = (lineOptions: LineMarkOptions, dataSource: string): Ma
 
   return [
     // area around item that triggers hover
-    getItemHoverArea(chartTooltips, dataSource, dimension, metric, name, scaleType, getLineYEncoding(lineOptions, metric)),
+    getItemHoverArea(chartTooltips, dataSource, dimension, metric, name, scaleType, getVoronoiYEncoding(lineOptions, metric)),
   ];
 };
 
@@ -364,7 +364,7 @@ const getDimensionInteractionMarks = (lineOptions: LineMarkOptions, dataSource: 
     // invisible points at fixed y for dimension-level voronoi
     getXAxisVoronoiPoints(name, dimensionField, scaleType),
     getXAxisVoronoiPath(lineOptions, `${name}_xAxisVoronoiPoints`, dimensionField),
-    getItemHoverArea(chartTooltips, dataSource, dimension, metric, name, scaleType, getLineYEncoding(lineOptions, metric)),
+    getItemHoverArea(chartTooltips, dataSource, dimension, metric, name, scaleType, getVoronoiYEncoding(lineOptions, metric)),
   ];
 };
 


### PR DESCRIPTION
## Description

The getVoronoiYEncoding helper function creates y encoding for voronoi points, so that the hoverable metric range points are included. This helper function needs to be used for the yEncoding prop when creating the hover area. The getVoronoiYEncoding function falls back to getLineYEncoding when there are no metric range hover points. 

## Related Issue

## Motivation and Context

When using the metric range displayOnHover prop  

## How Has This Been Tested?

Visually and unit tests 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
