### PR TITLE
Feat/direct label auto stack

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
@@ -14,7 +14,7 @@ import { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../../../Chart';
-import { Axis, ChartInspect, Legend, Line, LineDirectLabel } from '../../../../../components';
+import { Axis, Legend, Line, LineDirectLabel } from '../../../../../components';
 import useChartProps from '../../../../../hooks/useChartProps';
 import { workspaceTrendsData } from '../../../../../stories/data/data';
 import { bindWithProps } from '../../../../../test-utils';

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../../../Chart';
+import { Axis, ChartInspect, Legend, Line, LineDirectLabel } from '../../../../../components';
+import useChartProps from '../../../../../hooks/useChartProps';
+import { workspaceTrendsData } from '../../../../../stories/data/data';
+import { bindWithProps } from '../../../../../test-utils';
+import { ChartProps } from '../../../../../types';
+
+export default {
+  title: 'React Spectrum Charts 2/Line/Features/Direct Label/Cascade',
+  component: LineDirectLabel,
+  argTypes: {
+    value: {
+      control: { type: 'select' },
+      options: ['last', 'average', 'series'],
+    },
+    position: {
+      control: { type: 'select' },
+      options: ['start', 'end'],
+    },
+  },
+};
+
+const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400, backgroundColor: 'gray-50' };
+
+// DATA 
+
+const twoSeriesData = workspaceTrendsData
+  .filter((d) => d.series === 'Add Freeform table' || d.series === 'Add Fallout')
+  .map((d) => (d.series === 'Add Fallout' ? { ...d, users: d.users + 4000 } : d));
+
+// Three series that diverge near  the end to expose label overlap behavior
+const threeSeriesDivergingData = [
+  { datetime: 1667890800000, users: 1000, series: 'Series A' },
+  { datetime: 1667977200000, users: 1400, series: 'Series A' },
+  { datetime: 1668063600000, users: 1900, series: 'Series A' },
+  { datetime: 1668150000000, users: 2500, series: 'Series A' },
+  { datetime: 1668236400000, users: 3200, series: 'Series A' },
+  { datetime: 1668322800000, users: 4000, series: 'Series A' },
+  { datetime: 1668409200000, users: 5000, series: 'Series A' },
+
+  { datetime: 1667890800000, users: 2500, series: 'Series B' },
+  { datetime: 1667977200000, users: 2600, series: 'Series B' },
+  { datetime: 1668063600000, users: 2500, series: 'Series B' },
+  { datetime: 1668150000000, users: 2600, series: 'Series B' },
+  { datetime: 1668236400000, users: 2500, series: 'Series B' },
+  { datetime: 1668322800000, users: 2600, series: 'Series B' },
+  { datetime: 1668409200000, users: 2500, series: 'Series B' },
+
+  { datetime: 1667890800000, users: 5000, series: 'Series C' },
+  { datetime: 1667977200000, users: 4200, series: 'Series C' },
+  { datetime: 1668063600000, users: 3500, series: 'Series C' },
+  { datetime: 1668150000000, users: 2900, series: 'Series C' },
+  { datetime: 1668236400000, users: 1800, series: 'Series C' },
+  { datetime: 1668322800000, users: 1000, series: 'Series C' },
+  { datetime: 1668409200000, users: 400, series: 'Series C' },
+];
+
+// Six series: A/B/C cluster near ~3000 at the end, D/E cluster near ~1400, F isolated at ~300
+const sixSeriesData = [
+  { datetime: 1667890800000, users: 7000, series: 'Series A' },
+  { datetime: 1667977200000, users: 6200, series: 'Series A' },
+  { datetime: 1668063600000, users: 5400, series: 'Series A' },
+  { datetime: 1668150000000, users: 4400, series: 'Series A' },
+  { datetime: 1668236400000, users: 3600, series: 'Series A' },
+  { datetime: 1668322800000, users: 3100, series: 'Series A' },
+  { datetime: 1668409200000, users: 3050, series: 'Series A' },
+
+  { datetime: 1667890800000, users: 500, series: 'Series B' },
+  { datetime: 1667977200000, users: 1000, series: 'Series B' },
+  { datetime: 1668063600000, users: 1600, series: 'Series B' },
+  { datetime: 1668150000000, users: 2200, series: 'Series B' },
+  { datetime: 1668236400000, users: 2600, series: 'Series B' },
+  { datetime: 1668322800000, users: 2900, series: 'Series B' },
+  { datetime: 1668409200000, users: 2900, series: 'Series B' },
+
+  { datetime: 1667890800000, users: 3500, series: 'Series C' },
+  { datetime: 1667977200000, users: 3400, series: 'Series C' },
+  { datetime: 1668063600000, users: 3300, series: 'Series C' },
+  { datetime: 1668150000000, users: 3200, series: 'Series C' },
+  { datetime: 1668236400000, users: 3100, series: 'Series C' },
+  { datetime: 1668322800000, users: 3000, series: 'Series C' },
+  { datetime: 1668409200000, users: 2800, series: 'Series C' },
+
+  { datetime: 1667890800000, users: 2000, series: 'Series D' },
+  { datetime: 1667977200000, users: 2100, series: 'Series D' },
+  { datetime: 1668063600000, users: 1900, series: 'Series D' },
+  { datetime: 1668150000000, users: 1700, series: 'Series D' },
+  { datetime: 1668236400000, users: 1600, series: 'Series D' },
+  { datetime: 1668322800000, users: 1450, series: 'Series D' },
+  { datetime: 1668409200000, users: 1450, series: 'Series D' },
+
+  { datetime: 1667890800000, users: 800, series: 'Series E' },
+  { datetime: 1667977200000, users: 900, series: 'Series E' },
+  { datetime: 1668063600000, users: 1100, series: 'Series E' },
+  { datetime: 1668150000000, users: 1200, series: 'Series E' },
+  { datetime: 1668236400000, users: 1300, series: 'Series E' },
+  { datetime: 1668322800000, users: 1350, series: 'Series E' },
+  { datetime: 1668409200000, users: 1350, series: 'Series E' },
+
+  { datetime: 1667890800000, users: 600, series: 'Series F' },
+  { datetime: 1667977200000, users: 500, series: 'Series F' },
+  { datetime: 1668063600000, users: 450, series: 'Series F' },
+  { datetime: 1668150000000, users: 380, series: 'Series F' },
+  { datetime: 1668236400000, users: 350, series: 'Series F' },
+  { datetime: 1668322800000, users: 320, series: 'Series F' },
+  { datetime: 1668409200000, users: 300, series: 'Series F' },
+];
+
+// 20 series data to demonstrate what happens when labels cannot all fit on screen
+const manySeriesData = (
+    [
+        ['Series A',  9800, 9500],
+        ['Series B',  9000, 8700],
+        ['Series C',  8200, 7900],
+        ['Series D',  7500, 7200],
+        ['Series E',  6800, 6500],
+        ['Series F',  6100, 5800],
+        ['Series G',  5400, 5200],
+        ['Series H',  4800, 4600],
+        ['Series I',  4200, 4000],
+        ['Series J',  3600, 3400],
+        ['Series K',  3100, 2900],
+        ['Series L',  2600, 2400],
+        ['Series M',  2100, 1900],
+        ['Series N',  1700, 1500],
+        ['Series O',  1300, 1100],
+        ['Series P',  1000,  800],
+        ['Series Q',   700,  550],
+        ['Series R',   450,  350],
+        ['Series S',   250,  180],
+        ['Series T',   120,   60],
+    ] as [string, number, number][]
+).flatMap(([series, start, end]) =>
+    Array.from({ length: 7 }, (_, i) => ({
+        datetime: 1667890800000 + i * 86400000,
+        users: Math.round(start + (end - start) * (i / 6)),
+        series,
+    }))
+);
+
+// TEMPLATES
+
+const LineDirectLabelTwoSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: twoSeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelThreeSeriesDivergeStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesDivergingData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelSixSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: sixSeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelManySeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: manySeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+    </Chart>
+  );
+};
+
+const LineDirectLabelManySeriesLegendStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: manySeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+// BINDINGS
+
+const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
+DirectLabelTwoSeries.args = { value: 'last' };
+
+const DirectLabelThreeSeriesDiverge = bindWithProps(LineDirectLabelThreeSeriesDivergeStory);
+DirectLabelThreeSeriesDiverge.args = { value: 'last' };
+
+const DirectLabelSixSeries = bindWithProps(LineDirectLabelSixSeriesStory);
+DirectLabelSixSeries.args = { value: 'last' };
+
+const DirectLabelManySeries = bindWithProps(LineDirectLabelManySeriesStory);
+DirectLabelManySeries.args = { value: 'last' };
+
+const DirectLabelManySeriesLegend = bindWithProps(LineDirectLabelManySeriesLegendStory);
+DirectLabelManySeriesLegend.args = { value: 'last' };
+
+export {
+  DirectLabelTwoSeries,
+  DirectLabelThreeSeriesDiverge,
+  DirectLabelSixSeries,
+  DirectLabelManySeries,
+  DirectLabelManySeriesLegend,
+};

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -39,146 +39,7 @@ const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400
 
 // DATA 
 
-const twoSeriesData = workspaceTrendsData
-  .filter((d) => d.series === 'Add Freeform table' || d.series === 'Add Fallout')
-  .map((d) => (d.series === 'Add Fallout' ? { ...d, users: d.users + 4000 } : d));
 
-// Three series that converge near the same value at the end to expose label overlap behavior
-const threeSeriesConvergingData = [
-  { datetime: 1667890800000, users: 5200, series: 'Series A' },
-  { datetime: 1667977200000, users: 4600, series: 'Series A' },
-  { datetime: 1668063600000, users: 4000, series: 'Series A' },
-  { datetime: 1668150000000, users: 3200, series: 'Series A' },
-  { datetime: 1668236400000, users: 2600, series: 'Series A' },
-  { datetime: 1668322800000, users: 2200, series: 'Series A' },
-  { datetime: 1668409200000, users: 2050, series: 'Series A' },
-
-  { datetime: 1667890800000, users: 400, series: 'Series B' },
-  { datetime: 1667977200000, users: 800, series: 'Series B' },
-  { datetime: 1668063600000, users: 1200, series: 'Series B' },
-  { datetime: 1668150000000, users: 1600, series: 'Series B' },
-  { datetime: 1668236400000, users: 1800, series: 'Series B' },
-  { datetime: 1668322800000, users: 1950, series: 'Series B' },
-  { datetime: 1668409200000, users: 1900, series: 'Series B' },
-
-  { datetime: 1667890800000, users: 2400, series: 'Series C' },
-  { datetime: 1667977200000, users: 2300, series: 'Series C' },
-  { datetime: 1668063600000, users: 2200, series: 'Series C' },
-  { datetime: 1668150000000, users: 2100, series: 'Series C' },
-  { datetime: 1668236400000, users: 2050, series: 'Series C' },
-  { datetime: 1668322800000, users: 2000, series: 'Series C' },
-  { datetime: 1668409200000, users: 2000, series: 'Series C' },
-];
-
-// Three series that diverge near  the end to expose label overlap behavior
-const threeSeriesDivergingData = [
-  { datetime: 1667890800000, users: 1000, series: 'Series A' },
-  { datetime: 1667977200000, users: 1400, series: 'Series A' },
-  { datetime: 1668063600000, users: 1900, series: 'Series A' },
-  { datetime: 1668150000000, users: 2500, series: 'Series A' },
-  { datetime: 1668236400000, users: 3200, series: 'Series A' },
-  { datetime: 1668322800000, users: 4000, series: 'Series A' },
-  { datetime: 1668409200000, users: 5000, series: 'Series A' },
-
-  { datetime: 1667890800000, users: 2500, series: 'Series B' },
-  { datetime: 1667977200000, users: 2600, series: 'Series B' },
-  { datetime: 1668063600000, users: 2500, series: 'Series B' },
-  { datetime: 1668150000000, users: 2600, series: 'Series B' },
-  { datetime: 1668236400000, users: 2500, series: 'Series B' },
-  { datetime: 1668322800000, users: 2600, series: 'Series B' },
-  { datetime: 1668409200000, users: 2500, series: 'Series B' },
-
-  { datetime: 1667890800000, users: 5000, series: 'Series C' },
-  { datetime: 1667977200000, users: 4200, series: 'Series C' },
-  { datetime: 1668063600000, users: 3500, series: 'Series C' },
-  { datetime: 1668150000000, users: 2900, series: 'Series C' },
-  { datetime: 1668236400000, users: 1800, series: 'Series C' },
-  { datetime: 1668322800000, users: 1000, series: 'Series C' },
-  { datetime: 1668409200000, users: 400, series: 'Series C' },
-];
-
-// Six series: A/B/C cluster near ~3000 at the end, D/E cluster near ~1400, F isolated at ~300
-const sixSeriesData = [
-  { datetime: 1667890800000, users: 7000, series: 'Series A' },
-  { datetime: 1667977200000, users: 6200, series: 'Series A' },
-  { datetime: 1668063600000, users: 5400, series: 'Series A' },
-  { datetime: 1668150000000, users: 4400, series: 'Series A' },
-  { datetime: 1668236400000, users: 3600, series: 'Series A' },
-  { datetime: 1668322800000, users: 3100, series: 'Series A' },
-  { datetime: 1668409200000, users: 3050, series: 'Series A' },
-
-  { datetime: 1667890800000, users: 500, series: 'Series B' },
-  { datetime: 1667977200000, users: 1000, series: 'Series B' },
-  { datetime: 1668063600000, users: 1600, series: 'Series B' },
-  { datetime: 1668150000000, users: 2200, series: 'Series B' },
-  { datetime: 1668236400000, users: 2600, series: 'Series B' },
-  { datetime: 1668322800000, users: 2900, series: 'Series B' },
-  { datetime: 1668409200000, users: 2900, series: 'Series B' },
-
-  { datetime: 1667890800000, users: 3500, series: 'Series C' },
-  { datetime: 1667977200000, users: 3400, series: 'Series C' },
-  { datetime: 1668063600000, users: 3300, series: 'Series C' },
-  { datetime: 1668150000000, users: 3200, series: 'Series C' },
-  { datetime: 1668236400000, users: 3100, series: 'Series C' },
-  { datetime: 1668322800000, users: 3000, series: 'Series C' },
-  { datetime: 1668409200000, users: 2800, series: 'Series C' },
-
-  { datetime: 1667890800000, users: 2000, series: 'Series D' },
-  { datetime: 1667977200000, users: 2100, series: 'Series D' },
-  { datetime: 1668063600000, users: 1900, series: 'Series D' },
-  { datetime: 1668150000000, users: 1700, series: 'Series D' },
-  { datetime: 1668236400000, users: 1600, series: 'Series D' },
-  { datetime: 1668322800000, users: 1450, series: 'Series D' },
-  { datetime: 1668409200000, users: 1450, series: 'Series D' },
-
-  { datetime: 1667890800000, users: 800, series: 'Series E' },
-  { datetime: 1667977200000, users: 900, series: 'Series E' },
-  { datetime: 1668063600000, users: 1100, series: 'Series E' },
-  { datetime: 1668150000000, users: 1200, series: 'Series E' },
-  { datetime: 1668236400000, users: 1300, series: 'Series E' },
-  { datetime: 1668322800000, users: 1350, series: 'Series E' },
-  { datetime: 1668409200000, users: 1350, series: 'Series E' },
-
-  { datetime: 1667890800000, users: 600, series: 'Series F' },
-  { datetime: 1667977200000, users: 500, series: 'Series F' },
-  { datetime: 1668063600000, users: 450, series: 'Series F' },
-  { datetime: 1668150000000, users: 380, series: 'Series F' },
-  { datetime: 1668236400000, users: 350, series: 'Series F' },
-  { datetime: 1668322800000, users: 320, series: 'Series F' },
-  { datetime: 1668409200000, users: 300, series: 'Series F' },
-];
-
-// 20 series data to demonstrate what happens when labels cannot all fit on screen
-const manySeriesData = (
-	[
-		['Series A',  9800, 9500],
-		['Series B',  9000, 8700],
-		['Series C',  8200, 7900],
-		['Series D',  7500, 7200],
-		['Series E',  6800, 6500],
-		['Series F',  6100, 5800],
-		['Series G',  5400, 5200],
-		['Series H',  4800, 4600],
-		['Series I',  4200, 4000],
-		['Series J',  3600, 3400],
-		['Series K',  3100, 2900],
-		['Series L',  2600, 2400],
-		['Series M',  2100, 1900],
-		['Series N',  1700, 1500],
-		['Series O',  1300, 1100],
-		['Series P',  1000,  800],
-		['Series Q',   700,  550],
-		['Series R',   450,  350],
-		['Series S',   250,  180],
-		['Series T',   120,   60],
-	] as [string, number, number][]
-).flatMap(([series, start, end]) =>
-	Array.from({ length: 7 }, (_, i) => ({
-		datetime: 1667890800000 + i * 86400000,
-		users: Math.round(start + (end - start) * (i / 6)),
-		series,
-	}))
-);
 
 // TEMPLATES
 
@@ -211,76 +72,6 @@ const LineDirectLabelWithInspectStory: StoryFn<typeof LineDirectLabel> = (args):
   );
 };
 
-const LineDirectLabelTwoSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: twoSeriesData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const LineDirectLabelThreeSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesConvergingData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const LineDirectLabelThreeSeriesDivergeStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesDivergingData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const LineDirectLabelSixSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: sixSeriesData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const LineDirectLabelManySeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: manySeriesData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
 // BINDINGS
 
 const DirectLabelDefault = bindWithProps(LineDirectLabelStory);
@@ -295,21 +86,6 @@ DirectLabelValueAverage.args = { value: 'average' };
 const DirectLabelWithInspect = bindWithProps(LineDirectLabelWithInspectStory);
 DirectLabelWithInspect.args = { value: 'last' };
 
-const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
-DirectLabelTwoSeries.args = { value: 'last' };
-
-const DirectLabelThreePlusSeries = bindWithProps(LineDirectLabelThreeSeriesStory);
-DirectLabelThreePlusSeries.args = { value: 'last' };
-
-const DirectLabelThreeSeriesDiverge = bindWithProps(LineDirectLabelThreeSeriesDivergeStory);
-DirectLabelThreeSeriesDiverge.args = { value: 'last' };
-
-const DirectLabelSixSeries = bindWithProps(LineDirectLabelSixSeriesStory);
-DirectLabelSixSeries.args = { value: 'last' };
-
-const DirectLabelManySeries = bindWithProps(LineDirectLabelManySeriesStory);
-DirectLabelManySeries.args = { value: 'last' };
-
 const DirectLabelPositionStart = bindWithProps(LineDirectLabelStory);
 DirectLabelPositionStart.args = { value: 'series', position: 'start' };
 
@@ -318,10 +94,5 @@ export {
   DirectLabelValueLast,
   DirectLabelValueAverage,
   DirectLabelPositionStart,
-  DirectLabelTwoSeries,
-  DirectLabelThreePlusSeries,
-  DirectLabelThreeSeriesDiverge,
-  DirectLabelSixSeries,
-  DirectLabelManySeries,
   DirectLabelWithInspect,
 };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -41,6 +41,33 @@ const twoSeriesData = workspaceTrendsData
   .filter((d) => d.series === 'Add Freeform table' || d.series === 'Add Fallout')
   .map((d) => (d.series === 'Add Fallout' ? { ...d, users: d.users + 4000 } : d));
 
+// Three series that converge near the same value at the end to expose label overlap behavior
+const threeSeriesConvergingData = [
+  { datetime: 1667890800000, users: 5200, series: 'Series A' },
+  { datetime: 1667977200000, users: 4600, series: 'Series A' },
+  { datetime: 1668063600000, users: 4000, series: 'Series A' },
+  { datetime: 1668150000000, users: 3200, series: 'Series A' },
+  { datetime: 1668236400000, users: 2600, series: 'Series A' },
+  { datetime: 1668322800000, users: 2200, series: 'Series A' },
+  { datetime: 1668409200000, users: 2050, series: 'Series A' },
+
+  { datetime: 1667890800000, users: 400, series: 'Series B' },
+  { datetime: 1667977200000, users: 800, series: 'Series B' },
+  { datetime: 1668063600000, users: 1200, series: 'Series B' },
+  { datetime: 1668150000000, users: 1600, series: 'Series B' },
+  { datetime: 1668236400000, users: 1800, series: 'Series B' },
+  { datetime: 1668322800000, users: 1950, series: 'Series B' },
+  { datetime: 1668409200000, users: 1900, series: 'Series B' },
+
+  { datetime: 1667890800000, users: 2400, series: 'Series C' },
+  { datetime: 1667977200000, users: 2300, series: 'Series C' },
+  { datetime: 1668063600000, users: 2200, series: 'Series C' },
+  { datetime: 1668150000000, users: 2100, series: 'Series C' },
+  { datetime: 1668236400000, users: 2050, series: 'Series C' },
+  { datetime: 1668322800000, users: 2000, series: 'Series C' },
+  { datetime: 1668409200000, users: 2000, series: 'Series C' },
+];
+
 const LineDirectLabelStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
   const chartProps = useChartProps(defaultChartProps);
   return (
@@ -99,7 +126,92 @@ DirectLabelWithInspect.args = { value: 'last' };
 const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
 DirectLabelTwoSeries.args = { value: 'last' };
 
+const LineDirectLabelThreeSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesConvergingData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const DirectLabelThreePlusSeries = bindWithProps(LineDirectLabelThreeSeriesStory);
+DirectLabelThreePlusSeries.args = { value: 'last' };
+
+// Six series: A/B/C cluster near ~3000 at the end, D/E cluster near ~1400, F isolated at ~300
+const sixSeriesData = [
+  { datetime: 1667890800000, users: 7000, series: 'Series A' },
+  { datetime: 1667977200000, users: 6200, series: 'Series A' },
+  { datetime: 1668063600000, users: 5400, series: 'Series A' },
+  { datetime: 1668150000000, users: 4400, series: 'Series A' },
+  { datetime: 1668236400000, users: 3600, series: 'Series A' },
+  { datetime: 1668322800000, users: 3100, series: 'Series A' },
+  { datetime: 1668409200000, users: 3050, series: 'Series A' },
+
+  { datetime: 1667890800000, users: 500, series: 'Series B' },
+  { datetime: 1667977200000, users: 1000, series: 'Series B' },
+  { datetime: 1668063600000, users: 1600, series: 'Series B' },
+  { datetime: 1668150000000, users: 2200, series: 'Series B' },
+  { datetime: 1668236400000, users: 2600, series: 'Series B' },
+  { datetime: 1668322800000, users: 2900, series: 'Series B' },
+  { datetime: 1668409200000, users: 2900, series: 'Series B' },
+
+  { datetime: 1667890800000, users: 3500, series: 'Series C' },
+  { datetime: 1667977200000, users: 3400, series: 'Series C' },
+  { datetime: 1668063600000, users: 3300, series: 'Series C' },
+  { datetime: 1668150000000, users: 3200, series: 'Series C' },
+  { datetime: 1668236400000, users: 3100, series: 'Series C' },
+  { datetime: 1668322800000, users: 3000, series: 'Series C' },
+  { datetime: 1668409200000, users: 2800, series: 'Series C' },
+
+  { datetime: 1667890800000, users: 2000, series: 'Series D' },
+  { datetime: 1667977200000, users: 2100, series: 'Series D' },
+  { datetime: 1668063600000, users: 1900, series: 'Series D' },
+  { datetime: 1668150000000, users: 1700, series: 'Series D' },
+  { datetime: 1668236400000, users: 1600, series: 'Series D' },
+  { datetime: 1668322800000, users: 1450, series: 'Series D' },
+  { datetime: 1668409200000, users: 1450, series: 'Series D' },
+
+  { datetime: 1667890800000, users: 800, series: 'Series E' },
+  { datetime: 1667977200000, users: 900, series: 'Series E' },
+  { datetime: 1668063600000, users: 1100, series: 'Series E' },
+  { datetime: 1668150000000, users: 1200, series: 'Series E' },
+  { datetime: 1668236400000, users: 1300, series: 'Series E' },
+  { datetime: 1668322800000, users: 1350, series: 'Series E' },
+  { datetime: 1668409200000, users: 1350, series: 'Series E' },
+
+  { datetime: 1667890800000, users: 600, series: 'Series F' },
+  { datetime: 1667977200000, users: 500, series: 'Series F' },
+  { datetime: 1668063600000, users: 450, series: 'Series F' },
+  { datetime: 1668150000000, users: 380, series: 'Series F' },
+  { datetime: 1668236400000, users: 350, series: 'Series F' },
+  { datetime: 1668322800000, users: 320, series: 'Series F' },
+  { datetime: 1668409200000, users: 300, series: 'Series F' },
+];
+
+const LineDirectLabelSixSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: sixSeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const DirectLabelSixSeries = bindWithProps(LineDirectLabelSixSeriesStory);
+DirectLabelSixSeries.args = { value: 'last' };
+
 const DirectLabelPositionStart = bindWithProps(LineDirectLabelStory);
 DirectLabelPositionStart.args = { value: 'series', position: 'start' };
 
-export { DirectLabelDefault, DirectLabelValueLast, DirectLabelValueAverage, DirectLabelWithInspect, DirectLabelTwoSeries, DirectLabelPositionStart };
+export { DirectLabelDefault, DirectLabelValueLast, DirectLabelValueAverage, DirectLabelWithInspect, DirectLabelTwoSeries, DirectLabelThreePlusSeries, DirectLabelSixSeries, DirectLabelPositionStart };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -37,6 +37,8 @@ export default {
 
 const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400, backgroundColor: 'gray-50' };
 
+// DATA 
+
 const twoSeriesData = workspaceTrendsData
   .filter((d) => d.series === 'Add Freeform table' || d.series === 'Add Fallout')
   .map((d) => (d.series === 'Add Fallout' ? { ...d, users: d.users + 4000 } : d));
@@ -68,80 +70,32 @@ const threeSeriesConvergingData = [
   { datetime: 1668409200000, users: 2000, series: 'Series C' },
 ];
 
-const LineDirectLabelStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps(defaultChartProps);
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
+// Three series that diverge near  the end to expose label overlap behavior
+const threeSeriesDivergingData = [
+  { datetime: 1667890800000, users: 1000, series: 'Series A' },
+  { datetime: 1667977200000, users: 1400, series: 'Series A' },
+  { datetime: 1668063600000, users: 1900, series: 'Series A' },
+  { datetime: 1668150000000, users: 2500, series: 'Series A' },
+  { datetime: 1668236400000, users: 3200, series: 'Series A' },
+  { datetime: 1668322800000, users: 4000, series: 'Series A' },
+  { datetime: 1668409200000, users: 5000, series: 'Series A' },
 
-const LineDirectLabelWithInspectStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps(defaultChartProps);
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-        <ChartInspect>{(datum: Record<string, string>) => <div>{datum.users}</div>}</ChartInspect>
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
+  { datetime: 1667890800000, users: 2500, series: 'Series B' },
+  { datetime: 1667977200000, users: 2600, series: 'Series B' },
+  { datetime: 1668063600000, users: 2500, series: 'Series B' },
+  { datetime: 1668150000000, users: 2600, series: 'Series B' },
+  { datetime: 1668236400000, users: 2500, series: 'Series B' },
+  { datetime: 1668322800000, users: 2600, series: 'Series B' },
+  { datetime: 1668409200000, users: 2500, series: 'Series B' },
 
-const LineDirectLabelTwoSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: twoSeriesData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const DirectLabelDefault = bindWithProps(LineDirectLabelStory);
-DirectLabelDefault.args = { value: 'series' };
-
-const DirectLabelValueLast = bindWithProps(LineDirectLabelStory);
-DirectLabelValueLast.args = { value: 'last' };
-
-const DirectLabelValueAverage = bindWithProps(LineDirectLabelStory);
-DirectLabelValueAverage.args = { value: 'average' };
-
-const DirectLabelWithInspect = bindWithProps(LineDirectLabelWithInspectStory);
-DirectLabelWithInspect.args = { value: 'last' };
-
-const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
-DirectLabelTwoSeries.args = { value: 'last' };
-
-const LineDirectLabelThreeSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesConvergingData });
-  return (
-    <Chart {...chartProps} debug>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line dimension="datetime" metric="users" color="series" scaleType="time">
-        <LineDirectLabel {...args} />
-      </Line>
-      <Legend highlight />
-    </Chart>
-  );
-};
-
-const DirectLabelThreePlusSeries = bindWithProps(LineDirectLabelThreeSeriesStory);
-DirectLabelThreePlusSeries.args = { value: 'last' };
+  { datetime: 1667890800000, users: 5000, series: 'Series C' },
+  { datetime: 1667977200000, users: 4200, series: 'Series C' },
+  { datetime: 1668063600000, users: 3500, series: 'Series C' },
+  { datetime: 1668150000000, users: 2900, series: 'Series C' },
+  { datetime: 1668236400000, users: 1800, series: 'Series C' },
+  { datetime: 1668322800000, users: 1000, series: 'Series C' },
+  { datetime: 1668409200000, users: 400, series: 'Series C' },
+];
 
 // Six series: A/B/C cluster near ~3000 at the end, D/E cluster near ~1400, F isolated at ~300
 const sixSeriesData = [
@@ -194,6 +148,111 @@ const sixSeriesData = [
   { datetime: 1668409200000, users: 300, series: 'Series F' },
 ];
 
+// 20 series data to demonstrate what happens when labels cannot all fit on screen
+const manySeriesData = (
+	[
+		['Series A',  9800, 9500],
+		['Series B',  9000, 8700],
+		['Series C',  8200, 7900],
+		['Series D',  7500, 7200],
+		['Series E',  6800, 6500],
+		['Series F',  6100, 5800],
+		['Series G',  5400, 5200],
+		['Series H',  4800, 4600],
+		['Series I',  4200, 4000],
+		['Series J',  3600, 3400],
+		['Series K',  3100, 2900],
+		['Series L',  2600, 2400],
+		['Series M',  2100, 1900],
+		['Series N',  1700, 1500],
+		['Series O',  1300, 1100],
+		['Series P',  1000,  800],
+		['Series Q',   700,  550],
+		['Series R',   450,  350],
+		['Series S',   250,  180],
+		['Series T',   120,   60],
+	] as [string, number, number][]
+).flatMap(([series, start, end]) =>
+	Array.from({ length: 7 }, (_, i) => ({
+		datetime: 1667890800000 + i * 86400000,
+		users: Math.round(start + (end - start) * (i / 6)),
+		series,
+	}))
+);
+
+// TEMPLATES
+
+const LineDirectLabelStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelWithInspectStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+        <ChartInspect>{(datum: Record<string, string>) => <div>{datum.users}</div>}</ChartInspect>
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelTwoSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: twoSeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelThreeSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesConvergingData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const LineDirectLabelThreeSeriesDivergeStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: threeSeriesDivergingData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
 const LineDirectLabelSixSeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
   const chartProps = useChartProps({ ...defaultChartProps, data: sixSeriesData });
   return (
@@ -208,10 +267,61 @@ const LineDirectLabelSixSeriesStory: StoryFn<typeof LineDirectLabel> = (args): R
   );
 };
 
+const LineDirectLabelManySeriesStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: manySeriesData });
+  return (
+    <Chart {...chartProps} debug>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time">
+        <LineDirectLabel {...args} />
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+// BINDINGS
+
+const DirectLabelDefault = bindWithProps(LineDirectLabelStory);
+DirectLabelDefault.args = { value: 'series' };
+
+const DirectLabelValueLast = bindWithProps(LineDirectLabelStory);
+DirectLabelValueLast.args = { value: 'last' };
+
+const DirectLabelValueAverage = bindWithProps(LineDirectLabelStory);
+DirectLabelValueAverage.args = { value: 'average' };
+
+const DirectLabelWithInspect = bindWithProps(LineDirectLabelWithInspectStory);
+DirectLabelWithInspect.args = { value: 'last' };
+
+const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
+DirectLabelTwoSeries.args = { value: 'last' };
+
+const DirectLabelThreePlusSeries = bindWithProps(LineDirectLabelThreeSeriesStory);
+DirectLabelThreePlusSeries.args = { value: 'last' };
+
+const DirectLabelThreeSeriesDiverge = bindWithProps(LineDirectLabelThreeSeriesDivergeStory);
+DirectLabelThreeSeriesDiverge.args = { value: 'last' };
+
 const DirectLabelSixSeries = bindWithProps(LineDirectLabelSixSeriesStory);
 DirectLabelSixSeries.args = { value: 'last' };
+
+const DirectLabelManySeries = bindWithProps(LineDirectLabelManySeriesStory);
+DirectLabelManySeries.args = { value: 'last' };
 
 const DirectLabelPositionStart = bindWithProps(LineDirectLabelStory);
 DirectLabelPositionStart.args = { value: 'series', position: 'start' };
 
-export { DirectLabelDefault, DirectLabelValueLast, DirectLabelValueAverage, DirectLabelWithInspect, DirectLabelTwoSeries, DirectLabelThreePlusSeries, DirectLabelSixSeries, DirectLabelPositionStart };
+export {
+  DirectLabelDefault,
+  DirectLabelValueLast,
+  DirectLabelValueAverage,
+  DirectLabelPositionStart,
+  DirectLabelTwoSeries,
+  DirectLabelThreePlusSeries,
+  DirectLabelThreeSeriesDiverge,
+  DirectLabelSixSeries,
+  DirectLabelManySeries,
+  DirectLabelWithInspect,
+};

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -181,17 +181,40 @@ describe('getLineDirectLabelData', () => {
 		expect(excludeFilter).toBeUndefined();
 	});
 
-	test('includes series count and rank transforms', () => {
+	test('includes rank window transform', () => {
 		const data = getLineDirectLabelData('line0', defaultLabelSpecOptions, defaultLineOptions);
 		const transforms = getTransforms(data);
-		const countAgg = transforms.find(
-			(t) => t.type === 'joinaggregate' && 'as' in t && asArray(t.as).includes('_seriesCount')
-		);
 		const rankWindow = transforms.find(
 			(t) => t.type === 'window' && 'as' in t && asArray(t.as).includes('_metricRank')
 		);
-		expect(countAgg).toBeDefined();
 		expect(rankWindow).toBeDefined();
+	});
+
+	test('includes _scaledY formula transform', () => {
+		const data = getLineDirectLabelData('line0', defaultLabelSpecOptions, defaultLineOptions);
+		const transforms = getTransforms(data);
+		const formula = transforms.find((t) => t.type === 'formula' && 'as' in t && t.as === '_scaledY');
+		expect(formula).toBeDefined();
+		expect((formula as { expr: string }).expr).toContain(`scale('yLinear', datum["${DEFAULT_METRIC}"])`);
+	});
+
+	test('includes _adjustedY formula transform', () => {
+		const data = getLineDirectLabelData('line0', defaultLabelSpecOptions, defaultLineOptions);
+		const transforms = getTransforms(data);
+		const formula = transforms.find((t) => t.type === 'formula' && 'as' in t && t.as === '_adjustedY');
+		expect(formula).toBeDefined();
+		expect((formula as { expr: string }).expr).toBe('datum._scaledY - datum._metricRank * 16');
+	});
+
+	test('includes _cumMaxAdjusted cumulative window transform', () => {
+		const data = getLineDirectLabelData('line0', defaultLabelSpecOptions, defaultLineOptions);
+		const transforms = getTransforms(data);
+		const window = transforms.find(
+			(t) => t.type === 'window' && 'as' in t && asArray(t.as).includes('_cumMaxAdjusted')
+		);
+		expect(window).toBeDefined();
+		expect(window).toHaveProperty('ops', ['max']);
+		expect(window).toHaveProperty('fields', ['_adjustedY']);
 	});
 
 	test('uses line name and index in data name', () => {
@@ -330,42 +353,34 @@ describe('getLineDirectLabelMarks', () => {
 	});
 
 	describe('y offset signal evaluation', () => {
-		const evalOffsetSignal = (
-			datum: Record<string, unknown>,
-			scaleImpl = (_name: string, v: number) => v
-		): number => {
+		const evalOffsetSignal = (datum: Record<string, number>): number => {
 			const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
 			const signal = (marks[0].encode?.enter?.y as { offset: { signal: string } }).offset.signal;
-			const isValid = (v: unknown) => v !== null && v !== undefined && !Number.isNaN(v as number);
-			return new Function('datum', 'scale', 'isValid', 'max', `return ${signal}`)(datum, scaleImpl, isValid, Math.max);
+			return new Function('datum', `return ${signal}`)(datum);
 		};
 
-		test('2-series rank 1: label placed 12px above the line', () => {
-			expect(evalOffsetSignal({ _seriesCount: 2, _metricRank: 1 })).toBe(-12);
+		test('rank 1 always places label 12px above the line terminus', () => {
+			// cumMaxAdjusted = _scaledY - 1*16 for rank 1
+			// offset = (100 - 16) + 1*16 - 12 - 100 = -12
+			expect(evalOffsetSignal({ _metricRank: 1, _scaledY: 100, _cumMaxAdjusted: 84 })).toBe(-12);
 		});
 
-		test('2-series rank 2: label placed 22px below the line', () => {
-			expect(evalOffsetSignal({ _seriesCount: 2, _metricRank: 2 })).toBe(22);
+		test('rank 2 well-separated from rank 1: also placed 12px above', () => {
+			// rank2 adjustedY (200 - 32 = 168) > rank1 adjustedY, so cumMaxAdjusted = 168
+			// offset = 168 + 2*16 - 12 - 200 = -12
+			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 200, _cumMaxAdjusted: 168 })).toBe(-12);
 		});
 
-		test('3+ series rank 1: no valid lags, defaults to 12px above the line', () => {
-			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 1, _lag1: null })).toBe(-12);
+		test('rank 2 close to rank 1: pushed above natural position to avoid overlap', () => {
+			// rank1 adjustedY (100 - 16 = 84) > rank2 adjustedY (108 - 32 = 76), so cumMaxAdjusted = 84
+			// offset = 84 + 2*16 - 12 - 108 = -4 (less negative than -12, meaning pushed further up)
+			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 108, _cumMaxAdjusted: 84 })).toBe(-4);
 		});
 
-		test('3+ series rank 2: pushed up enough to clear label above it', () => {
-			// lag1 at y=200, current series at y=100 → 4 + 200 - 100 = 104px offset
-			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 2, [DEFAULT_METRIC]: 100, _lag1: 200 })).toBe(104);
-		});
-
-		test('3+ series rank 3: cascades off both preceding labels', () => {
-			// lag1 at y=300, lag2 at y=200, current at y=100
-			// lag1 term: 4 + 300 - 100 = 204, lag2 term: 20 + 200 - 100 = 120 → max(-12, 204, 120) = 204
-			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 3, [DEFAULT_METRIC]: 100, _lag1: 300, _lag2: 200 })).toBe(204);
-		});
-
-		test('3+ series: null lag does not contribute to max', () => {
-			// lag2 is null, only lag1 contributes: 4 + 150 - 100 = 54
-			expect(evalOffsetSignal({ _seriesCount: 4, _metricRank: 3, [DEFAULT_METRIC]: 100, _lag1: 150, _lag2: null })).toBe(54);
+		test('rank 3 very close to preceding labels: label placed below line terminus', () => {
+			// cumMaxAdjusted still 84 (all three close together)
+			// offset = 84 + 3*16 - 12 - 112 = 8 (positive = below line)
+			expect(evalOffsetSignal({ _metricRank: 3, _scaledY: 112, _cumMaxAdjusted: 84 })).toBe(8);
 		});
 
 		test('y field is the metric', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -329,10 +329,50 @@ describe('getLineDirectLabelMarks', () => {
 		expect(marks[0].encode?.enter?.align).toEqual({ value: 'right' });
 	});
 
-	test('y offset switches based on series count and rank', () => {
-		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
-		const y = marks[0].encode?.enter?.y as { scale: string; field: string; offset: { signal: string } };
-		expect(y.offset).toEqual({ signal: 'datum._seriesCount === 2 && datum._metricRank === 2 ? 22 : -12' });
+	describe('y offset signal evaluation', () => {
+		const evalOffsetSignal = (
+			datum: Record<string, unknown>,
+			scaleImpl = (_name: string, v: number) => v
+		): number => {
+			const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
+			const signal = (marks[0].encode?.enter?.y as { offset: { signal: string } }).offset.signal;
+			const isValid = (v: unknown) => v !== null && v !== undefined && !Number.isNaN(v as number);
+			return new Function('datum', 'scale', 'isValid', 'max', `return ${signal}`)(datum, scaleImpl, isValid, Math.max);
+		};
+
+		test('2-series rank 1: label placed 12px above the line', () => {
+			expect(evalOffsetSignal({ _seriesCount: 2, _metricRank: 1 })).toBe(-12);
+		});
+
+		test('2-series rank 2: label placed 22px below the line', () => {
+			expect(evalOffsetSignal({ _seriesCount: 2, _metricRank: 2 })).toBe(22);
+		});
+
+		test('3+ series rank 1: no valid lags, defaults to 12px above the line', () => {
+			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 1, _lag1: null })).toBe(-12);
+		});
+
+		test('3+ series rank 2: pushed up enough to clear label above it', () => {
+			// lag1 at y=200, current series at y=100 → 4 + 200 - 100 = 104px offset
+			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 2, [DEFAULT_METRIC]: 100, _lag1: 200 })).toBe(104);
+		});
+
+		test('3+ series rank 3: cascades off both preceding labels', () => {
+			// lag1 at y=300, lag2 at y=200, current at y=100
+			// lag1 term: 4 + 300 - 100 = 204, lag2 term: 20 + 200 - 100 = 120 → max(-12, 204, 120) = 204
+			expect(evalOffsetSignal({ _seriesCount: 3, _metricRank: 3, [DEFAULT_METRIC]: 100, _lag1: 300, _lag2: 200 })).toBe(204);
+		});
+
+		test('3+ series: null lag does not contribute to max', () => {
+			// lag2 is null, only lag1 contributes: 4 + 150 - 100 = 54
+			expect(evalOffsetSignal({ _seriesCount: 4, _metricRank: 3, [DEFAULT_METRIC]: 100, _lag1: 150, _lag2: null })).toBe(54);
+		});
+
+		test('y field is the metric', () => {
+			const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
+			const y = marks[0].encode?.enter?.y as { field: string };
+			expect(y.field).toBe(DEFAULT_METRIC);
+		});
 	});
 
 	test('uses metricAxis for y scale when provided', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -20,9 +20,6 @@ import { getScaleName } from '../scale/scaleSpecBuilder';
 import { getDimensionField, getFacetsFromOptions } from '../specUtils';
 import { LineDirectLabelOptions, LineDirectLabelSpecOptions, LineSpecOptions, LabelValue } from '../types';
 
-// Each datum gets _lag1.._lagN fields (metric of the series N ranks above),
-// enabling the offset signal to compute the full cascading push without cross-datum state.
-const MAX_LABEL_OFFSET_SERIES = 20;
 const LABEL_LINE_HEIGHT = 16;
 
 /**
@@ -36,6 +33,7 @@ export const getLineDirectLabelData = (
 	const { color, dimension, excludeSeries, metric, position, scaleType, value } = labelOptions;
 	const dimField = getDimensionField(dimension, scaleType);
 	const isStart = position === 'start';
+	const yScaleName = lineOptions.metricAxis || 'yLinear';
 
 	const { facets } = getFacetsFromOptions({
 		color: lineOptions.color,
@@ -78,24 +76,20 @@ export const getLineDirectLabelData = (
 				]
 			: []),
 		{
-			type: 'joinaggregate' as const,
-			fields: [metric],
-			ops: ['count' as const],
-			as: ['_seriesCount'],
-		},
-		{
 			type: 'window' as const,
 			sort: { field: [metric], order: ['descending' as const] },
 			ops: ['rank' as const],
 			as: ['_metricRank'],
 		},
+		{ type: 'formula' as const, as: '_scaledY', expr: `scale('${yScaleName}', datum["${metric}"])` },
+		{ type: 'formula' as const, as: '_adjustedY', expr: `datum._scaledY - datum._metricRank * ${LABEL_LINE_HEIGHT}` },
 		{
 			type: 'window' as const,
 			sort: { field: ['_metricRank'], order: ['ascending' as const] },
-			ops: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, () => 'lag' as const),
-			fields: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, () => metric),
-			params: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => i + 1),
-			as: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => `_lag${i + 1}`),
+			frame: [null, 0] as [null, number],
+			ops: ['max' as const],
+			fields: ['_adjustedY'],
+			as: ['_cumMaxAdjusted'],
 		},
 	];
 
@@ -152,17 +146,7 @@ export const getLineDirectLabelMarks = (
 
 	const opacityRules = getLineOpacity(lineOptions);
 
-	// For each preceding rank k, compute the minimum offset needed so this label sits at
-	// least LABEL_LINE_HEIGHT px below label k's effective position (which itself was pushed
-	// by the same rule from rank 1 onward). Taking the max across all k gives the exact
-	// cascaded push without requiring cross-datum state in the signal.
-	const lagTerms = Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => {
-		const k = i + 1;
-		const baseShift = k * LABEL_LINE_HEIGHT - 12;
-		return `isValid(datum._lag${k}) ? ${baseShift} + scale('${yScaleName}', datum._lag${k}) - scale('${yScaleName}', datum["${metric}"]) : -1e9`;
-	});
-	// Combines offset logic for handling 1, 2, and 3+ series
-	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : max(-12, ${lagTerms.join(', ')})`;
+	const offsetSignal = `datum._cumMaxAdjusted + datum._metricRank * ${LABEL_LINE_HEIGHT} - 12 - datum._scaledY`;
 
 	const baseEnter = {
 		text: { signal: textExpr },

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -20,6 +20,11 @@ import { getScaleName } from '../scale/scaleSpecBuilder';
 import { getDimensionField, getFacetsFromOptions } from '../specUtils';
 import { LineDirectLabelOptions, LineDirectLabelSpecOptions, LineSpecOptions, LabelValue } from '../types';
 
+// Each datum gets _lag1.._lagN fields (metric of the series N ranks above),
+// enabling the offset signal to compute the full cascading push without cross-datum state.
+const MAX_LABEL_OFFSET_SERIES = 20;
+const LABEL_LINE_HEIGHT = 16;
+
 /**
  * Derived dataset: one row per series at the last (max-dimension) data point.
  */
@@ -84,6 +89,14 @@ export const getLineDirectLabelData = (
 			ops: ['rank' as const],
 			as: ['_metricRank'],
 		},
+		{
+			type: 'window' as const,
+			sort: { field: ['_metricRank'], order: ['ascending' as const] },
+			ops: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, () => 'lag' as const),
+			fields: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, () => metric),
+			params: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => i + 1),
+			as: Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => `_lag${i + 1}`),
+		},
 	];
 
 	return {
@@ -139,6 +152,17 @@ export const getLineDirectLabelMarks = (
 
 	const opacityRules = getLineOpacity(lineOptions);
 
+	// For each preceding rank k, compute the minimum offset needed so this label sits at
+	// least LABEL_LINE_HEIGHT px below label k's effective position (which itself was pushed
+	// by the same rule from rank 1 onward). Taking the max across all k gives the exact
+	// cascaded push without requiring cross-datum state in the signal.
+	const lagTerms = Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => {
+		const k = i + 1;
+		const baseShift = k * LABEL_LINE_HEIGHT - 12;
+		return `isValid(datum._lag${k}) ? ${baseShift} + scale('${yScaleName}', datum._lag${k}) - scale('${yScaleName}', datum["${metric}"]) : -1e9`;
+	});
+	const offsetSignal = `max(-12, ${lagTerms.join(', ')})`;
+
 	const baseEnter = {
 		text: { signal: textExpr },
 		align: { value: isStart ? ('left' as const) : ('right' as const) },
@@ -151,7 +175,7 @@ export const getLineDirectLabelMarks = (
 		y: {
 			scale: yScaleName,
 			field: metric,
-			offset: { signal: 'datum._seriesCount === 2 && datum._metricRank === 2 ? 22 : -12' },
+			offset: { signal: offsetSignal },
 		},
 	};
 

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -159,9 +159,12 @@ export const getLineDirectLabelMarks = (
 	const lagTerms = Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => {
 		const k = i + 1;
 		const baseShift = k * LABEL_LINE_HEIGHT - 12;
+		// k * 16 - 12 + yi - y
 		return `isValid(datum._lag${k}) ? ${baseShift} + scale('${yScaleName}', datum._lag${k}) - scale('${yScaleName}', datum["${metric}"]) : -1e9`;
 	});
 	const offsetSignal = `max(-12, ${lagTerms.join(', ')})`;
+	// Combines offset logic for handling 1, 2, and 3+ series
+	const finalOffsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (${offsetSignal})`;
 
 	const baseEnter = {
 		text: { signal: textExpr },
@@ -175,7 +178,7 @@ export const getLineDirectLabelMarks = (
 		y: {
 			scale: yScaleName,
 			field: metric,
-			offset: { signal: offsetSignal },
+			offset: { signal: finalOffsetSignal },
 		},
 	};
 

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -76,6 +76,12 @@ export const getLineDirectLabelData = (
 				]
 			: []),
 		{
+			type: 'joinaggregate' as const,
+			fields: [metric],
+			ops: ['count' as const],
+			as: ['_seriesCount'],
+		},
+		{
 			type: 'window' as const,
 			sort: { field: [metric], order: ['descending' as const] },
 			ops: ['rank' as const],
@@ -146,7 +152,8 @@ export const getLineDirectLabelMarks = (
 
 	const opacityRules = getLineOpacity(lineOptions);
 
-	const offsetSignal = `datum._cumMaxAdjusted + datum._metricRank * ${LABEL_LINE_HEIGHT} - 12 - datum._scaledY`;
+	// Combined logic for direct label offset given 1, 2, or 3+ series
+	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (datum._cumMaxAdjusted + datum._metricRank * ${LABEL_LINE_HEIGHT} - 12 - datum._scaledY)`
 
 	const baseEnter = {
 		text: { signal: textExpr },

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -159,12 +159,10 @@ export const getLineDirectLabelMarks = (
 	const lagTerms = Array.from({ length: MAX_LABEL_OFFSET_SERIES - 1 }, (_, i) => {
 		const k = i + 1;
 		const baseShift = k * LABEL_LINE_HEIGHT - 12;
-		// k * 16 - 12 + yi - y
 		return `isValid(datum._lag${k}) ? ${baseShift} + scale('${yScaleName}', datum._lag${k}) - scale('${yScaleName}', datum["${metric}"]) : -1e9`;
 	});
-	const offsetSignal = `max(-12, ${lagTerms.join(', ')})`;
 	// Combines offset logic for handling 1, 2, and 3+ series
-	const finalOffsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (${offsetSignal})`;
+	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : max(-12, ${lagTerms.join(', ')})`;
 
 	const baseEnter = {
 		text: { signal: textExpr },
@@ -178,7 +176,7 @@ export const getLineDirectLabelMarks = (
 		y: {
 			scale: yScaleName,
 			field: metric,
-			offset: { signal: finalOffsetSignal },
+			offset: { signal: offsetSignal },
 		},
 	};
 

--- a/planning/research/direct-label-stacking.md
+++ b/planning/research/direct-label-stacking.md
@@ -1,0 +1,109 @@
+# Direct Label Auto-Stacking
+
+## Problem
+
+When multiple line series share a similar metric value at the end of the chart, their direct labels render at nearly the same y-position and overlap. The goal is to push each label down just enough to avoid collisions — a "cascade" — without hardcoding anything for a fixed number of series.
+
+---
+
+## The Cascade Rule
+
+Labels are ranked by metric value, highest first (rank 1 = highest). The effective y-position of each label must satisfy:
+
+```
+effectiveY[k] >= effectiveY[k-1] + LABEL_LINE_HEIGHT
+```
+
+Working recursively from the top:
+
+```
+effectiveY[1] = scaledY[1] - 12          (nudge the top label up 12px)
+effectiveY[k] = max(scaledY[k] - 12, effectiveY[k-1] + LABEL_LINE_HEIGHT)
+```
+
+The offset applied to the Vega mark is:
+
+```
+offset[k] = effectiveY[k] - scaledY[k]
+```
+
+---
+
+## The Key Insight
+
+Unrolling the recurrence reveals that `effectiveY[k]` can be expressed as a **single max over all preceding rows** rather than a chain of recursive lookups:
+
+```
+effectiveY[k] = max over j ≤ k of (scaledY[j] + (k - j) × h - 12)
+```
+
+where `h = LABEL_LINE_HEIGHT = 16`.
+
+Factoring out the constant `k × h - 12`:
+
+```
+effectiveY[k] = ( max over j ≤ k of (scaledY[j] - j × h) ) + k × h - 12
+```
+
+Define:
+
+```
+_adjustedY[j] = scaledY[j] - j × h
+```
+
+Then:
+
+```
+effectiveY[k] = cummax(_adjustedY, 1..k) + k × h - 12
+offset[k]     = effectiveY[k] - scaledY[k]
+              = cummax(_adjustedY, 1..k) + k × h - 12 - scaledY[k]
+```
+
+The cumulative max is a standard window operation — Vega computes it natively with `frame: [null, 0]`.
+
+---
+
+## Worked Example
+
+Three labels at pixel positions `scaledY = [100, 104, 108]`, `h = 16`:
+
+| rank | `scaledY` | `_adjustedY` (scaledY − rank×16) | `_cumMaxAdjusted` | `effectiveY` | `offset` |
+|------|-----------|----------------------------------|-------------------|--------------|---------|
+| 1    | 100       | 84                               | 84                | 88           | −12     |
+| 2    | 104       | 72                               | 84                | 104          | 0       |
+| 3    | 108       | 60                               | 84                | 120          | +12     |
+
+Labels land at pixels 88, 104, 120 — exactly 16px apart, no overlap.
+
+---
+
+## Vega Implementation
+
+### Data transforms (in `getLineDirectLabelData`)
+
+```
+1. joinaggregate → _extremeDim          (find the last data point per series)
+2. filter                               (keep only rows at _extremeDim)
+3. window rank (desc by metric)         (assign _metricRank: 1 = highest)
+4. formula: _scaledY = scale('yLinear', datum[metric])
+5. formula: _adjustedY = _scaledY − _metricRank × 16
+6. window max, frame [null, 0]          (_cumMaxAdjusted = running max of _adjustedY)
+```
+
+Step 6 uses `frame: [null, 0]`, which means "from the start of the sorted sequence up to the current row" — this is how Vega expresses a cumulative (running) aggregation.
+
+### Offset signal (in `getLineDirectLabelMarks`)
+
+```
+datum._cumMaxAdjusted + datum._metricRank * 16 - 12 - datum._scaledY
+```
+
+This single expression replaces what was previously 19 separate lag fields and a 19-term `max(...)` call.
+
+---
+
+## Why the Old Approach Was Verbose
+
+Vega signal expressions cannot loop or iterate — they evaluate on one datum with no access to other rows. The only way to reference preceding series' values was to pre-materialize them as named fields at spec-build time: `_lag1`, `_lag2`, … `_lag19`. The offset signal then listed all 19 terms explicitly. Both the window transform arrays and the signal string grew linearly with `MAX_LABEL_OFFSET_SERIES`, making the Vega spec large and capping the feature at 20 series.
+
+The cumulative max reformulation moves the multi-row aggregation into Vega's engine (where looping is native), keeping the spec constant-size for any number of series.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Direct labels automatically adjust positioning to avoid overlapping when using 3+ series. For example, if multiple series converge, direct labels will stack below one another such that they stay as close to their intended position as possible without overlapping each other. Labels that do not overlap default to sitting above their respective series.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The current <LineDirectLabel> auto-positioning handles the two-series case: the higher series gets a label above, the lower series gets a label below. For three or more series, the expected behavior is that all labels stack above their respective line termini. The current behavior for 3+ series is unverified so this adds explicit logic for this case.

## How Has This Been Tested?

Unit tests cover the auto-stacking/cascading offset logic by evaluating the generated Vega signal expressions against mock data. The tests verify:

- With 2 series, the higher-ranked label is placed 12px above its respective line and the lower-ranked label is placed 22px below its respective line.
- With 3+ series, all labels stack below using a cascading algorithm that pushes each label far enough below the one above such that it doesn't overlap.
- Null/missing lag values don't contribute to the stacking calculation.
- The cascading math produces the correct pixel offsets for rank 2 and rank 3 labels given known input values.

Visual behavior was tested through Storybook stories covering 2 series, 3 series diverging, 6 series, and 20 series datasets.

## Screenshots (if appropriate):

<img width="818" height="423" alt="image" src="https://github.com/user-attachments/assets/81c31620-1d40-4925-8c4b-539882dd1710" />
<img width="818" height="423" alt="image" src="https://github.com/user-attachments/assets/eaba525d-ded7-4a24-acb0-ff4014dae596" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
