### PR TITLE
fix: metric range voronoi clip

### DIFF
--- a/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
@@ -20,7 +20,7 @@ import { Axis, ChartPopover, ChartTooltip, Legend, Line, MetricRange } from '../
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
-import { workspaceTrendsDataWithAnomalies, workspaceTrendsDataWithExtremeMetricRange, workspaceTrendsDataWithForecast, workspaceTrendsDataWithNullsInMetricRange } from '../../data/data';
+import { workspaceTrendsDataWithAnomalies, workspaceTrendsDataWithBoundaryMetricRange, workspaceTrendsDataWithExtremeMetricRange, workspaceTrendsDataWithForecast, workspaceTrendsDataWithNullsInMetricRange, workspaceTrendsDataWithOutOfDomainMetricRange } from '../../data/data';
 
 export default {
   title: 'RSC/MetricRange',
@@ -124,6 +124,36 @@ const LineOpacityByKeyStory: StoryFn<typeof MetricRange> = (args): ReactElement 
         <MetricRange {...args} />
       </Line>
       <Legend lineWidth={{ value: 0 }} highlight opacity="series" />
+    </Chart>
+  );
+};
+
+const MetricRangeWithHoverPointsOutsideDomainStory: StoryFn<typeof MetricRange> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithOutOfDomainMetricRange });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <MetricRange {...args} />
+        <ChartTooltip>{dialogContent}</ChartTooltip>
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
+const MetricRangeWithHoverPointsAtDomainBoundaryStory: StoryFn<typeof MetricRange> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithBoundaryMetricRange });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <MetricRange {...args} />
+        <ChartTooltip>{dialogContent}</ChartTooltip>
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
     </Chart>
   );
 };
@@ -250,6 +280,36 @@ WithHoverPoints.args = {
   hoverPoint: true,
 };
 
+// Forecast metric at the first forecast row (3738) equals exactly the max historical value,
+// placing the hover point at the very top boundary of the y domain. Verifies that clip: true
+// does not clip points sitting exactly on the domain edge — they should be fully visible.
+const WithHoverPointsAtDomainBoundary = bindWithProps(MetricRangeWithHoverPointsAtDomainBoundaryStory);
+WithHoverPointsAtDomainBoundary.args = {
+  lineType: 'shortDash',
+  lineWidth: 'S',
+  rangeOpacity: 0.2,
+  metricEnd: 'metricEnd',
+  metricStart: 'metricStart',
+  metric: 'metric',
+  hoverPoint: true,
+  scaleAxisToFit: false,
+};
+
+// Hover points on forecast rows whose metric values (5000–9500) exceed the y domain (~200–3738).
+// Toggle scaleAxisToFit to expand the y domain to include metric range values.
+// Without clip:true on the hover point marks, points render above the chart and cause flickering.
+const WithHoverPointsOutsideDomain = bindWithProps(MetricRangeWithHoverPointsOutsideDomainStory);
+WithHoverPointsOutsideDomain.args = {
+  lineType: 'shortDash',
+  lineWidth: 'S',
+  rangeOpacity: 0.2,
+  metricEnd: 'metricEnd',
+  metricStart: 'metricStart',
+  metric: 'metric',
+  hoverPoint: true,
+  scaleAxisToFit: false,
+};
+
 export {
   Basic,
   DisplayOnHover,
@@ -260,4 +320,6 @@ export {
   LineOpacityByKey,
   WithBreaks,
   WithHoverPoints,
+  WithHoverPointsAtDomainBoundary,
+  WithHoverPointsOutsideDomain,
 };

--- a/packages/react-spectrum-charts/src/stories/data/data.ts
+++ b/packages/react-spectrum-charts/src/stories/data/data.ts
@@ -1301,3 +1301,30 @@ export const peopleTotalComboData = [
   { datetime: 1668322800000, people: 30, total: 120 },
   { datetime: 1668409200000, people: 2, total: 122 },
 ];
+
+// Historical line values top out at ~3738. Forecast metric values (5000–9500) are well above
+// that ceiling, placing hoverPoint marks outside the y domain when scaleAxisToFit is false.
+// Forecast metric (4000) equals the top of the y domain (Vega extends 3738 to a nice 4000),
+// placing the hover point precisely at the top boundary. Used to verify that clip: true
+// does not clip points that sit exactly on the domain edge.
+export const workspaceTrendsDataWithBoundaryMetricRange = [
+  { datetime: 1667890800000, value: 3738, series: 'Add Fallout' },
+  { datetime: 1667977200000, value: 2704, series: 'Add Fallout' },
+  { datetime: 1668063600000, value: 1730, series: 'Add Fallout' },
+  { datetime: 1668150000000, value: 465, series: 'Add Fallout' },
+  { datetime: 1668236400000, value: 200, series: 'Add Fallout' },
+  { datetime: 1668322800000, value: null, metric: 4000, metricStart: 2500, metricEnd: 5500, series: 'Add Fallout' },
+  { datetime: 1668409200000, value: null, metric: 3000, metricStart: 2000, metricEnd: 4000, series: 'Add Fallout' },
+  { datetime: 1668495600000, value: null, metric: 2500, metricStart: 1500, metricEnd: 3500, series: 'Add Fallout' },
+];
+
+export const workspaceTrendsDataWithOutOfDomainMetricRange = [
+  { datetime: 1667890800000, value: 3738, series: 'Add Fallout' },
+  { datetime: 1667977200000, value: 2704, series: 'Add Fallout' },
+  { datetime: 1668063600000, value: 1730, series: 'Add Fallout' },
+  { datetime: 1668150000000, value: 465, series: 'Add Fallout' },
+  { datetime: 1668236400000, value: 200, series: 'Add Fallout' },
+  { datetime: 1668322800000, value: null, metric: 5000, metricStart: 3500, metricEnd: 6500, series: 'Add Fallout' },
+  { datetime: 1668409200000, value: null, metric: 7000, metricStart: 5500, metricEnd: 8500, series: 'Add Fallout' },
+  { datetime: 1668495600000, value: null, metric: 9500, metricStart: 7500, metricEnd: 11500, series: 'Add Fallout' },
+];

--- a/packages/vega-spec-builder/src/data/dataUtils.ts
+++ b/packages/vega-spec-builder/src/data/dataUtils.ts
@@ -128,15 +128,21 @@ export const getSeriesIdTransform = (facets: string[]): FormulaTransform[] => {
 export const getFilteredTooltipData = (
   chartTooltips: ChartTooltipOptions[],
   validNumericKeys?: string[],
-  metricRangeHoverableMetrics?: string[]
+  metricRangeHoverableMetrics?: string[],
+  metricRangeScaleName?: string
 ): { name: string; source: string; transform?: { type: 'filter'; expr: string }[] } => {
   const transforms: { type: 'filter'; expr: string }[] = [];
 
   if (validNumericKeys?.length) {
     // looping through metricRangeHoverableMetrics because there could be multiple metric ranges within a Line chart
     let metricValidExprs: string[] = [];
-    if (metricRangeHoverableMetrics && metricRangeHoverableMetrics.length > 0) { 
-      metricValidExprs = metricRangeHoverableMetrics.map((m) => `isValid(datum["${m}"])`);
+    if (metricRangeHoverableMetrics && metricRangeHoverableMetrics.length > 0) {
+      const scaleName = metricRangeScaleName ?? 'yLinear';
+      // Exclude rows where the metric maps outside [0, height] — those rows have no visible
+      // representation in the chart and should not receive voronoi cells, tooltips, or popovers.
+      metricValidExprs = metricRangeHoverableMetrics.map(
+        (m) => `isValid(datum["${m}"]) && scale('${scaleName}', datum['${m}']) >= 0 && scale('${scaleName}', datum['${m}']) <= height`
+      );
     }
     const orClause = metricValidExprs.length ? ` || ${metricValidExprs.join(' || ')}` : '';
     validNumericKeys.forEach((key) => {

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -187,16 +187,25 @@ describe('getVoronoiYEncoding()', () => {
     expect(encoding).toEqual([{ scale: 'yLinear', field: 'value' }]);
   });
 
-  test('returns conditional y encoding with MetricRange fallback when hoverPoint is true', () => {
+  test('returns conditional y encoding with clamped MetricRange fallback when hoverPoint is true', () => {
     const encoding = getVoronoiYEncoding(
       { ...defaultLineMarkOptions, metricRanges: [{ metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'metric', hoverPoint: true }] },
       'value'
     );
     expect(encoding).toEqual([
       { test: 'isValid(datum["value"])', scale: 'yLinear', field: 'value' },
-      { test: 'isValid(datum["metric"])', scale: 'yLinear', field: 'metric' },
+      { test: 'isValid(datum["metric"])', signal: `clamp(scale('yLinear', datum['metric']), 0, height)` },
       { scale: 'yLinear', field: 'value' },
     ]);
+  });
+
+  test('clamps metric range y to [0, height - 1] so out-of-domain values do not create oversized voronoi cells', () => {
+    const encoding = getVoronoiYEncoding(
+      { ...defaultLineMarkOptions, metricRanges: [{ metricEnd: 'metricEnd', metricStart: 'metricStart', metric: 'forecastMetric', hoverPoint: true }] },
+      'value'
+    );
+    const metricRuleEntry = (encoding as Array<{ test?: string; signal?: string }>).find(e => e.test?.includes('forecastMetric'));
+    expect(metricRuleEntry).toHaveProperty('signal', `clamp(scale('yLinear', datum['forecastMetric']), 0, height)`);
   });
 
   test('excludes MetricRange metrics where hoverPoint is false', () => {

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -315,7 +315,13 @@ export const getVoronoiYEncoding = (lineOptions: LineMarkOptions, metric: string
   const yScale = metricAxis || 'yLinear';
   return [
     { test: `isValid(datum["${metric}"])`, scale: yScale, field: metric },
-    ...hoverPointMetrics.map(mrMetric => ({ test: `isValid(datum["${mrMetric}"])`, scale: yScale, field: mrMetric })),
+    // Clamp metric range y positions to [0, height] so out-of-domain values don't produce
+    // negative y-coordinates. An unclamped out-of-domain point creates an abnormally large
+    // voronoi cell that dominates the visible chart area and causes hover flicker.
+    ...hoverPointMetrics.map(mrMetric => ({
+      test: `isValid(datum["${mrMetric}"])`,
+      signal: `clamp(scale('${yScale}', datum['${mrMetric}']), 0, height)`,
+    })),
     { scale: yScale, field: metric },
   ];
 };

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -158,7 +158,8 @@ export const addData = produce<Data[], [LineSpecOptions, { timeGranularity?: Gra
       const metricRangeHoverableMetrics = options.metricRanges
         .filter((mr) => mr.hoverPoint && mr.metric)
         .map((mr) => mr.metric as string);
-      data.push(getLineHighlightedData(options), getFilteredTooltipData(chartTooltips, validNumericKeys, metricRangeHoverableMetrics));
+      const metricRangeScaleName = options.metricAxis ?? 'yLinear';
+      data.push(getLineHighlightedData(options), getFilteredTooltipData(chartTooltips, validNumericKeys, metricRangeHoverableMetrics, metricRangeScaleName));
       if (hasHoverableMetricRanges) {
         const filteredHighlightData = getFilteredIsValidData(`${name}_filteredHighlightedData`, `${name}_highlightedData`, metric);
         data.push(filteredHighlightData);

--- a/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterSpecBuilder.test.ts
@@ -72,16 +72,22 @@ describe('addData()', () => {
         { type: 'filter', expr: 'isValid(datum["value"]) && isFinite(datum["value"])' },
       ]);
     });
-    test('ORs metricRangeHoverMetrics into each validNumericKeys filter', () => {
+    test('ORs metricRangeHoverMetrics into each validNumericKeys filter, excluding out-of-domain rows', () => {
       const result = getFilteredTooltipData([{}], ['value'], ['metric']);
       expect(result.transform).toStrictEqual([
-        { type: 'filter', expr: '(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metric"])' },
+        { type: 'filter', expr: `(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metric"]) && scale('yLinear', datum['metric']) >= 0 && scale('yLinear', datum['metric']) <= height` },
       ]);
     });
     test('supports multiple metricRangeHoverMetrics joined with OR', () => {
       const result = getFilteredTooltipData([{}], ['value'], ['metricA', 'metricB']);
       expect(result.transform).toStrictEqual([
-        { type: 'filter', expr: '(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metricA"]) || isValid(datum["metricB"])' },
+        { type: 'filter', expr: `(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metricA"]) && scale('yLinear', datum['metricA']) >= 0 && scale('yLinear', datum['metricA']) <= height || isValid(datum["metricB"]) && scale('yLinear', datum['metricB']) >= 0 && scale('yLinear', datum['metricB']) <= height` },
+      ]);
+    });
+    test('uses provided scale name in domain check', () => {
+      const result = getFilteredTooltipData([{}], ['value'], ['metric'], 'yCustom');
+      expect(result.transform).toStrictEqual([
+        { type: 'filter', expr: `(isValid(datum["value"]) && isFinite(datum["value"])) || isValid(datum["metric"]) && scale('yCustom', datum['metric']) >= 0 && scale('yCustom', datum['metric']) <= height` },
       ]);
     });
     test('adds validNumericKeys filters then excludeDataKeys filter', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a `MetricRange` child has `hoverPoint: true` and its metric values fall outside the y-axis domain (e.g. forecast values on a chart where `scaleAxisToFit` is false), hovering over the chart caused continuous flickering.

Two fixes:

1. **Voronoi y-encoding clamp** — `getVoronoiYEncoding` now clamps metric range seed points to `[0, height]` using `clamp(scale(...), 0, height)`. An unclamped out-of-domain value (e.g. y = -600) produced a voronoi cell that dominated the entire chart area, causing every mouse movement to trigger a hover → layout recalculation loop.

2. **Domain filter on `filteredTableForTooltip`** — `getFilteredTooltipData` now accepts an optional list of metric range hover metrics and excludes rows where the metric maps outside `[0, height]` on the y scale. This prevents tooltips and popovers from firing on rows that have no visible representation in the chart.

## Related Issue

## Motivation and Context

When `MetricRange` data is outside of the y domain, and `scaleAxisToFit: false` (the default), those values are not included in the y scale, and the resulting out-of-domain voronoi seeds caused the chart to flicker continuously on hover.

## How Has This Been Tested?

- Added a Storybook story (`WithHoverPointsOutsideDomain` under `RSC/MetricRange`) with forecast rows whose metric values (5000–9500) far exceed the historical y domain (~200–3738). Manually verified no flickering and no tooltips on the out-of-domain forecast points.
- Added a second story (`WithHoverPointsAtDomainBoundary`) where the first forecast metric value sits exactly at the top of the y domain (4000). Manually verified that the hover point renders fully and is not clipped.
- Updated unit tests in `lineMarkUtils.test.ts` to assert the clamped voronoi signal expression.
- Updated unit tests in `scatterSpecBuilder.test.ts` to assert the domain-check filter expression on `filteredTableForTooltip`.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.