### PR TITLE
feat: create s2 LineForecast component

### DIFF
--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -192,6 +192,61 @@ The transition between segments is seamless — the line connects solid and dott
 
 ---
 
+## Forecast (LineForecast)
+
+The `LineForecast` component is an S2-exclusive child of `Line`. It visually distinguishes a forecast region from historical data: the line transitions from solid to dotted at the forecast boundary, a vertical rule marks the start of the forecast, and an optional label appears above the rule.
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" labelFormat="time" ticks baseline />
+  <Axis position="left" grid />
+  <Line color="series" metric="value" dimension="datetime" scaleType="time">
+    <LineForecast metric="forecastValue" start={1725148800000} label="Forecast" />
+  </Line>
+</Chart>
+```
+
+The `start` value must be a dimension value that exists in the data (for time axes, epoch milliseconds). Rows at or after `start` are rendered as the forecast segment. Rows before `start` use the `metric` field on `Line`; rows in the forecast region use the `metric` field on `LineForecast`.
+
+When `gradient` is set on the parent `Line`, the gradient is also rendered in the forecast region at a reduced opacity (40% of the historical gradient) to reinforce the uncertainty of the forecast.
+
+### LineForecast props
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>metric *</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Key in the data containing the forecast values.</td>
+        </tr>
+        <tr>
+            <td>start *</td>
+            <td>number | string</td>
+            <td>–</td>
+            <td>Dimension value at which the forecast begins. For time axes, provide epoch milliseconds. Rows at or after this value are rendered as the forecast segment.</td>
+        </tr>
+        <tr>
+            <td>label</td>
+            <td>string</td>
+            <td>'Forecast'</td>
+            <td>Text shown above the boundary rule. Hidden automatically when fewer than 80px remain between the boundary and the right edge of the chart.</td>
+        </tr>
+    </tbody>
+</table>
+
+_* required_
+
+---
+
 ## Line props (S2)
 
 :::note Not all base Line props are supported
@@ -210,9 +265,9 @@ The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `Metri
     <tbody>
         <tr>
             <td>children</td>
-            <td>ChartInspect | ChartPopover | LineDirectLabel</td>
+            <td>ChartInspect | ChartPopover | LineDirectLabel | LineForecast</td>
             <td>–</td>
-            <td>Optional child components for tooltips, popovers, and inline direct labels.</td>
+            <td>Optional child components for tooltips, popovers, inline direct labels, and forecast regions.</td>
         </tr>
         <tr>
             <td>color</td>

--- a/packages/react-spectrum-charts-s2/src/components/LineForecast/LineForecast.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/LineForecast/LineForecast.tsx
@@ -10,14 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { LineForecastProps } from '../../types';
+
+const LineForecast: FC<LineForecastProps> = ({ metric, start, label }: LineForecastProps) => {
+  return null;
+};
+
+LineForecast.displayName = 'LineForecast';
+
+export { LineForecast };

--- a/packages/react-spectrum-charts-s2/src/components/LineForecast/index.ts
+++ b/packages/react-spectrum-charts-s2/src/components/LineForecast/index.ts
@@ -10,14 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+export { LineForecast } from './LineForecast';

--- a/packages/react-spectrum-charts-s2/src/components/index.ts
+++ b/packages/react-spectrum-charts-s2/src/components/index.ts
@@ -20,6 +20,7 @@ export * from './EmptyState';
 export * from './Legend';
 export * from './Line';
 export * from './LineDirectLabel';
+export * from './LineForecast';
 export * from './LoadingState';
 export * from './ReferenceLine';
 export * from './Title';

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
@@ -255,6 +255,7 @@ describe('rscPropsToSpecBuilderOptions()', () => {
             chartInspects: [],
             color: 'series',
             dimension: 'datetime',
+            forecasts: [],
             hasOnClick: false,
             hasOnContextMenu: false,
             lineDirectLabels: [],

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
@@ -18,6 +18,7 @@ import {
   ChartPopoverOptions,
   DonutSummaryOptions,
   LegendOptions,
+  LineForecastOptions,
   LineDirectLabelOptions,
   LineOptions,
   MarkOptions,
@@ -35,6 +36,7 @@ import { ChartPopover } from '../components/ChartPopover';
 import { Legend } from '../components/Legend';
 import { Line } from '../components/Line';
 import { LineDirectLabel } from '../components/LineDirectLabel';
+import { LineForecast } from '../components/LineForecast';
 import { ReferenceLine } from '../components/ReferenceLine';
 import { Title } from '../components/Title';
 import { Donut, DonutSummary, SegmentLabel } from '../rc';
@@ -48,6 +50,7 @@ import {
   DonutProps,
   DonutSummaryProps,
   LegendProps,
+  LineForecastProps,
   LineDirectLabelProps,
   LineProps,
   ReferenceLineProps,
@@ -73,6 +76,7 @@ export const childrenToOptions = (
   chartInspects: ChartInspectOptions[];
   chartPopovers: ChartPopoverOptions[];
   donutSummaries: DonutSummaryOptions[];
+  forecasts: LineForecastOptions[];
   legends: LegendOptions[];
   lineDirectLabels: LineDirectLabelOptions[];
   lines: LineOptions[];
@@ -88,6 +92,7 @@ export const childrenToOptions = (
   const chartInspects: ChartInspectOptions[] = [];
   const chartPopovers: ChartPopoverOptions[] = [];
   const donutSummaries: DonutSummaryOptions[] = [];
+  const forecasts: LineForecastOptions[] = [];
   const legends: LegendOptions[] = [];
   const lineDirectLabels: LineDirectLabelOptions[] = [];
   const lines: LineOptions[] = [];
@@ -138,6 +143,10 @@ export const childrenToOptions = (
         legends.push(getLegendOptions(child.props as LegendProps));
         break;
 
+      case LineForecast.displayName:
+        forecasts.push(child.props as LineForecastProps);
+        break;
+
       case LineDirectLabel.displayName:
         lineDirectLabels.push(child.props as LineDirectLabelProps);
         break;
@@ -172,6 +181,7 @@ export const childrenToOptions = (
     chartInspects,
     chartPopovers,
     donutSummaries,
+    forecasts,
     legends,
     lineDirectLabels,
     lines,

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
@@ -15,6 +15,7 @@ import { DEFAULT_COLOR } from '@spectrum-charts/constants';
 
 import { ChartPopover } from '../components/ChartPopover';
 import { ChartInspect } from '../components/ChartInspect';
+import { LineForecast } from '../components/LineForecast';
 import { getLineOptions } from './lineAdapter';
 
 describe('getLineOptions()', () => {
@@ -40,6 +41,18 @@ describe('getLineOptions()', () => {
   test('should set hasOnContextMenu to true if onContextMenu prop exists and is not undefined', () => {
     expect(getLineOptions({ onContextMenu: () => {} }).hasOnContextMenu).toBe(true);
     expect(getLineOptions({ onContextMenu: undefined }).hasOnContextMenu).toBe(false);
+  });
+  it('should convert LineForecast children to forecasts array', () => {
+    const options = getLineOptions({
+      children: [createElement(LineForecast, { metric: 'forecastValue', start: 1725148800000 })],
+    });
+    expect(options.forecasts).toHaveLength(1);
+    expect(options.forecasts?.[0]).toHaveProperty('metric', 'forecastValue');
+    expect(options.forecasts?.[0]).toHaveProperty('start', 1725148800000);
+  });
+  it('should return empty forecasts array when no LineForecast children', () => {
+    const options = getLineOptions({});
+    expect(options.forecasts).toHaveLength(0);
   });
   it('should pass through included props', () => {
     const options = getLineOptions({ color: DEFAULT_COLOR });

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
@@ -15,11 +15,12 @@ import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
 export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMode: _contextMenuMode, ...lineProps }: LineProps): LineOptions => {
-  const { chartInspects, chartPopovers, lineDirectLabels } = childrenToOptions(children);
+  const { chartInspects, chartPopovers, forecasts, lineDirectLabels } = childrenToOptions(children);
   return {
     ...lineProps,
     chartInspects,
     chartPopovers,
+    forecasts,
     hasOnClick: Boolean(onClick),
     hasOnContextMenu: Boolean(onContextMenu),
     lineDirectLabels,

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
@@ -95,20 +95,7 @@ WithForecast.args = {
   scaleType: 'time',
 };
 
-const ForecastWithGradientStory: StoryFn<typeof Line> = (args): ReactElement => {
-  const chartProps = useChartProps(defaultChartProps);
-  return (
-    <Chart {...chartProps}>
-      <Axis position="left" grid />
-      <Axis position="bottom" labelFormat="time" />
-      <Line {...args}>
-        <LineForecast metric="forecastValue" start={1725148800000} label="Forecast" />
-      </Line>
-    </Chart>
-  );
-};
-
-const WithForecastAndGradient = bindWithProps(ForecastWithGradientStory);
+const WithForecastAndGradient = bindWithProps(ForecastStory);
 WithForecastAndGradient.args = {
   color: 'series',
   name: 'line0',
@@ -163,6 +150,55 @@ WithForecastEarly.args = {
   scaleType: 'time',
 };
 
+const forecastDataMultiSeries = [
+  { datetime: 1704067200000, value: 100, forecastValue: null, series: 'Visitors' },
+  { datetime: 1706745600000, value: 110, forecastValue: null, series: 'Visitors' },
+  { datetime: 1709251200000, value: 105, forecastValue: null, series: 'Visitors' },
+  { datetime: 1711929600000, value: 120, forecastValue: null, series: 'Visitors' },
+  { datetime: 1714521600000, value: 130, forecastValue: null, series: 'Visitors' },
+  { datetime: 1717200000000, value: 125, forecastValue: null, series: 'Visitors' },
+  { datetime: 1719792000000, value: 135, forecastValue: null, series: 'Visitors' },
+  { datetime: 1722470400000, value: 140, forecastValue: null, series: 'Visitors' },
+  { datetime: 1725148800000, value: null, forecastValue: 148, series: 'Visitors' },
+  { datetime: 1727740800000, value: null, forecastValue: 155, series: 'Visitors' },
+  { datetime: 1730419200000, value: null, forecastValue: 162, series: 'Visitors' },
+  { datetime: 1733011200000, value: null, forecastValue: 158, series: 'Visitors' },
+  { datetime: 1704067200000, value: 80,  forecastValue: null, series: 'Pageviews' },
+  { datetime: 1706745600000, value: 88,  forecastValue: null, series: 'Pageviews' },
+  { datetime: 1709251200000, value: 84,  forecastValue: null, series: 'Pageviews' },
+  { datetime: 1711929600000, value: 95,  forecastValue: null, series: 'Pageviews' },
+  { datetime: 1714521600000, value: 102, forecastValue: null, series: 'Pageviews' },
+  { datetime: 1717200000000, value: 98,  forecastValue: null, series: 'Pageviews' },
+  { datetime: 1719792000000, value: 108, forecastValue: null, series: 'Pageviews' },
+  { datetime: 1722470400000, value: 112, forecastValue: null, series: 'Pageviews' },
+  { datetime: 1725148800000, value: null, forecastValue: 118, series: 'Pageviews' },
+  { datetime: 1727740800000, value: null, forecastValue: 124, series: 'Pageviews' },
+  { datetime: 1730419200000, value: null, forecastValue: 130, series: 'Pageviews' },
+  { datetime: 1733011200000, value: null, forecastValue: 126, series: 'Pageviews' },
+];
+
+const ForecastMultiSeriesStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: forecastDataMultiSeries });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1725148800000} label="Forecast" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecastMultiSeries = bindWithProps(ForecastMultiSeriesStory);
+WithForecastMultiSeries.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+};
+
 const ForecastCustomLabelStory: StoryFn<typeof Line> = (args): ReactElement => {
   const chartProps = useChartProps(defaultChartProps);
   return (
@@ -185,4 +221,4 @@ WithForecastCustomLabel.args = {
   scaleType: 'time',
 };
 
-export { WithForecast, WithForecastAndGradient, WithForecastNearEnd, WithForecastEarly, WithForecastCustomLabel };
+export { WithForecast, WithForecastAndGradient, WithForecastMultiSeries, WithForecastNearEnd, WithForecastEarly, WithForecastCustomLabel };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
@@ -163,4 +163,26 @@ WithForecastEarly.args = {
   scaleType: 'time',
 };
 
-export { WithForecast, WithForecastAndGradient, WithForecastNearEnd, WithForecastEarly };
+const ForecastCustomLabelStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1725148800000} label="Projected" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecastCustomLabel = bindWithProps(ForecastCustomLabelStory);
+WithForecastCustomLabel.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+};
+
+export { WithForecast, WithForecastAndGradient, WithForecastNearEnd, WithForecastEarly, WithForecastCustomLabel };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/LineForecast/LineForecast.story.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../../Chart';
+import { Axis, Line, LineForecast } from '../../../../components';
+import useChartProps from '../../../../hooks/useChartProps';
+import { bindWithProps } from '../../../../test-utils';
+import { ChartProps } from '../../../../types';
+
+export default {
+  title: 'React Spectrum Charts 2/Line/Features/LineForecast',
+  component: Line,
+};
+
+const forecastData = [
+  { datetime: 1704067200000, value: 100, forecastValue: null, series: 'Visitors' },
+  { datetime: 1706745600000, value: 110, forecastValue: null, series: 'Visitors' },
+  { datetime: 1709251200000, value: 105, forecastValue: null, series: 'Visitors' },
+  { datetime: 1711929600000, value: 120, forecastValue: null, series: 'Visitors' },
+  { datetime: 1714521600000, value: 130, forecastValue: null, series: 'Visitors' },
+  { datetime: 1717200000000, value: 125, forecastValue: null, series: 'Visitors' },
+  { datetime: 1719792000000, value: 135, forecastValue: null, series: 'Visitors' },
+  { datetime: 1722470400000, value: 140, forecastValue: null, series: 'Visitors' },
+  { datetime: 1725148800000, value: null, forecastValue: 148, series: 'Visitors' },
+  { datetime: 1727740800000, value: null, forecastValue: 155, series: 'Visitors' },
+  { datetime: 1730419200000, value: null, forecastValue: 162, series: 'Visitors' },
+  { datetime: 1733011200000, value: null, forecastValue: 158, series: 'Visitors' },
+];
+
+// Forecast starts near the end — only 2 forecast points
+const forecastDataNearEnd = [
+  { datetime: 1704067200000, value: 100, forecastValue: null, series: 'Visitors' },
+  { datetime: 1706745600000, value: 110, forecastValue: null, series: 'Visitors' },
+  { datetime: 1709251200000, value: 105, forecastValue: null, series: 'Visitors' },
+  { datetime: 1711929600000, value: 120, forecastValue: null, series: 'Visitors' },
+  { datetime: 1714521600000, value: 130, forecastValue: null, series: 'Visitors' },
+  { datetime: 1717200000000, value: 125, forecastValue: null, series: 'Visitors' },
+  { datetime: 1719792000000, value: 135, forecastValue: null, series: 'Visitors' },
+  { datetime: 1722470400000, value: 140, forecastValue: null, series: 'Visitors' },
+  { datetime: 1725148800000, value: 145, forecastValue: null, series: 'Visitors' },
+  { datetime: 1727740800000, value: 150, forecastValue: null, series: 'Visitors' },
+  { datetime: 1730419200000, value: null, forecastValue: 158, series: 'Visitors' },
+  { datetime: 1733011200000, value: null, forecastValue: 162, series: 'Visitors' },
+];
+
+// Forecast starts near the beginning — only 2 historical points
+const forecastDataEarly = [
+  { datetime: 1704067200000, value: 100, forecastValue: null, series: 'Visitors' },
+  { datetime: 1706745600000, value: 110, forecastValue: null, series: 'Visitors' },
+  { datetime: 1709251200000, value: null, forecastValue: 108, series: 'Visitors' },
+  { datetime: 1711929600000, value: null, forecastValue: 120, series: 'Visitors' },
+  { datetime: 1714521600000, value: null, forecastValue: 132, series: 'Visitors' },
+  { datetime: 1717200000000, value: null, forecastValue: 128, series: 'Visitors' },
+  { datetime: 1719792000000, value: null, forecastValue: 138, series: 'Visitors' },
+  { datetime: 1722470400000, value: null, forecastValue: 142, series: 'Visitors' },
+  { datetime: 1725148800000, value: null, forecastValue: 148, series: 'Visitors' },
+  { datetime: 1727740800000, value: null, forecastValue: 155, series: 'Visitors' },
+  { datetime: 1730419200000, value: null, forecastValue: 162, series: 'Visitors' },
+  { datetime: 1733011200000, value: null, forecastValue: 158, series: 'Visitors' },
+];
+
+const defaultChartProps: ChartProps = { data: forecastData, minWidth: 400, maxWidth: 800, height: 400 };
+
+const ForecastStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1725148800000} label="Forecast" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecast = bindWithProps(ForecastStory);
+WithForecast.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+};
+
+const ForecastWithGradientStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1725148800000} label="Forecast" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecastAndGradient = bindWithProps(ForecastWithGradientStory);
+WithForecastAndGradient.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+  gradient: true,
+  opacity: { value: 0.5 },
+};
+
+const ForecastNearEndStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: forecastDataNearEnd });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1730419200000} label="Forecast" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecastNearEnd = bindWithProps(ForecastNearEndStory);
+WithForecastNearEnd.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+};
+
+const ForecastEarlyStory: StoryFn<typeof Line> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: forecastDataEarly });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" />
+      <Line {...args}>
+        <LineForecast metric="forecastValue" start={1709251200000} label="Forecast" />
+      </Line>
+    </Chart>
+  );
+};
+
+const WithForecastEarly = bindWithProps(ForecastEarlyStory);
+WithForecastEarly.args = {
+  color: 'series',
+  name: 'line0',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time',
+};
+
+export { WithForecast, WithForecastAndGradient, WithForecastNearEnd, WithForecastEarly };

--- a/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
@@ -14,6 +14,7 @@ import { JSXElementConstructor, ReactElement } from 'react';
 import { LineOptions } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { ChartPopoverElement, ChartInspectElement } from '../dialogs';
+import { LineForecastElement } from './supplemental/lineForecast.types';
 import { LineDirectLabelElement } from './supplemental/lineDirectLabel.types';
 import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
 
@@ -26,11 +27,11 @@ import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
  */
 export type ContextMenuMode = 'interaction' | 'dimension' | 'item';
 
-type LineChildElement = ChartPopoverElement | ChartInspectElement | LineDirectLabelElement;
+type LineChildElement = ChartPopoverElement | ChartInspectElement | LineForecastElement | LineDirectLabelElement;
 export interface LineProps
   extends Omit<
     LineOptions,
-    'chartPopovers' | 'chartInspects' | 'hasOnClick' | 'hasOnContextMenu' | 'lineDirectLabels' | 'markType'
+    'chartPopovers' | 'chartInspects' | 'forecasts' | 'hasOnClick' | 'hasOnContextMenu' | 'lineDirectLabels' | 'markType'
   > {
   children?: Children<LineChildElement>;
   /** Callback that will be run when a point/section is clicked */

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/index.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/index.ts
@@ -13,5 +13,6 @@
 export * from './barAnnotation.types';
 export * from './barDirectLabel.types';
 export * from './dountSummary.types';
+export * from './lineForecast.types';
 export * from './lineDirectLabel.types';
 export * from './segmentLabel.types';

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineForecast.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineForecast.types.ts
@@ -9,15 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { JSXElementConstructor, ReactElement } from 'react';
 
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+import { LineForecastOptions } from '@spectrum-charts/vega-spec-builder-s2';
+
+export interface LineForecastProps extends LineForecastOptions {}
+
+export type LineForecastElement = ReactElement<LineForecastProps, JSXElementConstructor<LineForecastProps>>;

--- a/packages/react-spectrum-charts-s2/src/utils/utils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.ts
@@ -35,6 +35,7 @@ import {
   Legend,
   Line,
   LineDirectLabel,
+  LineForecast,
   ReferenceLine,
   Title,
 } from '../components';
@@ -52,6 +53,7 @@ import {
   DonutElement,
   DonutSummaryElement,
   LegendElement,
+  LineForecastElement,
   LineDirectLabelElement,
   LineElement,
   SegmentLabelElement,
@@ -63,6 +65,7 @@ type MarkChildElement =
   | ChartInspectElement
   | ChartPopoverElement
   | DonutSummaryElement
+  | LineForecastElement
   | LineDirectLabelElement
   | SegmentLabelElement;
 type RscElement =
@@ -117,6 +120,7 @@ export const sanitizeChildren = (children: unknown): (ChartChildElement | MarkCh
     Legend.displayName,
     Line.displayName,
     LineDirectLabel.displayName,
+    LineForecast.displayName,
     ReferenceLine.displayName,
     SegmentLabel.displayName,
     Title.displayName,
@@ -149,6 +153,7 @@ export const sanitizeMarkChildren = (children: unknown): MarkChildElement[] => {
     ChartInspect.displayName,
     ChartPopover.displayName,
     DonutSummary.displayName,
+    LineForecast.displayName,
     LineDirectLabel.displayName,
     SegmentLabel.displayName,
   ]);

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
@@ -251,6 +251,28 @@ describe('getLineGradientMark()', () => {
     expect(fillOpacity).toEqual({ signal: `scale('${OPACITY_SCALE}', datum.weight) * 0.2` });
   });
 
+  test('should use signal-based fillOpacity for alternate segments with static opacity', () => {
+    const gradientMark = getLineGradientMark(
+      { ...defaultLineMarkOptions, alternateSegmentKey: 'line0_alternateFlag' },
+      'line0_facet'
+    );
+    const fillOpacity = gradientMark.encode?.enter?.fillOpacity as { signal: string };
+    expect(fillOpacity.signal).toContain('line0_alternateFlag');
+    expect(fillOpacity.signal).toContain('0.08');
+    expect(fillOpacity.signal).toContain('0.2');
+  });
+
+  test('should use signal-based fillOpacity for alternate segments with dynamic opacity facet', () => {
+    const gradientMark = getLineGradientMark(
+      { ...defaultLineMarkOptions, alternateSegmentKey: 'line0_alternateFlag', opacity: 'weight' },
+      'line0_facet'
+    );
+    const fillOpacity = gradientMark.encode?.enter?.fillOpacity as { signal: string };
+    expect(fillOpacity.signal).toContain('line0_alternateFlag');
+    expect(fillOpacity.signal).toContain(`scale('${OPACITY_SCALE}', datum.weight) * 0.08`);
+    expect(fillOpacity.signal).toContain(`scale('${OPACITY_SCALE}', datum.weight) * 0.2`);
+  });
+
   test('should include hover opacity rules when interactive', () => {
     const gradientMark = getLineGradientMark(
       { ...defaultLineMarkOptions, interactiveMarkName: 'line0', chartInspects: [{}] },

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
@@ -79,6 +79,7 @@ export const getLineYEncoding = (lineMarkOptions: LineMarkOptions, metric: strin
 };
 
 const GRADIENT_BASE_OPACITY = 0.2;
+const FORECAST_GRADIENT_RATIO = 0.4;
 
 /**
  * Generates an area mark with a gradient fill beneath the line, fading from the line's color to transparent.
@@ -111,14 +112,34 @@ export const getLineGradientMark = (lineMarkOptions: LineMarkOptions, dataSource
   };
 };
 
-const getGradientFillEncoding = ({ color, colorScheme, opacity }: LineMarkOptions) => {
+const getGradientFillEncoding = ({ color, colorScheme, name, opacity, alternateSegmentKey }: LineMarkOptions) => {
   const colorSignal = getColorProductionRuleSignalString(color, colorScheme);
   return {
     fill: {
       signal: `{gradient: 'linear', stops: [{offset: 0, color: ${colorSignal}}, {offset: 1, color: 'transparent'}], x1: 0, y1: 0, x2: 0, y2: 1}`,
     },
-    fillOpacity: getGradientOpacity(opacity),
+    fillOpacity: getGradientFillOpacity(name, opacity, alternateSegmentKey),
   };
+};
+
+const getGradientFillOpacity = (
+  name: string,
+  opacity: LineMarkOptions['opacity'],
+  alternateSegmentKey: LineMarkOptions['alternateSegmentKey']
+): { value: number } | { signal: string } => {
+  if (!alternateSegmentKey) {
+    return getGradientOpacity(opacity);
+  }
+  const forecastGradientOpacity = GRADIENT_BASE_OPACITY * FORECAST_GRADIENT_RATIO;
+  const normalOpacitySignal =
+    typeof opacity === 'string'
+      ? `scale('${OPACITY_SCALE}', datum.${opacity}) * ${GRADIENT_BASE_OPACITY}`
+      : String(opacity.value * GRADIENT_BASE_OPACITY);
+  const altOpacitySignal =
+    typeof opacity === 'string'
+      ? `scale('${OPACITY_SCALE}', datum.${opacity}) * ${forecastGradientOpacity}`
+      : String(opacity.value * forecastGradientOpacity);
+  return { signal: `datum.${name}_alternateFlag ? ${altOpacitySignal} : ${normalOpacitySignal}` };
 };
 
 const getGradientOpacity = (opacity: LineMarkOptions['opacity']): { value: number } | { signal: string } => {

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -522,6 +522,15 @@ describe('lineSpecBuilder', () => {
       ).toStrictEqual([defaultSpec.scales?.[0], defaultSpec.scales?.[1], metricRangeMetricScale]);
     });
 
+    test('with metricAxis adds a named metric scale', () => {
+      const scales = setScales(startingSpec.scales ?? [], {
+        ...defaultLineOptions,
+        metricAxis: 'myAxis',
+      });
+      const namedScale = scales.find((s) => s.name === 'myAxis');
+      expect(namedScale).toBeDefined();
+    });
+
     test('with forecasts uses effectiveValue field for the y-scale domain', () => {
       const scales = setScales(startingSpec.scales ?? [], {
         ...defaultLineOptions,

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -440,6 +440,46 @@ describe('lineSpecBuilder', () => {
       expect(resultData.find((d) => d.name === 'line0_bridge')).toBeUndefined();
       expect(resultData.find((d) => d.name === 'line0_with_bridges')).toBeUndefined();
     });
+
+    test('with forecasts adds alternateFlag and effectiveValue transforms to table and 3 segment data sources', () => {
+      const resultData = addData(baseData ?? [], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const tableData = resultData.find((d) => d.name === TABLE);
+      expect(tableData?.transform?.some((t) => t.type === 'formula' && (t as { as: string }).as === 'line0_alternateFlag')).toBe(true);
+      expect(tableData?.transform?.some((t) => t.type === 'formula' && (t as { as: string }).as === 'line0_effectiveValue')).toBe(true);
+
+      const expectedSegmentData = getAlternateSegmentData('line0', `${DEFAULT_TIME_DIMENSION}0`);
+      expect(resultData.find((d) => d.name === 'line0_segmented')).toStrictEqual(expectedSegmentData[0]);
+      expect(resultData.find((d) => d.name === 'line0_bridge')).toStrictEqual(expectedSegmentData[1]);
+      expect(resultData.find((d) => d.name === 'line0_with_bridges')).toStrictEqual(expectedSegmentData[2]);
+    });
+
+    test('with forecasts effectiveValue uses isValid to choose between main metric and forecast metric', () => {
+      const resultData = addData(baseData ?? [], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const tableData = resultData.find((d) => d.name === TABLE);
+      const effectiveValueTransform = tableData?.transform?.find(
+        (t) => t.type === 'formula' && (t as { as: string }).as === 'line0_effectiveValue'
+      );
+      expect(effectiveValueTransform).toHaveProperty(
+        'expr',
+        "isValid(datum['value']) ? datum['value'] : datum['forecastValue']"
+      );
+    });
+
+    test('with forecasts and alternateSegmentKey set, forecasts are skipped', () => {
+      const resultData = addData(baseData ?? [], {
+        ...defaultLineOptions,
+        alternateSegmentKey: 'isEstimated',
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const tableData = resultData.find((d) => d.name === TABLE);
+      expect(tableData?.transform?.some((t) => t.type === 'formula' && (t as { as: string }).as === 'line0_effectiveValue')).toBe(false);
+    });
   });
 
   describe('setScales()', () => {
@@ -480,6 +520,19 @@ describe('lineSpecBuilder', () => {
           metricRanges: [{ scaleAxisToFit: true, metricEnd, metricStart }],
         })
       ).toStrictEqual([defaultSpec.scales?.[0], defaultSpec.scales?.[1], metricRangeMetricScale]);
+    });
+
+    test('with forecasts uses effectiveValue field for the y-scale domain', () => {
+      const scales = setScales(startingSpec.scales ?? [], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const yScale = scales.find((s) => s.name === 'yLinear');
+      expect(yScale).toBeDefined();
+      expect(yScale?.domain).toHaveProperty('fields');
+      const fields = (yScale?.domain as { fields: string[] }).fields;
+      expect(fields).toContain('line0_effectiveValue');
+      expect(fields).not.toContain('value');
     });
   });
 
@@ -656,6 +709,66 @@ describe('lineSpecBuilder', () => {
       const groupMark = marks[0] as { marks: { encode: { enter: { strokeDash: unknown } } }[] };
       const strokeDash = groupMark.marks[0].encode.enter.strokeDash;
       expect(strokeDash).toHaveProperty('signal');
+    });
+
+    test('with forecasts uses line0_with_bridges as facet data', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const groupMark = marks.find((m) => m.name === 'line0_group') as { from: { facet: { data: string } } };
+      expect(groupMark?.from?.facet?.data).toBe('line0_with_bridges');
+    });
+
+    test('with forecasts extends facet groupby with segmentId', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const groupMark = marks.find((m) => m.name === 'line0_group') as { from: { facet: { groupby: string[] } } };
+      expect(groupMark?.from?.facet?.groupby).toContain('line0_segmentId');
+    });
+
+    test('with forecasts pushes boundary rule before the line group', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const boundaryIndex = marks.findIndex((m) => m.name === 'line0_forecast0_boundary');
+      const groupIndex = marks.findIndex((m) => m.name === 'line0_group');
+      expect(boundaryIndex).toBeGreaterThanOrEqual(0);
+      expect(boundaryIndex).toBeLessThan(groupIndex);
+    });
+
+    test('with forecasts pushes label after the line group', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const labelIndex = marks.findIndex((m) => m.name === 'line0_forecast0_label');
+      const groupIndex = marks.findIndex((m) => m.name === 'line0_group');
+      expect(labelIndex).toBeGreaterThan(groupIndex);
+    });
+
+    test('with forecasts line mark strokeDash uses a signal (dotted for forecast)', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const groupMark = marks.find((m) => m.name === 'line0_group') as { marks: { encode: { enter: { strokeDash: unknown } } }[] };
+      expect(groupMark?.marks?.[0]?.encode?.enter?.strokeDash).toHaveProperty('signal');
+    });
+
+    test('with forecasts line mark y-encoding uses effectiveValue field', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        forecasts: [{ metric: 'forecastValue', start: 1725148800000 }],
+      });
+      const groupMark = marks.find((m) => m.name === 'line0_group') as { marks: { encode: { enter: { y: { field: string }[] } } }[] };
+      const yEncoding = groupMark?.marks?.[0]?.encode?.enter?.y;
+      expect(yEncoding).toBeDefined();
+      expect(Array.isArray(yEncoding)).toBe(true);
+      expect(yEncoding?.[0]).toHaveProperty('field', 'line0_effectiveValue');
     });
   });
 

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -36,6 +36,7 @@ import { getDualAxisScaleNames } from '../scale/scaleUtils';
 import { addHoveredItemSignal, getFirstRscSeriesIdSignal, getLastRscSeriesIdSignal } from '../signal/signalSpecBuilder';
 import { addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
 import { getLineDirectLabelData, getLineDirectLabelMarks, getLineDirectLabelSpecOptions } from '../lineDirectLabel';
+import { getForecastAlternateFlagTransform, getForecastEffectiveValueTransform, getLineForecastBoundaryMark, getLineForecastLabelMarks, getLineForecastSpecOptions } from '../lineForecast';
 import { addTrendlineData, getTrendlineMarks, getTrendlineScales, setTrendlineSignals } from '../trendline';
 import { ColorScheme, HighlightedItem, LineOptions, LineSpecOptions, ScSpec } from '../types';
 import { getLineHighlightedData, getLineStaticPointData } from './lineDataUtils';
@@ -64,6 +65,7 @@ export const addLine = produce<
       colorScheme = DEFAULT_COLOR_SCHEME,
       dimension = DEFAULT_TIME_DIMENSION,
       dualMetricAxis = false,
+      forecasts = [],
       gradient = false,
       hasOnClick = false,
       hasOnContextMenu = false,
@@ -93,6 +95,7 @@ export const addLine = produce<
       colorScheme,
       dimension,
       dualMetricAxis,
+      forecasts,
       gradient,
       hasOnClick,
       hasOnContextMenu,
@@ -138,7 +141,7 @@ export const addLine = produce<
 );
 
 export const addData = produce<Data[], [LineSpecOptions]>((data, options) => {
-  const { alternateSegmentKey, chartInspects, dimension, highlightedItem, isSparkline, isMethodLast, name, scaleType, staticPoint } =
+  const { alternateSegmentKey, chartInspects, dimension, forecasts, highlightedItem, isSparkline, isMethodLast, metric, name, scaleType, staticPoint } =
     options;
   const tableData = getTableData(data);
   if (scaleType === 'time') {
@@ -149,6 +152,15 @@ export const addData = produce<Data[], [LineSpecOptions]>((data, options) => {
     tableData.transform.push({ type: 'formula', as: `${name}_alternateFlag`, expr: `datum["${alternateSegmentKey}"]` });
     // time data was transformed above, so we need to use the transformed dimension
     const dimSortField = scaleType === 'time' ? `${dimension}0` : dimension;
+    data.push(...getAlternateSegmentData(name, dimSortField));
+  }
+  if (!alternateSegmentKey && forecasts.length > 0) {
+    tableData.transform = tableData.transform ?? [];
+    const dimSortField = scaleType === 'time' ? `${dimension}0` : dimension;
+    tableData.transform.push(
+      getForecastAlternateFlagTransform(name, dimension, forecasts[0].start),
+      getForecastEffectiveValueTransform(name, metric, forecasts)
+    );
     data.push(...getAlternateSegmentData(name, dimSortField));
   }
   if (isInteractive(options) || highlightedItem !== undefined) {
@@ -241,11 +253,30 @@ export const setScales = produce<Scale[], [LineSpecOptions]>((scales, options) =
 // The order that marks are added is important since it determines the draw order.
 export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) => {
   const { alternateSegmentKey, color, gradient, highlightedItem, isSparkline, lineType, name, opacity, staticPoint } = options;
+  const forecasts = options.forecasts ?? [];
+  const hasForecast = !alternateSegmentKey && forecasts.length > 0;
 
   const { facets } = getFacetsFromOptions({ color, lineType, opacity });
-  // when alternateSegmentKey is set, facet by segmentId so each contiguous run gets its own path with its own strokeDash
-  const facetData = alternateSegmentKey ? `${name}_with_bridges` : FILTERED_TABLE;
-  const facetGroupby = alternateSegmentKey ? [...facets, `${name}_segmentId`] : facets;
+  // when alternateSegmentKey or forecasts are active, facet by segmentId so each contiguous run
+  // gets its own path with its own strokeDash
+  const usesAlternateSegments = !!alternateSegmentKey || hasForecast;
+  const facetData = usesAlternateSegments ? `${name}_with_bridges` : FILTERED_TABLE;
+  const facetGroupby = usesAlternateSegments ? [...facets, `${name}_segmentId`] : facets;
+
+  // when forecasts are present, override metric to effectiveValue and set alternateSegmentKey
+  // to trigger getAlternateSegmentStrokeDash in getLineMark
+  const markOptions = hasForecast
+    ? {
+        ...options,
+        metric: `${name}_effectiveValue`,
+        alternateSegmentKey: `${name}_alternateFlag`,
+        }
+    : options;
+
+  // boundary rules are drawn behind the main line group
+  for (const [i, forecast] of forecasts.entries()) {
+    marks.push(getLineForecastBoundaryMark(getLineForecastSpecOptions(forecast, i, options)));
+  }
 
   marks.push({
     name: `${name}_group`,
@@ -258,24 +289,31 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
       },
     },
     marks: [
-      ...(gradient ? [getLineGradientMark(options, `${name}_facet`)] : []),
-      getLineMark(options, `${name}_facet`),
+      ...(gradient ? [getLineGradientMark(markOptions, `${name}_facet`)] : []),
+      getLineMark(markOptions, `${name}_facet`),
     ],
   });
   if (staticPoint || isSparkline) marks.push(getLineStaticPoint(options));
   marks.push(...getMetricRangeGroupMarks(options));
   if (isInteractive(options) || highlightedItem !== undefined) {
-    marks.push(...getLineHoverMarks(options, `${FILTERED_TABLE}ForInspect`));
+    marks.push(...getLineHoverMarks(markOptions, `${FILTERED_TABLE}ForInspect`));
   }
   marks.push(...getTrendlineMarks(options));
   for (const [i, label] of (options.lineDirectLabels ?? []).entries()) {
     const specOpts = getLineDirectLabelSpecOptions(label, i, options);
     marks.push(...getLineDirectLabelMarks(options.name, specOpts, options, options.backgroundColor, options.colorScheme));
   }
+  // forecast labels are drawn last so they appear on top of other marks
+  for (const [i, forecast] of forecasts.entries()) {
+    marks.push(...getLineForecastLabelMarks(getLineForecastSpecOptions(forecast, i, options)));
+  }
 });
 
 const getMetricKeys = (lineOptions: LineSpecOptions) => {
-  const metricKeys = [lineOptions.metric];
+  const hasForecast = (lineOptions.forecasts ?? []).length > 0 && !lineOptions.alternateSegmentKey;
+  // when forecasts are present, use effectiveValue for the y-scale domain since it covers both
+  // the historical metric and forecast metric(s) in a single unified field
+  const metricKeys = hasForecast ? [`${lineOptions.name}_effectiveValue`] : [lineOptions.metric];
 
   // metric range fields should be added if metric-axis will be scaled to fit
   const metricRanges = getMetricRanges(lineOptions);

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -159,7 +159,7 @@ export const addData = produce<Data[], [LineSpecOptions]>((data, options) => {
     const dimSortField = scaleType === 'time' ? `${dimension}0` : dimension;
     tableData.transform.push(
       getForecastAlternateFlagTransform(name, dimension, forecasts[0].start),
-      getForecastEffectiveValueTransform(name, metric, forecasts)
+      getForecastEffectiveValueTransform(name, metric, forecasts[0].metric)
     );
     data.push(...getAlternateSegmentData(name, dimSortField));
   }

--- a/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
@@ -39,6 +39,7 @@ export const defaultLineOptions: LineSpecOptions = {
   chartInspects: [],
   name: 'line0',
   dimension: DEFAULT_TIME_DIMENSION,
+  forecasts: [],
   gradient: false,
   hasOnClick: false,
   hasOnContextMenu: false,

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -34,6 +34,7 @@ const defaultLineOptions: LineSpecOptions = {
 	color: DEFAULT_COLOR,
 	colorScheme: DEFAULT_COLOR_SCHEME,
 	dimension: DEFAULT_TIME_DIMENSION,
+	forecasts: [],
 	gradient: false,
 	hasOnClick: false,
 	hasOnContextMenu: false,

--- a/packages/vega-spec-builder-s2/src/lineForecast/index.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/index.ts
@@ -10,14 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+export { getForecastAlternateFlagTransform, getForecastEffectiveValueTransform, getLineForecastBoundaryMark, getLineForecastLabelMarks, getLineForecastSpecOptions } from './lineForecastUtils';

--- a/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { getForecastEffectiveValueTransform } from './lineForecastUtils';
+
+describe('getForecastEffectiveValueTransform', () => {
+  test('builds a formula that uses the historical metric when valid, falling back to forecast', () => {
+    const transform = getForecastEffectiveValueTransform('line0', 'value', 'forecastValue');
+    expect(transform.as).toBe('line0_effectiveValue');
+    expect(transform.expr).toBe("isValid(datum['value']) ? datum['value'] : datum['forecastValue']");
+  });
+});

--- a/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
@@ -22,14 +22,11 @@ export const getForecastAlternateFlagTransform = (name: string, dimension: strin
   expr: `datum['${dimension}'] >= ${JSON.stringify(start)}`,
 });
 
-export const getForecastEffectiveValueTransform = (name: string, metric: string, forecasts: LineForecastOptions[]): FormulaTransform => {
-  let expr = `datum['${forecasts[forecasts.length - 1].metric}']`;
-  for (let i = forecasts.length - 2; i >= 0; i--) {
-    expr = `isValid(datum['${forecasts[i].metric}']) ? datum['${forecasts[i].metric}'] : ${expr}`;
-  }
-  expr = `isValid(datum['${metric}']) ? datum['${metric}'] : ${expr}`;
-  return { type: 'formula', as: `${name}_effectiveValue`, expr };
-};
+export const getForecastEffectiveValueTransform = (name: string, metric: string, forecastMetric: string): FormulaTransform => ({
+  type: 'formula',
+  as: `${name}_effectiveValue`,
+  expr: `isValid(datum['${metric}']) ? datum['${metric}'] : datum['${forecastMetric}']`,
+});
 
 export const getLineForecastSpecOptions = (
   forecast: LineForecastOptions,

--- a/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FormulaTransform, Mark } from 'vega';
+
+import { BACKGROUND_COLOR } from '@spectrum-charts/constants';
+
+import { getScaleName } from '../scale/scaleSpecBuilder';
+import { LineForecastOptions, LineForecastSpecOptions, LineSpecOptions } from '../types';
+
+export const getForecastAlternateFlagTransform = (name: string, dimension: string, start: LineForecastOptions['start']): FormulaTransform => ({
+  type: 'formula',
+  as: `${name}_alternateFlag`,
+  expr: `datum['${dimension}'] >= ${JSON.stringify(start)}`,
+});
+
+export const getForecastEffectiveValueTransform = (name: string, metric: string, forecasts: LineForecastOptions[]): FormulaTransform => {
+  let expr = `datum['${forecasts[forecasts.length - 1].metric}']`;
+  for (let i = forecasts.length - 2; i >= 0; i--) {
+    expr = `isValid(datum['${forecasts[i].metric}']) ? datum['${forecasts[i].metric}'] : ${expr}`;
+  }
+  expr = `isValid(datum['${metric}']) ? datum['${metric}'] : ${expr}`;
+  return { type: 'formula', as: `${name}_effectiveValue`, expr };
+};
+
+export const getLineForecastSpecOptions = (
+  forecast: LineForecastOptions,
+  index: number,
+  lineOptions: LineSpecOptions
+): LineForecastSpecOptions => ({
+  color: lineOptions.color,
+  colorScheme: lineOptions.colorScheme,
+  dimension: lineOptions.dimension,
+  index,
+  label: forecast.label ?? 'Forecast',
+  lineName: lineOptions.name,
+  metric: forecast.metric,
+  metricAxis: lineOptions.metricAxis,
+  scaleType: lineOptions.scaleType,
+  start: forecast.start,
+});
+
+export const getLineForecastBoundaryMark = (specOpts: LineForecastSpecOptions): Mark => {
+  const { index, lineName, scaleType, start } = specOpts;
+  const xScaleName = getScaleName('x', scaleType);
+  const startSignal = `scale('${xScaleName}', ${JSON.stringify(start)})`;
+  return {
+    name: `${lineName}_forecast${index}_boundary`,
+    description: `${lineName}_forecast${index}_boundary`,
+    type: 'rule',
+    interactive: false,
+    encode: {
+      enter: {
+        y: { value: 0 },
+        y2: { signal: 'height' },
+        stroke: { value: '#909090' },
+        strokeWidth: { value: 1 },
+      },
+      update: {
+        x: { signal: startSignal },
+      },
+    },
+  };
+};
+
+export const getLineForecastLabelMarks = (specOpts: LineForecastSpecOptions): Mark[] => {
+  const { index, label, lineName, scaleType, start } = specOpts;
+  const xScaleName = getScaleName('x', scaleType);
+  const startSignal = `scale('${xScaleName}', ${JSON.stringify(start)})`;
+  const xSignal = `${startSignal} + 8`;
+  const opacityRules = [
+    { test: `width - ${startSignal} < 80`, value: 0 },
+    { value: 1 },
+  ];
+  const baseEnter = {
+    text: { value: label },
+    fontSize: { value: 14 },
+    baseline: { value: 'top' as const },
+  };
+  return [
+    {
+      name: `${lineName}_forecast${index}_label_bg`,
+      description: `${lineName}_forecast${index}_label_bg`,
+      type: 'text',
+      interactive: false,
+      encode: {
+        enter: {
+          ...baseEnter,
+          stroke: { signal: BACKGROUND_COLOR },
+          strokeWidth: { value: 2 },
+          fill: { value: 'transparent' },
+        },
+        update: {
+          x: { signal: xSignal },
+          y: { value: 4 },
+          opacity: opacityRules,
+        },
+      },
+    },
+    {
+      name: `${lineName}_forecast${index}_label`,
+      description: `${lineName}_forecast${index}_label`,
+      type: 'text',
+      interactive: false,
+      encode: {
+        enter: {
+          ...baseEnter,
+          fill: { value: '#505050' },
+        },
+        update: {
+          x: { signal: xSignal },
+          y: { value: 4 },
+          opacity: opacityRules,
+        },
+      },
+    },
+  ];
+};

--- a/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
@@ -56,6 +56,7 @@ const defaultLineOptions: LineSpecOptions = {
   color: DEFAULT_COLOR,
   colorScheme: DEFAULT_COLOR_SCHEME,
   dimension: DEFAULT_TIME_DIMENSION,
+  forecasts: [],
   gradient: false,
   hasOnClick: false,
   hasOnContextMenu: false,

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineTestUtils.ts
@@ -22,6 +22,7 @@ import { LineSpecOptions, TrendlineSpecOptions } from '../types';
 export const defaultLineOptions: LineSpecOptions = {
   chartPopovers: [],
   chartInspects: [],
+  forecasts: [],
   gradient: false,
   hasOnClick: false,
   hasOnContextMenu: false,

--- a/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
@@ -24,6 +24,7 @@ import {
   PartiallyRequired,
   ScaleType,
 } from '../specUtil.types';
+import { LineForecastOptions } from './supplemental/lineForecastSpec.types';
 import { LineDirectLabelOptions } from './supplemental/lineDirectLabelSpec.types';
 import { MetricRangeOptions } from './supplemental/metricRangeSpec.types';
 import { TrendlineOptions } from './supplemental/trendlineSpec.types';
@@ -90,6 +91,7 @@ export interface LineOptions {
   // children
   chartPopovers?: ChartPopoverOptions[];
   chartInspects?: ChartInspectOptions[];
+  forecasts?: LineForecastOptions[];
   lineDirectLabels?: LineDirectLabelOptions[];
   metricRanges?: MetricRangeOptions[];
   trendlines?: TrendlineOptions[];
@@ -100,6 +102,7 @@ type LineOptionsWithDefaults =
   | 'chartInspects'
   | 'color'
   | 'dimension'
+  | 'forecasts'
   | 'gradient'
   | 'hasOnClick'
   | 'hasOnContextMenu'

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineForecastSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineForecastSpec.types.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ColorScheme } from '../../chartSpec.types';
+import { ColorFacet, ScaleType } from '../../specUtil.types';
+
+export interface LineForecastOptions {
+  /** Data field containing the forecasted metric values */
+  metric: string;
+  /** Dimension value (timestamp for time scale, number for linear) where the forecast begins */
+  start: number;
+  /** Label text shown at the forecast boundary. Defaults to 'Forecast'. */
+  label?: string;
+}
+
+export interface LineForecastSpecOptions {
+  color: ColorFacet;
+  colorScheme: ColorScheme;
+  dimension: string;
+  index: number;
+  label: string;
+  lineName: string;
+  metric: string;
+  metricAxis: string | undefined;
+  scaleType: ScaleType;
+  start: number;
+}


### PR DESCRIPTION
## Description

Adds a `<LineForecast> `child component to the S2 `<Line>` chart that renders a forecast region using the alternate-segment approach. The historical and forecast portions share a single line mark, with the forecast segment rendered as a dotted line and separated by a vertical boundary rule with an optional label.

- `metric (string)` — data field containing the forecast values
- `start (number | string)` — dimension value at which the forecast begins; rows at or after this value are rendered as forecast
- ` label (string, default 'Forecast')` — text shown above the boundary rule; hidden automatically when fewer than 80px remain to the right edge

## Related Issue

## Motivation and Context

Creates a clear way on how to implement forecasted data into a line chart. 

## How Has This Been Tested?

Unit testing, storybook stories. 

## Screenshots (if appropriate):

<img width="858" height="467" alt="Screenshot 2026-05-22 at 3 56 08 PM" src="https://github.com/user-attachments/assets/170359d5-9550-467b-82a3-77f4768256a9" />
<img width="836" height="448" alt="Screenshot 2026-05-22 at 3 56 13 PM" src="https://github.com/user-attachments/assets/a3cca42f-ba6a-42c6-bf33-4ead18a56d15" />
<img width="847" height="447" alt="Screenshot 2026-05-22 at 3 56 18 PM" src="https://github.com/user-attachments/assets/515d2e2b-4f6b-4aa1-be9e-18affd4e947b" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
