### PR TITLE
[AN-450442] S2 Line: Direct label background rect stays opaque during highlight

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -102,4 +102,24 @@ DirectLabelTwoSeries.args = { value: 'last' };
 const DirectLabelPositionStart = bindWithProps(LineDirectLabelStory);
 DirectLabelPositionStart.args = { value: 'series', position: 'start' };
 
-export { DirectLabelDefault, DirectLabelValueLast, DirectLabelValueAverage, DirectLabelWithInspect, DirectLabelTwoSeries, DirectLabelPositionStart };
+// Story demonstrating that the background halo remains fully opaque when hovering a series.
+// Hover over a series in the legend to dim other series — the background rect behind the label
+// must stay at full opacity so chart content does not bleed through the label text.
+const LineDirectLabelHoverOpaqueBackgroundStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const DirectLabelOpaqueBackground = bindWithProps(LineDirectLabelHoverOpaqueBackgroundStory);
+DirectLabelOpaqueBackground.args = { value: 'last' };
+
+export { DirectLabelDefault, DirectLabelValueLast, DirectLabelValueAverage, DirectLabelWithInspect, DirectLabelTwoSeries, DirectLabelPositionStart, DirectLabelOpaqueBackground };

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -346,10 +346,24 @@ describe('getLineDirectLabelMarks', () => {
 		expect(y.scale).toBe('yLinear');
 	});
 
-	test('both marks have opacity in update encoding', () => {
+	test('foreground mark has opacity in update encoding', () => {
 		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
-		expect(marks[0].encode?.update).toHaveProperty('opacity');
 		expect(marks[1].encode?.update).toHaveProperty('opacity');
+	});
+
+	test('background mark opacity is always hardcoded to 1 regardless of hover/highlight state', () => {
+		// The background halo must stay fully opaque so it continues to mask chart content behind
+		// the label text. Only the foreground text mark should dim during hover/highlight dimming.
+		const lineOptionsWithInteractivity: LineSpecOptions = {
+			...defaultLineOptions,
+			interactiveMarkName: 'line0_voronoi',
+		};
+		const marksDefault = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
+		const marksInteractive = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, lineOptionsWithInteractivity, 'gray-50', 'light');
+
+		// Background mark (marks[0]) must always be { value: 1 }, not conditional opacity rules
+		expect(marksDefault[0].encode?.update).toHaveProperty('opacity', { value: 1 });
+		expect(marksInteractive[0].encode?.update).toHaveProperty('opacity', { value: 1 });
 	});
 
 	test('both marks have fontWeight 700 in update encoding', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -167,7 +167,9 @@ export const getLineDirectLabelMarks = (
 				strokeWidth: { value: DIRECT_LABEL_BACKGROUND_STROKE_WIDTH },
 				fill: { value: 'transparent' },
 			},
-			update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
+			// Background rect must remain fully opaque at all times so it continues to mask content
+			// behind the label. Only the colored text mark should dim during hover/highlight.
+			update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: { value: 1 } },
 		},
 	};
 


### PR DESCRIPTION
## Description
Fixes direct label background rect remaining opaque during hover/highlight dimming. Separates the opacity encoding so the background rect always uses `{ value: 1 }` while the colored text mark uses the highlight opacity signal.

## Related Issue
Jira: AN-450442 (AN-450439)

## Motivation and Context
When hovering a line series, non-hovered series dim. The direct label background rect was incorrectly inheriting the highlight opacity, causing it to fade with the text instead of staying opaque to maintain label legibility.

## How Has This Been Tested?
- Unit tests updated and passing (`lineDirectLabelUtils.test.ts`)
- Regression story added: `LineDirectLabel.story.tsx (DirectLabelOpaqueBackground)`
- MetricRange and Trendline confirmed unaffected
- Build and TSC verified clean

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)