### PR TITLE
feat: s2 legend alignment

### DIFF
--- a/packages/docs/docs/spectrum2/legend.md
+++ b/packages/docs/docs/spectrum2/legend.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 4
+---
+
+# Legend (S2)
+
+The `Legend` component in the S2 package supports all props from the [base Legend component](/docs/api/components/Legend) plus the S2-exclusive `align` prop for controlling legend alignment along its edge.
+
+```jsx
+import { Chart, Axis, Line, Legend } from '@spectrum-charts/react-spectrum-charts-s2';
+```
+
+---
+
+## Legend alignment
+
+The `align` prop controls where the legend is anchored along its edge — start, middle, or end. The meaning of each value depends on the legend's `position`:
+
+| `position` | `align: 'start'` | `align: 'middle'` | `align: 'end'` |
+|---|---|---|---|
+| `'bottom'` / `'top'` | left-aligned | centered (default) | right-aligned |
+| `'left'` / `'right'` | top-aligned | centered (default) | bottom-aligned |
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" labelFormat="time" />
+  <Axis position="left" grid />
+  <Line color="series" />
+  <Legend position="bottom" align="start" title="Operating system" />
+</Chart>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `align` | `'start' \| 'middle' \| 'end'` | `'middle'` | Alignment of the legend along its edge. For horizontal legends (bottom/top): `'start'` = left, `'middle'` = center, `'end'` = right. For vertical legends (left/right): `'start'` = top, `'middle'` = center, `'end'` = bottom. |

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -69,7 +69,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Spectrum 2 (Alpha)',
       collapsed: false,
-      items: ['spectrum2/overview', 'spectrum2/line', 'spectrum2/bar'],
+      items: ['spectrum2/overview', 'spectrum2/line', 'spectrum2/bar', 'spectrum2/legend'],
     },
     {
       type: 'category',

--- a/packages/react-spectrum-charts-s2/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/VegaChart.tsx
@@ -17,7 +17,7 @@ import { Options as TooltipOptions } from 'vega-tooltip';
 
 import { TABLE } from '@spectrum-charts/constants';
 import { getLocale } from '@spectrum-charts/locales';
-import { ChartData, getVegaEmbedOptions } from '@spectrum-charts/vega-spec-builder-s2';
+import { ChartData, UserMeta, applyUserMetaConfigPatches, getVegaEmbedOptions } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { useDebugSpec } from './hooks/useDebugSpec';
 import { extractValues, isVegaData } from './hooks/useSpec';
@@ -116,18 +116,11 @@ export const VegaChart: FC<VegaChartProps> = ({
           return signal;
         });
       }
-      embed(containerRef.current, specCopy, {
-        // Note: getVegaEmbedOptions from vega-spec-builder-s2 always uses S2 configuration
-        ...getVegaEmbedOptions({
-          locale,
-          height,
-          width,
-          padding,
-          renderer,
-          config,
-        }),
-        tooltip,
-      }).then(({ view }) => {
+      const embedOptions = getVegaEmbedOptions({ locale, height, width, padding, renderer, config });
+      const { patches } = (specCopy.usermeta as UserMeta | undefined) ?? {};
+      const finalConfig = applyUserMetaConfigPatches(patches, embedOptions.config);
+
+      embed(containerRef.current, specCopy, { ...embedOptions, config: finalConfig, tooltip }).then(({ view }) => {
         chartView.current = view;
         onNewView(view);
         view.resize();

--- a/packages/react-spectrum-charts-s2/src/components/Legend/Legend.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/Legend/Legend.tsx
@@ -16,6 +16,7 @@ import { FC } from 'react';
 import { LegendProps } from '../../types';
 
 const Legend: FC<LegendProps> = ({
+  align,
   color,
   defaultHiddenSeries,
   descriptions,

--- a/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
@@ -376,7 +376,7 @@ describe('Chart', () => {
       expect(inspectElement).toBeInTheDocument();
       if (!inspectElement) return;
 
-      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(176);
+      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(162);
       expect(getPxValue(inspectElement.style.getPropertyValue('left'))).toBe(35);
     });
 
@@ -391,7 +391,7 @@ describe('Chart', () => {
       expect(inspectElement).toBeInTheDocument();
       if (!inspectElement) return;
 
-      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(213);
+      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(197);
       expect(getPxValue(inspectElement.style.getPropertyValue('left'))).toBe(35);
     });
   });

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/TrellisBar.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/TrellisBar.test.tsx
@@ -45,9 +45,9 @@ describe('TrellisBar', () => {
     const popoverAnchor = await screen.findByTestId('rsc-popover-anchor');
     expect(popoverAnchor).toHaveStyle('position: absolute');
     expect(popoverAnchor).toHaveStyle('width: 85.60000000000002px');
-    expect(popoverAnchor).toHaveStyle('height: 8.421428571428521px');
+    expect(popoverAnchor).toHaveStyle('height: 8.215714285714284px');
     expect(popoverAnchor).toHaveStyle('left: 316.5px');
-    expect(popoverAnchor).toHaveStyle('top: 352.30714285714294px');
+    expect(popoverAnchor).toHaveStyle('top: 344.2385714285714px');
   });
 
   test('HorizontalBarHorizontalTrellis renders correctly', async () => {
@@ -111,8 +111,8 @@ describe('TrellisBar', () => {
       // Y Trellis Group should have Y Translate. X Translate should be 0.
       // First chart should not have been tra.
       expect(trellisCharts[0]).toHaveAttribute('transform', 'translate(0,0)');
-      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,244.9438202247191)');
-      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,489.8876404494382)');
+      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,238.95131086142322)');
+      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,477.90262172284645)');
     });
 
     test('WithCustomTrellisPadding has correct padding for horizontal trellis', async () => {

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendAlign.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendAlign.story.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { Legend } from '../../../components';
+import { bindWithProps } from '../../../test-utils';
+import { LegendBarStory } from './LegendStoryUtils';
+
+export default {
+  title: 'React Spectrum Charts 2/Legend/Features/Align',
+  component: Legend,
+};
+
+const descriptions = [
+  { seriesName: 'Windows', description: 'Most popular operating system, especially in business' },
+  { seriesName: 'Mac', description: 'Popular for content creation, home and development' },
+  { seriesName: 'Other', description: 'Linux accounts for the majority of "other" operating systems' },
+];
+
+const legendLabels = [
+  { seriesName: 'Windows', label: 'Custom Windows' },
+  { seriesName: 'Mac', label: 'Custom Mac' },
+  { seriesName: 'Other', label: 'Custom Other' },
+];
+
+const Align = bindWithProps(LegendBarStory);
+Align.args = {
+  align: 'start',
+  descriptions,
+  highlight: true,
+  legendLabels,
+  title: 'Operating system',
+};
+
+export { Align };

--- a/packages/themes/src/spectrum2Theme.ts
+++ b/packages/themes/src/spectrum2Theme.ts
@@ -93,6 +93,7 @@ export function getSpectrum2VegaConfig(colorScheme: 'light' | 'dark'): Config {
     legend: {
       columnPadding: DEFAULT_LEGEND_COLUMN_PADDING,
       labelColor: FONT_COLOR,
+      padding: 8,
       labelFont: ADOBE_CLEAN_FONT,
       labelFontSize: DEFAULT_FONT_SIZE,
       labelFontWeight: 'normal',

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
@@ -293,6 +293,48 @@ describe('addLegend()', () => {
       expect(legend?.title).toBe('My title');
     });
 
+    describe('align', () => {
+      test('align start pushes a legend.layout.bottom anchor patch to usermeta.patches', () => {
+        const spec = addLegend(defaultSpec, { align: 'start' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { bottom: { anchor: 'start' } } } }]);
+      });
+
+      test('align middle passes through as anchor middle', () => {
+        const spec = addLegend(defaultSpec, { align: 'middle' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { bottom: { anchor: 'middle' } } } }]);
+      });
+
+      test('align end pushes anchor end', () => {
+        const spec = addLegend(defaultSpec, { align: 'end' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { bottom: { anchor: 'end' } } } }]);
+      });
+
+      test('align top position patches layout.top', () => {
+        const spec = addLegend(defaultSpec, { align: 'start', position: 'top' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { top: { anchor: 'start' } } } }]);
+      });
+
+      test('align left position patches layout.left', () => {
+        const spec = addLegend(defaultSpec, { align: 'start', position: 'left' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { left: { anchor: 'start' } } } }]);
+      });
+
+      test('align right position patches layout.right', () => {
+        const spec = addLegend(defaultSpec, { align: 'end', position: 'right' });
+        expect(spec.usermeta.patches).toStrictEqual([{ legend: { layout: { right: { anchor: 'end' } } } }]);
+      });
+
+      test('no align leaves usermeta.patches unset', () => {
+        const spec = addLegend(defaultSpec, {});
+        expect(spec.usermeta.patches).toBeUndefined();
+      });
+
+      test('does not write to spec.config', () => {
+        const spec = addLegend(defaultSpec, { align: 'start' });
+        expect(spec.config).toBeUndefined();
+      });
+    });
+
     test('should add fields to scales if they have not been added', () => {
       const legendSpec = addLegend(
         { ...defaultSpec, scales: [{ name: COLOR_SCALE, type: 'ordinal' }] },

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
@@ -62,6 +62,7 @@ export const addLegend = produce<
   (
     spec,
     {
+      align,
       color,
       hasMouseInteraction = false,
       hasOnClick = false,
@@ -90,6 +91,7 @@ export const addLegend = produce<
 
     // put options back together now that all defaults are set
     const legendOptions: LegendSpecOptions = {
+      align,
       color: formattedColor,
       hasMouseInteraction,
       hasOnClick,
@@ -106,6 +108,12 @@ export const addLegend = produce<
       colorScheme,
       ...options,
     };
+
+    if (align !== undefined) {
+      if (!spec.usermeta) spec.usermeta = {};
+      if (!spec.usermeta.patches) spec.usermeta.patches = [];
+      spec.usermeta.patches.push({ legend: { layout: { [position]: { anchor: align } } } });
+    }
 
     // Order matters here. Facets rely on the scales being set up.
     spec.scales = addScales(spec.scales ?? [], legendOptions);

--- a/packages/vega-spec-builder-s2/src/types/legendSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/legendSpec.types.ts
@@ -26,6 +26,13 @@ export type LegendDescription = { seriesName: string; description: string; title
 export type LegendLabel = { seriesName: string | number; label: string; maxLength?: number };
 
 export interface LegendOptions {
+  /**
+   * Alignment of the legend along its main axis.
+   * For horizontal legends (bottom/top): start=left, middle=center, end=right.
+   * For vertical legends (left/right): start=top, middle=center, end=bottom.
+   * @default 'middle'
+   */
+  align?: 'start' | 'middle' | 'end';
   /** color or key in the data that is used as the color facet for the symbols */
   color?: ColorFacet;
   /** series that should be hidden by default (uncontrolled) */

--- a/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Spec, SymbolShape } from 'vega';
+import { Config, Spec, SymbolShape } from 'vega';
 
 import { GROUP_DATA, MARK_ID, SERIES_ID, TRENDLINE_VALUE } from '@spectrum-charts/constants';
 
@@ -41,6 +41,7 @@ export type UserMeta = {
   interactiveMarks?: string[];
   chartOrientation?: Orientation;
   metricAxisCount?: number;
+  patches?: Partial<Config>[];
 };
 
 export interface MarkBounds {

--- a/packages/vega-spec-builder-s2/src/vegaEmbedUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/vegaEmbedUtils.test.ts
@@ -9,12 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Config } from 'vega';
+
 import { numberLocales } from '@spectrum-charts/locales';
 
 import { applyUserMetaConfigPatches, getVegaEmbedOptions } from './vegaEmbedUtils';
 
 describe('applyUserMetaConfigPatches()', () => {
-  const base = {
+  const base: Config = {
     legend: {
       layout: {
         bottom: { anchor: 'middle', direction: 'horizontal', center: true, offset: 24 },
@@ -98,9 +100,9 @@ describe('applyUserMetaConfigPatches()', () => {
   });
 
   test('does not mutate the original config', () => {
-    const original = { legend: { layout: { bottom: { anchor: 'middle' } } } };
+    const original: Config = { legend: { layout: { bottom: { anchor: 'middle' } } } };
     applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'start' } } } }], original);
-    expect(original.legend.layout.bottom.anchor).toBe('middle');
+    expect(original.legend?.layout?.bottom?.anchor).toBe('middle');
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/vegaEmbedUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/vegaEmbedUtils.test.ts
@@ -11,7 +11,98 @@
  */
 import { numberLocales } from '@spectrum-charts/locales';
 
-import { getVegaEmbedOptions } from './vegaEmbedUtils';
+import { applyUserMetaConfigPatches, getVegaEmbedOptions } from './vegaEmbedUtils';
+
+describe('applyUserMetaConfigPatches()', () => {
+  const base = {
+    legend: {
+      layout: {
+        bottom: { anchor: 'middle', direction: 'horizontal', center: true, offset: 24 },
+        top: { anchor: 'middle', direction: 'horizontal' },
+      },
+      padding: 8,
+    },
+    axis: { labelFontSize: 12 },
+  };
+
+  test('returns config unchanged when patches is undefined', () => {
+    expect(applyUserMetaConfigPatches(undefined, base)).toBe(base);
+  });
+
+  test('returns config unchanged when patches is empty', () => {
+    expect(applyUserMetaConfigPatches([], base)).toBe(base);
+  });
+
+  test('overrides a primitive leaf value', () => {
+    const result = applyUserMetaConfigPatches([{ axis: { labelFontSize: 14 } }], base);
+    expect(result.axis?.labelFontSize).toBe(14);
+  });
+
+  test('preserves sibling keys not mentioned in the patch', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'start' } } } }], base);
+    expect(result.legend?.layout?.bottom).toHaveProperty('direction', 'horizontal');
+    expect(result.legend?.layout?.bottom).toHaveProperty('center', true);
+    expect(result.legend?.layout?.bottom).toHaveProperty('offset', 24);
+  });
+
+  test('overrides only the patched key in a nested object', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'start' } } } }], base);
+    expect(result.legend?.layout?.bottom).toHaveProperty('anchor', 'start');
+  });
+
+  test('does not affect sibling position layouts when patching one position', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'start' } } } }], base);
+    expect(result.legend?.layout?.top).toStrictEqual({ anchor: 'middle', direction: 'horizontal' });
+  });
+
+  test('does not affect unrelated config sections', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'end' } } } }], base);
+    expect(result.axis).toStrictEqual({ labelFontSize: 12 });
+    expect(result.legend?.padding).toBe(8);
+  });
+
+  test('patch creates nested structure if base key is absent', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { layout: { left: { anchor: 'start' } } } }], base);
+    expect(result.legend?.layout?.left).toStrictEqual({ anchor: 'start' });
+  });
+
+  test('applies multiple patches in order — later patches win', () => {
+    const result = applyUserMetaConfigPatches(
+      [
+        { legend: { layout: { bottom: { anchor: 'start' } } } },
+        { legend: { layout: { bottom: { anchor: 'end' } } } },
+      ],
+      base
+    );
+    expect(result.legend?.layout?.bottom).toHaveProperty('anchor', 'end');
+  });
+
+  test('replaces arrays instead of merging them', () => {
+    const withArray = { ...base, signals: [{ name: 'a' }] } as typeof base & { signals: object[] };
+    const result = applyUserMetaConfigPatches([{ signals: [{ name: 'b' }, { name: 'c' }] } as never], withArray);
+    expect((result as typeof withArray).signals).toStrictEqual([{ name: 'b' }, { name: 'c' }]);
+  });
+
+  test('treats SignalRef objects as leaf values, not recursed into', () => {
+    const withSignal = { ...base, legend: { ...base.legend, symbolSize: { signal: 'mySize' } } };
+    const result = applyUserMetaConfigPatches(
+      [{ legend: { symbolSize: { signal: 'otherSize' } } } as never],
+      withSignal
+    );
+    expect((result as typeof withSignal).legend.symbolSize).toStrictEqual({ signal: 'otherSize' });
+  });
+
+  test('patch with null value overrides base value', () => {
+    const result = applyUserMetaConfigPatches([{ legend: { padding: null } } as never], base);
+    expect(result.legend?.padding).toBeNull();
+  });
+
+  test('does not mutate the original config', () => {
+    const original = { legend: { layout: { bottom: { anchor: 'middle' } } } };
+    applyUserMetaConfigPatches([{ legend: { layout: { bottom: { anchor: 'start' } } } }], original);
+    expect(original.legend.layout.bottom.anchor).toBe('middle');
+  });
+});
 
 describe('getVegaEmbedOptions()', () => {
   it('should return the correct options', () => {

--- a/packages/vega-spec-builder-s2/src/vegaEmbedUtils.ts
+++ b/packages/vega-spec-builder-s2/src/vegaEmbedUtils.ts
@@ -39,7 +39,7 @@ const deepMerge = (base: Record<string, unknown>, patch: Record<string, unknown>
     const patchIsPlainObject =
       patchVal !== null && typeof patchVal === 'object' && !Array.isArray(patchVal) && !('signal' in patchVal);
     const baseIsPlainObject =
-      baseVal !== null && typeof baseVal === 'object' && !Array.isArray(baseVal) && !('signal' in (baseVal as object));
+      baseVal !== null && typeof baseVal === 'object' && !Array.isArray(baseVal) && !('signal' in baseVal);
     if (patchIsPlainObject && baseIsPlainObject) {
       result[key] = deepMerge(baseVal as Record<string, unknown>, patchVal as Record<string, unknown>);
     } else {

--- a/packages/vega-spec-builder-s2/src/vegaEmbedUtils.ts
+++ b/packages/vega-spec-builder-s2/src/vegaEmbedUtils.ts
@@ -17,6 +17,38 @@ import { LocaleCode, NumberLocaleCode, TimeLocaleCode, getLocale } from '@spectr
 import { getExpressionFunctions } from './expressionFunctions';
 import { getChartConfig } from './specUtils';
 
+/**
+ * WARNING: This is a last-resort escape hatch for working around gaps in Vega's functionality.
+ * It must NOT be used as a general config customization pattern. Each patch is deep-merged into
+ * the embed config before Vega sees it, bypassing Vega's own mergeConfig (which has known bugs
+ * with nested objects like legend.layout.*). Patches introduce unstructured state that is hard
+ * to trace and reason about — if Vega supports the use case directly, use that instead.
+ */
+export const applyUserMetaConfigPatches = (patches: Partial<Config>[] | undefined, config: Config): Config => {
+  if (!patches?.length) return config;
+  return patches.reduce(
+    (acc, patch) => deepMerge(acc as Record<string, unknown>, patch as Record<string, unknown>) as Config,
+    config
+  );
+};
+
+const deepMerge = (base: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> => {
+  const result = { ...base };
+  for (const [key, patchVal] of Object.entries(patch)) {
+    const baseVal = base[key];
+    const patchIsPlainObject =
+      patchVal !== null && typeof patchVal === 'object' && !Array.isArray(patchVal) && !('signal' in patchVal);
+    const baseIsPlainObject =
+      baseVal !== null && typeof baseVal === 'object' && !Array.isArray(baseVal) && !('signal' in (baseVal as object));
+    if (patchIsPlainObject && baseIsPlainObject) {
+      result[key] = deepMerge(baseVal as Record<string, unknown>, patchVal as Record<string, unknown>);
+    } else {
+      result[key] = patchVal;
+    }
+  }
+  return result;
+};
+
 export const getVegaEmbedOptions = ({
   locale = 'en-US',
   height = 400,


### PR DESCRIPTION
# Legend alignment for S2 (`align` prop)

## Description

Adds `align?: 'start' | 'middle' | 'end'` to the S2 `Legend` component, allowing consumers to control where the legend is anchored along its edge. For horizontal legends (bottom/top) this maps to left/middle/right; for vertical (left/right) it maps to top/middle/bottom.

Also adds `legend.padding: 8` to the S2 theme to match the design specification (8px between the legend box edge and its symbols/labels).

## Related Issue

## Motivation and Context

The S2 `Legend` had no way to control alignment — it always rendered centered. Some chart designs require left- or right-aligned legends, particularly in dashboards where legends are edge-anchored to align with adjacent elements.

The implementation required working around an issue in Vega's `mergeConfig` utility, which replaces `legend.layout.*` position objects entirely rather than merging them. The solution routes alignment intent through a new `usermeta.patches` mechanism, where alignment is expressed as a partial `Partial<Config>` fragment and deep-merged into the embed config in `VegaChart.tsx` after all spec changes have been completed by the spec builder. 

This is a heavy handed solution that we will not be leveraging for other use-cases unless absolutely necessary. 

## How Has This Been Tested?

- Unit tests for `applyUserMetaConfigPatches` / `deepMerge` covering: primitive overrides, deep object preservation, sibling key isolation, array replacement, SignalRef leaf handling, multiple patches, null overrides, and immutability.
- Unit tests for `addLegend` verifying that each `align` value writes the correct `usermeta.patches` entry and that `spec.config` is never touched.
- Integration tests (Storybook render tests) updated for layout shifts caused by the `legend.padding: 8` theme change.
- Storybook story `LegendAlign` in `Features/Align` showing all three values via Storybook controls with highlight, descriptions, legendLabels, and title active simultaneously.

## Screenshots (if appropriate):

See Storybook: React Spectrum Charts 2 / Legend / Features / Align

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
