### PR TITLE
feat: S/M/L font scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ cursor
 
 # catch all for temporary outputs
 tmp/
-
-# scout
-.scout/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ cursor
 
 # catch all for temporary outputs
 tmp/
+
+# scout
+.scout/

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -194,11 +194,11 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 export const DIRECT_LABEL_FONT_WEIGHT = 700 as const;
 export const DIRECT_LABEL_BACKGROUND_STROKE_WIDTH = 4;
 
-/** Direct label font size consants */
+/** Direct label font size constants */
 export const DIRECT_LABEL_FONT_SIZE_S = 14;
 export const DIRECT_LABEL_FONT_SIZE_M = 16;
 export const DIRECT_LABEL_FONT_SIZE_L = 18;
-/** Direct label font weight consants */
+/** Direct label font weight constants */
 export const DIRECT_LABEL_FONT_WEIGHT_S = 700 as const;
 export const DIRECT_LABEL_FONT_WEIGHT_M = 700 as const;
 export const DIRECT_LABEL_FONT_WEIGHT_L = 700 as const;

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -35,6 +35,10 @@ export const DEFAULT_LINE_WIDTHS = ['M'];
 
 /** Vega signal name for the chart-size-derived stroke width, driven by a reactive expression. */
 export const CHART_SIZE_STROKE_WIDTH = 'rscChartSizeStrokeWidth';
+/** Vega signal name for the chart-size-derived font size, driven by a reactive expression. */
+export const CHART_SIZE_FONT_SIZE = 'rscChartSizeFontSize';
+/** Vega signal name for the chart-size-derived font weight, driven by a reactive expression. */
+export const CHART_SIZE_FONT_WEIGHT = 'rscChartSizeFontWeight';
 
 /** Vega signal name for the chart-size-derived hover point stroke width, driven by a reactive expression. */
 export const CHART_SIZE_HOVER_STROKE_WIDTH = 'rscChartSizeHoverStrokeWidth';
@@ -189,6 +193,15 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 // S2 direct label shared style constants (used by LineDirectLabel and ReferenceLine)
 export const DIRECT_LABEL_FONT_WEIGHT = 700 as const;
 export const DIRECT_LABEL_BACKGROUND_STROKE_WIDTH = 4;
+
+/** Direct label font size consants */
+export const DIRECT_LABEL_FONT_SIZE_S = 14;
+export const DIRECT_LABEL_FONT_SIZE_M = 16;
+export const DIRECT_LABEL_FONT_SIZE_L = 18;
+/** Direct label font weight consants */
+export const DIRECT_LABEL_FONT_WEIGHT_S = 700 as const;
+export const DIRECT_LABEL_FONT_WEIGHT_M = 700 as const;
+export const DIRECT_LABEL_FONT_WEIGHT_L = 700 as const;
 
 // S2 reference line label constants — alias the shared direct label values
 export const REFERENCE_LINE_LABEL_FONT_WEIGHT = DIRECT_LABEL_FONT_WEIGHT;

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -37,8 +37,6 @@ export const DEFAULT_LINE_WIDTHS = ['M'];
 export const CHART_SIZE_STROKE_WIDTH = 'rscChartSizeStrokeWidth';
 /** Vega signal name for the chart-size-derived font size, driven by a reactive expression. */
 export const CHART_SIZE_FONT_SIZE = 'rscChartSizeFontSize';
-/** Vega signal name for the chart-size-derived font weight, driven by a reactive expression. */
-export const CHART_SIZE_FONT_WEIGHT = 'rscChartSizeFontWeight';
 
 /** Vega signal name for the chart-size-derived hover point stroke width, driven by a reactive expression. */
 export const CHART_SIZE_HOVER_STROKE_WIDTH = 'rscChartSizeHoverStrokeWidth';
@@ -198,10 +196,6 @@ export const DIRECT_LABEL_BACKGROUND_STROKE_WIDTH = 4;
 export const DIRECT_LABEL_FONT_SIZE_S = 14;
 export const DIRECT_LABEL_FONT_SIZE_M = 16;
 export const DIRECT_LABEL_FONT_SIZE_L = 18;
-/** Direct label font weight constants */
-export const DIRECT_LABEL_FONT_WEIGHT_S = 700 as const;
-export const DIRECT_LABEL_FONT_WEIGHT_M = 700 as const;
-export const DIRECT_LABEL_FONT_WEIGHT_L = 700 as const;
 
 // S2 reference line label constants — alias the shared direct label values
 export const REFERENCE_LINE_LABEL_FONT_WEIGHT = DIRECT_LABEL_FONT_WEIGHT;

--- a/packages/react-spectrum-charts-s2/src/components/LineDirectLabel/LineDirectLabel.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/LineDirectLabel/LineDirectLabel.tsx
@@ -22,7 +22,6 @@ const LineDirectLabel: FC<LineDirectLabelProps> = ({
   prefix,
   excludeSeries,
   fontSize,
-  fontWeight,
 }: LineDirectLabelProps) => {
   return null;
 };

--- a/packages/react-spectrum-charts-s2/src/components/LineDirectLabel/LineDirectLabel.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/LineDirectLabel/LineDirectLabel.tsx
@@ -21,6 +21,8 @@ const LineDirectLabel: FC<LineDirectLabelProps> = ({
   format,
   prefix,
   excludeSeries,
+  fontSize,
+  fontWeight,
 }: LineDirectLabelProps) => {
   return null;
 };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -35,7 +35,6 @@ export default {
       options: ['start', 'end'],
     },
     fontSize: { control: { type: 'number' } },
-    fontWeight: { control: { type: 'number' } },
   },
 };
 

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -194,7 +194,7 @@ const DirectLabelSizeScalingStory: StoryFn<typeof LineDirectLabel> = (args): Rea
     </div>
   );
 };
-//data={workspaceTrendsData} width={width} height={CHART_HEIGHT} backgroundColor="gray-50"
+
 export const DirectLabelSizeScaling = DirectLabelSizeScalingStory;
 
 const DirectLabelDefault = bindWithProps(LineDirectLabelStory);

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -9,9 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 
 import { StoryFn } from '@storybook/react';
+
+import { CHART_SIZE_BREAKPOINTS } from '@spectrum-charts/constants';
 
 import { Chart } from '../../../../Chart';
 import { Axis, ChartInspect, Legend, Line, LineDirectLabel } from '../../../../components';
@@ -32,10 +34,12 @@ export default {
       control: { type: 'select' },
       options: ['start', 'end'],
     },
+    fontSize: { control: { type: 'number' } },
+    fontWeight: { control: { type: 'number' } },
   },
 };
 
-const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400, backgroundColor: 'gray-50' };
+const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 100, maxWidth: 1000, height: 400, backgroundColor: 'gray-50' };
 
 // DATA 
 
@@ -73,6 +77,125 @@ const LineDirectLabelWithInspectStory: StoryFn<typeof LineDirectLabel> = (args):
 };
 
 // BINDINGS
+
+const CHART_HEIGHT = 400;
+const MAX_WIDTH = CHART_SIZE_BREAKPOINTS.L + 200;
+const THUMB_HEIGHT = 32;
+
+const HANDLE_STYLES = `
+  .rsc-dl-size-handle {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    border: none;
+    outline: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: ${CHART_HEIGHT}px;
+    pointer-events: none;
+    z-index: 20;
+  }
+  .rsc-dl-size-handle::-webkit-slider-runnable-track {
+    background: transparent;
+    height: ${CHART_HEIGHT}px;
+  }
+  .rsc-dl-size-handle::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 8px;
+    height: ${THUMB_HEIGHT}px;
+    border-radius: 4px;
+    background: #999;
+    cursor: ew-resize;
+    pointer-events: all;
+    margin-top: ${(CHART_HEIGHT - THUMB_HEIGHT) / 2}px;
+  }
+  .rsc-dl-size-handle::-moz-range-track { background: transparent; }
+  .rsc-dl-size-handle::-moz-range-thumb {
+    width: 8px;
+    height: ${THUMB_HEIGHT}px;
+    border-radius: 4px;
+    background: #999;
+    border: none;
+    cursor: ew-resize;
+  }
+`;
+
+const THRESHOLDS = [
+  { px: CHART_SIZE_BREAKPOINTS.M, label: 'M' },
+  { px: CHART_SIZE_BREAKPOINTS.L, label: 'L' },
+];
+
+const DirectLabelSizeScalingStory: StoryFn<typeof LineDirectLabel> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  const [width, setWidth] = useState(600);
+
+  let currentSize = 'L';
+  if (width < CHART_SIZE_BREAKPOINTS.M) currentSize = 'S';
+  else if (width < CHART_SIZE_BREAKPOINTS.L) currentSize = 'M';
+
+  return (
+    <div style={{ padding: '16px 0' }}>
+      <style>{HANDLE_STYLES}</style>
+      <div style={{ marginBottom: 8, fontSize: 13, color: '#666' }}>
+        Width: <strong>{Math.round(width)}px</strong> — Size tier: <strong>{currentSize}</strong>
+      </div>
+      <div style={{ position: 'relative', minWidth: MAX_WIDTH }}>
+        {THRESHOLDS.map(({ px, label }) => (
+          <div
+            key={label}
+            style={{
+              position: 'absolute',
+              left: px,
+              top: 0,
+              bottom: 0,
+              width: 1,
+              background: 'rgba(220, 60, 60, 0.6)',
+              zIndex: 10,
+              pointerEvents: 'none',
+            }}
+          >
+            <span
+              style={{
+                position: 'absolute',
+                top: 2,
+                left: 3,
+                fontSize: 10,
+                color: 'rgba(220, 60, 60, 0.9)',
+                whiteSpace: 'nowrap',
+                lineHeight: 1,
+              }}
+            >
+              {label} ({px}px)
+            </span>
+          </div>
+        ))}
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <Chart {...chartProps} data={workspaceTrendsData} width={width} height={CHART_HEIGHT} debug> 
+            <Axis position="left" grid title="Users" />
+            <Axis position="bottom" labelFormat="time" baseline ticks />
+            <Line dimension="datetime" metric="users" color="series" scaleType="time">
+              <LineDirectLabel value="series" {...args} />
+            </Line>
+            <Legend highlight />
+          </Chart>
+          <input
+            type="range"
+            className="rsc-dl-size-handle"
+            aria-label="Chart width"
+            min={0}
+            max={MAX_WIDTH}
+            value={Math.round(width)}
+            onChange={(e) => setWidth(Math.max(100, Number(e.target.value)))}
+            style={{ width: MAX_WIDTH }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+//data={workspaceTrendsData} width={width} height={CHART_HEIGHT} backgroundColor="gray-50"
+export const DirectLabelSizeScaling = DirectLabelSizeScalingStory;
 
 const DirectLabelDefault = bindWithProps(LineDirectLabelStory);
 DirectLabelDefault.args = { value: 'series' };

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineDirectLabel.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineDirectLabel.types.ts
@@ -40,10 +40,6 @@ export interface LineDirectLabelProps {
    * Override font size in pixels. When omitted, font size scales automatically with chart size.
    */
   fontSize?: number;
-  /**
-   * Override font weight. When omitted, font weight scales automatically with chart size.
-   */
-  fontWeight?: number;
 }
 
 export type LineDirectLabelElement = ReactElement<

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineDirectLabel.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/lineDirectLabel.types.ts
@@ -36,6 +36,14 @@ export interface LineDirectLabelProps {
   prefix?: string;
   /** Series values to exclude from labeling. */
   excludeSeries?: string[];
+  /**
+   * Override font size in pixels. When omitted, font size scales automatically with chart size.
+   */
+  fontSize?: number;
+  /**
+   * Override font weight. When omitted, font weight scales automatically with chart size.
+   */
+  fontWeight?: number;
 }
 
 export type LineDirectLabelElement = ReactElement<

--- a/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
@@ -218,9 +218,9 @@ describe('areaSpecBuilder', () => {
       expect(signals[3]).toHaveProperty('name', SELECTED_ITEM);
       expect(signals[4]).toHaveProperty('name', SELECTED_SERIES);
       expect(signals[5]).toHaveProperty('name', SELECTED_GROUP);
-      expect(signals[9]).toHaveProperty('name', `${defaultAreaOptions.name}_${HOVERED_ITEM}`);
-      expect(signals[9].on).toHaveLength(2);
-      expect(signals[10]).toHaveProperty('name', `${defaultAreaOptions.name}_controlledHoveredId`);
+      expect(signals[11]).toHaveProperty('name', `${defaultAreaOptions.name}_${HOVERED_ITEM}`);
+      expect(signals[11].on).toHaveLength(2);
+      expect(signals[12]).toHaveProperty('name', `${defaultAreaOptions.name}_controlledHoveredId`);
     });
 
     test('should exclude data with key from update if inspect has excludeDataKey', () => {

--- a/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
@@ -218,9 +218,9 @@ describe('areaSpecBuilder', () => {
       expect(signals[3]).toHaveProperty('name', SELECTED_ITEM);
       expect(signals[4]).toHaveProperty('name', SELECTED_SERIES);
       expect(signals[5]).toHaveProperty('name', SELECTED_GROUP);
-      expect(signals[11]).toHaveProperty('name', `${defaultAreaOptions.name}_${HOVERED_ITEM}`);
-      expect(signals[11].on).toHaveLength(2);
-      expect(signals[12]).toHaveProperty('name', `${defaultAreaOptions.name}_controlledHoveredId`);
+      expect(signals[10]).toHaveProperty('name', `${defaultAreaOptions.name}_${HOVERED_ITEM}`);
+      expect(signals[10].on).toHaveLength(2);
+      expect(signals[11]).toHaveProperty('name', `${defaultAreaOptions.name}_controlledHoveredId`);
     });
 
     test('should exclude data with key from update if inspect has excludeDataKey', () => {

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -21,6 +21,8 @@ import {
   CHART_SIZE_POINT_SIZES,
   CHART_SIZE_STROKE_WIDTH,
   CHART_SIZE_STROKE_WIDTHS,
+  CHART_SIZE_FONT_SIZE,
+  CHART_SIZE_FONT_WEIGHT,
   REFERENCE_LINE_LABEL_BACKGROUND_STROKE,
   CONTROLLED_HIGHLIGHTED_ITEM,
   CONTROLLED_HIGHLIGHTED_SERIES,
@@ -43,6 +45,12 @@ import {
   SYMBOL_SHAPE_SCALE,
   SYMBOL_SIZE_SCALE,
   TABLE,
+  DIRECT_LABEL_FONT_SIZE_S,
+  DIRECT_LABEL_FONT_SIZE_M,
+  DIRECT_LABEL_FONT_SIZE_L,
+  DIRECT_LABEL_FONT_WEIGHT_S,
+  DIRECT_LABEL_FONT_WEIGHT_M,
+  DIRECT_LABEL_FONT_WEIGHT_L
 } from '@spectrum-charts/constants';
 import { colorSchemes, getS2ColorValue } from '@spectrum-charts/themes';
 
@@ -272,6 +280,16 @@ export const getDefaultSignals = ({
     update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${CHART_SIZE_POINT_SIZES.S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${CHART_SIZE_POINT_SIZES.M} : ${CHART_SIZE_POINT_SIZES.L}`,
   };
 
+  const chartSizeFontSizeSignal: Signal = {
+    name: CHART_SIZE_FONT_SIZE,
+    update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_SIZE_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_SIZE_M} : ${DIRECT_LABEL_FONT_SIZE_L}`
+  }
+
+  const chartSizeFontWeightSignal: Signal = {
+    name: CHART_SIZE_FONT_WEIGHT,
+    update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_WEIGHT_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_WEIGHT_M} : ${DIRECT_LABEL_FONT_WEIGHT_L}`
+  }
+
   return [
     getGenericValueSignal(BACKGROUND_COLOR, getS2ColorValue(signalBackgroundColor, colorScheme)),
     getGenericValueSignal(REFERENCE_LINE_LABEL_BACKGROUND_STROKE, referenceLineLabelStroke),
@@ -288,6 +306,8 @@ export const getDefaultSignals = ({
     chartSizeStrokeWidthSignal,
     chartSizeHoverStrokeWidthSignal,
     chartSizePointSizeSignal,
+    chartSizeFontSizeSignal,
+    chartSizeFontWeightSignal,
   ];
 };
 

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -22,7 +22,6 @@ import {
   CHART_SIZE_STROKE_WIDTH,
   CHART_SIZE_STROKE_WIDTHS,
   CHART_SIZE_FONT_SIZE,
-  CHART_SIZE_FONT_WEIGHT,
   REFERENCE_LINE_LABEL_BACKGROUND_STROKE,
   CONTROLLED_HIGHLIGHTED_ITEM,
   CONTROLLED_HIGHLIGHTED_SERIES,
@@ -48,9 +47,6 @@ import {
   DIRECT_LABEL_FONT_SIZE_S,
   DIRECT_LABEL_FONT_SIZE_M,
   DIRECT_LABEL_FONT_SIZE_L,
-  DIRECT_LABEL_FONT_WEIGHT_S,
-  DIRECT_LABEL_FONT_WEIGHT_M,
-  DIRECT_LABEL_FONT_WEIGHT_L
 } from '@spectrum-charts/constants';
 import { colorSchemes, getS2ColorValue } from '@spectrum-charts/themes';
 
@@ -285,11 +281,6 @@ export const getDefaultSignals = ({
     update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_SIZE_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_SIZE_M} : ${DIRECT_LABEL_FONT_SIZE_L}`
   }
 
-  const chartSizeFontWeightSignal: Signal = {
-    name: CHART_SIZE_FONT_WEIGHT,
-    update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_WEIGHT_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_WEIGHT_M} : ${DIRECT_LABEL_FONT_WEIGHT_L}`
-  }
-
   return [
     getGenericValueSignal(BACKGROUND_COLOR, getS2ColorValue(signalBackgroundColor, colorScheme)),
     getGenericValueSignal(REFERENCE_LINE_LABEL_BACKGROUND_STROKE, referenceLineLabelStroke),
@@ -307,7 +298,6 @@ export const getDefaultSignals = ({
     chartSizeHoverStrokeWidthSignal,
     chartSizePointSizeSignal,
     chartSizeFontSizeSignal,
-    chartSizeFontWeightSignal,
   ];
 };
 

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
@@ -25,7 +25,6 @@ import {
 
 import {
   defaultChartSizeFontSizeSignal,
-  defaultChartSizeFontWeightSignal,
   defaultChartSizeHoverStrokeWidthSignal,
   defaultChartSizePointSizeSignal,
   defaultChartSizeStrokeWidthSignal,
@@ -168,7 +167,6 @@ describe('addLegend()', () => {
           defaultChartSizeHoverStrokeWidthSignal,
           defaultChartSizePointSizeSignal,
           defaultChartSizeFontSizeSignal,
-          defaultChartSizeFontWeightSignal,
           {
             name: `legend0_${HOVERED_SERIES}`,
             value: null,

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
@@ -24,6 +24,8 @@ import {
 } from '@spectrum-charts/constants';
 
 import {
+  defaultChartSizeFontSizeSignal,
+  defaultChartSizeFontWeightSignal,
   defaultChartSizeHoverStrokeWidthSignal,
   defaultChartSizePointSizeSignal,
   defaultChartSizeStrokeWidthSignal,
@@ -165,6 +167,8 @@ describe('addLegend()', () => {
           defaultChartSizeStrokeWidthSignal,
           defaultChartSizeHoverStrokeWidthSignal,
           defaultChartSizePointSizeSignal,
+          defaultChartSizeFontSizeSignal,
+          defaultChartSizeFontWeightSignal,
           {
             name: `legend0_${HOVERED_SERIES}`,
             value: null,

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -12,6 +12,8 @@
 import { Data, SourceData } from 'vega';
 
 import {
+	CHART_SIZE_FONT_SIZE,
+	CHART_SIZE_FONT_WEIGHT,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -69,6 +71,8 @@ const defaultLabelSpecOptions: LineDirectLabelSpecOptions = {
 	prefix: '',
 	scaleType: 'time',
 	value: 'last',
+	fontSize: undefined,
+	fontWeight: undefined,
 };
 
 describe('getLineDirectLabelSpecOptions', () => {
@@ -120,6 +124,26 @@ describe('getLineDirectLabelSpecOptions', () => {
 	test('preserves position=start', () => {
 		const result = getLineDirectLabelSpecOptions({ position: 'start' }, 0, defaultLineOptions);
 		expect(result.position).toBe('start');
+	});
+
+	test('defaults fontSize to undefined', () => {
+		const result = getLineDirectLabelSpecOptions({}, 0, defaultLineOptions);
+		expect(result.fontSize).toBeUndefined();
+	});
+
+	test('defaults fontWeight to undefined', () => {
+		const result = getLineDirectLabelSpecOptions({}, 0, defaultLineOptions);
+		expect(result.fontWeight).toBeUndefined();
+	});
+
+	test('passes through explicit fontSize', () => {
+		const result = getLineDirectLabelSpecOptions({ fontSize: 18 }, 0, defaultLineOptions);
+		expect(result.fontSize).toBe(18);
+	});
+
+	test('passes through explicit fontWeight', () => {
+		const result = getLineDirectLabelSpecOptions({ fontWeight: 400 }, 0, defaultLineOptions);
+		expect(result.fontWeight).toBe(400);
 	});
 });
 
@@ -410,10 +434,30 @@ describe('getLineDirectLabelMarks', () => {
 		expect(marks[1].encode?.update).toHaveProperty('opacity');
 	});
 
-	test('both marks have fontWeight 700 in update encoding', () => {
+	test('both marks use fontWeight signal when fontWeight is not set', () => {
 		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
-		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { value: 700 });
-		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { value: 700 });
+		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { signal: CHART_SIZE_FONT_WEIGHT });
+		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { signal: CHART_SIZE_FONT_WEIGHT });
+	});
+
+	test('both marks use fontSize signal when fontSize is not set', () => {
+		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
+		expect(marks[0].encode?.update).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
+		expect(marks[1].encode?.update).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
+	});
+
+	test('explicit fontWeight overrides the signal', () => {
+		const opts = { ...defaultLabelSpecOptions, fontWeight: 400 };
+		const marks = getLineDirectLabelMarks('line0', opts, defaultLineOptions, 'gray-50', 'light');
+		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { value: 400 });
+		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { value: 400 });
+	});
+
+	test('explicit fontSize overrides the signal', () => {
+		const opts = { ...defaultLabelSpecOptions, fontSize: 20 };
+		const marks = getLineDirectLabelMarks('line0', opts, defaultLineOptions, 'gray-50', 'light');
+		expect(marks[0].encode?.update).toHaveProperty('fontSize', { value: 20 });
+		expect(marks[1].encode?.update).toHaveProperty('fontSize', { value: 20 });
 	});
 
 	test('adds prefix to text expression', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -13,7 +13,6 @@ import { Data, SourceData } from 'vega';
 
 import {
 	CHART_SIZE_FONT_SIZE,
-	CHART_SIZE_FONT_WEIGHT,
 	DEFAULT_COLOR,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
@@ -72,7 +71,6 @@ const defaultLabelSpecOptions: LineDirectLabelSpecOptions = {
 	scaleType: 'time',
 	value: 'last',
 	fontSize: undefined,
-	fontWeight: undefined,
 };
 
 describe('getLineDirectLabelSpecOptions', () => {
@@ -131,20 +129,11 @@ describe('getLineDirectLabelSpecOptions', () => {
 		expect(result.fontSize).toBeUndefined();
 	});
 
-	test('defaults fontWeight to undefined', () => {
-		const result = getLineDirectLabelSpecOptions({}, 0, defaultLineOptions);
-		expect(result.fontWeight).toBeUndefined();
-	});
-
 	test('passes through explicit fontSize', () => {
 		const result = getLineDirectLabelSpecOptions({ fontSize: 18 }, 0, defaultLineOptions);
 		expect(result.fontSize).toBe(18);
 	});
 
-	test('passes through explicit fontWeight', () => {
-		const result = getLineDirectLabelSpecOptions({ fontWeight: 400 }, 0, defaultLineOptions);
-		expect(result.fontWeight).toBe(400);
-	});
 });
 
 describe('getLineDirectLabelData', () => {
@@ -434,23 +423,10 @@ describe('getLineDirectLabelMarks', () => {
 		expect(marks[1].encode?.update).toHaveProperty('opacity');
 	});
 
-	test('both marks use fontWeight signal when fontWeight is not set', () => {
-		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
-		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { signal: CHART_SIZE_FONT_WEIGHT });
-		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { signal: CHART_SIZE_FONT_WEIGHT });
-	});
-
 	test('both marks use fontSize signal when fontSize is not set', () => {
 		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
 		expect(marks[0].encode?.update).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
 		expect(marks[1].encode?.update).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
-	});
-
-	test('explicit fontWeight overrides the signal', () => {
-		const opts = { ...defaultLabelSpecOptions, fontWeight: 400 };
-		const marks = getLineDirectLabelMarks('line0', opts, defaultLineOptions, 'gray-50', 'light');
-		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { value: 400 });
-		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { value: 400 });
 	});
 
 	test('explicit fontSize overrides the signal', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -14,6 +14,7 @@ import { Data, SourceData } from 'vega';
 import {
 	CHART_SIZE_FONT_SIZE,
 	DEFAULT_COLOR,
+	DIRECT_LABEL_FONT_WEIGHT,
 	DEFAULT_COLOR_SCHEME,
 	DEFAULT_METRIC,
 	DEFAULT_TIME_DIMENSION,
@@ -421,6 +422,12 @@ describe('getLineDirectLabelMarks', () => {
 		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
 		expect(marks[0].encode?.update).toHaveProperty('opacity');
 		expect(marks[1].encode?.update).toHaveProperty('opacity');
+	});
+
+	test('both marks have fixed fontWeight from DIRECT_LABEL_FONT_WEIGHT', () => {
+		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, defaultLineOptions, 'gray-50', 'light');
+		expect(marks[0].encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
+		expect(marks[1].encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
 	});
 
 	test('both marks use fontSize signal when fontSize is not set', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -151,6 +151,8 @@ export const getLineDirectLabelMarks = (
 	const yScaleName = lineOptions.metricAxis || 'yLinear';
 
 	const opacityRules = getLineOpacity(lineOptions);
+	const fontWeightEncoding = labelOptions.fontWeight == null ? { signal: CHART_SIZE_FONT_WEIGHT } : { value: labelOptions.fontWeight as FontWeight };
+  	const fontSizeEncoding = labelOptions.fontSize == null ? { signal: CHART_SIZE_FONT_SIZE } : { value: labelOptions.fontSize };
 
 	// Combined logic for direct label offset given 1, 2, or 3+ series
 	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (datum._cumMaxAdjusted + datum._metricRank * ${LABEL_LINE_HEIGHT} - 12 - datum._scaledY)`
@@ -184,8 +186,8 @@ export const getLineDirectLabelMarks = (
 				fill: { value: 'transparent' },
 			},
 			update: {
-				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
-				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },
+				fontWeight: fontWeightEncoding,
+				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},
 		},
@@ -202,8 +204,8 @@ export const getLineDirectLabelMarks = (
 				fill: getColorProductionRule(labelOptions.color, labelOptions.colorScheme),
 			},
 			update: {
-				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
-				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },
+				fontWeight: fontWeightEncoding,
+				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},
 		},

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -11,7 +11,7 @@
  */
 import { Data, FontWeight, Mark, TextMark, Transforms } from 'vega';
 
-import { CHART_SIZE_FONT_SIZE, CHART_SIZE_FONT_WEIGHT, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
+import { CHART_SIZE_FONT_SIZE, CHART_SIZE_FONT_WEIGHT, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getLineOpacity } from '../line/lineMarkUtils';
@@ -183,7 +183,6 @@ export const getLineDirectLabelMarks = (
 				strokeWidth: { value: DIRECT_LABEL_BACKGROUND_STROKE_WIDTH },
 				fill: { value: 'transparent' },
 			},
-			// update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
 			update: {
 				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
 				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },
@@ -202,7 +201,6 @@ export const getLineDirectLabelMarks = (
 				...baseEnter,
 				fill: getColorProductionRule(labelOptions.color, labelOptions.colorScheme),
 			},
-			// update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
 			update: {
 				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
 				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -9,9 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Data, FontWeight, Mark, TextMark, Transforms } from 'vega';
+import { Data, Mark, TextMark, Transforms } from 'vega';
 
-import { CHART_SIZE_FONT_SIZE, CHART_SIZE_FONT_WEIGHT, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
+import { CHART_SIZE_FONT_SIZE, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getLineOpacity } from '../line/lineMarkUtils';
@@ -151,7 +151,6 @@ export const getLineDirectLabelMarks = (
 	const yScaleName = lineOptions.metricAxis || 'yLinear';
 
 	const opacityRules = getLineOpacity(lineOptions);
-	const fontWeightEncoding = labelOptions.fontWeight == null ? { signal: CHART_SIZE_FONT_WEIGHT } : { value: labelOptions.fontWeight as FontWeight };
   	const fontSizeEncoding = labelOptions.fontSize == null ? { signal: CHART_SIZE_FONT_SIZE } : { value: labelOptions.fontSize };
 
 	// Combined logic for direct label offset given 1, 2, or 3+ series
@@ -186,7 +185,6 @@ export const getLineDirectLabelMarks = (
 				fill: { value: 'transparent' },
 			},
 			update: {
-				fontWeight: fontWeightEncoding,
 				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},
@@ -204,7 +202,6 @@ export const getLineDirectLabelMarks = (
 				fill: getColorProductionRule(labelOptions.color, labelOptions.colorScheme),
 			},
 			update: {
-				fontWeight: fontWeightEncoding,
 				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},
@@ -235,5 +232,4 @@ export const getLineDirectLabelSpecOptions = (
 	scaleType: lineOptions.scaleType,
 	value: labelOptions.value ?? 'last',
 	fontSize: labelOptions.fontSize,
-	fontWeight: labelOptions.fontWeight,
 });

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -11,7 +11,7 @@
  */
 import { Data, Mark, TextMark, Transforms } from 'vega';
 
-import { CHART_SIZE_FONT_SIZE, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
+import { CHART_SIZE_FONT_SIZE, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getLineOpacity } from '../line/lineMarkUtils';
@@ -185,6 +185,7 @@ export const getLineDirectLabelMarks = (
 				fill: { value: 'transparent' },
 			},
 			update: {
+				fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
 				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},
@@ -202,6 +203,7 @@ export const getLineDirectLabelMarks = (
 				fill: getColorProductionRule(labelOptions.color, labelOptions.colorScheme),
 			},
 			update: {
+				fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
 				fontSize: fontSizeEncoding,
 				opacity: opacityRules,
 			},

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -9,9 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Data, Mark, TextMark, Transforms } from 'vega';
+import { Data, FontWeight, Mark, TextMark, Transforms } from 'vega';
 
-import { DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
+import { CHART_SIZE_FONT_SIZE, CHART_SIZE_FONT_WEIGHT, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, FILTERED_TABLE, SERIES_ID } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getLineOpacity } from '../line/lineMarkUtils';
@@ -183,7 +183,12 @@ export const getLineDirectLabelMarks = (
 				strokeWidth: { value: DIRECT_LABEL_BACKGROUND_STROKE_WIDTH },
 				fill: { value: 'transparent' },
 			},
-			update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
+			// update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
+			update: {
+				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
+				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },
+				opacity: opacityRules,
+			},
 		},
 	};
 
@@ -197,7 +202,12 @@ export const getLineDirectLabelMarks = (
 				...baseEnter,
 				fill: getColorProductionRule(labelOptions.color, labelOptions.colorScheme),
 			},
-			update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
+			// update: { fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT }, opacity: opacityRules },
+			update: {
+				fontWeight: labelOptions.fontWeight != null ? { value: labelOptions.fontWeight as FontWeight } : { signal: CHART_SIZE_FONT_WEIGHT },
+				fontSize: labelOptions.fontSize != null ? { value: labelOptions.fontSize } : { signal: CHART_SIZE_FONT_SIZE },
+				opacity: opacityRules,
+			},
 		},
 	};
 
@@ -224,4 +234,6 @@ export const getLineDirectLabelSpecOptions = (
 	prefix: labelOptions.prefix ?? '',
 	scaleType: lineOptions.scaleType,
 	value: labelOptions.value ?? 'last',
+	fontSize: labelOptions.fontSize,
+	fontWeight: labelOptions.fontWeight,
 });

--- a/packages/vega-spec-builder-s2/src/specTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specTestUtils.ts
@@ -13,6 +13,8 @@ import { Signal } from 'vega';
 
 import {
   CHART_SIZE_BREAKPOINTS,
+  CHART_SIZE_FONT_SIZE,
+  CHART_SIZE_FONT_WEIGHT,
   CHART_SIZE_HOVER_STROKE_WIDTH,
   CHART_SIZE_HOVER_STROKE_WIDTHS,
   CHART_SIZE_POINT_SIZE,
@@ -21,6 +23,12 @@ import {
   CHART_SIZE_STROKE_WIDTHS,
   CONTROLLED_HIGHLIGHTED_ITEM,
   CONTROLLED_HIGHLIGHTED_SERIES,
+  DIRECT_LABEL_FONT_SIZE_L,
+  DIRECT_LABEL_FONT_SIZE_M,
+  DIRECT_LABEL_FONT_SIZE_S,
+  DIRECT_LABEL_FONT_WEIGHT_L,
+  DIRECT_LABEL_FONT_WEIGHT_M,
+  DIRECT_LABEL_FONT_WEIGHT_S,
   HIGHLIGHTED_GROUP,
   SELECTED_GROUP,
   SELECTED_ITEM,
@@ -51,6 +59,16 @@ export const defaultChartSizePointSizeSignal = {
   update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${CHART_SIZE_POINT_SIZES.S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${CHART_SIZE_POINT_SIZES.M} : ${CHART_SIZE_POINT_SIZES.L}`,
 };
 
+export const defaultChartSizeFontSizeSignal = {
+  name: CHART_SIZE_FONT_SIZE,
+  update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_SIZE_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_SIZE_M} : ${DIRECT_LABEL_FONT_SIZE_L}`,
+};
+
+export const defaultChartSizeFontWeightSignal = {
+  name: CHART_SIZE_FONT_WEIGHT,
+  update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_WEIGHT_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_WEIGHT_M} : ${DIRECT_LABEL_FONT_WEIGHT_L}`,
+};
+
 export const defaultSignals: Signal[] = [
   defaultHighlightedItemSignal,
   defaultHighlightedGroupSignal,
@@ -61,4 +79,6 @@ export const defaultSignals: Signal[] = [
   defaultChartSizeStrokeWidthSignal,
   defaultChartSizeHoverStrokeWidthSignal,
   defaultChartSizePointSizeSignal,
+  defaultChartSizeFontSizeSignal,
+  defaultChartSizeFontWeightSignal,
 ];

--- a/packages/vega-spec-builder-s2/src/specTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specTestUtils.ts
@@ -14,7 +14,6 @@ import { Signal } from 'vega';
 import {
   CHART_SIZE_BREAKPOINTS,
   CHART_SIZE_FONT_SIZE,
-  CHART_SIZE_FONT_WEIGHT,
   CHART_SIZE_HOVER_STROKE_WIDTH,
   CHART_SIZE_HOVER_STROKE_WIDTHS,
   CHART_SIZE_POINT_SIZE,
@@ -26,9 +25,6 @@ import {
   DIRECT_LABEL_FONT_SIZE_L,
   DIRECT_LABEL_FONT_SIZE_M,
   DIRECT_LABEL_FONT_SIZE_S,
-  DIRECT_LABEL_FONT_WEIGHT_L,
-  DIRECT_LABEL_FONT_WEIGHT_M,
-  DIRECT_LABEL_FONT_WEIGHT_S,
   HIGHLIGHTED_GROUP,
   SELECTED_GROUP,
   SELECTED_ITEM,
@@ -64,11 +60,6 @@ export const defaultChartSizeFontSizeSignal = {
   update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_SIZE_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_SIZE_M} : ${DIRECT_LABEL_FONT_SIZE_L}`,
 };
 
-export const defaultChartSizeFontWeightSignal = {
-  name: CHART_SIZE_FONT_WEIGHT,
-  update: `rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.M} ? ${DIRECT_LABEL_FONT_WEIGHT_S} : rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? ${DIRECT_LABEL_FONT_WEIGHT_M} : ${DIRECT_LABEL_FONT_WEIGHT_L}`,
-};
-
 export const defaultSignals: Signal[] = [
   defaultHighlightedItemSignal,
   defaultHighlightedGroupSignal,
@@ -80,5 +71,4 @@ export const defaultSignals: Signal[] = [
   defaultChartSizeHoverStrokeWidthSignal,
   defaultChartSizePointSizeSignal,
   defaultChartSizeFontSizeSignal,
-  defaultChartSizeFontWeightSignal,
 ];

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineDirectLabelSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineDirectLabelSpec.types.ts
@@ -37,6 +37,10 @@ export interface LineDirectLabelOptions {
   prefix?: string;
   /** Series values to exclude from labeling. */
   excludeSeries?: string[];
+  /** Label font size override */
+  fontSize?: number;
+  /** Label font weight override */
+  fontWeight?: number;
 }
 
 type LineDirectLabelOptionsWithDefaults = 'value' | 'position' | 'excludeSeries';

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineDirectLabelSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/lineDirectLabelSpec.types.ts
@@ -39,8 +39,6 @@ export interface LineDirectLabelOptions {
   excludeSeries?: string[];
   /** Label font size override */
   fontSize?: number;
-  /** Label font weight override */
-  fontWeight?: number;
 }
 
 type LineDirectLabelOptionsWithDefaults = 'value' | 'position' | 'excludeSeries';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added auto scaling for Direct Labels so that their font size adjusts between S/M/L depending on chart size.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The S2 design spec requires that direct label font size and weight scale down for medium and small chart contexts — a direct label appropriate for a large full-page chart is visually heavy on a sparkline or trellis panel.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests verify that:
- Both marks emit { signal: 'rscChartSizeFontSize' } and { signal: 'rscChartSizeFontWeight' } by default
- When fonSize/fontWeight are explicitly set on the label options, the marks emit use that value instead
- When fontSize/fontWeight is not explicitly set, they are passed as undefined

Also added new storybook story "Direct Label Size Scaling" for visually testing behavior.

## Screenshots (if appropriate):
<img width="978" height="443" alt="image" src="https://github.com/user-attachments/assets/e8338682-429e-4a61-bd9e-a2e57fd5baaf" />
<img width="978" height="443" alt="image" src="https://github.com/user-attachments/assets/62feae45-1968-43d4-8359-aa243eccaac2" />
<img width="978" height="443" alt="image" src="https://github.com/user-attachments/assets/803fe3d7-4ef2-47d4-9d2d-6e3f351ceaf6" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
