### PR TITLE
feat: add context menu interaction prop

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -64,6 +64,7 @@ export const FILTERED_TABLE = 'filteredTable';
 export const CONTROLLED_HIGHLIGHTED_TABLE = 'controlledHighlightedTable';
 
 // vega data field names
+export const DIMENSION_FIELD = 'rscDimensionField';
 export const GROUP_DATA = 'rscGroupData';
 export const MARK_ID = 'rscMarkId';
 export const GROUP_ID = 'rscGroupId';

--- a/packages/docs/docs/api/visualizations/Line.md
+++ b/packages/docs/docs/api/visualizations/Line.md
@@ -155,6 +155,12 @@ const [menu, setMenu] = useState({ x: 0, y: 0, datum: null, open: false });
             <td>Callback function that will be executed when a point or section of the line is right-clicked. Receives the native mouse event (e.g. for <code>clientX</code>/<code>clientY</code> and <code>preventDefault()</code>) and the data point. Use this to show your own custom context menu anchored to the clicked point.</td>
         </tr>
         <tr>
+            <td>contextMenuMode</td>
+            <td>'interaction' | 'dimension' | 'item'</td>
+            <td>'interaction'</td>
+            <td>Controls which interactions can trigger <code>onContextMenu</code>.<br/><code>'interaction'</code>: fires for any hover interaction (default).<br/><code>'dimension'</code>: fires when a dimension value (x-axis column) is right-clicked; the callback receives all series data for that dimension.<br/><code>'item'</code>: fires only when an individual data point is right-clicked.</td>
+        </tr>
+        <tr>
             <td>onMouseOver</td>
             <td>function</td>
             <td>–</td>

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -272,6 +272,12 @@ The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `Metri
             <td>Callback fired on right-click. Use this to show a custom context menu anchored to the clicked point.</td>
         </tr>
         <tr>
+            <td>contextMenuMode</td>
+            <td>'interaction' | 'dimension' | 'item'</td>
+            <td>'interaction'</td>
+            <td>Controls which interactions can trigger <code>onContextMenu</code>. <code>'interaction'</code> fires for any hover interaction (default). <code>'dimension'</code> fires when a dimension value is right-clicked; the callback receives all series data for that dimension. <code>'item'</code> fires only when an individual data point is right-clicked.</td>
+        </tr>
+        <tr>
             <td>opacity</td>
             <td>number | string</td>
             <td>–</td>

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -273,9 +273,9 @@ The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `Metri
         </tr>
         <tr>
             <td>contextMenuMode</td>
-            <td>'interaction' | 'dimension' | 'item'</td>
+            <td>'interaction' | 'item'</td>
             <td>'interaction'</td>
-            <td>Controls which interactions can trigger <code>onContextMenu</code>. <code>'interaction'</code> fires for any hover interaction (default). <code>'dimension'</code> fires when a dimension value is right-clicked; the callback receives all series data for that dimension. <code>'item'</code> fires only when an individual data point is right-clicked.</td>
+            <td>Controls which interactions can trigger <code>onContextMenu</code>. <code>'interaction'</code> fires for any hover interaction (default). <code>'item'</code> fires only when an individual data point is right-clicked.</td>
         </tr>
         <tr>
             <td>opacity</td>

--- a/packages/react-spectrum-charts-s2/src/components/Line/Line.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/Line/Line.tsx
@@ -30,6 +30,7 @@ const Line: FC<LineProps> = ({
   padding,
   interactionMode = DEFAULT_INTERACTION_MODE,
   interpolate,
+  contextMenuMode = 'interaction',
 }: LineProps) => {
   return null;
 };

--- a/packages/react-spectrum-charts-s2/src/hooks/useMarkOnClickDetails.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useMarkOnClickDetails.tsx
@@ -12,6 +12,7 @@
 import { createElement, useMemo } from 'react';
 
 import { Bar, BarElement, Chart, ChartChildElement, Line, LineElement, MarkCallback } from '../index';
+import { ContextMenuMode } from '../types/marks/line.types';
 import { ContextMenuCallback } from '../types/util.types';
 import { getAllMarkElements } from '../utils';
 
@@ -21,6 +22,7 @@ export type MarkOnClickDetail = {
   markName?: string;
   onClick?: MarkCallback;
   onContextMenu?: ContextMenuCallback;
+  contextMenuMode?: ContextMenuMode;
 };
 
 export default function useMarkOnClickDetails(children: ChartChildElement[]): MarkOnClickDetail[] {
@@ -39,6 +41,7 @@ export default function useMarkOnClickDetails(children: ChartChildElement[]): Ma
           markName: mark.name,
           onClick: mark.element.props.onClick,
           onContextMenu: mark.element.props.onContextMenu,
+          contextMenuMode: 'contextMenuMode' in mark.element.props ? mark.element.props.contextMenuMode : undefined,
         })) as MarkOnClickDetail[],
     [markElements]
   );

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
@@ -256,6 +256,7 @@ describe('rscPropsToSpecBuilderOptions()', () => {
             color: 'series',
             dimension: 'datetime',
             hasOnClick: false,
+            hasOnContextMenu: false,
             lineDirectLabels: [],
             markType: 'line',
             metric: 'value',

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
@@ -37,6 +37,10 @@ describe('getLineOptions()', () => {
     expect(getLineOptions({ onClick: () => {} }).hasOnClick).toBe(true);
     expect(getLineOptions({ onClick: undefined }).hasOnClick).toBe(false);
   });
+  test('should set hasOnContextMenu to true if onContextMenu prop exists and is not undefined', () => {
+    expect(getLineOptions({ onContextMenu: () => {} }).hasOnContextMenu).toBe(true);
+    expect(getLineOptions({ onContextMenu: undefined }).hasOnContextMenu).toBe(false);
+  });
   it('should pass through included props', () => {
     const options = getLineOptions({ color: DEFAULT_COLOR });
     expect(options).toHaveProperty('color', DEFAULT_COLOR);

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
@@ -14,13 +14,14 @@ import { LineOptions } from '@spectrum-charts/vega-spec-builder-s2';
 import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
-export const getLineOptions = ({ children, onClick, ...lineProps }: LineProps): LineOptions => {
+export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMode, ...lineProps }: LineProps): LineOptions => {
   const { chartPopovers, chartTooltips, lineDirectLabels } = childrenToOptions(children);
   return {
     ...lineProps,
     chartPopovers,
     chartTooltips,
     hasOnClick: Boolean(onClick),
+    hasOnContextMenu: Boolean(onContextMenu),
     lineDirectLabels,
     markType: 'line',
   };

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
@@ -14,7 +14,7 @@ import { LineOptions } from '@spectrum-charts/vega-spec-builder-s2';
 import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
-export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMode, ...lineProps }: LineProps): LineOptions => {
+export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMode: _contextMenuMode, ...lineProps }: LineProps): LineOptions => {
   const { chartPopovers, chartTooltips, lineDirectLabels } = childrenToOptions(children);
   return {
     ...lineProps,

--- a/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
@@ -17,17 +17,34 @@ import { ChartPopoverElement, ChartTooltipElement } from '../dialogs';
 import { LineDirectLabelElement } from './supplemental/lineDirectLabel.types';
 import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
 
+/**
+ * Controls which interaction marks can trigger `onContextMenu`.
+ * Acts as a filter on top of whatever marks `interactionMode` generates.
+ * - `'interaction'` (default) — fires on all marks the current `interactionMode` generates
+ * - `'dimension'` — only fires from dimension strips; not applicable in S2 (no dimension interaction mode)
+ * - `'item'` — only fires from individual hover points
+ */
+export type ContextMenuMode = 'interaction' | 'dimension' | 'item';
+
 type LineChildElement = ChartPopoverElement | ChartTooltipElement | LineDirectLabelElement;
 export interface LineProps
   extends Omit<
     LineOptions,
-    'chartPopovers' | 'chartTooltips' | 'hasOnClick' | 'lineDirectLabels' | 'markType'
+    'chartPopovers' | 'chartTooltips' | 'hasOnClick' | 'hasOnContextMenu' | 'lineDirectLabels' | 'markType'
   > {
   children?: Children<LineChildElement>;
   /** Callback that will be run when a point/section is clicked */
   onClick?: MarkCallback;
-  /** Callback that will be run when a point/section is right-clicked. Use to show a custom context menu. */
+  /**
+   * Callback that will be run when a point/section is right-clicked. Use to show a custom context menu.
+   * Use `contextMenuMode` to control which marks can trigger it.
+   */
   onContextMenu?: ContextMenuCallback;
+  /**
+   * Controls which marks can trigger `onContextMenu`.
+   * @default 'interaction'
+   */
+  contextMenuMode?: ContextMenuMode;
 }
 
 export type LineElement = ReactElement<LineProps, JSXElementConstructor<LineProps>>;

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
@@ -11,8 +11,9 @@
  */
 import { Item, View } from 'vega';
 
-import { COMPONENT_NAME } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, DIMENSION_FIELD, FILTERED_TABLE, GROUP_DATA } from '@spectrum-charts/constants';
 
+import { ContextMenuMode } from '../types/marks/line.types';
 import {
   ActionItem,
   GetOnMarkClickCallbackArgs,
@@ -347,6 +348,18 @@ describe('getOnChartMarkContextMenuCallback()', () => {
   });
 
   describe('contextMenuMode filtering', () => {
+    const xAxisVoronoiItem = {
+      datum: { date: 1000, value: 42 },
+      bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+      mark: {
+        role: 'mark',
+        name: 'line0_xAxisVoronoi',
+        marktype: 'path',
+        group: { x: 0, y: 0 },
+        items: [],
+      },
+    } as unknown as ActionItem;
+
     const hoverItem = {
       datum: { date: 1000, value: 42 },
       bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
@@ -369,6 +382,25 @@ describe('getOnChartMarkContextMenuCallback()', () => {
       expect(onContextMenu).toHaveBeenCalledTimes(2);
     });
 
+    test("'dimension' allows _xAxisVoronoi marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'dimension' },
+      ]);
+      callback(fakeContextMenuEvent, xAxisVoronoiItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test("'dimension' blocks _voronoi and hover marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'dimension' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).not.toHaveBeenCalled();
+    });
+
     test("'item' allows hover marks", () => {
       const onContextMenu = jest.fn();
       const callback = getOnChartMarkContextMenuCallback(chartView, [
@@ -378,13 +410,112 @@ describe('getOnChartMarkContextMenuCallback()', () => {
       expect(onContextMenu).toHaveBeenCalledTimes(1);
     });
 
-    test("'item' blocks _voronoi marks", () => {
+    test("'item' blocks _voronoi and _xAxisVoronoi marks", () => {
       const onContextMenu = jest.fn();
       const callback = getOnChartMarkContextMenuCallback(chartView, [
         { markName: 'line0', onContextMenu, contextMenuMode: 'item' },
       ]);
       callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, xAxisVoronoiItem);
       expect(onContextMenu).not.toHaveBeenCalled();
+    });
+
+    test('enriches datum with GROUP_DATA when mark is _xAxisVoronoi and DIMENSION_FIELD is present', () => {
+      const row1 = { date: 1000, value: 10, series: 'a' };
+      const row2 = { date: 1000, value: 20, series: 'b' };
+      const row3 = { date: 2000, value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithDimensionField = {
+        datum: { date: 1000, value: 42, [DIMENSION_FIELD]: 'date' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithDimensionField);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
+    });
+
+    test('handles Date dimension values in GROUP_DATA enrichment', () => {
+      const date1 = new Date(1000);
+      const date2 = new Date(2000);
+      const row1 = { date: date1, value: 10, series: 'a' };
+      const row2 = { date: date1, value: 20, series: 'b' };
+      const row3 = { date: date2, value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithDate = {
+        datum: { date: date1, value: 42, [DIMENSION_FIELD]: 'date' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithDate);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
+    });
+
+    test("unknown contextMenuMode falls back to allowing the mark", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'unknown' as ContextMenuMode },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test('handles string dimension values in GROUP_DATA enrichment', () => {
+      const row1 = { category: 'A', value: 10, series: 'a' };
+      const row2 = { category: 'A', value: 20, series: 'b' };
+      const row3 = { category: 'B', value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithString = {
+        datum: { category: 'A', value: 42, [DIMENSION_FIELD]: 'category' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithString);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
     });
   });
 });

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
@@ -11,7 +11,7 @@
  */
 import { Item, View } from 'vega';
 
-import { COMPONENT_NAME, FILTERED_TABLE, GROUP_DATA, DIMENSION_FIELD } from '@spectrum-charts/constants';
+import { COMPONENT_NAME } from '@spectrum-charts/constants';
 
 import {
   ActionItem,

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
@@ -11,7 +11,7 @@
  */
 import { Item, View } from 'vega';
 
-import { COMPONENT_NAME } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, FILTERED_TABLE, GROUP_DATA, DIMENSION_FIELD } from '@spectrum-charts/constants';
 
 import {
   ActionItem,
@@ -344,5 +344,47 @@ describe('getOnChartMarkContextMenuCallback()', () => {
       expect.objectContaining({ clientX: 100, clientY: 200 }),
       { date: 1000, value: 42 }
     );
+  });
+
+  describe('contextMenuMode filtering', () => {
+    const hoverItem = {
+      datum: { date: 1000, value: 42 },
+      bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+      mark: {
+        role: 'mark',
+        name: 'line0_hover0',
+        marktype: 'symbol',
+        group: { x: 0, y: 0 },
+        items: [],
+      },
+    } as unknown as ActionItem;
+
+    test("'interaction' allows all mark types", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'interaction' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(2);
+    });
+
+    test("'item' allows hover marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'item' },
+      ]);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test("'item' blocks _voronoi marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'item' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      expect(onContextMenu).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.ts
@@ -13,8 +13,9 @@ import { MutableRefObject } from 'react';
 
 import { Item, Scene, SceneGroup, SceneItem, ScenegraphEvent, View } from 'vega';
 
-import { COMPONENT_NAME, SERIES_ID } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, DIMENSION_FIELD, FILTERED_TABLE, GROUP_DATA, SERIES_ID } from '@spectrum-charts/constants';
 import { Datum, MarkBounds } from '@spectrum-charts/vega-spec-builder-s2';
+import { ContextMenuMode } from '../types/marks/line.types';
 
 import { MarkMouseInputDetail } from '../hooks/useMarkMouseInputDetails';
 import { MarkOnClickDetail } from '../hooks/useMarkOnClickDetails';
@@ -129,16 +130,41 @@ export const getOnChartMarkContextMenuCallback = (
     if (!item || !markClickDetails?.length || isLegendItem(item) || !chartView.current) return;
     if (event.type !== 'contextmenu') return;
 
+    // Capture the mark name before getGroupOrAreaMarkItemFromItem may unwrap the item
+    const fullMarkName = isItemSceneItem(item) ? (item.mark as unknown as { name: string }).name : '';
+
     item = getGroupOrAreaMarkItemFromItem(item);
     if (!userDidNotClickOnLegend(item)) return;
 
     const itemName = getItemName(item);
     const detail = markClickDetails.find((d) => d.markName === itemName);
-    if (detail?.onContextMenu) {
+    if (detail?.onContextMenu && contextMenuModeAllowsMark(detail.contextMenuMode, fullMarkName)) {
       const nativeEvent = (event as unknown as { sourceEvent?: MouseEvent }).sourceEvent ?? (event as unknown as MouseEvent);
-      detail.onContextMenu(nativeEvent, item.datum);
+      let datum = item.datum;
+      if (fullMarkName.endsWith('_xAxisVoronoi')) {
+        const dimensionField = datum[DIMENSION_FIELD] as string;
+        if (dimensionField) {
+          const dimensionValue = toComparableValue(datum[dimensionField]);
+          const tableData = chartView.current.data(FILTERED_TABLE);
+          datum = { ...datum, [GROUP_DATA]: tableData.filter((d) => toComparableValue(d[dimensionField]) === dimensionValue) };
+        }
+      }
+      detail.onContextMenu(nativeEvent, datum);
     }
   };
+};
+
+const toComparableValue = (val: unknown): string | number => {
+  if (val instanceof Date) return val.getTime();
+  if (typeof val === 'number') return val;
+  return val as string;
+};
+
+const contextMenuModeAllowsMark = (contextMenuMode: ContextMenuMode | undefined, fullMarkName: string): boolean => {
+  if (!contextMenuMode || contextMenuMode === 'interaction') return true;
+  if (contextMenuMode === 'dimension') return fullMarkName.endsWith('_xAxisVoronoi');
+  if (contextMenuMode === 'item') return /_hover\d/.test(fullMarkName);
+  return true;
 };
 
 const getGroupOrAreaMarkItemFromItem = (item: NonNullable<ActionItem>) => {

--- a/packages/react-spectrum-charts/src/components/Line/Line.tsx
+++ b/packages/react-spectrum-charts/src/components/Line/Line.tsx
@@ -28,6 +28,7 @@ const Line: FC<LineProps> = ({
   lineType = { value: 'solid' },
   padding,
   interactionMode = DEFAULT_INTERACTION_MODE,
+  contextMenuMode = 'interaction',
 }: LineProps) => {
   return null;
 };

--- a/packages/react-spectrum-charts/src/hooks/useMarkOnClickDetails.tsx
+++ b/packages/react-spectrum-charts/src/hooks/useMarkOnClickDetails.tsx
@@ -12,6 +12,7 @@
 import { createElement, useMemo } from 'react';
 
 import { Bar, BarElement, Chart, ChartChildElement, Line, LineElement, MarkCallback } from '../index';
+import { ContextMenuMode } from '../types/marks/line.types';
 import { ContextMenuCallback } from '../types/util.types';
 import { getAllMarkElements } from '../utils';
 
@@ -21,6 +22,7 @@ export type MarkOnClickDetail = {
   markName?: string;
   onClick?: MarkCallback;
   onContextMenu?: ContextMenuCallback;
+  contextMenuMode?: ContextMenuMode;
 };
 
 export default function useMarkOnClickDetails(children: ChartChildElement[]): MarkOnClickDetail[] {
@@ -39,6 +41,7 @@ export default function useMarkOnClickDetails(children: ChartChildElement[]): Ma
           markName: mark.name,
           onClick: mark.element.props.onClick,
           onContextMenu: mark.element.props.onContextMenu,
+          contextMenuMode: 'contextMenuMode' in mark.element.props ? mark.element.props.contextMenuMode : undefined,
         })) as MarkOnClickDetail[],
     [markElements]
   );

--- a/packages/react-spectrum-charts/src/rscToSbAdapter/chartAdapter.test.ts
+++ b/packages/react-spectrum-charts/src/rscToSbAdapter/chartAdapter.test.ts
@@ -214,6 +214,7 @@ describe('rscPropsToSpecBuilderOptions()', () => {
             dimension: 'datetime',
             hasMouseInteraction: false,
             hasOnClick: false,
+            hasOnContextMenu: false,
             linePointAnnotations: [],
             markType: 'line',
             metric: 'value',

--- a/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.test.ts
+++ b/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.test.ts
@@ -49,6 +49,10 @@ describe('getLineOptions()', () => {
     expect(getLineOptions({ onClick: () => {} }).hasOnClick).toBe(true);
     expect(getLineOptions({ onClick: undefined }).hasOnClick).toBe(false);
   });
+  test('should set hasOnContextMenu to true if onContextMenu prop exists and is not undefined', () => {
+    expect(getLineOptions({ onContextMenu: () => {} }).hasOnContextMenu).toBe(true);
+    expect(getLineOptions({ onContextMenu: undefined }).hasOnContextMenu).toBe(false);
+  });
   test('should set hasMouseInteraction to true if onMouseOver prop exists', () => {
     expect(getLineOptions({ onMouseOver: () => {} }).hasMouseInteraction).toBe(true);
     expect(getLineOptions({ onMouseOver: undefined }).hasMouseInteraction).toBe(false);

--- a/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.ts
@@ -14,7 +14,7 @@ import { LineOptions } from '@spectrum-charts/vega-spec-builder';
 import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
-export const getLineOptions = ({ children, contextMenuMode, onClick, onContextMenu, onMouseOver, onMouseOut, ...lineProps }: LineProps): LineOptions => {
+export const getLineOptions = ({ children, contextMenuMode: _contextMenuMode, onClick, onContextMenu, onMouseOver, onMouseOut, ...lineProps }: LineProps): LineOptions => {
   const { chartPopovers, chartTooltips, linePointAnnotations, metricRanges, trendlines } = childrenToOptions(children);
 
   return {

--- a/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts/src/rscToSbAdapter/lineAdapter.ts
@@ -14,14 +14,15 @@ import { LineOptions } from '@spectrum-charts/vega-spec-builder';
 import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
-export const getLineOptions = ({ children, onClick, onMouseOver, onMouseOut, ...lineProps }: LineProps): LineOptions => {
+export const getLineOptions = ({ children, contextMenuMode, onClick, onContextMenu, onMouseOver, onMouseOut, ...lineProps }: LineProps): LineOptions => {
   const { chartPopovers, chartTooltips, linePointAnnotations, metricRanges, trendlines } = childrenToOptions(children);
-  
+
   return {
     ...lineProps,
     chartPopovers,
     chartTooltips,
     hasOnClick: Boolean(onClick),
+    hasOnContextMenu: Boolean(onContextMenu),
     hasMouseInteraction: Boolean(onMouseOut || onMouseOver),
     linePointAnnotations,
     markType: 'line',

--- a/packages/react-spectrum-charts/src/stories/components/Line/Line.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Line/Line.story.tsx
@@ -449,6 +449,57 @@ OnClickWithTooltip.args = {
   ...OnClick.args,
 };
 
+const DimensionContextMenuStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const [contextMenuInfo, setContextMenuInfo] = useState<{ datetime: string; series: string[] } | null>(null);
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <div>
+      <div style={{ width: '800px', minHeight: '60px', padding: '8px', border: '1px solid #ccc', marginBottom: '8px' }}>
+        {contextMenuInfo ? (
+          <div data-testid="context-menu-data">
+            <div><strong>Right-clicked dimension:</strong> {contextMenuInfo.datetime}</div>
+            <div><strong>Series in group:</strong> {contextMenuInfo.series.join(', ')}</div>
+          </div>
+        ) : (
+          <div data-testid="no-context-menu">Right-click anywhere on the chart to see dimension context menu data</div>
+        )}
+      </div>
+      <Chart {...chartProps}>
+        <Axis position="left" grid title="Users" />
+        <Axis position="bottom" labelFormat="time" baseline ticks />
+        <Line
+          {...args}
+          onContextMenu={(_e, datum) => {
+            action('onContextMenu')(datum);
+            const groupData = datum[GROUP_DATA] as Datum[];
+            setContextMenuInfo({
+              datetime: formatTimestamp(+(datum.datetime0 ?? datum.datetime)),
+              series: groupData?.map((d) => String(d.series)) ?? [],
+            });
+          }}
+        />
+        <Legend highlight />
+      </Chart>
+    </div>
+  );
+};
+
+const DimensionContextMenu = bindWithProps(DimensionContextMenuStory);
+DimensionContextMenu.args = {
+  ...defaultArgs,
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+  interactionMode: 'dimension',
+  contextMenuMode: 'dimension',
+};
+DimensionContextMenu.argTypes = {
+  contextMenuMode: {
+    control: { type: 'radio' },
+    options: ['interaction', 'dimension', 'item'],
+  },
+};
+
 const WithGapsInData = bindWithProps(WithGapsInDataStory);
 WithGapsInData.args = {
   ...defaultArgs,
@@ -536,6 +587,7 @@ export {
   SparklineWithStaticPoint,
   OnClick,
   OnClickWithTooltip,
+  DimensionContextMenu,
   OnMouseInputs,
   WithGapsInData,
 };

--- a/packages/react-spectrum-charts/src/types/marks/line.types.ts
+++ b/packages/react-spectrum-charts/src/types/marks/line.types.ts
@@ -17,17 +17,34 @@ import { ChartPopoverElement, ChartTooltipElement } from '../dialogs';
 import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
 import { LinePointAnnotationElement, MetricRangeElement, TrendlineElement } from './supplemental';
 
+/**
+ * Controls which interaction marks can trigger `onContextMenu`.
+ * Acts as a filter on top of whatever marks `interactionMode` generates.
+ * - `'interaction'` (default) — fires on all marks the current `interactionMode` generates
+ * - `'dimension'` — only fires from dimension strips (`_xAxisVoronoi`); datum includes `rscGroupData`
+ * - `'item'` — only fires from individual hover points (`_hover*`)
+ */
+export type ContextMenuMode = 'interaction' | 'dimension' | 'item';
+
 type LineChildElement = ChartTooltipElement | ChartPopoverElement | LinePointAnnotationElement | MetricRangeElement | TrendlineElement;
 export interface LineProps
   extends Omit<
     LineOptions,
-    'chartPopovers' | 'chartTooltips' | 'hasOnClick' | 'hasMouseInteraction' | 'linePointAnnotations' | 'markType' | 'metricRanges' | 'trendlines'
+    'chartPopovers' | 'chartTooltips' | 'hasOnClick' | 'hasOnContextMenu' | 'hasMouseInteraction' | 'linePointAnnotations' | 'markType' | 'metricRanges' | 'trendlines'
   > {
   children?: Children<LineChildElement>;
   /** Callback that will be run when a point/section is clicked */
   onClick?: MarkCallback;
-  /** Callback that will be run when a point/section is right-clicked. Use to show a custom context menu. */
+  /**
+   * Callback that will be run when a point/section is right-clicked. Use to show a custom context menu.
+   * Use `contextMenuMode` to control which marks can trigger it.
+   */
   onContextMenu?: ContextMenuCallback;
+  /**
+   * Controls which marks can trigger `onContextMenu`.
+   * @default 'interaction'
+   */
+  contextMenuMode?: ContextMenuMode;
   /** Callback that will be run when a point/section is hovered */
   onMouseOver?: MarkCallback;
   /** Callback that will be run when a point/section is no longer hovered */

--- a/packages/react-spectrum-charts/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts/src/utils/markClickUtils.test.ts
@@ -11,7 +11,7 @@
  */
 import { Item, View } from 'vega';
 
-import { COMPONENT_NAME } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, DIMENSION_FIELD, FILTERED_TABLE, GROUP_DATA } from '@spectrum-charts/constants';
 
 import {
   ActionItem,
@@ -426,6 +426,110 @@ describe('getOnChartMarkContextMenuCallback()', () => {
       expect.objectContaining({ clientX: 100, clientY: 200 }),
       { date: 1000, value: 42 }
     );
+  });
+
+  describe('contextMenuMode filtering', () => {
+    const xAxisVoronoiItem = {
+      datum: { date: 1000, value: 42 },
+      bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+      mark: {
+        role: 'mark',
+        name: 'line0_xAxisVoronoi',
+        marktype: 'path',
+        group: { x: 0, y: 0 },
+        items: [],
+      },
+    } as unknown as ActionItem;
+
+    const hoverItem = {
+      datum: { date: 1000, value: 42 },
+      bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+      mark: {
+        role: 'mark',
+        name: 'line0_hover0',
+        marktype: 'symbol',
+        group: { x: 0, y: 0 },
+        items: [],
+      },
+    } as unknown as ActionItem;
+
+    test("'interaction' allows all mark types", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'interaction' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(2);
+    });
+
+    test("'dimension' allows _xAxisVoronoi marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'dimension' },
+      ]);
+      callback(fakeContextMenuEvent, xAxisVoronoiItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test("'dimension' blocks _voronoi and hover marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'dimension' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).not.toHaveBeenCalled();
+    });
+
+    test("'item' allows hover marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'item' },
+      ]);
+      callback(fakeContextMenuEvent, hoverItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test("'item' blocks _voronoi and _xAxisVoronoi marks", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'item' },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      callback(fakeContextMenuEvent, xAxisVoronoiItem);
+      expect(onContextMenu).not.toHaveBeenCalled();
+    });
+
+    test('enriches datum with GROUP_DATA when mark is _xAxisVoronoi and DIMENSION_FIELD is present', () => {
+      const row1 = { date: 1000, value: 10, series: 'a' };
+      const row2 = { date: 1000, value: 20, series: 'b' };
+      const row3 = { date: 2000, value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithDimensionField = {
+        datum: { date: 1000, value: 42, [DIMENSION_FIELD]: 'date' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithDimensionField);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
+    });
   });
 });
 

--- a/packages/react-spectrum-charts/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts/src/utils/markClickUtils.test.ts
@@ -13,6 +13,7 @@ import { Item, View } from 'vega';
 
 import { COMPONENT_NAME, DIMENSION_FIELD, FILTERED_TABLE, GROUP_DATA } from '@spectrum-charts/constants';
 
+import { ContextMenuMode } from '../types/marks/line.types';
 import {
   ActionItem,
   GetOnMarkClickCallbackArgs,
@@ -527,6 +528,75 @@ describe('getOnChartMarkContextMenuCallback()', () => {
       ]);
       callback(fakeContextMenuEvent, itemWithDimensionField);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
+    });
+
+    test('handles Date dimension values in GROUP_DATA enrichment', () => {
+      const date1 = new Date(1000);
+      const date2 = new Date(2000);
+      const row1 = { date: date1, value: 10, series: 'a' };
+      const row2 = { date: date1, value: 20, series: 'b' };
+      const row3 = { date: date2, value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithDate = {
+        datum: { date: date1, value: 42, [DIMENSION_FIELD]: 'date' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithDate);
+      const [, datum] = onContextMenu.mock.calls[0];
+      expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
+    });
+
+    test("unknown contextMenuMode falls back to allowing the mark", () => {
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(chartView, [
+        { markName: 'line0', onContextMenu, contextMenuMode: 'unknown' as ContextMenuMode },
+      ]);
+      callback(fakeContextMenuEvent, lineMarkItem);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+    });
+
+    test('handles string dimension values in GROUP_DATA enrichment', () => {
+      const row1 = { category: 'A', value: 10, series: 'a' };
+      const row2 = { category: 'A', value: 20, series: 'b' };
+      const row3 = { category: 'B', value: 30, series: 'a' };
+      const mockChartView = {
+        current: {
+          data: (name: string) => (name === FILTERED_TABLE ? [row1, row2, row3] : []),
+        } as unknown as View,
+      };
+      const itemWithString = {
+        datum: { category: 'A', value: 42, [DIMENSION_FIELD]: 'category' },
+        bounds: { x1: 5, y1: 10, x2: 15, y2: 20 },
+        mark: {
+          role: 'mark',
+          name: 'line0_xAxisVoronoi',
+          marktype: 'path',
+          group: { x: 0, y: 0 },
+          items: [],
+        },
+      } as unknown as ActionItem;
+      const onContextMenu = jest.fn();
+      const callback = getOnChartMarkContextMenuCallback(mockChartView, [
+        { markName: 'line0', onContextMenu },
+      ]);
+      callback(fakeContextMenuEvent, itemWithString);
       const [, datum] = onContextMenu.mock.calls[0];
       expect(datum).toHaveProperty(GROUP_DATA, [row1, row2]);
     });

--- a/packages/react-spectrum-charts/src/utils/markClickUtils.ts
+++ b/packages/react-spectrum-charts/src/utils/markClickUtils.ts
@@ -13,7 +13,8 @@ import { MutableRefObject } from 'react';
 
 import { Item, Scene, SceneGroup, SceneItem, ScenegraphEvent, View } from 'vega';
 
-import { COMPONENT_NAME, SERIES_ID } from '@spectrum-charts/constants';
+import { COMPONENT_NAME, DIMENSION_FIELD, FILTERED_TABLE, GROUP_DATA, SERIES_ID } from '@spectrum-charts/constants';
+import { ContextMenuMode } from '../types/marks/line.types';
 import { Datum, MarkBounds } from '@spectrum-charts/vega-spec-builder';
 
 import { ThumbnailPopoverConfig } from '../hooks/useAxisThumbnailPopover';
@@ -135,16 +136,41 @@ export const getOnChartMarkContextMenuCallback = (
     if (!item || !markClickDetails?.length || isLegendItem(item) || !chartView.current) return;
     if (event.type !== 'contextmenu') return;
 
+    // Capture the mark name before getGroupOrAreaMarkItemFromItem may unwrap the item
+    const fullMarkName = isItemSceneItem(item) ? (item.mark as unknown as { name: string }).name : '';
+
     item = getGroupOrAreaMarkItemFromItem(item);
     if (!userDidNotClickOnLegend(item)) return;
 
     const itemName = getItemName(item);
     const detail = markClickDetails.find((d) => d.markName === itemName);
-    if (detail?.onContextMenu) {
+    if (detail?.onContextMenu && contextMenuModeAllowsMark(detail.contextMenuMode, fullMarkName)) {
       const nativeEvent = (event as unknown as { sourceEvent?: MouseEvent }).sourceEvent ?? (event as unknown as MouseEvent);
-      detail.onContextMenu(nativeEvent, item.datum);
+      let datum = item.datum;
+      if (fullMarkName.endsWith('_xAxisVoronoi')) {
+        const dimensionField = datum[DIMENSION_FIELD] as string;
+        if (dimensionField) {
+          const dimensionValue = toComparableValue(datum[dimensionField]);
+          const tableData = chartView.current.data(FILTERED_TABLE);
+          datum = { ...datum, [GROUP_DATA]: tableData.filter((d) => toComparableValue(d[dimensionField]) === dimensionValue) };
+        }
+      }
+      detail.onContextMenu(nativeEvent, datum);
     }
   };
+};
+
+const toComparableValue = (val: unknown): string | number => {
+  if (val instanceof Date) return val.getTime();
+  if (typeof val === 'number') return val;
+  return val as string;
+};
+
+const contextMenuModeAllowsMark = (contextMenuMode: ContextMenuMode | undefined, fullMarkName: string): boolean => {
+  if (!contextMenuMode || contextMenuMode === 'interaction') return true;
+  if (contextMenuMode === 'dimension') return fullMarkName.endsWith('_xAxisVoronoi');
+  if (contextMenuMode === 'item') return /_hover\d/.test(fullMarkName);
+  return true;
 };
 
 const getGroupOrAreaMarkItemFromItem = (item: NonNullable<ActionItem>) => {

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -66,6 +66,7 @@ export const addLine = produce<
       dualMetricAxis = false,
       gradient = false,
       hasOnClick = false,
+      hasOnContextMenu = false,
       index = 0,
       lineDirectLabels = [],
       lineType = { value: 'solid' },
@@ -91,6 +92,7 @@ export const addLine = produce<
       dualMetricAxis,
       gradient,
       hasOnClick,
+      hasOnContextMenu,
       index,
       lineDirectLabels,
       interactiveMarkName: getInteractiveMarkName(
@@ -98,6 +100,7 @@ export const addLine = produce<
           chartPopovers,
           chartTooltips,
           hasOnClick,
+          hasOnContextMenu,
           highlightedItem: options.highlightedItem,
           metricRanges,
           trendlines,

--- a/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
@@ -40,6 +40,7 @@ export const defaultLineOptions: LineSpecOptions = {
   dimension: DEFAULT_TIME_DIMENSION,
   gradient: false,
   hasOnClick: false,
+  hasOnContextMenu: false,
   idKey: MARK_ID,
   index: 0,
   markType: 'line',

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.ts
@@ -135,15 +135,18 @@ export const isInteractive = (options: {
   chartPopovers?: ChartPopoverOptions[];
   chartTooltips?: ChartTooltipOptions[];
   hasOnClick?: boolean;
+  hasOnContextMenu?: boolean;
   metricRanges?: MetricRangeOptions[];
   trendlines?: TrendlineOptions[];
 }): boolean => {
   const hasOnClick = 'hasOnClick' in options && options.hasOnClick;
+  const hasOnContextMenu = 'hasOnContextMenu' in options && options.hasOnContextMenu;
   const metricRanges = ('metricRanges' in options && options.metricRanges) || [];
   const trendlines = ('trendlines' in options && options.trendlines) || [];
 
   return (
     hasOnClick ||
+    hasOnContextMenu ||
     hasPopover(options) ||
     hasTooltip(options) ||
     trendlines.some((trendline) => trendline.displayOnHover) ||
@@ -460,6 +463,7 @@ export const getInteractiveMarkName = (
     chartPopovers?: ChartPopoverOptions[];
     chartTooltips?: ChartTooltipOptions[];
     hasOnClick?: boolean;
+    hasOnContextMenu?: boolean;
     highlightedItem?: HighlightedItem;
     metricRanges?: MetricRangeOptions[];
     trendlines?: TrendlineOptions[];

--- a/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
@@ -43,6 +43,8 @@ export interface LineOptions {
   dimension?: string;
   /** `true` if BarProps has an onClick callback. Will add the mouse pointer to the bar on hover. */
   hasOnClick?: boolean;
+  /** `true` if LineProps has an onContextMenu callback. Ensures interactive marks are generated even without tooltip/click. */
+  hasOnContextMenu?: boolean;
   /** Line type or key in the data that is used as the line type facet */
   lineType?: LineTypeFacet;
   /** Opacity or key in the data that is used as the opacity facet */
@@ -84,6 +86,7 @@ type LineOptionsWithDefaults =
   | 'dimension'
   | 'gradient'
   | 'hasOnClick'
+  | 'hasOnContextMenu'
   | 'lineDirectLabels'
   | 'lineType'
   | 'metric'

--- a/packages/vega-spec-builder/src/line/lineDataUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineDataUtils.test.ts
@@ -79,7 +79,10 @@ describe('getUniqueDimensionData()', () => {
     expect(data).toEqual({
       name: 'line0_uniqueXValues',
       source: FILTERED_TABLE,
-      transform: [{ type: 'aggregate', groupby: [DEFAULT_TRANSFORMED_TIME_DIMENSION] }],
+      transform: [
+        { type: 'aggregate', groupby: [DEFAULT_TRANSFORMED_TIME_DIMENSION] },
+        { type: 'formula', expr: `"${DEFAULT_TRANSFORMED_TIME_DIMENSION}"`, as: 'rscDimensionField' },
+      ],
     });
   });
 });

--- a/packages/vega-spec-builder/src/line/lineDataUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineDataUtils.ts
@@ -14,6 +14,7 @@ import { SourceData } from 'vega';
 import {
   CONTROLLED_HIGHLIGHTED_ITEM,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
+  DIMENSION_FIELD,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
   GROUP_ID,
@@ -99,6 +100,11 @@ export const getUniqueDimensionData = (lineName: string, scaleType: ScaleType, d
       {
         type: 'aggregate',
         groupby: [dimensionField],
+      },
+      {
+        type: 'formula',
+        expr: `"${dimensionField}"`,
+        as: DIMENSION_FIELD,
       },
     ],
   };

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.test.ts
@@ -422,7 +422,10 @@ describe('lineSpecBuilder', () => {
       expect(resultData.find((d) => d.name === 'line0_uniqueXValues')).toStrictEqual({
         name: 'line0_uniqueXValues',
         source: FILTERED_TABLE,
-        transform: [{ type: 'aggregate', groupby: [DEFAULT_TRANSFORMED_TIME_DIMENSION] }],
+        transform: [
+          { type: 'aggregate', groupby: [DEFAULT_TRANSFORMED_TIME_DIMENSION] },
+          { type: 'formula', expr: `"${DEFAULT_TRANSFORMED_TIME_DIMENSION}"`, as: 'rscDimensionField' },
+        ],
       });
     });
   });

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -66,6 +66,7 @@ export const addLine = produce<
       dimension = DEFAULT_TIME_DIMENSION,
       dualMetricAxis = false,
       hasOnClick = false,
+      hasOnContextMenu = false,
       hasMouseInteraction = false,
       index = 0,
       linePointAnnotations = [],
@@ -90,6 +91,7 @@ export const addLine = produce<
       dimension,
       dualMetricAxis,
       hasOnClick,
+      hasOnContextMenu,
       index,
       hasMouseInteraction,
       interactiveMarkName: getInteractiveMarkName(
@@ -97,6 +99,7 @@ export const addLine = produce<
           chartPopovers,
           chartTooltips,
           hasOnClick,
+          hasOnContextMenu,
           hasMouseInteraction,
           highlightedItem: options.highlightedItem,
           metricRanges,

--- a/packages/vega-spec-builder/src/line/lineTestUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineTestUtils.ts
@@ -39,6 +39,7 @@ export const defaultLineOptions: LineSpecOptions = {
   name: 'line0',
   dimension: DEFAULT_TIME_DIMENSION,
   hasOnClick: false,
+  hasOnContextMenu: false,
   linePointAnnotations: [],
   idKey: MARK_ID,
   index: 0,

--- a/packages/vega-spec-builder/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.ts
@@ -136,17 +136,20 @@ export const isInteractive = (options: {
   chartPopovers?: ChartPopoverOptions[];
   chartTooltips?: ChartTooltipOptions[];
   hasOnClick?: boolean;
+  hasOnContextMenu?: boolean;
   metricRanges?: MetricRangeOptions[];
   trendlines?: TrendlineOptions[];
   hasMouseInteraction?: boolean;
 }): boolean => {
   const hasOnClick = 'hasOnClick' in options && options.hasOnClick;
+  const hasOnContextMenu = 'hasOnContextMenu' in options && options.hasOnContextMenu;
   const hasMouseInteraction = 'hasMouseInteraction' in options && options.hasMouseInteraction;
   const metricRanges = ('metricRanges' in options && options.metricRanges) || [];
   const trendlines = ('trendlines' in options && options.trendlines) || [];
 
   return (
     hasOnClick ||
+    hasOnContextMenu ||
     hasMouseInteraction ||
     hasPopover(options) ||
     hasTooltip(options) ||
@@ -465,6 +468,7 @@ export const getInteractiveMarkName = (
     chartPopovers?: ChartPopoverOptions[];
     chartTooltips?: ChartTooltipOptions[];
     hasOnClick?: boolean;
+    hasOnContextMenu?: boolean;
     hasMouseInteraction?: boolean;
     highlightedItem?: HighlightedItem;
     metricRanges?: MetricRangeOptions[];

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
@@ -60,6 +60,7 @@ const defaultLineOptions: LineSpecOptions = {
   colorScheme: DEFAULT_COLOR_SCHEME,
   dimension: DEFAULT_TIME_DIMENSION,
   hasOnClick: false,
+  hasOnContextMenu: false,
   linePointAnnotations: [],
   idKey: MARK_ID,
   index: 0,

--- a/packages/vega-spec-builder/src/trendline/trendlineTestUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineTestUtils.ts
@@ -23,6 +23,7 @@ export const defaultLineOptions: LineSpecOptions = {
   chartPopovers: [],
   chartTooltips: [],
   hasOnClick: false,
+  hasOnContextMenu: false,
   linePointAnnotations: [],
   metricRanges: [],
   trendlines: [{ method: 'average' }],

--- a/packages/vega-spec-builder/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/lineSpec.types.ts
@@ -42,6 +42,8 @@ export interface LineOptions {
   dimension?: string;
   /** `true` if LineProps has an onClick callback. */
   hasOnClick?: boolean;
+  /** `true` if LineProps has an onContextMenu callback. */
+  hasOnContextMenu?: boolean;
   /** `true` if LineProps has interaction callbacks (onMouseOver, onMouseOut).*/
   hasMouseInteraction?: boolean;
   /** Line type or key in the data that is used as the line type facet */
@@ -81,6 +83,7 @@ type LineOptionsWithDefaults =
   | 'color'
   | 'dimension'
   | 'hasOnClick'
+  | 'hasOnContextMenu'
   | 'linePointAnnotations'
   | 'lineType'
   | 'metric'


### PR DESCRIPTION
# Add `contextMenuMode` prop to Line for dimension-aware context menus

## Description

Adds a `contextMenuMode` prop to `Line` (S1 and S2) and extends `onContextMenu` support to work correctly across all interaction modes — not just `interactionMode: 'nearest'`.

### New prop: `contextMenuMode`

```tsx
<Line
  interactionMode="dimension"
  onContextMenu={(event, datum) => { ... }}
  contextMenuMode="dimension"
/>
```

| Value | Behavior |
|---|---|
| `'interaction'` (default) | Fires on all marks the current `interactionMode` generates |
| `'dimension'` | Only fires from dimension strips; datum is enriched with `rscGroupData` — an array of all data rows matching the hovered dimension value |
| `'item'` | Only fires from individual hover points |

### `rscGroupData` enrichment

When a dimension strip is right-clicked, the datum passed to `onContextMenu` is enriched with a `rscGroupData` key containing all rows from `filteredTable` that share the same dimension value. This mirrors the tooltip's group data behavior and supports showing all series values for a hovered time bucket. Date, number, and string dimension types are all handled.

### `hasOnContextMenu` flag

Lines with only `onContextMenu` (no tooltip, popover, or onClick) previously generated no interactive marks, so the callback could never fire. A new `hasOnContextMenu` boolean is now included in `isInteractive()` to ensure hover and voronoi marks are always generated when a context menu handler is present.

## Related Issue

## Motivation and Context

Consumers building context menus on line charts with `interactionMode: 'dimension'` had no way to right-click a dimension strip and receive all the data for that dimension — only a single voronoi datum was available. This blocked a common pattern of showing a menu with all series values for a given date or category.

## How Has This Been Tested?

Unit tests added to `markClickUtils.test.ts` (S1 and S2) covering:

- `contextMenuMode: 'interaction'` passes all mark types
- `contextMenuMode: 'dimension'` allows `_xAxisVoronoi` marks, blocks voronoi and hover marks
- `contextMenuMode: 'item'` allows hover marks, blocks voronoi and `_xAxisVoronoi` marks
- Unknown `contextMenuMode` falls back to allowing the mark
- `GROUP_DATA` enrichment with numeric, Date, and string dimension values

`lineAdapter.test.ts` (S1 and S2) covers the `hasOnContextMenu` boolean conversion from the `onContextMenu` prop.

Existing spec builder and adapter snapshot tests updated to include `hasOnContextMenu: false` at its default value.

A `DimensionContextMenu` Storybook story was added to `Line.story.tsx` demonstrating the full flow with an interactive context menu that displays all series values for the right-clicked dimension.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.