### PR TITLE
ci: declare workflow-scope permissions on attach-release-artifacts and sonarcloud

### DIFF
--- a/.github/workflows/attach-release-artifacts.yml
+++ b/.github/workflows/attach-release-artifacts.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write # gh release upload requires releases write
+
 jobs:
   attach-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two workflows currently leave the workflow `GITHUB_TOKEN` scope implicit. This patch pins each to its minimum:

- `.github/workflows/attach-release-artifacts.yml` -- `contents: write`. The job packages a cursor-rules zip and uploads it via `gh release upload --clobber`, which hits the releases/assets API; that needs `contents: write`.
- `.github/workflows/sonarcloud.yml` -- `contents: read`. The single job checks out, runs `yarn lint`/`yarn test`, then `SonarSource/sonarqube-scan-action`. SonarCloud authenticates via `SONAR_TOKEN`; the workflow `GITHUB_TOKEN` is only used for the implicit checkout.

Style matches the workflow-level permissions blocks already declared by `publish-library.yml`, `publish-s2-library.yml`, `publish-prod-storybook.yml`, `publish-s2-storybook.yml`, and `pr-checks.yml` (all using a mix of `id-token: write`, `contents: write`, `pull-requests: write` depending on what they actually do).

Third-party action exposure that motivates pinning: `SonarSource/sonarqube-scan-action@master`, `actions/setup-node`, `actions/checkout`. Explicit scope keeps a hypothetical compromise (cf. `tj-actions/changed-files` CVE-2025-30066) contained.

No behavioural change to either workflow.