### PR TITLE
feat: adding LinePointAnnotation to s2

### DIFF
--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -79,6 +79,87 @@ S2 selection and hover states (stroke ring, opacity fading of other series) are 
 
 ---
 
+## Point annotations (LinePointAnnotation)
+
+The `LinePointAnnotation` component places a text label adjacent to each static point on the line. It requires `staticPoint` to be set on the parent `Line` — the annotation appears for every data point that has a visible static point.
+
+```jsx
+// data: [{ datetime: ..., value: 10, highlight: true, label: '10K' }, ...]
+<Chart data={data}>
+  <Axis position="bottom" labelFormat="time" ticks baseline />
+  <Axis position="left" grid />
+  <Line color="series" staticPoint="highlight">
+    <LinePointAnnotation textKey="label" />
+  </Line>
+</Chart>
+```
+
+![Line point annotation light](/img/s2_line_pointAnnotation_light.png#gh-light-mode-only)
+![Line point annotation dark](/img/s2_line_pointAnnotation_dark.png#gh-dark-mode-only)
+
+Labels are rendered in the series color with a background halo for legibility. The placement algorithm tries each position in the `anchor` array in order and uses the first one that fits within the chart bounds without overlapping other labels or points.
+
+### Controlling label placement
+
+By default, the algorithm tries `right`, `top`, `bottom`, then `left`. Pass a single string to fix the position, or an array to control the fallback order:
+
+```jsx
+{/* Always place the label to the left of the point */}
+<LinePointAnnotation textKey="label" anchor="left" />
+
+{/* Try top first, then fall back to bottom */}
+<LinePointAnnotation textKey="label" anchor={['top', 'bottom']} />
+```
+
+### Displaying different data fields
+
+The `textKey` prop sets which field in the data is used as the label text. It defaults to the `metric` field on the parent `Line`:
+
+```jsx
+{/* Use a pre-formatted string from the data */}
+<LinePointAnnotation textKey="formattedValue" />
+
+{/* Use the default metric field */}
+<LinePointAnnotation />
+```
+
+### LinePointAnnotation props
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>textKey</td>
+            <td>string</td>
+            <td>(metric field)</td>
+            <td>Key in the data whose value is displayed as the label text. Defaults to the <code>metric</code> prop of the parent <code>Line</code>.</td>
+        </tr>
+        <tr>
+            <td>anchor</td>
+            <td>'top' | 'bottom' | 'left' | 'right' | (string | string[])</td>
+            <td>['right', 'top', 'bottom', 'left']</td>
+            <td>
+                The preferred placement direction relative to the data point. When an array is provided, each position is tried in order until one fits without overlapping other labels or points. If no position fits, the label is not shown.
+            </td>
+        </tr>
+        <tr>
+            <td>matchLineColor</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>When true, the label text color matches the series color. In S2, labels always use the series color regardless of this setting.</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
 ## Line direct labels (LineDirectLabel)
 
 The `LineDirectLabel` component is an S2-exclusive child of `Line`. It places an inline text label at the end of each line series by default, making multi-series charts readable without requiring a separate legend. Use the `position` prop to move labels to the start instead.
@@ -250,7 +331,7 @@ _* required_
 ## Line props (S2)
 
 :::note Not all base Line props are supported
-The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `MetricRange`, `Trendline`, or `LinePointAnnotation`. `LinePointAnnotation` is replaced by [`LineDirectLabel`](#line-direct-labels-linedirectlabel).
+The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `MetricRange`, or `Trendline`.
 :::
 
 <table>
@@ -265,9 +346,9 @@ The S2 `Line` component does not yet support `onMouseOver`, `onMouseOut`, `Metri
     <tbody>
         <tr>
             <td>children</td>
-            <td>ChartInspect | ChartPopover | LineDirectLabel | LineForecast</td>
+            <td>ChartInspect | ChartPopover | LineDirectLabel | LineForecast | LinePointAnnotation</td>
             <td>–</td>
-            <td>Optional child components for tooltips, popovers, inline direct labels, and forecast regions.</td>
+            <td>Optional child components for tooltips, popovers, inline direct labels, forecast regions, and point annotations.</td>
         </tr>
         <tr>
             <td>color</td>

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -94,9 +94,6 @@ The `LinePointAnnotation` component places a text label adjacent to each static 
 </Chart>
 ```
 
-![Line point annotation light](/img/s2_line_pointAnnotation_light.png#gh-light-mode-only)
-![Line point annotation dark](/img/s2_line_pointAnnotation_dark.png#gh-dark-mode-only)
-
 Labels are rendered in the series color with a background halo for legibility. The placement algorithm tries each position in the `anchor` array in order and uses the first one that fits within the chart bounds without overlapping other labels or points.
 
 ### Controlling label placement

--- a/packages/react-spectrum-charts-s2/src/components/LinePointAnnotation/LinePointAnnotation.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/LinePointAnnotation/LinePointAnnotation.tsx
@@ -10,15 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './linePointAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { LinePointAnnotationProps } from '../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const LinePointAnnotation: FC<LinePointAnnotationProps> = ({
+  anchor = ['right', 'top', 'bottom', 'left'],
+  matchLineColor = false,
+  textKey = 'annotation',
+}) => {
+  return null;
+};
+
+// displayName is used to validate the component type in the spec builder
+LinePointAnnotation.displayName = 'LinePointAnnotation';
+export { LinePointAnnotation };

--- a/packages/react-spectrum-charts-s2/src/components/LinePointAnnotation/index.ts
+++ b/packages/react-spectrum-charts-s2/src/components/LinePointAnnotation/index.ts
@@ -9,16 +9,4 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './linePointAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+export * from './LinePointAnnotation';

--- a/packages/react-spectrum-charts-s2/src/components/index.ts
+++ b/packages/react-spectrum-charts-s2/src/components/index.ts
@@ -21,6 +21,7 @@ export * from './Legend';
 export * from './Line';
 export * from './LineDirectLabel';
 export * from './LineForecast';
+export * from './LinePointAnnotation';
 export * from './LoadingState';
 export * from './ReferenceLine';
 export * from './Title';

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
@@ -259,6 +259,7 @@ describe('rscPropsToSpecBuilderOptions()', () => {
             hasOnClick: false,
             hasOnContextMenu: false,
             lineDirectLabels: [],
+            linePointAnnotations: [],
             markType: 'line',
             metric: 'value',
             name: 'line0',

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { createElement } from 'react';
+
+import { LinePointAnnotation } from '../components/LinePointAnnotation';
+
+// sanitizeChildren pre-filters children based on a validDisplayNames allowlist, so the
+// "no displayName" and "unknown displayName" branches inside childrenToOptions are only
+// reachable by controlling what sanitizeChildren returns. We mock the utils module here
+// to exercise those defensive branches directly.
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  sanitizeChildren: jest.fn(),
+}));
+
+// Import after the mock is declared so childrenAdapter picks up the mocked sanitizeChildren.
+import { sanitizeChildren } from '../utils';
+import { childrenToOptions } from './childrenAdapter';
+
+const mockSanitizeChildren = sanitizeChildren as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('childrenToOptions — LinePointAnnotation case', () => {
+  test('pushes props into linePointAnnotations when LinePointAnnotation is a child', () => {
+    mockSanitizeChildren.mockReturnValue([
+      createElement(LinePointAnnotation, { textKey: 'label', anchor: 'left' }),
+    ]);
+
+    const result = childrenToOptions(null);
+    expect(result.linePointAnnotations).toHaveLength(1);
+    expect(result.linePointAnnotations[0]).toEqual({ textKey: 'label', anchor: 'left' });
+  });
+
+  test('returns empty linePointAnnotations when no LinePointAnnotation children', () => {
+    mockSanitizeChildren.mockReturnValue([]);
+
+    const result = childrenToOptions(null);
+    expect(result.linePointAnnotations).toHaveLength(0);
+  });
+
+  test('collects multiple LinePointAnnotation children', () => {
+    mockSanitizeChildren.mockReturnValue([
+      createElement(LinePointAnnotation, { textKey: 'label', key: 'a' }),
+      createElement(LinePointAnnotation, { textKey: 'value', key: 'b' }),
+    ]);
+
+    const result = childrenToOptions(null);
+    expect(result.linePointAnnotations).toHaveLength(2);
+  });
+});
+
+describe('childrenToOptions — error cases', () => {
+  test('logs an error and skips a child with no displayName', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // A plain function has no displayName property on its type.
+    const NoDisplayName = () => null;
+    delete (NoDisplayName as unknown as Record<string, unknown>).displayName;
+    mockSanitizeChildren.mockReturnValue([createElement(NoDisplayName)]);
+
+    const result = childrenToOptions(null);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Invalid component type. Component is missing display name.'
+    );
+    // The child is skipped — no side effects on any collection.
+    expect(result.linePointAnnotations).toHaveLength(0);
+    expect(result.lines).toHaveLength(0);
+    consoleSpy.mockRestore();
+  });
+
+  test('logs an error for a child whose displayName is not handled by the switch', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const UnknownComponent = () => null;
+    (UnknownComponent as unknown as Record<string, unknown>).displayName = 'UnknownComponent';
+    mockSanitizeChildren.mockReturnValue([createElement(UnknownComponent)]);
+
+    const result = childrenToOptions(null);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Invalid component type: ',
+      'UnknownComponent'
+    );
+    // The child is skipped — no side effects on any collection.
+    expect(result.linePointAnnotations).toHaveLength(0);
+    expect(result.lines).toHaveLength(0);
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
@@ -21,6 +21,7 @@ import {
   LineForecastOptions,
   LineDirectLabelOptions,
   LineOptions,
+  LinePointAnnotationOptions,
   MarkOptions,
   ReferenceLineOptions,
   SegmentLabelOptions,
@@ -37,6 +38,7 @@ import { Legend } from '../components/Legend';
 import { Line } from '../components/Line';
 import { LineDirectLabel } from '../components/LineDirectLabel';
 import { LineForecast } from '../components/LineForecast';
+import { LinePointAnnotation } from '../components/LinePointAnnotation';
 import { ReferenceLine } from '../components/ReferenceLine';
 import { Title } from '../components/Title';
 import { Donut, DonutSummary, SegmentLabel } from '../rc';
@@ -52,6 +54,7 @@ import {
   LegendProps,
   LineForecastProps,
   LineDirectLabelProps,
+  LinePointAnnotationProps,
   LineProps,
   ReferenceLineProps,
   SegmentLabelProps,
@@ -79,6 +82,7 @@ export const childrenToOptions = (
   forecasts: LineForecastOptions[];
   legends: LegendOptions[];
   lineDirectLabels: LineDirectLabelOptions[];
+  linePointAnnotations: LinePointAnnotationOptions[];
   lines: LineOptions[];
   marks: MarkOptions[];
   referenceLines: ReferenceLineOptions[];
@@ -95,6 +99,7 @@ export const childrenToOptions = (
   const forecasts: LineForecastOptions[] = [];
   const legends: LegendOptions[] = [];
   const lineDirectLabels: LineDirectLabelOptions[] = [];
+  const linePointAnnotations: LinePointAnnotationOptions[] = [];
   const lines: LineOptions[] = [];
   const marks: MarkOptions[] = [];
   const referenceLines: ReferenceLineOptions[] = [];
@@ -151,6 +156,10 @@ export const childrenToOptions = (
         lineDirectLabels.push(child.props as LineDirectLabelProps);
         break;
 
+      case LinePointAnnotation.displayName:
+        linePointAnnotations.push(child.props as LinePointAnnotationProps);
+        break;
+
       case Line.displayName:
         marks.push(getLineOptions(child.props as LineProps));
         lines.push(getLineOptions(child.props as LineProps));
@@ -184,6 +193,7 @@ export const childrenToOptions = (
     forecasts,
     legends,
     lineDirectLabels,
+    linePointAnnotations,
     lines,
     marks,
     referenceLines,

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.test.ts
@@ -16,6 +16,7 @@ import { DEFAULT_COLOR } from '@spectrum-charts/constants';
 import { ChartPopover } from '../components/ChartPopover';
 import { ChartInspect } from '../components/ChartInspect';
 import { LineForecast } from '../components/LineForecast';
+import { LinePointAnnotation } from '../components/LinePointAnnotation';
 import { getLineOptions } from './lineAdapter';
 
 describe('getLineOptions()', () => {
@@ -53,6 +54,17 @@ describe('getLineOptions()', () => {
   it('should return empty forecasts array when no LineForecast children', () => {
     const options = getLineOptions({});
     expect(options.forecasts).toHaveLength(0);
+  });
+  it('should convert LinePointAnnotation children to linePointAnnotations array', () => {
+    const options = getLineOptions({
+      children: [createElement(LinePointAnnotation, { textKey: 'label', anchor: 'left' })],
+    });
+    expect(options.linePointAnnotations).toHaveLength(1);
+    expect(options.linePointAnnotations?.[0]).toEqual({ textKey: 'label', anchor: 'left' });
+  });
+  it('should return empty linePointAnnotations array when no LinePointAnnotation children', () => {
+    const options = getLineOptions({});
+    expect(options.linePointAnnotations).toHaveLength(0);
   });
   it('should pass through included props', () => {
     const options = getLineOptions({ color: DEFAULT_COLOR });

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/lineAdapter.ts
@@ -15,7 +15,7 @@ import { LineProps } from '../types';
 import { childrenToOptions } from './childrenAdapter';
 
 export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMode: _contextMenuMode, ...lineProps }: LineProps): LineOptions => {
-  const { chartInspects, chartPopovers, forecasts, lineDirectLabels } = childrenToOptions(children);
+  const { chartInspects, chartPopovers, forecasts, lineDirectLabels, linePointAnnotations } = childrenToOptions(children);
   return {
     ...lineProps,
     chartInspects,
@@ -24,6 +24,7 @@ export const getLineOptions = ({ children, onClick, onContextMenu, contextMenuMo
     hasOnClick: Boolean(onClick),
     hasOnContextMenu: Boolean(onContextMenu),
     lineDirectLabels,
+    linePointAnnotations,
     markType: 'line',
   };
 };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/LinePointAnnotation/LinePointAnnotation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/LinePointAnnotation/LinePointAnnotation.story.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../../Chart';
+import { Axis, Legend, Line, LinePointAnnotation } from '../../../../components';
+import useChartProps from '../../../../hooks/useChartProps';
+import { workspaceTrendsDataWithAnnotations } from '../../../../stories/data/data';
+import { bindWithProps } from '../../../../test-utils';
+import { ChartProps } from '../../../../types';
+
+export default {
+  title: 'React Spectrum Charts 2/Line/Features/Point Annotation',
+  component: LinePointAnnotation,
+};
+
+const defaultChartProps: ChartProps = {
+  data: workspaceTrendsDataWithAnnotations,
+  minWidth: 400,
+  maxWidth: 800,
+  height: 400,
+};
+
+const LinePointAnnotationStory: StoryFn<typeof LinePointAnnotation> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps} debug={true}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series" dimension="datetime" metric="value" scaleType="time" staticPoint="staticPoint">
+        <LinePointAnnotation {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const Basic = bindWithProps(LinePointAnnotationStory);
+Basic.args = {
+  textKey: 'label',
+};
+
+const MatchLineColor = bindWithProps(LinePointAnnotationStory);
+MatchLineColor.args = {
+  textKey: 'label',
+  matchLineColor: true,
+};
+
+const AnchorLeft = bindWithProps(LinePointAnnotationStory);
+AnchorLeft.args = {
+  textKey: 'label',
+  anchor: 'left',
+};
+
+const MultipleAnchors = bindWithProps(LinePointAnnotationStory);
+MultipleAnchors.args = {
+  textKey: 'label',
+  anchor: ['top', 'right', 'bottom', 'left'],
+};
+
+export { Basic, MatchLineColor, AnchorLeft, MultipleAnchors };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
@@ -11,7 +11,7 @@
  */
 import { FADE_FACTOR } from '@spectrum-charts/constants';
 
-import { Line } from '../../components';
+import { Line, LinePointAnnotation } from '../../components';
 import { workspaceTrendsData } from '../../stories/data/data';
 import {
   allElementsHaveAttributeValue,
@@ -38,6 +38,13 @@ import { LineType } from './Features/LineType.story';
 import { Opacity } from './Features/LineOpacity.story';
 import { ItemInspect, Inspect } from './Features/Inspect/LineInspect.story';
 import { TrendScale, LinearTrendScale } from './Features/TrendScale/LineTrendScale.story';
+
+describe('LinePointAnnotation', () => {
+  // LinePointAnnotation is not a real React component. This test provides coverage for sonarqube
+  test('LinePointAnnotation pseudo element', () => {
+    render(<LinePointAnnotation />);
+  });
+});
 
 describe('Line', () => {
   // Line is not a real React component. This is test just provides test coverage for sonarqube

--- a/packages/react-spectrum-charts-s2/src/stories/data/data.ts
+++ b/packages/react-spectrum-charts-s2/src/stories/data/data.ts
@@ -1227,3 +1227,20 @@ export const workspaceTrendsDataWithNullsInMetricRange = [
     staticPoint: true,
   },
 ];
+
+export const workspaceTrendsDataWithAnnotations = [
+  { datetime: 1667890800000, point: 1, value: 3738, users: 477, series: 'Add Fallout' },
+  { datetime: 1667977200000, point: 2, value: 2704, users: 481, series: 'Add Fallout', staticPoint: true, label: '2.7K' },
+  { datetime: 1668063600000, point: 3, value: 1730, users: 483, series: 'Add Fallout' },
+  { datetime: 1668150000000, point: 4, value: 465, users: 310, series: 'Add Fallout', staticPoint: true, label: '465' },
+  { datetime: 1668236400000, point: 5, value: 31, users: 18, series: 'Add Fallout' },
+  { datetime: 1668322800000, point: 8, value: 108, users: 70, series: 'Add Fallout', staticPoint: true, label: '108' },
+  { datetime: 1668409200000, point: 12, value: 648, users: 438, series: 'Add Fallout' },
+  { datetime: 1667890800000, point: 4, value: 12208, users: 5253, series: 'Add Freeform table', staticPoint: true, label: '12.2K' },
+  { datetime: 1667977200000, point: 5, value: 11309, users: 5103, series: 'Add Freeform table', staticPoint: true, label: '11.3K' },
+  { datetime: 1668063600000, point: 17, value: 11099, users: 5047, series: 'Add Freeform table' },
+  { datetime: 1668150000000, point: 20, value: 7243, users: 3386, series: 'Add Freeform table' },
+  { datetime: 1668236400000, point: 21, value: 395, users: 205, series: 'Add Freeform table' },
+  { datetime: 1668322800000, point: 22, value: 1606, users: 790, series: 'Add Freeform table' },
+  { datetime: 1668409200000, point: 25, value: 10932, users: 4913, series: 'Add Freeform table', staticPoint: true, label: '10.9K' },
+];

--- a/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/line.types.ts
@@ -16,6 +16,7 @@ import { LineOptions } from '@spectrum-charts/vega-spec-builder-s2';
 import { ChartPopoverElement, ChartInspectElement } from '../dialogs';
 import { LineForecastElement } from './supplemental/lineForecast.types';
 import { LineDirectLabelElement } from './supplemental/lineDirectLabel.types';
+import { LinePointAnnotationElement } from './supplemental/linePointAnnotation.types';
 import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
 
 /**
@@ -27,11 +28,11 @@ import { Children, ContextMenuCallback, MarkCallback } from '../util.types';
  */
 export type ContextMenuMode = 'interaction' | 'dimension' | 'item';
 
-type LineChildElement = ChartPopoverElement | ChartInspectElement | LineForecastElement | LineDirectLabelElement;
+type LineChildElement = ChartPopoverElement | ChartInspectElement | LineForecastElement | LineDirectLabelElement | LinePointAnnotationElement;
 export interface LineProps
   extends Omit<
     LineOptions,
-    'chartPopovers' | 'chartInspects' | 'forecasts' | 'hasOnClick' | 'hasOnContextMenu' | 'lineDirectLabels' | 'markType'
+    'chartPopovers' | 'chartInspects' | 'forecasts' | 'hasOnClick' | 'hasOnContextMenu' | 'lineDirectLabels' | 'linePointAnnotations' | 'markType'
   > {
   children?: Children<LineChildElement>;
   /** Callback that will be run when a point/section is clicked */

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/index.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/index.ts
@@ -15,4 +15,5 @@ export * from './barDirectLabel.types';
 export * from './dountSummary.types';
 export * from './lineForecast.types';
 export * from './lineDirectLabel.types';
+export * from './linePointAnnotation.types';
 export * from './segmentLabel.types';

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/linePointAnnotation.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/linePointAnnotation.types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { JSXElementConstructor, ReactElement } from 'react';
+
+import { LabelAnchor } from 'vega';
+
+export interface LinePointAnnotationProps {
+  /** Specifies where to position the annotation relative to the data point. When an array is provided, each position is tried in order until one fits within the chart bounds and doesn't overlap with other annotations or points. */
+  anchor?: LabelAnchor | LabelAnchor[];
+  /** When true, the annotation text color matches the line/series color. */
+  matchLineColor?: boolean;
+  /** The key in the data that has the text to display */
+  textKey?: string;
+}
+
+export type LinePointAnnotationElement = ReactElement<
+  LinePointAnnotationProps,
+  JSXElementConstructor<LinePointAnnotationProps>
+>;

--- a/packages/react-spectrum-charts-s2/src/utils/utils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.ts
@@ -36,6 +36,7 @@ import {
   Line,
   LineDirectLabel,
   LineForecast,
+  LinePointAnnotation,
   ReferenceLine,
   Title,
 } from '../components';
@@ -121,6 +122,7 @@ export const sanitizeChildren = (children: unknown): (ChartChildElement | MarkCh
     Line.displayName,
     LineDirectLabel.displayName,
     LineForecast.displayName,
+    LinePointAnnotation.displayName,
     ReferenceLine.displayName,
     SegmentLabel.displayName,
     Title.displayName,

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/index.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/index.ts
@@ -9,16 +9,4 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-export * from './barAnnotationSpec.types';
-export * from './barDirectLabelSpec.types';
-export * from './dountSummarySpec.types';
-export * from './metricRangeSpec.types';
-export * from './scatterAnnotationSpec.types';
-export * from './scatterPathSpec.types';
-export * from './segmentLabelSpec.types';
-export * from './lineDirectLabelSpec.types';
-export * from './trendlineSpec.types';
-export * from './trendlineAnnotationSpec.types';
-export * from './linePointAnnotationSpec.types';
-export * from './lineForecastSpec.types';
+export * from './linePointAnnotationUtils';

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+
+import { defaultLineOptions } from '../lineTestUtils';
+import {
+	getLinePointAnnotationMarks,
+	getLinePointAnnotationSpecOptions,
+} from './linePointAnnotationUtils';
+
+const lineOptionsWithAnnotations = {
+	...defaultLineOptions,
+	linePointAnnotations: [{}],
+	staticPoint: 'staticPoint',
+};
+
+describe('getLinePointAnnotationSpecOptions', () => {
+	test('applies default anchor when not provided', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 0, defaultLineOptions);
+		expect(result.anchor).toEqual(['right', 'top', 'bottom', 'left']);
+	});
+
+	test('preserves provided anchor string', () => {
+		const result = getLinePointAnnotationSpecOptions({ anchor: 'left' }, 0, defaultLineOptions);
+		expect(result.anchor).toBe('left');
+	});
+
+	test('preserves provided anchor array', () => {
+		const result = getLinePointAnnotationSpecOptions({ anchor: ['top', 'bottom'] }, 0, defaultLineOptions);
+		expect(result.anchor).toEqual(['top', 'bottom']);
+	});
+
+	test('defaults matchLineColor to false', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 0, defaultLineOptions);
+		expect(result.matchLineColor).toBe(false);
+	});
+
+	test('preserves matchLineColor=true', () => {
+		const result = getLinePointAnnotationSpecOptions({ matchLineColor: true }, 0, defaultLineOptions);
+		expect(result.matchLineColor).toBe(true);
+	});
+
+	test('falls back to lineOptions.metric when textKey not provided', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 0, defaultLineOptions);
+		expect(result.textKey).toBe(defaultLineOptions.metric);
+	});
+
+	test('uses provided textKey over lineOptions.metric', () => {
+		const result = getLinePointAnnotationSpecOptions({ textKey: 'label' }, 0, defaultLineOptions);
+		expect(result.textKey).toBe('label');
+	});
+
+	test('sets name from lineName and index', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 2, defaultLineOptions);
+		expect(result.name).toBe('line0Annotation2');
+	});
+
+	test('sets correct index', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 3, defaultLineOptions);
+		expect(result.index).toBe(3);
+	});
+
+	test('attaches lineOptions reference', () => {
+		const result = getLinePointAnnotationSpecOptions({}, 0, defaultLineOptions);
+		expect(result.lineOptions).toBe(defaultLineOptions);
+	});
+});
+
+describe('getLinePointAnnotationMarks', () => {
+	test('returns empty array when linePointAnnotations is empty', () => {
+		const marks = getLinePointAnnotationMarks(defaultLineOptions);
+		expect(marks).toHaveLength(0);
+	});
+
+	test('returns two marks per annotation (background halo + foreground text)', () => {
+		const marks = getLinePointAnnotationMarks(lineOptionsWithAnnotations);
+		expect(marks).toHaveLength(2);
+	});
+
+	test('returns four marks for two annotations', () => {
+		const marks = getLinePointAnnotationMarks({
+			...defaultLineOptions,
+			linePointAnnotations: [{}, {}],
+		});
+		expect(marks).toHaveLength(4);
+	});
+
+	describe('background mark', () => {
+		const getBackgroundMark = () => getLinePointAnnotationMarks(lineOptionsWithAnnotations)[0];
+
+		test('has correct name with _bg suffix', () => {
+			expect(getBackgroundMark().name).toBe('line0Annotation0_bg');
+		});
+
+		test('is a text mark', () => {
+			expect(getBackgroundMark().type).toBe('text');
+		});
+
+		test('is non-interactive', () => {
+			expect(getBackgroundMark().interactive).toBe(false);
+		});
+
+		test('reads from static points mark', () => {
+			expect(getBackgroundMark().from).toEqual({ data: 'line0_staticPoints' });
+		});
+
+		test('encodes text from datum.datum.textKey', () => {
+			const marks = getLinePointAnnotationMarks({ ...lineOptionsWithAnnotations, linePointAnnotations: [{ textKey: 'label' }] });
+			expect(marks[0].encode?.enter).toHaveProperty('text', { signal: 'datum.datum.label' });
+		});
+
+		test('falls back to metric as textKey', () => {
+			expect(getBackgroundMark().encode?.enter).toHaveProperty('text', { signal: `datum.datum.${defaultLineOptions.metric}` });
+		});
+
+		test('has transparent fill for halo-only rendering', () => {
+			expect(getBackgroundMark().encode?.enter).toHaveProperty('fill', { value: 'transparent' });
+		});
+
+		test('uses background color signal for stroke', () => {
+			expect(getBackgroundMark().encode?.enter).toHaveProperty('stroke', { signal: BACKGROUND_COLOR });
+		});
+
+		test('uses correct halo stroke width', () => {
+			expect(getBackgroundMark().encode?.enter).toHaveProperty('strokeWidth', { value: DIRECT_LABEL_BACKGROUND_STROKE_WIDTH });
+		});
+
+		test('applies font weight in update encoding', () => {
+			expect(getBackgroundMark().encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
+		});
+
+		test('has label transform', () => {
+			const transform = getBackgroundMark().transform;
+			expect(transform).toHaveLength(1);
+			expect(transform?.[0]).toHaveProperty('type', 'label');
+		});
+
+		test('label transform uses chart size signal', () => {
+			const transform = getBackgroundMark().transform?.[0] as { size: unknown };
+			expect(transform.size).toEqual({ signal: '[width, height]' });
+		});
+
+		test('label transform wraps single anchor string in array', () => {
+			const marks = getLinePointAnnotationMarks({ ...lineOptionsWithAnnotations, linePointAnnotations: [{ anchor: 'left' }] });
+			const transform = marks[0].transform?.[0] as { anchor: unknown };
+			expect(transform.anchor).toEqual(['left']);
+		});
+
+		test('label transform passes anchor array through unchanged', () => {
+			const marks = getLinePointAnnotationMarks({ ...lineOptionsWithAnnotations, linePointAnnotations: [{ anchor: ['top', 'right'] }] });
+			const transform = marks[0].transform?.[0] as { anchor: unknown };
+			expect(transform.anchor).toEqual(['top', 'right']);
+		});
+
+		test('label transform uses default anchor when none provided', () => {
+			const transform = getBackgroundMark().transform?.[0] as { anchor: unknown };
+			expect(transform.anchor).toEqual(['right', 'top', 'bottom', 'left']);
+		});
+	});
+
+	describe('foreground mark', () => {
+		const getForegroundMark = () => getLinePointAnnotationMarks(lineOptionsWithAnnotations)[1];
+
+		test('has correct name without suffix', () => {
+			expect(getForegroundMark().name).toBe('line0Annotation0');
+		});
+
+		test('is a text mark', () => {
+			expect(getForegroundMark().type).toBe('text');
+		});
+
+		test('is non-interactive', () => {
+			expect(getForegroundMark().interactive).toBe(false);
+		});
+
+		test('reads from background mark to inherit label transform positions', () => {
+			expect(getForegroundMark().from).toEqual({ data: 'line0Annotation0_bg' });
+		});
+
+		test('fill uses series color from static point stroke (datum.stroke)', () => {
+			expect(getForegroundMark().encode?.enter).toHaveProperty('fill', { field: 'datum.stroke' });
+		});
+
+		test('has no label transform', () => {
+			expect(getForegroundMark().transform).toBeUndefined();
+		});
+
+		test('update encodes text from background mark datum', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('text', { field: 'text' });
+		});
+
+		test('update encodes x position from label transform output', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('x', { field: 'x' });
+		});
+
+		test('update encodes y position from label transform output', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('y', { field: 'y' });
+		});
+
+		test('update encodes align from label transform output', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('align', { field: 'align' });
+		});
+
+		test('update encodes baseline from label transform output', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('baseline', { field: 'baseline' });
+		});
+
+		test('update encodes opacity from label transform output (0 when label cannot be placed)', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('opacity', { field: 'opacity' });
+		});
+
+		test('applies font weight in update encoding', () => {
+			expect(getForegroundMark().encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
+		});
+	});
+
+	describe('multiple annotations', () => {
+		test('second annotation background reads from the same static points mark', () => {
+			const marks = getLinePointAnnotationMarks({
+				...defaultLineOptions,
+				linePointAnnotations: [{}, {}],
+			});
+			expect(marks[2].from).toEqual({ data: 'line0_staticPoints' });
+		});
+
+		test('second annotation foreground reads from its own background mark', () => {
+			const marks = getLinePointAnnotationMarks({
+				...defaultLineOptions,
+				linePointAnnotations: [{}, {}],
+			});
+			expect(marks[3].from).toEqual({ data: 'line0Annotation1_bg' });
+		});
+
+		test('each annotation has unique names via index', () => {
+			const marks = getLinePointAnnotationMarks({
+				...defaultLineOptions,
+				linePointAnnotations: [{}, {}],
+			});
+			expect(marks[0].name).toBe('line0Annotation0_bg');
+			expect(marks[1].name).toBe('line0Annotation0');
+			expect(marks[2].name).toBe('line0Annotation1_bg');
+			expect(marks[3].name).toBe('line0Annotation1');
+		});
+	});
+});

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { defaultLineOptions } from '../lineTestUtils';
 import {
@@ -186,8 +187,18 @@ describe('getLinePointAnnotationMarks', () => {
 			expect(getForegroundMark().from).toEqual({ data: 'line0Annotation0_bg' });
 		});
 
-		test('fill uses series color from static point stroke (datum.stroke)', () => {
-			expect(getForegroundMark().encode?.enter).toHaveProperty('fill', { field: 'datum.stroke' });
+		test('fill defaults to black (gray-900) when matchLineColor is false', () => {
+			expect(getForegroundMark().encode?.enter).toHaveProperty('fill', {
+				value: getS2ColorValue('gray-900', defaultLineOptions.colorScheme),
+			});
+		});
+
+		test('fill uses series color from static point stroke when matchLineColor is true', () => {
+			const marks = getLinePointAnnotationMarks({
+				...lineOptionsWithAnnotations,
+				linePointAnnotations: [{ matchLineColor: true }],
+			});
+			expect(marks[1].encode?.enter).toHaveProperty('fill', { field: 'datum.stroke' });
 		});
 
 		test('has no label transform', () => {

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { TextMark } from 'vega';
+
+import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+
+import { LinePointAnnotationOptions, LinePointAnnotationSpecOptions, LineSpecOptions } from '../../types';
+
+export const getLinePointAnnotationSpecOptions = (
+	{ anchor = ['right', 'top', 'bottom', 'left'], matchLineColor = false, textKey }: LinePointAnnotationOptions,
+	index: number,
+	lineOptions: LineSpecOptions
+): LinePointAnnotationSpecOptions => {
+	return {
+		anchor,
+		matchLineColor,
+		textKey: textKey ?? lineOptions.metric,
+		index,
+		name: `${lineOptions.name}Annotation${index}`,
+		lineOptions,
+	};
+};
+
+export const getLinePointAnnotations = (lineOptions: LineSpecOptions): LinePointAnnotationSpecOptions[] => {
+	return lineOptions.linePointAnnotations.map((annotation, index) =>
+		getLinePointAnnotationSpecOptions(annotation, index, lineOptions)
+	);
+};
+
+export const getLinePointAnnotationMarks = (lineOptions: LineSpecOptions): TextMark[] => {
+	const annotations = getLinePointAnnotations(lineOptions);
+	const marks: TextMark[] = [];
+
+	for (const annotation of annotations) {
+		const { anchor, name: linePointAnnotationName, textKey } = annotation;
+		const bgMarkName = `${linePointAnnotationName}_bg`;
+
+		// Background mark: runs the label transform for collision-avoiding placement.
+		// Uses transparent fill + background-color stroke for the halo.
+		// Vega's canvas renderer draws fill then stroke, so using a single mark with both
+		// would have the stroke cover the fill. Two marks avoids this.
+		marks.push({
+			name: bgMarkName,
+			type: 'text',
+			interactive: false,
+			from: { data: `${lineOptions.name}_staticPoints` },
+			encode: {
+				enter: {
+					text: { signal: `datum.datum.${textKey}` },
+					fill: { value: 'transparent' },
+					stroke: { signal: BACKGROUND_COLOR },
+					strokeWidth: { value: DIRECT_LABEL_BACKGROUND_STROKE_WIDTH },
+				},
+				update: {
+					fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
+				},
+			},
+			transform: [
+				{
+					type: 'label',
+					size: { signal: '[width, height]' },
+					anchor: Array.isArray(anchor) ? anchor : [anchor],
+				},
+			],
+		});
+
+		// Foreground mark: reads from the background mark to inherit its label-transform-computed
+		// positions (x, y, align, baseline, opacity). In S2, static points have fill=background
+		// and stroke=series color, so datum.datum.stroke gives the correct series color for the text.
+		marks.push({
+			name: linePointAnnotationName,
+			type: 'text',
+			interactive: false,
+			from: { data: bgMarkName },
+			encode: {
+				enter: {
+					fill: { field: 'datum.stroke' },
+				},
+				update: {
+					text: { field: 'text' },
+					x: { field: 'x' },
+					y: { field: 'y' },
+					align: { field: 'align' },
+					baseline: { field: 'baseline' },
+					opacity: { field: 'opacity' },
+					fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
+				},
+			},
+		});
+	}
+
+	return marks;
+};

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
@@ -12,6 +12,7 @@
 import { TextMark } from 'vega';
 
 import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { LinePointAnnotationOptions, LinePointAnnotationSpecOptions, LineSpecOptions } from '../../types';
 
@@ -37,18 +38,15 @@ export const getLinePointAnnotations = (lineOptions: LineSpecOptions): LinePoint
 };
 
 export const getLinePointAnnotationMarks = (lineOptions: LineSpecOptions): TextMark[] => {
-	const annotations = getLinePointAnnotations(lineOptions);
-	const marks: TextMark[] = [];
-
-	for (const annotation of annotations) {
-		const { anchor, name: linePointAnnotationName, textKey } = annotation;
+	return getLinePointAnnotations(lineOptions).flatMap((annotation) => {
+		const { anchor, matchLineColor, name: linePointAnnotationName, textKey } = annotation;
 		const bgMarkName = `${linePointAnnotationName}_bg`;
 
 		// Background mark: runs the label transform for collision-avoiding placement.
 		// Uses transparent fill + background-color stroke for the halo.
 		// Vega's canvas renderer draws fill then stroke, so using a single mark with both
 		// would have the stroke cover the fill. Two marks avoids this.
-		marks.push({
+		const backgroundMark: TextMark = {
 			name: bgMarkName,
 			type: 'text',
 			interactive: false,
@@ -71,19 +69,22 @@ export const getLinePointAnnotationMarks = (lineOptions: LineSpecOptions): TextM
 					anchor: Array.isArray(anchor) ? anchor : [anchor],
 				},
 			],
-		});
+		};
 
 		// Foreground mark: reads from the background mark to inherit its label-transform-computed
-		// positions (x, y, align, baseline, opacity). In S2, static points have fill=background
-		// and stroke=series color, so datum.datum.stroke gives the correct series color for the text.
-		marks.push({
+		// positions (x, y, align, baseline, opacity). 
+		// When matchLineColor is true, the fill uses the series color from the static point stroke (datum.stroke); otherwise defaults to black.
+		const labelFill = matchLineColor
+			? { field: 'datum.stroke' }
+			: { value: getS2ColorValue('gray-900', lineOptions.colorScheme) };
+		const foregroundMark: TextMark = {
 			name: linePointAnnotationName,
 			type: 'text',
 			interactive: false,
 			from: { data: bgMarkName },
 			encode: {
 				enter: {
-					fill: { field: 'datum.stroke' },
+					fill: labelFill,
 				},
 				update: {
 					text: { field: 'text' },
@@ -95,8 +96,8 @@ export const getLinePointAnnotationMarks = (lineOptions: LineSpecOptions): TextM
 					fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
 				},
 			},
-		});
-	}
+		};
 
-	return marks;
+		return [backgroundMark, foregroundMark];
+	});
 };

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -596,6 +596,64 @@ describe('lineSpecBuilder', () => {
       expect(addLineMarks([], { ...defaultLineOptions, staticPoint: 'staticPoint' })).toStrictEqual(displayPointMarks);
     });
 
+    describe('with annotations', () => {
+      test('adds background and foreground annotation marks when staticPoint is set', () => {
+        const marks = addLineMarks([], {
+          ...defaultLineOptions,
+          staticPoint: 'staticPoint',
+          linePointAnnotations: [{}],
+        });
+        // line0_group + line0_staticPoints + line0Annotation0_bg + line0Annotation0
+        expect(marks).toHaveLength(4);
+        expect(marks[2]).toHaveProperty('name', 'line0Annotation0_bg');
+        expect(marks[3]).toHaveProperty('name', 'line0Annotation0');
+      });
+
+      test('adds background and foreground annotation marks when isSparkline is set', () => {
+        const marks = addLineMarks([], {
+          ...defaultLineOptions,
+          isSparkline: true,
+          linePointAnnotations: [{}],
+        });
+        // line0_group + line0_staticPoints + line0Annotation0_bg + line0Annotation0
+        expect(marks).toHaveLength(4);
+        expect(marks[2]).toHaveProperty('name', 'line0Annotation0_bg');
+        expect(marks[3]).toHaveProperty('name', 'line0Annotation0');
+      });
+
+      test('does not add annotation marks when neither staticPoint nor isSparkline is set', () => {
+        const marks = addLineMarks([], {
+          ...defaultLineOptions,
+          linePointAnnotations: [{}],
+        });
+        expect(marks).toHaveLength(1); // line0_group only
+        expect(marks.find((m) => m.name?.includes('Annotation'))).toBeUndefined();
+      });
+
+      test('does not add annotation marks when linePointAnnotations is empty', () => {
+        const marks = addLineMarks([], {
+          ...defaultLineOptions,
+          staticPoint: 'staticPoint',
+          linePointAnnotations: [],
+        });
+        expect(marks).toStrictEqual(displayPointMarks);
+      });
+
+      test('adds two pairs of marks for two annotations', () => {
+        const marks = addLineMarks([], {
+          ...defaultLineOptions,
+          staticPoint: 'staticPoint',
+          linePointAnnotations: [{}, {}],
+        });
+        // line0_group + line0_staticPoints + 2×(bg + fg)
+        expect(marks).toHaveLength(6);
+        expect(marks[2]).toHaveProperty('name', 'line0Annotation0_bg');
+        expect(marks[3]).toHaveProperty('name', 'line0Annotation0');
+        expect(marks[4]).toHaveProperty('name', 'line0Annotation1_bg');
+        expect(marks[5]).toHaveProperty('name', 'line0Annotation1');
+      });
+    });
+
     test('with displayPointMark and metric range', () => {
       expect(
         addLineMarks([], {

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -37,6 +37,7 @@ import { addHoveredItemSignal, getFirstRscSeriesIdSignal, getLastRscSeriesIdSign
 import { addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
 import { getLineDirectLabelData, getLineDirectLabelMarks, getLineDirectLabelSpecOptions } from '../lineDirectLabel';
 import { getForecastAlternateFlagTransform, getForecastEffectiveValueTransform, getLineForecastBoundaryMark, getLineForecastLabelMarks, getLineForecastSpecOptions } from '../lineForecast';
+import { getLinePointAnnotationMarks } from './linePointAnnotation';
 import { addTrendlineData, getTrendlineMarks, getTrendlineScales, setTrendlineSignals } from '../trendline';
 import { ColorScheme, HighlightedItem, LineOptions, LineSpecOptions, ScSpec } from '../types';
 import { getLineHighlightedData, getLineStaticPointData } from './lineDataUtils';
@@ -72,6 +73,7 @@ export const addLine = produce<
       index = 0,
       lineCap = 'round',
       lineDirectLabels = [],
+      linePointAnnotations = [],
       lineType = { value: 'solid' },
       metric = DEFAULT_METRIC,
       metricAxis,
@@ -103,6 +105,7 @@ export const addLine = produce<
       index,
       lineCap,
       lineDirectLabels,
+      linePointAnnotations,
       interactiveMarkName: getInteractiveMarkName(
         {
           chartPopovers,
@@ -254,7 +257,7 @@ export const setScales = produce<Scale[], [LineSpecOptions]>((scales, options) =
 
 // The order that marks are added is important since it determines the draw order.
 export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) => {
-  const { alternateSegmentKey, color, gradient, highlightedItem, isSparkline, lineType, name, opacity, staticPoint } = options;
+  const { alternateSegmentKey, color, gradient, highlightedItem, isSparkline, linePointAnnotations, lineType, name, opacity, staticPoint } = options;
   const forecasts = options.forecasts ?? [];
   const hasForecast = !alternateSegmentKey && forecasts.length > 0;
 
@@ -296,6 +299,9 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
     ],
   });
   if (staticPoint || isSparkline) marks.push(getLineStaticPoint(options));
+  if ((staticPoint || isSparkline) && linePointAnnotations.length > 0) {
+    marks.push(...getLinePointAnnotationMarks(options));
+  }
   marks.push(...getMetricRangeGroupMarks(options));
   if (isInteractive(options) || highlightedItem !== undefined) {
     marks.push(...getLineHoverMarks(markOptions, `${FILTERED_TABLE}ForInspect`));

--- a/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineTestUtils.ts
@@ -57,6 +57,7 @@ export const defaultLineOptions: LineSpecOptions = {
   colorScheme: DEFAULT_COLOR_SCHEME,
   interactiveMarkName: undefined,
   lineDirectLabels: [],
+  linePointAnnotations: [],
   popoverMarkName: undefined,
   trendlines: [],
   interpolate: undefined,

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -42,6 +42,7 @@ const defaultLineOptions: LineSpecOptions = {
 	index: 0,
 	interactiveMarkName: undefined,
 	lineDirectLabels: [],
+	linePointAnnotations: [],
 	lineType: { value: 'solid' },
 	markType: 'line',
 	metric: DEFAULT_METRIC,

--- a/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
@@ -64,6 +64,7 @@ const defaultLineOptions: LineSpecOptions = {
   index: 0,
   interactiveMarkName: undefined,
   lineDirectLabels: [],
+  linePointAnnotations: [],
   lineType: { value: 'solid' },
   markType: 'line',
   metric: DEFAULT_METRIC,

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineTestUtils.ts
@@ -41,6 +41,7 @@ export const defaultLineOptions: LineSpecOptions = {
   scaleType: 'time',
   interactiveMarkName: undefined,
   lineDirectLabels: [],
+  linePointAnnotations: [],
   popoverMarkName: undefined,
   lineCap: 'round',
   interpolate: undefined,

--- a/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
@@ -26,6 +26,7 @@ import {
 } from '../specUtil.types';
 import { LineForecastOptions } from './supplemental/lineForecastSpec.types';
 import { LineDirectLabelOptions } from './supplemental/lineDirectLabelSpec.types';
+import { LinePointAnnotationOptions } from './supplemental/linePointAnnotationSpec.types';
 import { MetricRangeOptions } from './supplemental/metricRangeSpec.types';
 import { TrendlineOptions } from './supplemental/trendlineSpec.types';
 
@@ -99,6 +100,7 @@ export interface LineOptions {
   chartInspects?: ChartInspectOptions[];
   forecasts?: LineForecastOptions[];
   lineDirectLabels?: LineDirectLabelOptions[];
+  linePointAnnotations?: LinePointAnnotationOptions[];
   metricRanges?: MetricRangeOptions[];
   trendlines?: TrendlineOptions[];
 }
@@ -114,6 +116,7 @@ type LineOptionsWithDefaults =
   | 'hasOnContextMenu'
   | 'lineCap'
   | 'lineDirectLabels'
+  | 'linePointAnnotations'
   | 'lineType'
   | 'metric'
   | 'metricRanges'

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/linePointAnnotationSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/linePointAnnotationSpec.types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { LabelAnchor } from 'vega';
+
+import { PartiallyRequired } from '../../specUtil.types';
+import { LineSpecOptions } from '../lineSpec.types';
+
+export interface LinePointAnnotationOptions {
+	/** Specifies where to position the annotation relative to the data point. When an array is provided, each position is tried in order until one fits within the chart bounds and doesn't overlap with other annotations or points. If no position fits, the annotation is not displayed. */
+	anchor?: LabelAnchor | LabelAnchor[];
+	/** When true, the annotation text color matches the line/series color. When false, uses the default text color from the theme. */
+	matchLineColor?: boolean;
+	/** The key in the data that has the text to display */
+	textKey?: string;
+}
+
+type LinePointAnnotationOptionsWithDefaults = 'anchor' | 'matchLineColor' | 'textKey';
+
+export interface LinePointAnnotationSpecOptions
+	extends PartiallyRequired<LinePointAnnotationOptions, LinePointAnnotationOptionsWithDefaults> {
+	index: number;
+	name: string;
+	lineOptions: LineSpecOptions;
+}


### PR DESCRIPTION
## Description

Adding LinePointAnnotation as an option for the Line chart in s2. 

## Related Issue

## Motivation and Context

Adding functionality to Line chart in s2. 

## How Has This Been Tested?

Visually through Storybook and all unit tests (new and old) are passing. 

## Screenshots (if appropriate):
<img width="884" height="444" alt="Screenshot 2026-05-29 at 3 51 56 PM" src="https://github.com/user-attachments/assets/0d652baf-14c8-4c96-8452-e6210fec2276" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
