### PR TITLE
bug: add a filter that excludes NaN values from trendline, so the trendline does not sit at the top of the chart

### DIFF
--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -367,6 +367,7 @@ describe('lineSpecBuilder', () => {
           trendlines: [{ method: 'average' }],
         })[2].transform
       ).toStrictEqual([
+        { type: 'filter', expr: `isValid(datum["${DEFAULT_METRIC}"])` },
         {
           as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
           fields: [DEFAULT_METRIC, DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],

--- a/packages/vega-spec-builder-s2/src/scatter/scatterSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/scatter/scatterSpecBuilder.test.ts
@@ -75,8 +75,10 @@ describe('addData()', () => {
       trendlines: [{}],
     });
     expect(data).toHaveLength(3);
-    expect(data[2].transform).toHaveLength(1);
-    expect(data[2].transform?.[0].type).toBe('regression');
+    expect(data[2].transform).toHaveLength(3);
+    expect(data[2].transform?.[0].type).toBe('filter');
+    expect(data[2].transform?.[1].type).toBe('regression');
+    expect(data[2].transform?.[2].type).toBe('filter');
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineDataTransformUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineDataTransformUtils.ts
@@ -220,6 +220,18 @@ export const getSortTransform = (dimension: string): CollectTransform => ({
 });
 
 /**
+ * Gets the filter transform that excludes rows where the trendline metric is null or NaN.
+ * Without this, all-null series produce a null TRENDLINE_VALUE which Vega maps to pixel 0
+ * (top of chart), causing the trendline to appear at the top when it should not be visible.
+ * @param trendlineMetric field name of the metric used by the trendline
+ * @returns FilterTransform
+ */
+export const getMetricFilterTransform = (trendlineMetric: string): FilterTransform => ({
+  type: 'filter',
+  expr: `isValid(datum["${trendlineMetric}"])`,
+});
+
+/**
  * gets the filter transforms that will restrict the data to the dimension range
  * @param dimension
  * @param dimensionRange

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineDataUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineDataUtils.test.ts
@@ -69,6 +69,10 @@ describe('addTrendlineData()', () => {
       source: FILTERED_TABLE,
       transform: [
         {
+          type: 'filter',
+          expr: 'isValid(datum["value"])',
+        },
+        {
           as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
           fields: ['value', DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],
           groupby: ['series'],
@@ -126,10 +130,11 @@ describe('addTrendlineData()', () => {
     });
     expect(trendlineData).toHaveLength(3);
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform).toHaveLength(4);
     expect(trendlineData[2].transform?.[0]).toHaveProperty('type', 'collect');
     expect(trendlineData[2].transform?.[1]).toHaveProperty('type', 'window');
     expect(trendlineData[2].transform?.[2]).toHaveProperty('type', 'filter');
+    expect(trendlineData[2].transform?.[3]).toHaveProperty('type', 'filter');
   });
 
   test('should add filter transforms for regression method if trendline has excludeDataKey', () => {
@@ -140,7 +145,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'linear', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(6);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -151,7 +156,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for regression method if trendline does not have excludeDataKey', () => {
+  test('should always include metric validity filter for regression method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -159,8 +164,26 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'linear' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform?.[0]).toStrictEqual({
+      type: 'filter',
+      expr: 'isValid(datum["value"])',
+    });
+  });
+
+  test('should filter regression output to prevent NaN trendline values from rendering', () => {
+    const trendlineData = getDefaultData();
+
+    addTrendlineData(trendlineData, {
+      ...defaultLineOptions,
+      trendlines: [{ method: 'linear' }],
+    });
+    // transforms for _highResolutionData: inputFilter[0], regression[1], outputFilter[2], seriesId[3]
+    expect(trendlineData[2].transform?.[1]).toHaveProperty('type', 'regression');
+    expect(trendlineData[2].transform?.[2]).toStrictEqual({
+      type: 'filter',
+      expr: `isValid(datum["${TRENDLINE_VALUE}"])`,
+    });
   });
 
   test('should add filter transforms for aggregate method if trendline has excludeDataKey', () => {
@@ -171,7 +194,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'median', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(5);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -182,7 +205,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for aggregate method if trendline does not have excludeDataKey', () => {
+  test('should always include metric validity filter for aggregate method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -190,8 +213,11 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'median' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform?.[0]).toStrictEqual({
+      type: 'filter',
+      expr: 'isValid(datum["value"])',
+    });
   });
 
   test('should add filter transform for window method if trendline has excludeDataKey', () => {
@@ -202,7 +228,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'movingAverage-2', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(5);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -213,7 +239,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for window method if trendline does not have excludeDataKey', () => {
+  test('should always include trendline value validity filter for window method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -221,8 +247,37 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'movingAverage-2' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform?.[2]).toStrictEqual({
+      type: 'filter',
+      expr: `isValid(datum["${TRENDLINE_VALUE}"])`,
+    });
+  });
+
+  test('should add data sources for exponential or power trendlines on time scales', () => {
+    const expData = getDefaultData();
+    addTrendlineData(expData, { ...defaultLineOptions, trendlines: [{ method: 'exponential' }] });
+    expect(expData).toHaveLength(3);
+    expect(expData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+
+    const powData = getDefaultData();
+    addTrendlineData(powData, { ...defaultLineOptions, trendlines: [{ method: 'power' }] });
+    expect(powData).toHaveLength(3);
+    expect(powData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+  });
+
+  test('should use isValid metric filter for all regression methods', () => {
+    const linearData = getDefaultData();
+    addTrendlineData(linearData, { ...defaultLineOptions, trendlines: [{ method: 'linear' }] });
+    expect(linearData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
+
+    const expData = getDefaultData();
+    addTrendlineData(expData, { ...defaultLineOptions, trendlines: [{ method: 'exponential' }] });
+    expect(expData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
+
+    const powData = getDefaultData();
+    addTrendlineData(powData, { ...defaultLineOptions, trendlines: [{ method: 'power' }] });
+    expect(powData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineDataUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineDataUtils.ts
@@ -20,6 +20,7 @@ import {
   SELECTED_ITEM,
   SELECTED_SERIES,
   SERIES_ID,
+  TRENDLINE_VALUE,
 } from '@spectrum-charts/constants';
 
 import { getSeriesIdTransform, getTableData } from '../data/dataUtils';
@@ -28,6 +29,7 @@ import { getFacetsFromOptions } from '../specUtils';
 import { TrendlineMethod, TrendlineSpecOptions } from '../types';
 import {
   getAggregateTransform,
+  getMetricFilterTransform,
   getNormalizedDimensionTransform,
   getPartialWindowFilterTransforms,
   getRegressionExtentTransform,
@@ -115,7 +117,7 @@ export const getAggregateTrendlineData = (
   facets: string[]
 ) => {
   const data: SourceData[] = [];
-  const { dimensionRange, name, trendlineDimension } = trendlineOptions;
+  const { dimensionRange, name, trendlineDimension, trendlineMetric } = trendlineOptions;
   const dimensionRangeTransforms = getTrendlineDimensionRangeTransforms(trendlineDimension, dimensionRange);
   // high resolution data used for drawing the rule marks
   data.push({
@@ -123,6 +125,7 @@ export const getAggregateTrendlineData = (
     source: FILTERED_TABLE,
     transform: [
       ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
+      getMetricFilterTransform(trendlineMetric),
       ...dimensionRangeTransforms,
       ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, true),
       ...getSeriesIdTransform(facets),
@@ -134,6 +137,7 @@ export const getAggregateTrendlineData = (
       name: `${name}_data`,
       source: FILTERED_TABLE,
       transform: [
+        getMetricFilterTransform(trendlineMetric),
         ...dimensionRangeTransforms,
         ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
       ],
@@ -156,7 +160,7 @@ export const getRegressionTrendlineData = (
 ) => {
   const data: SourceData[] = [];
   const { dimension, metric } = markOptions;
-  const { dimensionRange, method, name, orientation, trendlineDimension } = trendlineOptions;
+  const { dimensionRange, method, name, orientation, trendlineDimension, trendlineMetric } = trendlineOptions;
   const { trendlineDimension: standardTrendlineDimension } = getTrendlineDimensionMetric(
     dimension,
     metric,
@@ -170,8 +174,10 @@ export const getRegressionTrendlineData = (
     source: FILTERED_TABLE,
     transform: [
       ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
+      getMetricFilterTransform(trendlineMetric),
       ...dimensionRangeTransforms,
       ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, true),
+      getMetricFilterTransform(TRENDLINE_VALUE),
       ...getSeriesIdTransform(facets),
     ],
   });
@@ -183,6 +189,7 @@ export const getRegressionTrendlineData = (
         name: `${name}_params`,
         source: FILTERED_TABLE,
         transform: [
+          getMetricFilterTransform(trendlineMetric),
           ...dimensionRangeTransforms,
           ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
         ],
@@ -216,6 +223,7 @@ const getWindowTrendlineData = (
   transform: [
     ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
     ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
+    getMetricFilterTransform(TRENDLINE_VALUE),
     ...getTrendlineDimensionRangeTransforms(markOptions.dimension, trendlineOptions.dimensionRange),
   ],
 });

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts
@@ -43,6 +43,7 @@ export const getTrendlineMarks = (markOptions: TrendlineParentOptions): (GroupMa
   const trendlines = getTrendlines(markOptions);
   for (const trendlineOptions of trendlines) {
     const { displayOnHover, method, name } = trendlineOptions;
+
     if (isAggregateMethod(method)) {
       marks.push(getTrendlineRuleMark(markOptions, trendlineOptions));
     } else {

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
@@ -375,6 +375,7 @@ describe('lineSpecBuilder', () => {
           trendlines: [{ method: 'average' }],
         }, undefined)[2].transform
       ).toStrictEqual([
+        { type: 'filter', expr: `isValid(datum["${DEFAULT_METRIC}"])` },
         {
           as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
           fields: [DEFAULT_METRIC, DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],

--- a/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
@@ -110,8 +110,10 @@ describe('addData()', () => {
       trendlines: [{}],
     });
     expect(data).toHaveLength(3);
-    expect(data[2].transform).toHaveLength(1);
-    expect(data[2].transform?.[0].type).toBe('regression');
+    expect(data[2].transform).toHaveLength(3);
+    expect(data[2].transform?.[0].type).toBe('filter');
+    expect(data[2].transform?.[1].type).toBe('regression');
+    expect(data[2].transform?.[2].type).toBe('filter');
   });
 });
 

--- a/packages/vega-spec-builder/src/trendline/trendlineDataTransformUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineDataTransformUtils.ts
@@ -220,6 +220,18 @@ export const getSortTransform = (dimension: string): CollectTransform => ({
 });
 
 /**
+ * Gets the filter transform that excludes rows where the trendline metric is null or NaN.
+ * Without this, all-null series produce a null TRENDLINE_VALUE which Vega maps to pixel 0
+ * (top of chart), causing the trendline to appear at the top when it should not be visible.
+ * @param trendlineMetric field name of the metric used by the trendline
+ * @returns FilterTransform
+ */
+export const getMetricFilterTransform = (trendlineMetric: string): FilterTransform => ({
+  type: 'filter',
+  expr: `isValid(datum["${trendlineMetric}"])`,
+});
+
+/**
  * gets the filter transforms that will restrict the data to the dimension range
  * @param dimension
  * @param dimensionRange

--- a/packages/vega-spec-builder/src/trendline/trendlineDataUtils.test.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineDataUtils.test.ts
@@ -69,6 +69,10 @@ describe('addTrendlineData()', () => {
       source: FILTERED_TABLE,
       transform: [
         {
+          type: 'filter',
+          expr: 'isValid(datum["value"])',
+        },
+        {
           as: [TRENDLINE_VALUE, `${DEFAULT_TIME_DIMENSION}Min`, `${DEFAULT_TIME_DIMENSION}Max`],
           fields: ['value', DEFAULT_TIME_DIMENSION, DEFAULT_TIME_DIMENSION],
           groupby: ['series'],
@@ -126,10 +130,11 @@ describe('addTrendlineData()', () => {
     });
     expect(trendlineData).toHaveLength(3);
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform).toHaveLength(4);
     expect(trendlineData[2].transform?.[0]).toHaveProperty('type', 'collect');
     expect(trendlineData[2].transform?.[1]).toHaveProperty('type', 'window');
     expect(trendlineData[2].transform?.[2]).toHaveProperty('type', 'filter');
+    expect(trendlineData[2].transform?.[3]).toHaveProperty('type', 'filter');
   });
 
   test('should add filter transforms for regression method if trendline has excludeDataKey', () => {
@@ -140,7 +145,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'linear', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(6);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -151,7 +156,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for regression method if trendline does not have excludeDataKey', () => {
+  test('should always include metric validity filter for regression method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -159,8 +164,26 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'linear' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform?.[0]).toStrictEqual({
+      type: 'filter',
+      expr: 'isValid(datum["value"])',
+    });
+  });
+
+  test('should filter regression output to prevent NaN trendline values from rendering', () => {
+    const trendlineData = getDefaultData();
+
+    addTrendlineData(trendlineData, {
+      ...defaultLineOptions,
+      trendlines: [{ method: 'linear' }],
+    });
+    // transforms for _highResolutionData: inputFilter[0], regression[1], outputFilter[2], seriesId[3]
+    expect(trendlineData[2].transform?.[1]).toHaveProperty('type', 'regression');
+    expect(trendlineData[2].transform?.[2]).toStrictEqual({
+      type: 'filter',
+      expr: `isValid(datum["${TRENDLINE_VALUE}"])`,
+    });
   });
 
   test('should add filter transforms for aggregate method if trendline has excludeDataKey', () => {
@@ -171,7 +194,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'median', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(5);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -182,7 +205,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for aggregate method if trendline does not have excludeDataKey', () => {
+  test('should always include metric validity filter for aggregate method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -190,8 +213,11 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'median' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform?.[0]).toStrictEqual({
+      type: 'filter',
+      expr: 'isValid(datum["value"])',
+    });
   });
 
   test('should add filter transform for window method if trendline has excludeDataKey', () => {
@@ -202,7 +228,7 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'movingAverage-2', excludeDataKeys: ['exclude1', 'exclude2'] }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(4);
+    expect(trendlineData[2].transform).toHaveLength(5);
     expect(trendlineData[2].transform?.[0]).toStrictEqual({
       type: 'filter',
       expr: '!datum.exclude1',
@@ -213,7 +239,7 @@ describe('addTrendlineData()', () => {
     });
   });
 
-  test('should not add filter transform for window method if trendline does not have excludeDataKey', () => {
+  test('should always include trendline value validity filter for window method', () => {
     const trendlineData = getDefaultData();
 
     addTrendlineData(trendlineData, {
@@ -221,8 +247,37 @@ describe('addTrendlineData()', () => {
       trendlines: [{ method: 'movingAverage-2' }],
     });
     expect(trendlineData[2]).toHaveProperty('name', 'line0Trendline0_data');
-    expect(trendlineData[2].transform).toHaveLength(2);
-    expect(trendlineData[2].transform).not.toContain(expect.objectContaining({ type: 'filter' }));
+    expect(trendlineData[2].transform).toHaveLength(3);
+    expect(trendlineData[2].transform?.[2]).toStrictEqual({
+      type: 'filter',
+      expr: `isValid(datum["${TRENDLINE_VALUE}"])`,
+    });
+  });
+
+  test('should add data sources for exponential or power trendlines on time scales', () => {
+    const expData = getDefaultData();
+    addTrendlineData(expData, { ...defaultLineOptions, trendlines: [{ method: 'exponential' }] });
+    expect(expData).toHaveLength(3);
+    expect(expData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+
+    const powData = getDefaultData();
+    addTrendlineData(powData, { ...defaultLineOptions, trendlines: [{ method: 'power' }] });
+    expect(powData).toHaveLength(3);
+    expect(powData[2]).toHaveProperty('name', 'line0Trendline0_highResolutionData');
+  });
+
+  test('should use isValid metric filter for all regression methods', () => {
+    const linearData = getDefaultData();
+    addTrendlineData(linearData, { ...defaultLineOptions, trendlines: [{ method: 'linear' }] });
+    expect(linearData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
+
+    const expData = getDefaultData();
+    addTrendlineData(expData, { ...defaultLineOptions, trendlines: [{ method: 'exponential' }] });
+    expect(expData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
+
+    const powData = getDefaultData();
+    addTrendlineData(powData, { ...defaultLineOptions, trendlines: [{ method: 'power' }] });
+    expect(powData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
   });
 });
 

--- a/packages/vega-spec-builder/src/trendline/trendlineDataUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineDataUtils.ts
@@ -20,6 +20,7 @@ import {
   SELECTED_ITEM,
   SELECTED_SERIES,
   SERIES_ID,
+  TRENDLINE_VALUE,
 } from '@spectrum-charts/constants';
 
 import { getSeriesIdTransform, getTableData } from '../data/dataUtils';
@@ -28,6 +29,7 @@ import { getFacetsFromOptions } from '../specUtils';
 import { TrendlineMethod, TrendlineSpecOptions } from '../types';
 import {
   getAggregateTransform,
+  getMetricFilterTransform,
   getNormalizedDimensionTransform,
   getPartialWindowFilterTransforms,
   getRegressionExtentTransform,
@@ -115,7 +117,7 @@ export const getAggregateTrendlineData = (
   facets: string[]
 ) => {
   const data: SourceData[] = [];
-  const { dimensionRange, name, trendlineDimension } = trendlineOptions;
+  const { dimensionRange, name, trendlineDimension, trendlineMetric } = trendlineOptions;
   const dimensionRangeTransforms = getTrendlineDimensionRangeTransforms(trendlineDimension, dimensionRange);
   // high resolution data used for drawing the rule marks
   data.push({
@@ -123,6 +125,7 @@ export const getAggregateTrendlineData = (
     source: FILTERED_TABLE,
     transform: [
       ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
+      getMetricFilterTransform(trendlineMetric),
       ...dimensionRangeTransforms,
       ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, true),
       ...getSeriesIdTransform(facets),
@@ -134,6 +137,7 @@ export const getAggregateTrendlineData = (
       name: `${name}_data`,
       source: FILTERED_TABLE,
       transform: [
+        getMetricFilterTransform(trendlineMetric),
         ...dimensionRangeTransforms,
         ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
       ],
@@ -156,7 +160,7 @@ export const getRegressionTrendlineData = (
 ) => {
   const data: SourceData[] = [];
   const { dimension, metric } = markOptions;
-  const { dimensionRange, method, name, orientation, trendlineDimension } = trendlineOptions;
+  const { dimensionRange, method, name, orientation, trendlineDimension, trendlineMetric } = trendlineOptions;
   const { trendlineDimension: standardTrendlineDimension } = getTrendlineDimensionMetric(
     dimension,
     metric,
@@ -170,8 +174,10 @@ export const getRegressionTrendlineData = (
     source: FILTERED_TABLE,
     transform: [
       ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
+      getMetricFilterTransform(trendlineMetric),
       ...dimensionRangeTransforms,
       ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, true),
+      getMetricFilterTransform(TRENDLINE_VALUE),
       ...getSeriesIdTransform(facets),
     ],
   });
@@ -183,6 +189,7 @@ export const getRegressionTrendlineData = (
         name: `${name}_params`,
         source: FILTERED_TABLE,
         transform: [
+          getMetricFilterTransform(trendlineMetric),
           ...dimensionRangeTransforms,
           ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
         ],
@@ -216,6 +223,7 @@ const getWindowTrendlineData = (
   transform: [
     ...getExcludeDataKeyTransforms(trendlineOptions.excludeDataKeys),
     ...getTrendlineStatisticalTransforms(markOptions, trendlineOptions, false),
+    getMetricFilterTransform(TRENDLINE_VALUE),
     ...getTrendlineDimensionRangeTransforms(markOptions.dimension, trendlineOptions.dimensionRange),
   ],
 });

--- a/packages/vega-spec-builder/src/trendline/trendlineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineMarkUtils.ts
@@ -43,6 +43,7 @@ export const getTrendlineMarks = (markOptions: TrendlineParentOptions): (GroupMa
   const trendlines = getTrendlines(markOptions);
   for (const trendlineOptions of trendlines) {
     const { displayOnHover, method, name } = trendlineOptions;
+
     if (isAggregateMethod(method)) {
       marks.push(getTrendlineRuleMark(markOptions, trendlineOptions));
     } else {


### PR DESCRIPTION
## Description

Add a filter to exclude trendline values that are NaN or null, to prevent the trendline from sitting at the top of the chart. It should not display at all in that case. 

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Storybook, unit tests. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
