### PR TITLE
feat: s2 line direct label auto stack - feedback updates 

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/Cascade/LineDirectLabelCascade.story.tsx
@@ -227,19 +227,19 @@ const LineDirectLabelManySeriesLegendStory: StoryFn<typeof LineDirectLabel> = (a
 // BINDINGS
 
 const DirectLabelTwoSeries = bindWithProps(LineDirectLabelTwoSeriesStory);
-DirectLabelTwoSeries.args = { value: 'last' };
+DirectLabelTwoSeries.args = { value: 'series' };
 
 const DirectLabelThreeSeriesDiverge = bindWithProps(LineDirectLabelThreeSeriesDivergeStory);
-DirectLabelThreeSeriesDiverge.args = { value: 'last' };
+DirectLabelThreeSeriesDiverge.args = { value: 'series' };
 
 const DirectLabelSixSeries = bindWithProps(LineDirectLabelSixSeriesStory);
-DirectLabelSixSeries.args = { value: 'last' };
+DirectLabelSixSeries.args = { value: 'series' };
 
 const DirectLabelManySeries = bindWithProps(LineDirectLabelManySeriesStory);
-DirectLabelManySeries.args = { value: 'last' };
+DirectLabelManySeries.args = { value: 'series' };
 
 const DirectLabelManySeriesLegend = bindWithProps(LineDirectLabelManySeriesLegendStory);
-DirectLabelManySeriesLegend.args = { value: 'last' };
+DirectLabelManySeriesLegend.args = { value: 'series' };
 
 export {
   DirectLabelTwoSeries,

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DirectLabel/LineDirectLabel.story.tsx
@@ -84,7 +84,7 @@ const DirectLabelValueAverage = bindWithProps(LineDirectLabelStory);
 DirectLabelValueAverage.args = { value: 'average' };
 
 const DirectLabelWithInspect = bindWithProps(LineDirectLabelWithInspectStory);
-DirectLabelWithInspect.args = { value: 'last' };
+DirectLabelWithInspect.args = { value: 'series' };
 
 const DirectLabelPositionStart = bindWithProps(LineDirectLabelStory);
 DirectLabelPositionStart.args = { value: 'series', position: 'start' };

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -204,7 +204,7 @@ describe('getLineDirectLabelData', () => {
 		const transforms = getTransforms(data);
 		const formula = transforms.find((t) => t.type === 'formula' && 'as' in t && t.as === '_adjustedY');
 		expect(formula).toBeDefined();
-		expect((formula as { expr: string }).expr).toBe('datum._scaledY - datum._metricRank * 16');
+		expect((formula as { expr: string }).expr).toBe('datum._scaledY - datum._metricRank * 12');
 	});
 
 	test('includes _cumMaxAdjusted cumulative window transform', () => {
@@ -361,27 +361,27 @@ describe('getLineDirectLabelMarks', () => {
 		};
 
 		test('rank 1 always places label 12px above the line terminus', () => {
-			// cumMaxAdjusted = _scaledY - 1*16 for rank 1
-			// offset = (100 - 16) + 1*16 - 12 - 100 = -12
-			expect(evalOffsetSignal({ _metricRank: 1, _scaledY: 100, _cumMaxAdjusted: 84 })).toBe(-12);
+			// cumMaxAdjusted = _scaledY - 1*12 for rank 1
+			// offset = (100 - 12) + 1*12 - 12 - 100 = -12
+			expect(evalOffsetSignal({ _metricRank: 1, _scaledY: 100, _cumMaxAdjusted: 88 })).toBe(-12);
 		});
 
 		test('rank 2 well-separated from rank 1: also placed 12px above', () => {
-			// rank2 adjustedY (200 - 32 = 168) > rank1 adjustedY, so cumMaxAdjusted = 168
-			// offset = 168 + 2*16 - 12 - 200 = -12
-			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 200, _cumMaxAdjusted: 168 })).toBe(-12);
+			// rank2 adjustedY (200 - 24 = 176) > rank1 adjustedY, so cumMaxAdjusted = 176
+			// offset = 176 + 2*12 - 12 - 200 = -12
+			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 200, _cumMaxAdjusted: 176 })).toBe(-12);
 		});
 
 		test('rank 2 close to rank 1: pushed above natural position to avoid overlap', () => {
-			// rank1 adjustedY (100 - 16 = 84) > rank2 adjustedY (108 - 32 = 76), so cumMaxAdjusted = 84
-			// offset = 84 + 2*16 - 12 - 108 = -4 (less negative than -12, meaning pushed further up)
-			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 108, _cumMaxAdjusted: 84 })).toBe(-4);
+			// rank1 adjustedY (100 - 12 = 88) > rank2 adjustedY (108 - 24 = 84), so cumMaxAdjusted = 88
+			// offset = 88 + 2*12 - 12 - 108 = -8 (less negative than -12, meaning pushed further up)
+			expect(evalOffsetSignal({ _metricRank: 2, _scaledY: 108, _cumMaxAdjusted: 88 })).toBe(-8);
 		});
 
-		test('rank 3 very close to preceding labels: label placed below line terminus', () => {
-			// cumMaxAdjusted still 84 (all three close together)
-			// offset = 84 + 3*16 - 12 - 112 = 8 (positive = below line)
-			expect(evalOffsetSignal({ _metricRank: 3, _scaledY: 112, _cumMaxAdjusted: 84 })).toBe(8);
+		test('rank 3 very close to preceding labels: stacked exactly MIN_LABEL_GAP below rank 2', () => {
+			// rank1 adjustedY (100 - 12 = 88) dominates cumMaxAdjusted for all three
+			// offset = 88 + 3*12 - 12 - 112 = 0 (at line terminus, pushed down from natural -12)
+			expect(evalOffsetSignal({ _metricRank: 3, _scaledY: 112, _cumMaxAdjusted: 88 })).toBe(0);
 		});
 
 		test('y field is the metric', () => {

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -20,7 +20,7 @@ import { getScaleName } from '../scale/scaleSpecBuilder';
 import { getDimensionField, getFacetsFromOptions } from '../specUtils';
 import { LineDirectLabelOptions, LineDirectLabelSpecOptions, LineSpecOptions, LabelValue } from '../types';
 
-const LABEL_LINE_HEIGHT = 12;
+const MIN_LABEL_GAP = 12;
 
 /**
  * Derived dataset: one row per series at the last (max-dimension) data point.
@@ -88,7 +88,7 @@ export const getLineDirectLabelData = (
 			as: ['_metricRank'],
 		},
 		{ type: 'formula' as const, as: '_scaledY', expr: `scale('${yScaleName}', datum["${metric}"])` },
-		{ type: 'formula' as const, as: '_adjustedY', expr: `datum._scaledY - datum._metricRank * ${LABEL_LINE_HEIGHT}` },
+		{ type: 'formula' as const, as: '_adjustedY', expr: `datum._scaledY - datum._metricRank * ${MIN_LABEL_GAP}` },
 		{
 			type: 'window' as const,
 			sort: { field: ['_metricRank'], order: ['ascending' as const] },
@@ -153,7 +153,7 @@ export const getLineDirectLabelMarks = (
 	const opacityRules = getLineOpacity(lineOptions);
 
 	// Combined logic for direct label offset given 1, 2, or 3+ series
-	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (datum._cumMaxAdjusted + datum._metricRank * ${LABEL_LINE_HEIGHT} - 12 - datum._scaledY)`
+	const offsetSignal = `datum._seriesCount === 2 ? (datum._metricRank === 1 ? -12 : 22) : (datum._cumMaxAdjusted + datum._metricRank * ${MIN_LABEL_GAP} - 12 - datum._scaledY)`
 
 	const baseEnter = {
 		text: { signal: textExpr },

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -20,7 +20,7 @@ import { getScaleName } from '../scale/scaleSpecBuilder';
 import { getDimensionField, getFacetsFromOptions } from '../specUtils';
 import { LineDirectLabelOptions, LineDirectLabelSpecOptions, LineSpecOptions, LabelValue } from '../types';
 
-const LABEL_LINE_HEIGHT = 16;
+const LABEL_LINE_HEIGHT = 12;
 
 /**
  * Derived dataset: one row per series at the last (max-dimension) data point.


### PR DESCRIPTION
## Description

Reducing gap between cascading labels, updating stories to all use 'series' except for the specific 'value' stories. 

## Motivation and Context

Feedback updates. 

## How Has This Been Tested?

Storybook and unit tests. 

## Screenshots (if appropriate):

<img width="837" height="441" alt="Screenshot 2026-06-05 at 5 31 20 PM" src="https://github.com/user-attachments/assets/6af7e8f2-da6f-4dcf-b056-cc16bcd65547" />
<img width="847" height="439" alt="Screenshot 2026-06-05 at 5 31 28 PM" src="https://github.com/user-attachments/assets/a8a81b45-43dc-4576-97de-75c30661a1f7" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
