### PR TITLE
line point annotation bug fix 

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -189,6 +189,8 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 // S2 direct label shared style constants (used by LineDirectLabel and ReferenceLine)
 export const DIRECT_LABEL_FONT_WEIGHT = 700 as const;
 export const DIRECT_LABEL_BACKGROUND_STROKE_WIDTH = 4;
+// Offset from anchor mark edge to label boundary. Must be > DIRECT_LABEL_BACKGROUND_STROKE_WIDTH / 2 to prevent the background halo from touching the point fill.
+export const LINE_POINT_ANNOTATION_OFFSET = 3;
 
 // S2 reference line label constants — alias the shared direct label values
 export const REFERENCE_LINE_LABEL_FONT_WEIGHT = DIRECT_LABEL_FONT_WEIGHT;

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -189,7 +189,8 @@ export const BACKGROUND_COLOR = 'chartBackgroundColor';
 // S2 direct label shared style constants (used by LineDirectLabel and ReferenceLine)
 export const DIRECT_LABEL_FONT_WEIGHT = 700 as const;
 export const DIRECT_LABEL_BACKGROUND_STROKE_WIDTH = 4;
-// Offset from anchor mark edge to label boundary. Must be > DIRECT_LABEL_BACKGROUND_STROKE_WIDTH / 2 to prevent the background halo from touching the point fill.
+
+// Offset from anchor mark edge to label boundary.
 export const LINE_POINT_ANNOTATION_OFFSET = 3;
 
 // S2 reference line label constants — alias the shared direct label values

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, LINE_POINT_ANNOTATION_OFFSET } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { defaultLineOptions } from '../lineTestUtils';
@@ -166,6 +166,11 @@ describe('getLinePointAnnotationMarks', () => {
 			const transform = getBackgroundMark().transform?.[0] as { anchor: unknown };
 			expect(transform.anchor).toEqual(['right', 'top', 'bottom', 'left']);
 		});
+
+		test('label transform uses LINE_POINT_ANNOTATION_OFFSET to prevent background halo touching point fill', () => {
+			const transform = getBackgroundMark().transform?.[0] as { offset: unknown };
+			expect(transform.offset).toEqual([LINE_POINT_ANNOTATION_OFFSET]);
+		});
 	});
 
 	describe('foreground mark', () => {
@@ -193,12 +198,12 @@ describe('getLinePointAnnotationMarks', () => {
 			});
 		});
 
-		test('fill uses series color from static point stroke when matchLineColor is true', () => {
+		test('fill uses series color from static point fill when matchLineColor is true', () => {
 			const marks = getLinePointAnnotationMarks({
 				...lineOptionsWithAnnotations,
 				linePointAnnotations: [{ matchLineColor: true }],
 			});
-			expect(marks[1].encode?.enter).toHaveProperty('fill', { field: 'datum.stroke' });
+			expect(marks[1].encode?.enter).toHaveProperty('fill', { field: 'datum.fill' });
 		});
 
 		test('has no label transform', () => {

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts
@@ -11,7 +11,7 @@
  */
 import { TextMark } from 'vega';
 
-import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT } from '@spectrum-charts/constants';
+import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, LINE_POINT_ANNOTATION_OFFSET } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { LinePointAnnotationOptions, LinePointAnnotationSpecOptions, LineSpecOptions } from '../../types';
@@ -67,15 +67,16 @@ export const getLinePointAnnotationMarks = (lineOptions: LineSpecOptions): TextM
 					type: 'label',
 					size: { signal: '[width, height]' },
 					anchor: Array.isArray(anchor) ? anchor : [anchor],
+					offset: [LINE_POINT_ANNOTATION_OFFSET],
 				},
 			],
 		};
 
 		// Foreground mark: reads from the background mark to inherit its label-transform-computed
-		// positions (x, y, align, baseline, opacity). 
-		// When matchLineColor is true, the fill uses the series color from the static point stroke (datum.stroke); otherwise defaults to black.
+		// positions (x, y, align, baseline, opacity).
+		// datum.fill navigates: foreground.datum → bgMark item → bgMark.datum → staticPoint item → fill = series color
 		const labelFill = matchLineColor
-			? { field: 'datum.stroke' }
+			? { field: 'datum.fill' }
 			: { value: getS2ColorValue('gray-900', lineOptions.colorScheme) };
 		const foregroundMark: TextMark = {
 			name: linePointAnnotationName,


### PR DESCRIPTION
## Description

when matchLineColor is true, we need to use the fill instead of the stroke for the font text because the static points are solid. add an offset to the label because the background halo was removed on static point, which used to create the distance.

## Motivation and Context

Solving a bug on LinePointAnnotation, when `matchLineColor = true` the labels were showing as white and slightly overlapping with the static point. 

## How Has This Been Tested?

Unit tests and visual testing through storybook. 

## Screenshots (if appropriate):

<img width="859" height="436" alt="Screenshot 2026-06-08 at 3 10 11 PM" src="https://github.com/user-attachments/assets/78c0fea6-e777-4358-a4ef-21bd8b8c8b12" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
