### PR TITLE
fix: Insert reference line behind hover interactions

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -174,6 +174,17 @@ export const HOVER_SHAPE = 'diamond';
 // tooltip constants
 export const DIMENSION_HOVER_AREA = 'dimensionHoverArea';
 
+// Hover mark name suffixes — used both to construct mark names in builders and to identify
+// the first top-level hover mark when inserting 'front' reference lines.
+// Notes:
+//   - Bar: _dimensionHoverArea excluded — pushed BEFORE bar rect marks, so inserting before
+//     it would place the reference line behind all bars.
+//   - Scatter: hover marks are nested inside the group mark, not top-level, so no suffix needed.
+export const HOVER_RULE = '_hoverRule';         // line hover rule mark
+export const SELECT_BORDER = '_selectBorder';   // area selection border mark (with popover)
+export const AREA_HOVER_RULE = '_rule';         // area hover rule mark (dimension interaction)
+export const AREA_HOVER_POINT = '_point';       // area hover point mark
+
 //SVG Paths
 export const ROUNDED_SQUARE_PATH =
   'M -0.55 -1 h 1.1 a 0.45 0.45 0 0 1 0.45 0.45 v 1.1 a 0.45 0.45 0 0 1 -0.45 0.45 h -1.1 a 0.45 0.45 0 0 1 -0.45 -0.45 v -1.1 a 0.45 0.45 0 0 1 0.45 -0.45 z';

--- a/packages/react-spectrum-charts/src/stories/components/Line/Line.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Line/Line.story.tsx
@@ -150,6 +150,52 @@ const LineWithVisiblePointsStory: StoryFn<typeof Line> = (args): ReactElement =>
   );
 };
 
+// datetime 1667977200000 coincides with the "Add Fallout" static point.
+// Hover over that point to verify hover marks render above (front) or below (back) the reference line.
+const ReferenceLineLayerFrontStory: StoryFn<typeof Line> = (): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Value" />
+      <Axis position="bottom" labelFormat="time" baseline ticks>
+        <ReferenceLine value={1667977200000} layer="front" color="gray-500" />
+      </Axis>
+      <Line color="series" dimension="datetime" metric="value" scaleType="time" staticPoint="staticPoint">
+        <ChartTooltip>
+          {(datum) => (
+            <div>
+              <div>{formatTimestamp(datum.datetime as number)}</div>
+              <div>{datum.series}: {Number(datum.value).toLocaleString()}</div>
+            </div>
+          )}
+        </ChartTooltip>
+      </Line>
+    </Chart>
+  );
+};
+
+const ReferenceLineLayerBackStory: StoryFn<typeof Line> = (): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Value" />
+      <Axis position="bottom" labelFormat="time" baseline ticks>
+        <ReferenceLine value={1667977200000} layer="back" color="gray-500" />
+      </Axis>
+      <Line color="series" dimension="datetime" metric="value" scaleType="time" staticPoint="staticPoint">
+        <ChartTooltip>
+          {(datum) => (
+            <div>
+              <div>{formatTimestamp(datum.datetime as number)}</div>
+              <div>{datum.series}: {Number(datum.value).toLocaleString()}</div>
+            </div>
+          )}
+        </ChartTooltip>
+      </Line>
+    </Chart>
+  );
+};
+
 const LineWithHasPointStylesStory: StoryFn<typeof Line> = (args): ReactElement => {
   const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithHasPointStyles });
   return (
@@ -360,6 +406,12 @@ WithStaticPointsAndDialogs.args = {
   ],
 };
 
+const ReferenceLineLayerFront = bindWithProps(ReferenceLineLayerFrontStory);
+ReferenceLineLayerFront.args = {};
+
+const ReferenceLineLayerBack = bindWithProps(ReferenceLineLayerBackStory);
+ReferenceLineLayerBack.args = {};
+
 const BasicSparkline = bindWithProps(PlainLineStory);
 BasicSparkline.args = {
   ...defaultArgs,
@@ -478,6 +530,8 @@ export {
   WithStaticPoints,
   WithSolidAndHollowStaticPoints,
   WithStaticPointsAndDialogs,
+  ReferenceLineLayerFront,
+  ReferenceLineLayerBack,
   BasicSparkline,
   SparklineWithStaticPoint,
   OnClick,

--- a/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
@@ -13,6 +13,8 @@ import { produce } from 'immer';
 import { Data, Mark, Scale, Signal, SourceData } from 'vega';
 
 import {
+  AREA_HOVER_POINT,
+  AREA_HOVER_RULE,
   BACKGROUND_COLOR,
   COLOR_SCALE,
   CONTROLLED_HIGHLIGHTED_ITEM,
@@ -22,6 +24,7 @@ import {
   DEFAULT_TIME_DIMENSION,
   FILTERED_TABLE,
   GROUP_ID,
+  SELECT_BORDER,
   SELECTED_ITEM,
   SELECTED_SERIES,
 } from '@spectrum-charts/constants';
@@ -332,7 +335,7 @@ const getHoverMarks = (areaOptions: AreaSpecOptions): Mark[] => {
   if (!isInteractive(areaOptions) && highlightedItem === undefined) return [];
   const highlightMarks: Mark[] = [
     {
-      name: `${name}_point`,
+      name: `${name}${AREA_HOVER_POINT}`,
       type: 'symbol',
       from: { data: `${name}_highlightedData` },
       interactive: false,
@@ -350,7 +353,7 @@ const getHoverMarks = (areaOptions: AreaSpecOptions): Mark[] => {
   ];
   if (isHighlightedByDimension(areaOptions) || highlightedItem) {
     highlightMarks.unshift({
-      name: `${name}_rule`,
+      name: `${name}${AREA_HOVER_RULE}`,
       type: 'rule',
       from: { data: `${name}_highlightedData` },
       interactive: false,
@@ -392,7 +395,7 @@ const getSelectedAreaMarks = ({
   if (!chartPopovers.length) return [];
   return [
     {
-      name: `${name}_selectBorder`,
+      name: `${name}${SELECT_BORDER}`,
       type: 'area',
       from: { data: `${name}_selectedDataSeries` },
       interactive: false,

--- a/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.test.ts
@@ -22,6 +22,7 @@ import { spectrumColors } from '@spectrum-charts/themes';
 
 import { AxisSpecOptions, ReferenceLineSpecOptions } from '../types';
 import {
+  getFrontInsertionIndex,
   getPositionEncoding,
   getReferenceLineLabelsEncoding,
   getReferenceLineMarks,
@@ -134,6 +135,80 @@ describe('getPositionEncoding()', () => {
         'xBand'
       )
     ).toStrictEqual({ signal: "scale('xBand', 10) + bandwidth('xBand') / 2" });
+  });
+});
+
+describe('getFrontInsertionIndex()', () => {
+  const dataMark = (name: string) => ({ name, type: 'group' as const });
+  const hoverMark = (name: string) => ({ name, type: 'rule' as const });
+
+  test('returns marks.length when there are no hover marks', () => {
+    const marks = [dataMark('line0_group'), dataMark('line0_staticPoints')];
+    expect(getFrontInsertionIndex(marks)).toBe(2);
+  });
+
+  test('returns 0 for an empty marks array', () => {
+    expect(getFrontInsertionIndex([])).toBe(0);
+  });
+
+  // Line: [group, hoverRule, ...]
+  test('inserts before _hoverRule for a line chart', () => {
+    const marks = [dataMark('line0_group'), hoverMark('line0_hoverRule'), hoverMark('line0_hoverPoint')];
+    expect(getFrontInsertionIndex(marks)).toBe(1);
+  });
+
+  // Area with popover: [group, selectBorder, rule, point]
+  test('inserts before _selectBorder for an area chart with popover', () => {
+    const marks = [
+      dataMark('area0_group'),
+      hoverMark('area0_selectBorder'),
+      hoverMark('area0_rule'),
+      hoverMark('area0_point'),
+    ];
+    expect(getFrontInsertionIndex(marks)).toBe(1);
+  });
+
+  // Area with dimension interaction, no popover: [group, rule, point]
+  test('inserts before _rule for an area chart with dimension interaction', () => {
+    const marks = [dataMark('area0_group'), hoverMark('area0_rule'), hoverMark('area0_point')];
+    expect(getFrontInsertionIndex(marks)).toBe(1);
+  });
+
+  // Area with basic interaction, no popover, no dimension: [group, point]
+  test('inserts before _point for an area chart with basic interaction', () => {
+    const marks = [dataMark('area0_group'), hoverMark('area0_point')];
+    expect(getFrontInsertionIndex(marks)).toBe(1);
+  });
+
+  // Bar: _dimensionHoverArea is excluded from suffixes; fallback to end
+  test('returns marks.length for a bar chart (dimensionHoverArea excluded from suffixes)', () => {
+    const marks = [
+      { name: 'bar0_dimensionHoverArea', type: 'rect' as const },
+      dataMark('bar0_group'),
+    ];
+    expect(getFrontInsertionIndex(marks)).toBe(2);
+  });
+
+  // Multi-mark: inserts before the first builder's hover marks (known limitation)
+  test('inserts before the first hover mark across multiple marks', () => {
+    const marks = [
+      dataMark('line0_group'),
+      hoverMark('line0_hoverRule'),
+      dataMark('line1_group'),
+      hoverMark('line1_hoverRule'),
+    ];
+    // Inserts before line0_hoverRule; line1_group (data) ends up above the ref line — known limitation
+    expect(getFrontInsertionIndex(marks)).toBe(1);
+  });
+
+  // Back reference lines already unshifted should not affect the result
+  test('ignores back reference line marks when finding insertion point', () => {
+    const marks = [
+      { name: 'axis0ReferenceLine0', type: 'rule' as const },
+      dataMark('line0_group'),
+      hoverMark('line0_hoverRule'),
+    ];
+    expect(getFrontInsertionIndex(marks)).toBe(2);
   });
 });
 

--- a/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisReferenceLineUtils.ts
@@ -23,7 +23,7 @@ import {
   TextMark,
 } from 'vega';
 
-import { DEFAULT_FONT_COLOR, DEFAULT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+import { AREA_HOVER_POINT, AREA_HOVER_RULE, DEFAULT_FONT_COLOR, DEFAULT_LABEL_FONT_WEIGHT, HOVER_RULE, SELECT_BORDER } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
 import { getPathFromIcon, getStrokeDashFromLineType } from '../specUtils';
@@ -55,6 +55,17 @@ const applyReferenceLineOptionDefaults = (
 export const scaleTypeSupportsReferenceLines = (scaleType: ScaleType | undefined): boolean => {
   const supportedScaleTypes: ScaleType[] = ['band', 'linear', 'point', 'time', 'utc'];
   return Boolean(scaleType && supportedScaleTypes.includes(scaleType));
+};
+
+/**
+ * Returns the index at which 'front' reference line marks should be spliced in —
+ * just before the first hover/interactive mark, or at the end if none exist.
+ */
+export const getFrontInsertionIndex = (marks: Mark[]): number => {
+  const index = marks.findIndex(mark =>
+    [HOVER_RULE, SELECT_BORDER, AREA_HOVER_RULE, AREA_HOVER_POINT].some(suffix => mark.name?.endsWith(suffix))
+  );
+  return index === -1 ? marks.length : index;
 };
 
 export const getReferenceLineMarks = (

--- a/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/axis/axisSpecBuilder.ts
@@ -40,7 +40,7 @@ import { getDualAxisScaleNames, getScaleField } from '../scale/scaleUtils';
 import { getGenericValueSignal } from '../signal/signalSpecBuilder';
 import { AxisOptions, AxisSpecOptions, ColorScheme, Label, Orientation, Position, ScSpec, UserMeta } from '../types';
 import { getAxisLabelsEncoding, getControlledLabelAnchorValues, getLabelValue } from './axisLabelUtils';
-import { getReferenceLineMarks, getReferenceLines, scaleTypeSupportsReferenceLines } from './axisReferenceLineUtils';
+import { getFrontInsertionIndex, getReferenceLineMarks, getReferenceLines, scaleTypeSupportsReferenceLines } from './axisReferenceLineUtils';
 import {
   addAxisThumbnailSignals,
   getAxisThumbnailLabelOffset,
@@ -558,7 +558,7 @@ export const addAxesMarks = produce<
   if (scaleTypeSupportsReferenceLines(scaleType)) {
     const { back, front } = getReferenceLineMarks(options, scaleName);
     marks.unshift(...back);
-    marks.push(...front);
+    marks.splice(getFrontInsertionIndex(marks), 0, ...front);
   }
 
   const trellisGroupMark = marks.find((mark) => mark.name?.includes('Trellis')) as GroupMark;

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_OPACITY_RULE,
   DIMENSION_HOVER_AREA,
   FADE_FACTOR,
+  HOVER_RULE,
   HOVERED_ITEM,
   INTERACTION_MODE,
   LAST_RSC_SERIES_ID,
@@ -228,8 +229,8 @@ export const getLineHoverMarks = (
 
 const getHoverRule = (dimension: string, name: string, scaleType: ScaleType): RuleMark => {
   return {
-    name: `${name}_hoverRule`,
-    description: `${name}_hoverRule`,
+    name: `${name}${HOVER_RULE}`,
+    description: `${name}${HOVER_RULE}`,
     type: 'rule',
     from: { data: `${name}_highlightedData` },
     interactive: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
If the layer on ReferenceLine was set to 'front', the reference line was drawing in front of all elements, including hover interactions like points and rule lines. This change makes it so the ReferenceLine always draws behind interaction elements. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
While layer 'front' being in front of hover points and other similar marks seems correct, in practice it creates a poor experience. This is being considered a fix to S1. We have not decided on an approach for S2 yet. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests and existing tests pass

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
