### PR TITLE
fix: legend columns account for actual label  size rather than just using labelLimit

### DIFF
--- a/packages/react-spectrum-charts-s2/src/VegaChart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/VegaChart.test.tsx
@@ -54,15 +54,16 @@ describe('resizeView', () => {
 		jest.clearAllMocks();
 	});
 
-	test('calls width, height, resize, and runAsync when view exists and dimensions are valid', () => {
+	test('calls width, height, resize, and runAsync twice when view exists and dimensions are valid', async () => {
 		const mockView = createMockView();
 
 		resizeView(mockView, 800, 600);
+		await Promise.resolve();
 
 		expect(mockWidth).toHaveBeenCalledWith(800);
 		expect(mockHeight).toHaveBeenCalledWith(600);
 		expect(mockResize).toHaveBeenCalled();
-		expect(mockRunAsync).toHaveBeenCalled();
+		expect(mockRunAsync).toHaveBeenCalledTimes(2);
 	});
 
 	test('does not call view methods when view is undefined', () => {

--- a/packages/react-spectrum-charts-s2/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/VegaChart.tsx
@@ -39,7 +39,9 @@ expressionFunction('rscContainerWidth', function (this: { context: { dataflow: V
  */
 export const resizeView = (view: View | undefined, width: number, height: number): void => {
   if (view && width && height) {
-    view.width(width).height(height).resize().runAsync();
+    // Two passes: first updates width/height signals; second lets Vega re-settle layout
+    // after dependent changes (e.g. legend column count → legend height → plot area height).
+    view.width(width).height(height).resize().runAsync().then(() => view.runAsync());
   }
 };
 

--- a/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
@@ -376,7 +376,7 @@ describe('Chart', () => {
       expect(inspectElement).toBeInTheDocument();
       if (!inspectElement) return;
 
-      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(162);
+      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(187);
       expect(getPxValue(inspectElement.style.getPropertyValue('left'))).toBe(35);
     });
 
@@ -391,7 +391,7 @@ describe('Chart', () => {
       expect(inspectElement).toBeInTheDocument();
       if (!inspectElement) return;
 
-      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(197);
+      expect(getPxValue(inspectElement.style.getPropertyValue('top'))).toBe(225);
       expect(getPxValue(inspectElement.style.getPropertyValue('left'))).toBe(35);
     });
   });

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/TrellisBar.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/TrellisBar.test.tsx
@@ -45,9 +45,9 @@ describe('TrellisBar', () => {
     const popoverAnchor = await screen.findByTestId('rsc-popover-anchor');
     expect(popoverAnchor).toHaveStyle('position: absolute');
     expect(popoverAnchor).toHaveStyle('width: 85.60000000000002px');
-    expect(popoverAnchor).toHaveStyle('height: 8.215714285714284px');
+    expect(popoverAnchor).toHaveStyle('height: 8.575714285714298px');
     expect(popoverAnchor).toHaveStyle('left: 316.5px');
-    expect(popoverAnchor).toHaveStyle('top: 344.2385714285714px');
+    expect(popoverAnchor).toHaveStyle('top: 358.35857142857145px');
   });
 
   test('HorizontalBarHorizontalTrellis renders correctly', async () => {
@@ -111,8 +111,8 @@ describe('TrellisBar', () => {
       // Y Trellis Group should have Y Translate. X Translate should be 0.
       // First chart should not have been tra.
       expect(trellisCharts[0]).toHaveAttribute('transform', 'translate(0,0)');
-      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,238.95131086142322)');
-      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,477.90262172284645)');
+      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,249.43820224719101)');
+      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,498.87640449438203)');
     });
 
     test('WithCustomTrellisPadding has correct padding for horizontal trellis', async () => {

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/Legend.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/Legend.story.tsx
@@ -9,9 +9,74 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ChartPopover, Legend } from '../../../components';
+import { ReactElement } from 'react';
+
+import { View } from '@adobe/react-spectrum';
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, ChartPopover, Legend, Line } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
-import { LegendBarStory, LegendDisconnectedStory, defaultProps } from './LegendStoryUtils';
+import { LegendBarStory, LegendDisconnectedStory, LegendLineStory, defaultProps } from './LegendStoryUtils';
+
+const WEEK_DATETIMES = [
+  1780293600000, 1780380000000, 1780466400000, 1780552800000,
+  1780639200000, 1780725600000, 1780812000000,
+];
+
+const fiveSeriesNames = ['CJA Users', 'Accounts', 'Events', 'Page Views', 'Sessions'];
+const legendColumns5SeriesData = fiveSeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 1000 + si * 900 + di * 180, series }))
+);
+
+const longLabelSeriesNames = [
+  'Users',
+  'Events',
+  'Conversion Rate From All Marketing Channel Sources',
+];
+const legendColumnsLongLabelData = longLabelSeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 1000 + si * 1200 + di * 150, series }))
+);
+
+const twentySeriesNames = [
+  'DAU', 'MAU', 'CTR', 'CVR', 'Sessions',
+  'Accounts', 'Visitors', 'Pageviews', 'New Users', 'Returning',
+  'Unique Visitors', 'Time on Page', 'Bounce Rate', 'Revenue', 'Avg Session',
+  'Cart Abandonment', 'Email Open Rate', 'Customer LTV', 'Revenue Per Visit', 'Mobile Sessions',
+];
+const legendColumns20SeriesData = twentySeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 500 + si * 250 + di * 80, series }))
+);
+
+const makeResizableLegendLineStory = (data: Record<string, unknown>[]): StoryFn<typeof Legend> => {
+  const ResizableLegendLineStory: StoryFn<typeof Legend> = (args): ReactElement => {
+    const chartProps = useChartProps({ data, width: 'auto', height: '100%', padding: 2 });
+    return (
+      <View
+        backgroundColor="gray-50"
+        overflow="auto"
+        width={700}
+        minWidth={200}
+        maxWidth={1400}
+        height={350}
+        minHeight={200}
+        maxHeight={600}
+        borderColor="gray-400"
+        borderWidth="thick"
+        UNSAFE_style={{ resize: 'both' }}
+      >
+        <Chart {...chartProps}>
+          <Axis position="left" grid />
+          <Axis position="bottom" labelFormat="time" baseline ticks />
+          <Line color="series" dimension="datetime" metric="value" scaleType="time" />
+          <Legend {...args} />
+        </Chart>
+      </View>
+    );
+  };
+  return ResizableLegendLineStory;
+};
 
 export default {
   title: 'React Spectrum Charts 2/Legend/Features',
@@ -85,6 +150,33 @@ Supreme.args = {
   title: 'Operating system',
 };
 
+const LegendColumns = bindWithProps(LegendLineStory);
+LegendColumns.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
+const ResizableWith5Series = makeResizableLegendLineStory(legendColumns5SeriesData);
+const LegendColumnsExtended = bindWithProps(ResizableWith5Series);
+LegendColumnsExtended.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
+const ResizableWithLongLabel = makeResizableLegendLineStory(legendColumnsLongLabelData);
+const LegendColumnsLongLabel = bindWithProps(ResizableWithLongLabel);
+LegendColumnsLongLabel.args = {
+  labelLimit: 500,
+  highlight: true,
+};
+
+const ResizableWith20Series = makeResizableLegendLineStory(legendColumns20SeriesData);
+const LegendColumns20Series = bindWithProps(ResizableWith20Series);
+LegendColumns20Series.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
 export {
   Basic,
   Descriptions,
@@ -97,4 +189,8 @@ export {
   Position,
   Title,
   Supreme,
+  LegendColumns,
+  LegendColumnsExtended,
+  LegendColumnsLongLabel,
+  LegendColumns20Series,
 };

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/Legend.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/Legend.test.tsx
@@ -30,6 +30,8 @@ import {
   Basic,
   Descriptions,
   LabelLimit,
+  LegendColumns,
+  LegendColumnsExtended,
   OnClick,
   Popover,
   Position,
@@ -301,6 +303,18 @@ describe('Legend', () => {
     // Check that the legend title is present. Note that JSDOM causes this to not match the UI rendered storybook.
     // We're just testing that the chart renders with the titleLimit prop.
     expect(screen.getByText('Very long legend title that should be truncated')).toBeInTheDocument();
+  });
+
+  test('LegendColumns renders properly', async () => {
+    render(<LegendColumns {...LegendColumns.args} />);
+    const view = await screen.findByRole('graphics-document');
+    expect(view).toBeInTheDocument();
+  });
+
+  test('LegendColumnsExtended renders properly', async () => {
+    render(<LegendColumnsExtended {...LegendColumnsExtended.args} />);
+    const view = await screen.findByRole('graphics-document');
+    expect(view).toBeInTheDocument();
   });
 
   // Legend is not a real React component. This is test just provides test coverage for sonarqube

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendStoryUtils.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendStoryUtils.tsx
@@ -14,10 +14,35 @@ import React, { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../Chart';
-import { Axis, Bar, Legend } from '../../../components';
+import { Axis, Bar, Legend, Line } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { LegendProps } from '../../../types';
 import { browserData as data } from '../../data/data';
+
+// Jun 1–7 2026 daily data, 3 series mirroring a CJA multi-metric line chart
+export const legendColumnsData = [
+  { datetime: 1780293600000, value: 5173, series: 'CJA Users' },
+  { datetime: 1780380000000, value: 5382, series: 'CJA Users' },
+  { datetime: 1780466400000, value: 5359, series: 'CJA Users' },
+  { datetime: 1780552800000, value: 5117, series: 'CJA Users' },
+  { datetime: 1780639200000, value: 2987, series: 'CJA Users' },
+  { datetime: 1780725600000, value: 102, series: 'CJA Users' },
+  { datetime: 1780812000000, value: 98, series: 'CJA Users' },
+  { datetime: 1780293600000, value: 5771, series: 'Accounts' },
+  { datetime: 1780380000000, value: 5766, series: 'Accounts' },
+  { datetime: 1780466400000, value: 5833, series: 'Accounts' },
+  { datetime: 1780552800000, value: 5717, series: 'Accounts' },
+  { datetime: 1780639200000, value: 5277, series: 'Accounts' },
+  { datetime: 1780725600000, value: 210, series: 'Accounts' },
+  { datetime: 1780812000000, value: 185, series: 'Accounts' },
+  { datetime: 1780293600000, value: 12077019, series: 'Events' },
+  { datetime: 1780380000000, value: 12336199, series: 'Events' },
+  { datetime: 1780466400000, value: 12587046, series: 'Events' },
+  { datetime: 1780552800000, value: 11499035, series: 'Events' },
+  { datetime: 1780639200000, value: 5737435, series: 'Events' },
+  { datetime: 1780725600000, value: 42104, series: 'Events' },
+  { datetime: 1780812000000, value: 38291, series: 'Events' },
+];
 
 export const LegendBarStory: StoryFn<typeof Legend> = (args): ReactElement => {
   const chartProps = useChartProps({ data, width: 700 });
@@ -66,4 +91,16 @@ export const LegendDisconnectedStory: StoryFn<typeof Legend> = (args): ReactElem
 
 export const defaultProps: LegendProps = {
   onClick: undefined,
+};
+
+export const LegendLineStory: StoryFn<typeof Legend> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: legendColumnsData, width: 700, height: 300 });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series" dimension="datetime" metric="value" scaleType="time" />
+      <Legend {...args} />
+    </Chart>
+  );
 };

--- a/packages/react-spectrum-charts/src/VegaChart.test.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.test.tsx
@@ -55,15 +55,16 @@ describe('resizeView', () => {
 		jest.clearAllMocks();
 	});
 
-	test('calls width, height, resize, and runAsync when view exists and dimensions are valid', () => {
+	test('calls width, height, resize, and runAsync twice when view exists and dimensions are valid', async () => {
 		const mockView = createMockView();
 
 		resizeView(mockView, 800, 600);
+		await Promise.resolve();
 
 		expect(mockWidth).toHaveBeenCalledWith(800);
 		expect(mockHeight).toHaveBeenCalledWith(600);
 		expect(mockResize).toHaveBeenCalled();
-		expect(mockRunAsync).toHaveBeenCalled();
+		expect(mockRunAsync).toHaveBeenCalledTimes(2);
 	});
 
 	test('does not call view methods when view is undefined', () => {

--- a/packages/react-spectrum-charts/src/VegaChart.tsx
+++ b/packages/react-spectrum-charts/src/VegaChart.tsx
@@ -28,7 +28,9 @@ import { ChartProps } from './types';
  */
 export const resizeView = (view: View | undefined, width: number, height: number): void => {
   if (view && width && height) {
-    view.width(width).height(height).resize().runAsync();
+    // Two passes: first updates width/height signals; second lets Vega re-settle layout
+    // after dependent changes (e.g. legend column count → legend height → plot area height).
+    view.width(width).height(height).resize().runAsync().then(() => view.runAsync());
   }
 };
 

--- a/packages/react-spectrum-charts/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/Chart.test.tsx
@@ -377,7 +377,7 @@ describe('Chart', () => {
       expect(tooltip).toBeInTheDocument();
       if (!tooltip) return;
 
-      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(176);
+      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(201);
       expect(getPxValue(tooltip.style.getPropertyValue('left'))).toBe(35);
     });
 
@@ -392,7 +392,7 @@ describe('Chart', () => {
       expect(tooltip).toBeInTheDocument();
       if (!tooltip) return;
 
-      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(213);
+      expect(getPxValue(tooltip.style.getPropertyValue('top'))).toBe(241);
       expect(getPxValue(tooltip.style.getPropertyValue('left'))).toBe(35);
     });
   });

--- a/packages/react-spectrum-charts/src/stories/components/Bar/TrellisBar.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Bar/TrellisBar.test.tsx
@@ -45,9 +45,9 @@ describe('TrellisBar', () => {
     const popoverAnchor = await screen.findByTestId('rsc-popover-anchor');
     expect(popoverAnchor).toHaveStyle('position: absolute');
     expect(popoverAnchor).toHaveStyle('width: 85.60000000000002px');
-    expect(popoverAnchor).toHaveStyle('height: 8.421428571428521px');
+    expect(popoverAnchor).toHaveStyle('height: 8.781428571428592px');
     expect(popoverAnchor).toHaveStyle('left: 316.5px');
-    expect(popoverAnchor).toHaveStyle('top: 352.30714285714294px');
+    expect(popoverAnchor).toHaveStyle('top: 366.4271428571429px');
   });
 
   test('HorizontalBarHorizontalTrellis renders correctly', async () => {
@@ -111,8 +111,8 @@ describe('TrellisBar', () => {
       // Y Trellis Group should have Y Translate. X Translate should be 0.
       // First chart should not have been tra.
       expect(trellisCharts[0]).toHaveAttribute('transform', 'translate(0,0)');
-      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,244.9438202247191)');
-      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,489.8876404494382)');
+      expect(trellisCharts[1]).toHaveAttribute('transform', 'translate(0,255.4307116104869)');
+      expect(trellisCharts[2]).toHaveAttribute('transform', 'translate(0,510.8614232209738)');
     });
 
     test('WithCustomTrellisPadding has correct padding for horizontal trellis', async () => {

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
@@ -69,8 +69,8 @@ const legendColumns20SeriesData = twentySeriesNames.flatMap((series, si) =>
   WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 500 + si * 250 + di * 80, series }))
 );
 
-const makeResizableLegendLineStory = (data: Record<string, unknown>[]): StoryFn<typeof Legend> =>
-  (args): ReactElement => {
+const makeResizableLegendLineStory = (data: Record<string, unknown>[]): StoryFn<typeof Legend> => {
+  const ResizableLegendLineStory: StoryFn<typeof Legend> = (args): ReactElement => {
     const chartProps = useChartProps({ data, width: 'auto', height: '100%', padding: 2 });
     return (
       <View
@@ -95,6 +95,8 @@ const makeResizableLegendLineStory = (data: Record<string, unknown>[]): StoryFn<
       </View>
     );
   };
+  return ResizableLegendLineStory;
+};
 
 export default {
   title: 'RSC/Legend',

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
@@ -9,9 +9,92 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ChartPopover, Legend } from '../../../components';
-import { LegendBarStory, LegendDisconnectedStory, defaultProps } from './LegendStoryUtils';
+import { ReactElement } from 'react';
+
+import { View } from '@adobe/react-spectrum';
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, ChartPopover, Legend, Line } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
+import { LegendBarStory, LegendDisconnectedStory, LegendLineStory, defaultProps } from './LegendStoryUtils';
+
+// Shared datetime range: Jun 1–7 2026 (daily)
+const WEEK_DATETIMES = [
+  1780293600000, 1780380000000, 1780466400000, 1780552800000,
+  1780639200000, 1780725600000, 1780812000000,
+];
+
+// Story 1: 5 series, all short similar-sized labels
+const fiveSeriesNames = ['CJA Users', 'Accounts', 'Events', 'Page Views', 'Sessions'];
+const legendColumns5SeriesData = fiveSeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 1000 + si * 900 + di * 180, series }))
+);
+
+// Story 2: 3 series, one very long label (~350px), labelLimit 500
+const longLabelSeriesNames = [
+  'Users',
+  'Events',
+  'Conversion Rate From All Marketing Channel Sources',
+];
+const legendColumnsLongLabelData = longLabelSeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 1000 + si * 1200 + di * 150, series }))
+);
+
+// Story 3: 20 series of varying label lengths
+const twentySeriesNames = [
+  'DAU',
+  'MAU',
+  'CTR',
+  'CVR',
+  'Sessions',
+  'Accounts',
+  'Visitors',
+  'Pageviews',
+  'New Users',
+  'Returning',
+  'Unique Visitors',
+  'Time on Page',
+  'Bounce Rate',
+  'Revenue',
+  'Avg Session',
+  'Cart Abandonment',
+  'Email Open Rate',
+  'Customer LTV',
+  'Revenue Per Visit',
+  'Mobile Sessions',
+];
+const legendColumns20SeriesData = twentySeriesNames.flatMap((series, si) =>
+  WEEK_DATETIMES.map((datetime, di) => ({ datetime, value: 500 + si * 250 + di * 80, series }))
+);
+
+const makeResizableLegendLineStory = (data: Record<string, unknown>[]): StoryFn<typeof Legend> =>
+  (args): ReactElement => {
+    const chartProps = useChartProps({ data, width: 'auto', height: '100%', padding: 2 });
+    return (
+      <View
+        backgroundColor="gray-50"
+        overflow="auto"
+        width={700}
+        minWidth={200}
+        maxWidth={1400}
+        height={350}
+        minHeight={200}
+        maxHeight={600}
+        borderColor="gray-400"
+        borderWidth="thick"
+        UNSAFE_style={{ resize: 'both' }}
+      >
+        <Chart {...chartProps}>
+          <Axis position="left" grid />
+          <Axis position="bottom" labelFormat="time" baseline ticks />
+          <Line color="series" dimension="datetime" metric="value" scaleType="time" />
+          <Legend {...args} />
+        </Chart>
+      </View>
+    );
+  };
 
 export default {
   title: 'RSC/Legend',
@@ -85,6 +168,33 @@ Supreme.args = {
   title: 'Operating system',
 };
 
+const LegendColumns = bindWithProps(LegendLineStory);
+LegendColumns.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
+const ResizableWith5Series = makeResizableLegendLineStory(legendColumns5SeriesData);
+const LegendColumnsExtended = bindWithProps(ResizableWith5Series);
+LegendColumnsExtended.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
+const ResizableWithLongLabel = makeResizableLegendLineStory(legendColumnsLongLabelData);
+const LegendColumnsLongLabel = bindWithProps(ResizableWithLongLabel);
+LegendColumnsLongLabel.args = {
+  labelLimit: 500,
+  highlight: true,
+};
+
+const ResizableWith20Series = makeResizableLegendLineStory(legendColumns20SeriesData);
+const LegendColumns20Series = bindWithProps(ResizableWith20Series);
+LegendColumns20Series.args = {
+  labelLimit: 200,
+  highlight: true,
+};
+
 export {
   Basic,
   Descriptions,
@@ -97,4 +207,8 @@ export {
   Position,
   Title,
   Supreme,
+  LegendColumns,
+  LegendColumnsExtended,
+  LegendColumnsLongLabel,
+  LegendColumns20Series,
 };

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.test.tsx
@@ -30,6 +30,8 @@ import {
   Basic,
   Descriptions,
   LabelLimit,
+  LegendColumns,
+  LegendColumnsExtended,
   OnClick,
   Popover,
   Position,
@@ -301,6 +303,18 @@ describe('Legend', () => {
     // Check that the legend title is present. Note that JSDOM causes this to not match the UI rendered storybook.
     // We're just testing that the chart renders with the titleLimit prop.
     expect(screen.getByText('Very long legend title that should be truncated')).toBeInTheDocument();
+  });
+
+  test('LegendColumns renders properly', async () => {
+    render(<LegendColumns {...LegendColumns.args} />);
+    const view = await screen.findByRole('graphics-document');
+    expect(view).toBeInTheDocument();
+  });
+
+  test('LegendColumnsExtended renders properly', async () => {
+    render(<LegendColumnsExtended {...LegendColumnsExtended.args} />);
+    const view = await screen.findByRole('graphics-document');
+    expect(view).toBeInTheDocument();
   });
 
   // Legend is not a real React component. This is test just provides test coverage for sonarqube

--- a/packages/react-spectrum-charts/src/stories/components/Legend/LegendStoryUtils.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/LegendStoryUtils.tsx
@@ -14,10 +14,35 @@ import React, { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../Chart';
-import { Axis, Bar, Legend } from '../../../components';
+import { Axis, Bar, Legend, Line } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { LegendProps } from '../../../types';
 import { browserData as data } from '../../data/data';
+
+// Jun 1–7 2026 daily data, 3 series mirroring a CJA multi-metric line chart
+export const legendColumnsData = [
+  { datetime: 1780293600000, value: 5173, series: 'CJA Users' },
+  { datetime: 1780380000000, value: 5382, series: 'CJA Users' },
+  { datetime: 1780466400000, value: 5359, series: 'CJA Users' },
+  { datetime: 1780552800000, value: 5117, series: 'CJA Users' },
+  { datetime: 1780639200000, value: 2987, series: 'CJA Users' },
+  { datetime: 1780725600000, value: 102, series: 'CJA Users' },
+  { datetime: 1780812000000, value: 98, series: 'CJA Users' },
+  { datetime: 1780293600000, value: 5771, series: 'Accounts' },
+  { datetime: 1780380000000, value: 5766, series: 'Accounts' },
+  { datetime: 1780466400000, value: 5833, series: 'Accounts' },
+  { datetime: 1780552800000, value: 5717, series: 'Accounts' },
+  { datetime: 1780639200000, value: 5277, series: 'Accounts' },
+  { datetime: 1780725600000, value: 210, series: 'Accounts' },
+  { datetime: 1780812000000, value: 185, series: 'Accounts' },
+  { datetime: 1780293600000, value: 12077019, series: 'Events' },
+  { datetime: 1780380000000, value: 12336199, series: 'Events' },
+  { datetime: 1780466400000, value: 12587046, series: 'Events' },
+  { datetime: 1780552800000, value: 11499035, series: 'Events' },
+  { datetime: 1780639200000, value: 5737435, series: 'Events' },
+  { datetime: 1780725600000, value: 42104, series: 'Events' },
+  { datetime: 1780812000000, value: 38291, series: 'Events' },
+];
 
 export const LegendBarStory: StoryFn<typeof Legend> = (args): ReactElement => {
   const chartProps = useChartProps({ data, width: 700 });
@@ -66,4 +91,16 @@ export const LegendDisconnectedStory: StoryFn<typeof Legend> = (args): ReactElem
 
 export const defaultProps: LegendProps = {
   onClick: undefined,
+};
+
+export const LegendLineStory: StoryFn<typeof Legend> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: legendColumnsData, width: 700, height: 300 });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series" dimension="datetime" metric="value" scaleType="time" />
+      <Legend {...args} />
+    </Chart>
+  );
 };

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
@@ -103,7 +103,7 @@ const defaultLegend: Legend = {
   labelLimit: undefined,
   orient: 'bottom',
   title: undefined,
-  columns: { signal: 'floor(width / 220)' },
+  columns: { signal: "max(1, floor(width / (min(length(data('legend0_maxLabelWidth')) > 0 ? data('legend0_maxLabelWidth')[0].maxLabelWidth : 184, 184) + 36)))" },
 };
 
 const defaultLegendAggregateData: Data = {
@@ -122,6 +122,24 @@ const defaultLegendAggregateData: Data = {
   ],
 };
 
+const defaultLegendMaxLabelWidthData: Data = {
+  name: 'legend0_maxLabelWidth',
+  source: 'legend0Aggregate',
+  transform: [
+    {
+      type: 'formula',
+      as: 'displayLabel',
+      expr: "indexof(pluck(legend0_labels, 'seriesName'), datum.legend0Entries) > -1 ? legend0_labels[indexof(pluck(legend0_labels, 'seriesName'), datum.legend0Entries)].label : datum.legend0Entries",
+    },
+    { type: 'formula', as: 'labelWidth', expr: "getLabelWidth(datum.displayLabel, 'normal', 14)" },
+    { type: 'aggregate', fields: ['labelWidth'], ops: ['max'], as: ['maxLabelWidth'] },
+  ],
+};
+
+const defaultLegendLabelsSignal = { name: 'legend0_labels', value: [] };
+
+const defaultLegendData = [defaultLegendAggregateData, defaultLegendMaxLabelWidthData];
+
 const defaultLegendEntriesScale: Scale = {
   name: 'legend0Entries',
   type: 'ordinal',
@@ -133,8 +151,9 @@ describe('addLegend()', () => {
     test('no options, should setup default legend', () => {
       expect(addLegend(defaultSpec, {})).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
+        signals: [...defaultSignals, defaultLegendLabelsSignal],
         legends: [defaultLegend],
       });
     });
@@ -142,8 +161,9 @@ describe('addLegend()', () => {
     test('descriptions, should add encoding', () => {
       expect(addLegend(defaultSpec, { descriptions: [{ seriesName: 'test', description: 'test' }] })).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
+        signals: [...defaultSignals, defaultLegendLabelsSignal],
         legends: [{ ...defaultLegend, encode: defaultDescriptionLegendEncoding }],
       });
     });
@@ -151,7 +171,7 @@ describe('addLegend()', () => {
     test('highlight, should add encoding', () => {
       expect(addLegend(defaultSpec, { highlight: true })).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
         signals: [
           defaultHighlightedItemSignal,
@@ -172,6 +192,7 @@ describe('addLegend()', () => {
               { events: '@legend0_legendEntry:mouseout', update: 'null' },
             ],
           },
+          defaultLegendLabelsSignal,
         ],
         legends: [{ ...defaultLegend, encode: defaultHighlightLegendEncoding }],
       });
@@ -272,15 +293,8 @@ describe('addLegend()', () => {
       });
       const legend = legendSpec.legends?.[0];
       expect(legend?.labelLimit).toBe(300);
-      expect(legendSpec.legends).toEqual([
-        {
-          ...defaultLegend,
-          labelLimit: 300,
-          encode: defaultDescriptionLegendEncoding,
-          columns: { signal: 'max(1, floor(width / 336))' },
-        },
-      ]);
-      expect(legendSpec.data).toEqual([defaultLegendAggregateData]);
+      expect(legend?.columns).toEqual({ signal: "max(1, floor(width / (min(length(data('legend0_maxLabelWidth')) > 0 ? data('legend0_maxLabelWidth')[0].maxLabelWidth : 300, 300) + 36)))" });
+      expect(legendSpec.data).toHaveLength(2);
       expect(legendSpec.scales).toEqual([...(defaultSpec.scales || []), defaultLegendEntriesScale]);
     });
 
@@ -363,9 +377,7 @@ describe('addLegend()', () => {
 
 describe('addData()', () => {
   test('should add legend0Aggregate data', () => {
-    expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR] })).toStrictEqual([
-      defaultLegendAggregateData,
-    ]);
+    expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR] })).toStrictEqual(defaultLegendData);
   });
   test('should join multiple facets', () => {
     expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })).toStrictEqual([
@@ -381,6 +393,7 @@ describe('addData()', () => {
           },
         ],
       },
+      defaultLegendMaxLabelWidthData,
     ]);
   });
   test('should add legend group Id if keys has length', () => {

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
@@ -219,7 +219,7 @@ const getCategoricalLegend = (facets: Facet[], options: LegendSpecOptions, userM
     orient: position,
     title,
     encode: getEncodings(facets, options, userMeta),
-    columns: getColumns(position, labelLimit),
+    columns: getColumns(position, name, labelLimit),
     labelLimit,
   };
   if (titleLimit !== undefined) legend.titleLimit = titleLimit;
@@ -304,6 +304,31 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
       ],
     });
 
+    // Measure the actual max display label width so getColumns can compute an accurate column count.
+    const labelLookupExpr = `indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries) > -1 ? ${name}_labels[indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries)].label : datum.${name}Entries`;
+    data.push({
+      name: `${name}_maxLabelWidth`,
+      source: `${name}Aggregate`,
+      transform: [
+        {
+          type: 'formula',
+          as: 'displayLabel',
+          expr: labelLookupExpr,
+        },
+        {
+          type: 'formula',
+          as: 'labelWidth',
+          expr: "getLabelWidth(datum.displayLabel, 'normal', 14)",
+        },
+        {
+          type: 'aggregate',
+          fields: ['labelWidth'],
+          ops: ['max'],
+          as: ['maxLabelWidth'],
+        },
+      ],
+    });
+
     if (keys?.length) {
       const tableData = getTableData(data);
       if (!tableData.transform) {
@@ -332,8 +357,8 @@ export const addSignals = produce<Signal[], [LegendSpecOptions]>(
       addHighlightSignalLegendHoverEvents(signals, name, Boolean(isToggleable || hiddenSeries), keys);
     }
 
-    if (legendLabels) {
-      signals.push(getGenericValueSignal(`${name}_labels`, legendLabels));
-    }
+    // Always emit _labels so the _maxLabelWidth data transform can safely reference it.
+    // Defaults to [] when no legendLabels prop is set; the lookup falls through to datum.${name}Entries.
+    signals.push(getGenericValueSignal(`${name}_labels`, legendLabels ?? []));
   }
 );

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE } from '@spectrum-charts/constants';
+import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_LABEL_LIMIT, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE } from '@spectrum-charts/constants';
 import { spectrum2Colors } from '@spectrum-charts/themes';
 
 import { defaultLegendOptions } from './legendTestUtils';
@@ -130,54 +130,43 @@ describe('getHiddenSeriesColorRule()', () => {
   });
 });
 
+const getExpectedColumnsSignal = (name: string, effectiveLabelLimit: number) => {
+  const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
+  const maxWidthExpr = `length(data('${name}_maxLabelWidth')) > 0 ? data('${name}_maxLabelWidth')[0].maxLabelWidth : ${effectiveLabelLimit}`;
+  return { signal: `max(1, floor(width / (min(${maxWidthExpr}, ${effectiveLabelLimit}) + ${symbolAndSpacingWidth})))` };
+};
+
 describe('getColumns()', () => {
   test('should return undefined for left position', () => {
-    expect(getColumns('left')).toBeUndefined();
+    expect(getColumns('left', 'legend0')).toBeUndefined();
   });
 
   test('should return undefined for right position', () => {
-    expect(getColumns('right')).toBeUndefined();
+    expect(getColumns('right', 'legend0')).toBeUndefined();
   });
 
-  test('should return default signal for top position without labelLimit', () => {
-    expect(getColumns('top')).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when no labelLimit provided for top position', () => {
+    expect(getColumns('top', 'legend0')).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal for bottom position without labelLimit', () => {
-    expect(getColumns('bottom')).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when no labelLimit provided for bottom position', () => {
+    expect(getColumns('bottom', 'legend0')).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal when labelLimit is undefined', () => {
-    expect(getColumns('top', undefined)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when labelLimit is undefined', () => {
+    expect(getColumns('top', 'legend0', undefined)).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal when labelLimit is 0', () => {
-    expect(getColumns('bottom', 0)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use measured label widths capped at labelLimit when labelLimit is provided', () => {
+    expect(getColumns('top', 'legend0', 100)).toEqual(getExpectedColumnsSignal('legend0', 100));
   });
 
-  test('should return default signal when labelLimit is negative', () => {
-    expect(getColumns('top', -10)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use measured label widths capped at labelLimit for various labelLimit values', () => {
+    expect(getColumns('bottom', 'legend0', 50)).toEqual(getExpectedColumnsSignal('legend0', 50));
+    expect(getColumns('top', 'legend0', 200)).toEqual(getExpectedColumnsSignal('legend0', 200));
   });
 
-  test('should calculate columns based on labelLimit when provided', () => {
-    const labelLimit = 100;
-    const expectedItemWidth = labelLimit + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-    const expectedSignal = `max(1, floor(width / ${expectedItemWidth}))`;
-
-    expect(getColumns('top', labelLimit)).toEqual({ signal: expectedSignal });
-  });
-
-  test('should calculate columns with different labelLimit values', () => {
-    const labelLimit50 = 50;
-    const expectedItemWidth50 = 50 + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-    expect(getColumns('bottom', labelLimit50)).toEqual({
-      signal: `max(1, floor(width / ${expectedItemWidth50}))`,
-    });
-
-    const labelLimit200 = 200;
-    const expectedItemWidth200 = 200 + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING; // 200 + 16 + 20 = 236
-    expect(getColumns('top', labelLimit200)).toEqual({
-      signal: `max(1, floor(width / ${expectedItemWidth200}))`,
-    });
+  test('should use legend name in the data reference', () => {
+    expect(getColumns('top', 'myLegend', 100)).toEqual(getExpectedColumnsSignal('myLegend', 100));
   });
 });

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
@@ -29,6 +29,7 @@ import {
   CONTROLLED_HIGHLIGHTED_SERIES,
   CONTROLLED_HIGHLIGHTED_TABLE,
   DEFAULT_LEGEND_COLUMN_PADDING,
+  DEFAULT_LEGEND_LABEL_LIMIT,
   DEFAULT_LEGEND_SYMBOL_WIDTH,
   DEFAULT_OPACITY_RULE,
   FADE_FACTOR,
@@ -67,23 +68,17 @@ export interface Facet {
 }
 
 /**
- * Get the number of columns for the legend
- * @param position
- * @param labelLimit
- * @returns
+ * Get the number of columns for the legend.
+ * Uses actual measured label widths (via the ${name}_maxLabelWidth data source) capped at labelLimit
+ * so columns are based on real content rather than a fixed estimate.
  */
-export const getColumns = (position: Position, labelLimit?: number): SignalRef | undefined => {
+export const getColumns = (position: Position, name: string, labelLimit?: number): SignalRef | undefined => {
   if (['left', 'right'].includes(position)) return;
 
-  if (labelLimit !== undefined && labelLimit > 0) {
-    const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-
-    const itemWidth = labelLimit + symbolAndSpacingWidth;
-    return { signal: `max(1, floor(width / ${itemWidth}))` };
-  }
-
-  // Keeping hardcoded 220 for so we don't break existing behavior.
-  return { signal: 'floor(width / 220)' };
+  const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
+  const effectiveLabelLimit = labelLimit ?? DEFAULT_LEGEND_LABEL_LIMIT;
+  const maxWidthExpr = `length(data('${name}_maxLabelWidth')) > 0 ? data('${name}_maxLabelWidth')[0].maxLabelWidth : ${effectiveLabelLimit}`;
+  return { signal: `max(1, floor(width / (min(${maxWidthExpr}, ${effectiveLabelLimit}) + ${symbolAndSpacingWidth})))` };
 };
 
 /**

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
@@ -102,7 +102,7 @@ const defaultLegend: Legend = {
   labelLimit: undefined,
   orient: 'bottom',
   title: undefined,
-  columns: { signal: 'floor(width / 220)' },
+  columns: { signal: "max(1, floor(width / (min(length(data('legend0_maxLabelWidth')) > 0 ? data('legend0_maxLabelWidth')[0].maxLabelWidth : 184, 184) + 36)))" },
 };
 
 const defaultLegendAggregateData: Data = {
@@ -121,6 +121,24 @@ const defaultLegendAggregateData: Data = {
   ],
 };
 
+const defaultLegendMaxLabelWidthData: Data = {
+  name: 'legend0_maxLabelWidth',
+  source: 'legend0Aggregate',
+  transform: [
+    {
+      type: 'formula',
+      as: 'displayLabel',
+      expr: "indexof(pluck(legend0_labels, 'seriesName'), datum.legend0Entries) > -1 ? legend0_labels[indexof(pluck(legend0_labels, 'seriesName'), datum.legend0Entries)].label : datum.legend0Entries",
+    },
+    { type: 'formula', as: 'labelWidth', expr: "getLabelWidth(datum.displayLabel, 'normal', 14)" },
+    { type: 'aggregate', fields: ['labelWidth'], ops: ['max'], as: ['maxLabelWidth'] },
+  ],
+};
+
+const defaultLegendLabelsSignal = { name: 'legend0_labels', value: [] };
+
+const defaultLegendData = [defaultLegendAggregateData, defaultLegendMaxLabelWidthData];
+
 const defaultLegendEntriesScale: Scale = {
   name: 'legend0Entries',
   type: 'ordinal',
@@ -132,8 +150,9 @@ describe('addLegend()', () => {
     test('no options, should setup default legend', () => {
       expect(addLegend(defaultSpec, {})).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
+        signals: [...defaultSignals, defaultLegendLabelsSignal],
         legends: [defaultLegend],
       });
     });
@@ -141,8 +160,9 @@ describe('addLegend()', () => {
     test('descriptions, should add encoding', () => {
       expect(addLegend(defaultSpec, { descriptions: [{ seriesName: 'test', description: 'test' }] })).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
+        signals: [...defaultSignals, defaultLegendLabelsSignal],
         legends: [{ ...defaultLegend, encode: defaultTooltipLegendEncoding }],
       });
     });
@@ -150,7 +170,7 @@ describe('addLegend()', () => {
     test('highlight, should add encoding', () => {
       expect(addLegend(defaultSpec, { highlight: true })).toStrictEqual({
         ...defaultSpec,
-        data: [defaultLegendAggregateData],
+        data: defaultLegendData,
         scales: [...(defaultSpec.scales || []), defaultLegendEntriesScale],
         signals: [
           defaultHighlightedItemSignal,
@@ -170,6 +190,7 @@ describe('addLegend()', () => {
               { events: '@legend0_legendEntry:mouseout', update: 'null' },
             ],
           },
+          defaultLegendLabelsSignal,
         ],
         legends: [{ ...defaultLegend, encode: defaultHighlightLegendEncoding }],
       });
@@ -270,15 +291,8 @@ describe('addLegend()', () => {
       });
       const legend = legendSpec.legends?.[0];
       expect(legend?.labelLimit).toBe(300);
-      expect(legendSpec.legends).toEqual([
-        {
-          ...defaultLegend,
-          labelLimit: 300,
-          encode: defaultTooltipLegendEncoding,
-          columns: { signal: 'max(1, floor(width / 336))' },
-        },
-      ]);
-      expect(legendSpec.data).toEqual([defaultLegendAggregateData]);
+      expect(legend?.columns).toEqual({ signal: "max(1, floor(width / (min(length(data('legend0_maxLabelWidth')) > 0 ? data('legend0_maxLabelWidth')[0].maxLabelWidth : 300, 300) + 36)))" });
+      expect(legendSpec.data).toHaveLength(2);
       expect(legendSpec.scales).toEqual([...(defaultSpec.scales || []), defaultLegendEntriesScale]);
     });
 
@@ -319,9 +333,7 @@ describe('addLegend()', () => {
 
 describe('addData()', () => {
   test('should add legend0Aggregate data', () => {
-    expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR] })).toStrictEqual([
-      defaultLegendAggregateData,
-    ]);
+    expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR] })).toStrictEqual(defaultLegendData);
   });
   test('should join multiple facets', () => {
     expect(addData([], { ...defaultLegendOptions, facets: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })).toStrictEqual([
@@ -337,6 +349,7 @@ describe('addData()', () => {
           },
         ],
       },
+      defaultLegendMaxLabelWidthData,
     ]);
   });
   test('should add legend group Id if keys has length', () => {

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
@@ -211,7 +211,7 @@ const getCategoricalLegend = (facets: Facet[], options: LegendSpecOptions, userM
     orient: position,
     title,
     encode: getEncodings(facets, options, userMeta),
-    columns: getColumns(position, labelLimit),
+    columns: getColumns(position, name, labelLimit),
     labelLimit,
   };
   if (titleLimit !== undefined) legend.titleLimit = titleLimit;
@@ -296,6 +296,31 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
       ],
     });
 
+    // Measure the actual max display label width so getColumns can compute an accurate column count.
+    const labelLookupExpr = `indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries) > -1 ? ${name}_labels[indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries)].label : datum.${name}Entries`;
+    data.push({
+      name: `${name}_maxLabelWidth`,
+      source: `${name}Aggregate`,
+      transform: [
+        {
+          type: 'formula',
+          as: 'displayLabel',
+          expr: labelLookupExpr,
+        },
+        {
+          type: 'formula',
+          as: 'labelWidth',
+          expr: "getLabelWidth(datum.displayLabel, 'normal', 14)",
+        },
+        {
+          type: 'aggregate',
+          fields: ['labelWidth'],
+          ops: ['max'],
+          as: ['maxLabelWidth'],
+        },
+      ],
+    });
+
     if (keys?.length) {
       const tableData = getTableData(data);
       if (!tableData.transform) {
@@ -324,8 +349,8 @@ export const addSignals = produce<Signal[], [LegendSpecOptions]>(
       addHighlightSignalLegendHoverEvents(signals, name, Boolean(isToggleable || hiddenSeries), keys);
     }
 
-    if (legendLabels) {
-      signals.push(getGenericValueSignal(`${name}_labels`, legendLabels));
-    }
+    // Always emit _labels so the _maxLabelWidth data transform can safely reference it.
+    // Defaults to [] when no legendLabels prop is set; the lookup falls through to datum.${name}Entries.
+    signals.push(getGenericValueSignal(`${name}_labels`, legendLabels ?? []));
   }
 );

--- a/packages/vega-spec-builder/src/legend/legendUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE } from '@spectrum-charts/constants';
+import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_LABEL_LIMIT, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
 import { defaultLegendOptions } from './legendTestUtils';
@@ -130,54 +130,43 @@ describe('getHiddenSeriesColorRule()', () => {
   });
 });
 
+const getExpectedColumnsSignal = (name: string, effectiveLabelLimit: number) => {
+  const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
+  const maxWidthExpr = `length(data('${name}_maxLabelWidth')) > 0 ? data('${name}_maxLabelWidth')[0].maxLabelWidth : ${effectiveLabelLimit}`;
+  return { signal: `max(1, floor(width / (min(${maxWidthExpr}, ${effectiveLabelLimit}) + ${symbolAndSpacingWidth})))` };
+};
+
 describe('getColumns()', () => {
   test('should return undefined for left position', () => {
-    expect(getColumns('left')).toBeUndefined();
+    expect(getColumns('left', 'legend0')).toBeUndefined();
   });
 
   test('should return undefined for right position', () => {
-    expect(getColumns('right')).toBeUndefined();
+    expect(getColumns('right', 'legend0')).toBeUndefined();
   });
 
-  test('should return default signal for top position without labelLimit', () => {
-    expect(getColumns('top')).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when no labelLimit provided for top position', () => {
+    expect(getColumns('top', 'legend0')).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal for bottom position without labelLimit', () => {
-    expect(getColumns('bottom')).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when no labelLimit provided for bottom position', () => {
+    expect(getColumns('bottom', 'legend0')).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal when labelLimit is undefined', () => {
-    expect(getColumns('top', undefined)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use DEFAULT_LEGEND_LABEL_LIMIT when labelLimit is undefined', () => {
+    expect(getColumns('top', 'legend0', undefined)).toEqual(getExpectedColumnsSignal('legend0', DEFAULT_LEGEND_LABEL_LIMIT));
   });
 
-  test('should return default signal when labelLimit is 0', () => {
-    expect(getColumns('bottom', 0)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use measured label widths capped at labelLimit when labelLimit is provided', () => {
+    expect(getColumns('top', 'legend0', 100)).toEqual(getExpectedColumnsSignal('legend0', 100));
   });
 
-  test('should return default signal when labelLimit is negative', () => {
-    expect(getColumns('top', -10)).toEqual({ signal: 'floor(width / 220)' });
+  test('should use measured label widths capped at labelLimit for various labelLimit values', () => {
+    expect(getColumns('bottom', 'legend0', 50)).toEqual(getExpectedColumnsSignal('legend0', 50));
+    expect(getColumns('top', 'legend0', 200)).toEqual(getExpectedColumnsSignal('legend0', 200));
   });
 
-  test('should calculate columns based on labelLimit when provided', () => {
-    const labelLimit = 100;
-    const expectedItemWidth = labelLimit + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-    const expectedSignal = `max(1, floor(width / ${expectedItemWidth}))`;
-
-    expect(getColumns('top', labelLimit)).toEqual({ signal: expectedSignal });
-  });
-
-  test('should calculate columns with different labelLimit values', () => {
-    const labelLimit50 = 50;
-    const expectedItemWidth50 = 50 + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-    expect(getColumns('bottom', labelLimit50)).toEqual({
-      signal: `max(1, floor(width / ${expectedItemWidth50}))`,
-    });
-
-    const labelLimit200 = 200;
-    const expectedItemWidth200 = 200 + DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING; // 200 + 16 + 20 = 236
-    expect(getColumns('top', labelLimit200)).toEqual({
-      signal: `max(1, floor(width / ${expectedItemWidth200}))`,
-    });
+  test('should use legend name in the data reference', () => {
+    expect(getColumns('top', 'myLegend', 100)).toEqual(getExpectedColumnsSignal('myLegend', 100));
   });
 });

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -29,6 +29,7 @@ import {
   CONTROLLED_HIGHLIGHTED_SERIES,
   CONTROLLED_HIGHLIGHTED_TABLE,
   DEFAULT_LEGEND_COLUMN_PADDING,
+  DEFAULT_LEGEND_LABEL_LIMIT,
   DEFAULT_LEGEND_SYMBOL_WIDTH,
   DEFAULT_OPACITY_RULE,
   FADE_FACTOR,
@@ -67,23 +68,17 @@ export interface Facet {
 }
 
 /**
- * Get the number of columns for the legend
- * @param position
- * @param labelLimit
- * @returns
+ * Get the number of columns for the legend.
+ * Uses actual measured label widths (via the ${name}_maxLabelWidth data source) capped at labelLimit
+ * so columns are based on real content rather than a fixed estimate.
  */
-export const getColumns = (position: Position, labelLimit?: number): SignalRef | undefined => {
+export const getColumns = (position: Position, name: string, labelLimit?: number): SignalRef | undefined => {
   if (['left', 'right'].includes(position)) return;
 
-  if (labelLimit !== undefined && labelLimit > 0) {
-    const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
-
-    const itemWidth = labelLimit + symbolAndSpacingWidth;
-    return { signal: `max(1, floor(width / ${itemWidth}))` };
-  }
-
-  // Keeping hardcoded 220 for so we don't break existing behavior.
-  return { signal: 'floor(width / 220)' };
+  const symbolAndSpacingWidth = DEFAULT_LEGEND_SYMBOL_WIDTH + DEFAULT_LEGEND_COLUMN_PADDING;
+  const effectiveLabelLimit = labelLimit ?? DEFAULT_LEGEND_LABEL_LIMIT;
+  const maxWidthExpr = `length(data('${name}_maxLabelWidth')) > 0 ? data('${name}_maxLabelWidth')[0].maxLabelWidth : ${effectiveLabelLimit}`;
+  return { signal: `max(1, floor(width / (min(${maxWidthExpr}, ${effectiveLabelLimit}) + ${symbolAndSpacingWidth})))` };
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Calculate the actual label text size to determine columns, rather than just relying on the labelLimit. Columns are calculated using the largest actual label.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This makes layouts where the labelLimit is higher, but the actual label sizes are small. Prior to this change, this type of layout would create a small number of columns even though there is plenty of space to spread the legend items out. This change will make legend layouts more natural. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
