### PR TITLE
feat: Add secondary reference line

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -252,7 +252,7 @@ export const REFERENCE_LINE_AUTO_RULE_X_START = {
   L: REFERENCE_LINE_START_CAP_ANCHOR + REFERENCE_LINE_CAP_RIGHT_TIP.L + REFERENCE_LINE_CAP_RULE_GAP + 3 / 2,   // 14.33333
 };
 
-// Right face x in path space for each end cap (from Figma-confirmed geometry). S and M share paths.
+// Right face x in path space for each end cap. S and M share paths.
 const REFERENCE_LINE_END_CAP_RIGHT_FACE_X: Record<ReferenceLineSize, number> = {
   XS: 3.34961,
   S: 5.40039,
@@ -305,6 +305,18 @@ export const REFERENCE_LINE_END_CAP_PATHS: Record<ReferenceLineSize, string> = {
   M: REFERENCE_LINE_END_CAP_PATH,
   L: 'M0.400196 -0.69283C-0.133137 -0.38491 -0.133138 0.38490 0.400195 0.69282L5.50019 3.63730C6.03353 3.94522 6.7002 3.56032 6.7002 2.94448L6.7002 -2.94449C6.7002 -3.56033 6.03353 -3.94523 5.5002 -3.63731L0.400196 -0.69283Z',
 };
+
+// Secondary reference line stroke color per size tier 
+// XS uses gray-600 for sparkline contexts; S/M/L match the primary gray-800.
+export const REFERENCE_LINE_SECONDARY_COLORS: Record<ReferenceLineSize, string> = {
+  XS: 'gray-600',
+  S: DEFAULT_FONT_COLOR,
+  M: DEFAULT_FONT_COLOR,
+  L: DEFAULT_FONT_COLOR,
+};
+
+// Secondary reference line label color — gray-600 for all sizes
+export const REFERENCE_LINE_SECONDARY_LABEL_COLOR = 'gray-600';
 
 // time constants
 export const MS_PER_DAY = 86400000;

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -306,8 +306,9 @@ export const REFERENCE_LINE_END_CAP_PATHS: Record<ReferenceLineSize, string> = {
   L: 'M0.400196 -0.69283C-0.133137 -0.38491 -0.133138 0.38490 0.400195 0.69282L5.50019 3.63730C6.03353 3.94522 6.7002 3.56032 6.7002 2.94448L6.7002 -2.94449C6.7002 -3.56033 6.03353 -3.94523 5.5002 -3.63731L0.400196 -0.69283Z',
 };
 
-// Secondary reference line stroke color per size tier 
+// Secondary reference line stroke color per size tier.
 // XS uses gray-600 for sparkline contexts; S/M/L match the primary gray-800.
+// Label color matches the stroke color for each tier.
 export const REFERENCE_LINE_SECONDARY_COLORS: Record<ReferenceLineSize, string> = {
   XS: 'gray-600',
   S: DEFAULT_FONT_COLOR,
@@ -315,8 +316,8 @@ export const REFERENCE_LINE_SECONDARY_COLORS: Record<ReferenceLineSize, string> 
   L: DEFAULT_FONT_COLOR,
 };
 
-// Secondary reference line label color — gray-600 for all sizes
-export const REFERENCE_LINE_SECONDARY_LABEL_COLOR = 'gray-600';
+// Secondary reference line stroke width — always 1px regardless of size.
+export const REFERENCE_LINE_SECONDARY_STROKE_WIDTH = 1;
 
 // time constants
 export const MS_PER_DAY = 86400000;

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -537,6 +537,26 @@ In S2, reference lines are **horizontal only** — place `<ReferenceLine>` insid
 </Axis>
 ```
 
+### Secondary style
+
+Set `secondary` to `true` to render a lighter, lower-emphasis reference line. Secondary lines have no caret caps and use a lighter stroke color, making them suitable for contextual values (averages, baselines) that should visually recede behind a primary target line.
+
+```jsx
+<Axis position="left" grid>
+  <ReferenceLine value={7500} label="Target" />
+  <ReferenceLine value={5000} label="Average" secondary />
+</Axis>
+```
+
+Stroke color by size when `secondary` is set:
+
+| Size | Stroke color |
+|------|-------------|
+| `'XS'` | `gray-600` |
+| `'S'` / `'M'` / `'L'` / auto | `gray-800` (same as primary) |
+
+The label color is `gray-600` for all sizes when `secondary` is true.
+
 ### Positioning on bar charts
 
 On bar charts with categorical axes, the `position` prop controls whether the reference line is positioned before, centered on, or after the specified value:
@@ -581,7 +601,13 @@ On bar charts with categorical axes, the `position` prop controls whether the re
             <td>size</td>
             <td>'XS' | 'S' | 'M' | 'L'</td>
             <td>auto</td>
-            <td>Controls the stroke weight and caret triangle dimensions. When omitted, both react to the chart width automatically (S below 400px, M below 800px, L at 800px+). Use `'XS'` for Sparkline contexts.</td>
+            <td>Controls the stroke weight and caret triangle dimensions. When omitted, both react to the chart width automatically (S below 400px, M below 800px, L at 800px+). Use <code>'XS'</code> for sparkline contexts.</td>
+        </tr>
+        <tr>
+            <td>secondary</td>
+            <td>boolean</td>
+            <td>–</td>
+            <td>When true, renders a lighter secondary style: no caret caps, full-width rule (no cap offsets), and a lighter stroke color (<code>gray-600</code> at XS, <code>gray-800</code> for other sizes). Use for contextual values (averages, baselines) that should recede behind a primary target line. The label is rendered in <code>gray-600</code> for all sizes.</td>
         </tr>
     </tbody>
 </table>

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -539,12 +539,12 @@ In S2, reference lines are **horizontal only** — place `<ReferenceLine>` insid
 
 ### Secondary style
 
-Set `secondary` to `true` to render a lighter, lower-emphasis reference line. Secondary lines have no caret caps and use a lighter stroke color, making them suitable for contextual values (averages, baselines) that should visually recede behind a primary target line.
+Set `secondary` to `true` to render a lighter, lower-emphasis reference line. Secondary lines have no caret caps and use a lighter stroke color, making them suitable for contextual reference values (baselines, prior-period comparisons) that should visually recede behind a primary target line.
 
 ```jsx
 <Axis position="left" grid>
   <ReferenceLine value={7500} label="Target" />
-  <ReferenceLine value={5000} label="Average" secondary />
+  <ReferenceLine value={5000} label="Last year" secondary />
 </Axis>
 ```
 
@@ -607,7 +607,7 @@ On bar charts with categorical axes, the `position` prop controls whether the re
             <td>secondary</td>
             <td>boolean</td>
             <td>–</td>
-            <td>When true, renders a lighter secondary style: no caret caps, full-width rule (no cap offsets), and a lighter stroke color (<code>gray-600</code> at XS, <code>gray-800</code> for other sizes). Use for contextual values (averages, baselines) that should recede behind a primary target line. The label is rendered in <code>gray-600</code> for all sizes.</td>
+            <td>When true, renders a lighter secondary style: no caret caps, full-width rule (no cap offsets), and a lighter stroke color (<code>gray-600</code> at XS, <code>gray-800</code> for other sizes). Use for contextual reference values (baselines, prior-period comparisons) that should recede behind a primary target line. The label is rendered in <code>gray-600</code> for all sizes.</td>
         </tr>
     </tbody>
 </table>

--- a/packages/docs/docs/spectrum2/line.md
+++ b/packages/docs/docs/spectrum2/line.md
@@ -548,14 +548,12 @@ Set `secondary` to `true` to render a lighter, lower-emphasis reference line. Se
 </Axis>
 ```
 
-Stroke color by size when `secondary` is set:
+Stroke weight is always 1px for secondary lines. Stroke and label color are size-dependent:
 
-| Size | Stroke color |
-|------|-------------|
+| Size | Stroke / label color |
+|------|---------------------|
 | `'XS'` | `gray-600` |
-| `'S'` / `'M'` / `'L'` / auto | `gray-800` (same as primary) |
-
-The label color is `gray-600` for all sizes when `secondary` is true.
+| `'S'` / `'M'` / `'L'` / auto | `gray-800` |
 
 ### Positioning on bar charts
 
@@ -607,7 +605,7 @@ On bar charts with categorical axes, the `position` prop controls whether the re
             <td>secondary</td>
             <td>boolean</td>
             <td>–</td>
-            <td>When true, renders a lighter secondary style: no caret caps, full-width rule (no cap offsets), and a lighter stroke color (<code>gray-600</code> at XS, <code>gray-800</code> for other sizes). Use for contextual reference values (baselines, prior-period comparisons) that should recede behind a primary target line. The label is rendered in <code>gray-600</code> for all sizes.</td>
+            <td>When true, renders a lighter secondary style: no caret caps, 1px stroke weight, full-width rule, and size-dependent color (<code>gray-600</code> at XS, <code>gray-800</code> for other sizes). Label color matches the stroke color. Use for contextual reference values (baselines, prior-period comparisons) that should recede behind a primary target line.</td>
         </tr>
     </tbody>
 </table>

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
@@ -72,7 +72,7 @@ SecondaryBasic.args = {
 
 const WithSecondary = bindWithProps(ReferenceLineStory);
 WithSecondary.args = {
-  label: 'Average',
+  label: 'Minimum',
   value: referenceValue,
   secondary: true,
 };
@@ -83,7 +83,7 @@ const PrimaryAndSecondaryStory: StoryFn<typeof ReferenceLine> = (): ReactElement
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users">
         <ReferenceLine value={referenceValue} label="Target" />
-        <ReferenceLine value={Math.round(referenceValue * 0.7)} label="Average" secondary />
+        <ReferenceLine value={Math.round(referenceValue * 0.7)} label="Minimum" secondary />
       </Axis>
       <Axis position="bottom" labelFormat="time" baseline ticks />
       <Line dimension="datetime" metric="users" color="series" scaleType="time" />

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
@@ -35,7 +35,7 @@ const referenceValue = 5000;
 const ReferenceLineStory: StoryFn<typeof ReferenceLine> = (args): ReactElement => {
   const chartProps = useChartProps(defaultChartProps);
   return (
-    <Chart {...chartProps} debug>
+    <Chart {...chartProps}>
       <Axis position="left" grid title="Users">
         <ReferenceLine {...args} />
       </Axis>
@@ -63,6 +63,35 @@ WithSize.args = {
   value: referenceValue,
   size: 'L',
 };
+
+const SecondaryBasic = bindWithProps(ReferenceLineStory);
+SecondaryBasic.args = {
+  value: referenceValue,
+  secondary: true,
+};
+
+const WithSecondary = bindWithProps(ReferenceLineStory);
+WithSecondary.args = {
+  label: 'Average',
+  value: referenceValue,
+  secondary: true,
+};
+
+const PrimaryAndSecondaryStory: StoryFn<typeof ReferenceLine> = (): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users">
+        <ReferenceLine value={referenceValue} label="Target" />
+        <ReferenceLine value={Math.round(referenceValue * 0.7)} label="Average" secondary />
+      </Axis>
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line dimension="datetime" metric="users" color="series" scaleType="time" />
+      <Legend highlight />
+    </Chart>
+  );
+};
+const PrimaryAndSecondary = PrimaryAndSecondaryStory;
 
 const CHART_HEIGHT = 400;
 const MAX_WIDTH = CHART_SIZE_BREAKPOINTS.L + 200;
@@ -184,4 +213,4 @@ const AutoDetectSizeStory = (): ReactElement => {
 
 export const AutoDetectSize = AutoDetectSizeStory;
 
-export { Basic, Label, WithSize };
+export { Basic, Label, PrimaryAndSecondary, SecondaryBasic, WithSecondary, WithSize };

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
@@ -29,7 +29,7 @@ import {
   REFERENCE_LINE_RULE_X2_OFFSET,
   REFERENCE_LINE_RULE_X_START,
   REFERENCE_LINE_SECONDARY_COLORS,
-  REFERENCE_LINE_SECONDARY_LABEL_COLOR,
+  REFERENCE_LINE_SECONDARY_STROKE_WIDTH,
   REFERENCE_LINE_SIZE_STROKE_WIDTHS,
   REFERENCE_LINE_START_CAP_PATHS,
 } from '@spectrum-charts/constants';
@@ -479,6 +479,14 @@ describe('secondary prop', () => {
       expect(rule.encode?.enter?.stroke).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_COLORS['XS']] });
     });
 
+    test('strokeWidth is always REFERENCE_LINE_SECONDARY_STROKE_WIDTH (1px) regardless of size', () => {
+      const autoRule = getReferenceLineRuleMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding);
+      expect(autoRule.encode?.enter?.strokeWidth).toStrictEqual({ value: REFERENCE_LINE_SECONDARY_STROKE_WIDTH });
+
+      const lRule = getReferenceLineRuleMark(defaultAxisOptions, { ...secondaryOptions, size: 'L' }, defaultYPositionEncoding);
+      expect(lRule.encode?.enter?.strokeWidth).toStrictEqual({ value: REFERENCE_LINE_SECONDARY_STROKE_WIDTH });
+    });
+
     test('x is fixed at 0 (no cap offset)', () => {
       const rule = getReferenceLineRuleMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding);
       expect(rule.encode?.update?.x).toStrictEqual({ value: 0 });
@@ -525,17 +533,25 @@ describe('secondary prop', () => {
   });
 
   describe('getReferenceLineTextMark() with secondary: true', () => {
-    test('label foreground fill uses REFERENCE_LINE_SECONDARY_LABEL_COLOR (gray-600)', () => {
+    test('auto mode: label fill matches stroke color (gray-800)', () => {
       const marks = getReferenceLineTextMark(
-        { ...secondaryOptions, label: 'Average' },
+        { ...secondaryOptions, label: 'Last year' },
         defaultYPositionEncoding
       );
-      expect(marks[1].encode?.enter?.fill).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_LABEL_COLOR] });
+      expect(marks[1].encode?.enter?.fill).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_COLORS['M']] });
+    });
+
+    test('size XS: label fill matches stroke color (gray-600)', () => {
+      const marks = getReferenceLineTextMark(
+        { ...secondaryOptions, size: 'XS', label: 'Last year' },
+        defaultYPositionEncoding
+      );
+      expect(marks[1].encode?.enter?.fill).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_COLORS['XS']] });
     });
 
     test('background mark is unaffected — still transparent fill', () => {
       const marks = getReferenceLineTextMark(
-        { ...secondaryOptions, label: 'Average' },
+        { ...secondaryOptions, label: 'Last year' },
         defaultYPositionEncoding
       );
       expect(marks[0].encode?.enter?.fill).toStrictEqual({ value: 'transparent' });

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
@@ -28,6 +28,8 @@ import {
   REFERENCE_LINE_END_CAP_ANCHOR_OFFSET,
   REFERENCE_LINE_RULE_X2_OFFSET,
   REFERENCE_LINE_RULE_X_START,
+  REFERENCE_LINE_SECONDARY_COLORS,
+  REFERENCE_LINE_SECONDARY_LABEL_COLOR,
   REFERENCE_LINE_SIZE_STROKE_WIDTHS,
   REFERENCE_LINE_START_CAP_PATHS,
 } from '@spectrum-charts/constants';
@@ -457,4 +459,100 @@ describe('size prop — explicit size variants', () => {
       expect(caps[0].encode?.enter?.path).toStrictEqual({ value: REFERENCE_LINE_END_CAP_PATHS[size] });
     }
   );
+});
+
+describe('secondary prop', () => {
+  const secondaryOptions: ReferenceLineSpecOptions = { ...defaultReferenceLineOptions, secondary: true };
+
+  describe('getReferenceLineRuleMark() with secondary: true', () => {
+    test('auto mode: stroke uses REFERENCE_LINE_SECONDARY_COLORS[M] (gray-800 — same as primary in M tier)', () => {
+      const rule = getReferenceLineRuleMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding);
+      expect(rule.encode?.enter?.stroke).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_COLORS['M']] });
+    });
+
+    test('size XS: stroke uses REFERENCE_LINE_SECONDARY_COLORS[XS] (gray-600)', () => {
+      const rule = getReferenceLineRuleMark(
+        defaultAxisOptions,
+        { ...secondaryOptions, size: 'XS' },
+        defaultYPositionEncoding
+      );
+      expect(rule.encode?.enter?.stroke).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_COLORS['XS']] });
+    });
+
+    test('x is fixed at 0 (no cap offset)', () => {
+      const rule = getReferenceLineRuleMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding);
+      expect(rule.encode?.update?.x).toStrictEqual({ value: 0 });
+    });
+
+    test('x2 spans full width', () => {
+      const rule = getReferenceLineRuleMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding);
+      expect(rule.encode?.update?.x2).toStrictEqual({ signal: 'width' });
+    });
+
+    test('explicit size: x and x2 still use secondary values (0 and width)', () => {
+      const rule = getReferenceLineRuleMark(
+        defaultAxisOptions,
+        { ...secondaryOptions, size: 'L' },
+        defaultYPositionEncoding
+      );
+      expect(rule.encode?.update?.x).toStrictEqual({ value: 0 });
+      expect(rule.encode?.update?.x2).toStrictEqual({ signal: 'width' });
+    });
+  });
+
+  describe('getReferenceLineStartCapMark() with secondary: true', () => {
+    test('returns empty array — no caret caps on secondary lines', () => {
+      expect(getReferenceLineStartCapMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding)).toStrictEqual([]);
+    });
+
+    test('returns empty array even with explicit size', () => {
+      expect(
+        getReferenceLineStartCapMark(defaultAxisOptions, { ...secondaryOptions, size: 'L' }, defaultYPositionEncoding)
+      ).toStrictEqual([]);
+    });
+  });
+
+  describe('getReferenceLineEndCapMark() with secondary: true', () => {
+    test('returns empty array — no caret caps on secondary lines', () => {
+      expect(getReferenceLineEndCapMark(defaultAxisOptions, secondaryOptions, defaultYPositionEncoding)).toStrictEqual([]);
+    });
+
+    test('returns empty array even with explicit size', () => {
+      expect(
+        getReferenceLineEndCapMark(defaultAxisOptions, { ...secondaryOptions, size: 'M' }, defaultYPositionEncoding)
+      ).toStrictEqual([]);
+    });
+  });
+
+  describe('getReferenceLineTextMark() with secondary: true', () => {
+    test('label foreground fill uses REFERENCE_LINE_SECONDARY_LABEL_COLOR (gray-600)', () => {
+      const marks = getReferenceLineTextMark(
+        { ...secondaryOptions, label: 'Average' },
+        defaultYPositionEncoding
+      );
+      expect(marks[1].encode?.enter?.fill).toStrictEqual({ value: spectrum2Colors.light[REFERENCE_LINE_SECONDARY_LABEL_COLOR] });
+    });
+
+    test('background mark is unaffected — still transparent fill', () => {
+      const marks = getReferenceLineTextMark(
+        { ...secondaryOptions, label: 'Average' },
+        defaultYPositionEncoding
+      );
+      expect(marks[0].encode?.enter?.fill).toStrictEqual({ value: 'transparent' });
+    });
+  });
+
+  test('getReferenceLineMarks() with secondary: true returns rule and text marks but no cap marks', () => {
+    const marks = getReferenceLineMarks(
+      {
+        ...defaultAxisOptions,
+        referenceLines: [{ ...defaultReferenceLineOptions, secondary: true, label: 'Average' }],
+      },
+      'yLinear'
+    );
+    expect(marks.some((m) => m.type === 'rule')).toBe(true);
+    expect(marks.some((m) => m.name?.includes('_label'))).toBe(true);
+    expect(marks.some((m) => m.name?.includes('_startCap'))).toBe(false);
+    expect(marks.some((m) => m.name?.includes('_endCap'))).toBe(false);
+  });
 });

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
@@ -26,7 +26,7 @@ import {
   REFERENCE_LINE_RULE_X2_OFFSET,
   REFERENCE_LINE_RULE_X_START,
   REFERENCE_LINE_SECONDARY_COLORS,
-  REFERENCE_LINE_SECONDARY_LABEL_COLOR,
+  REFERENCE_LINE_SECONDARY_STROKE_WIDTH,
   REFERENCE_LINE_SIZE_STROKE_WIDTHS,
   REFERENCE_LINE_START_CAP_PATHS,
   ReferenceLineSize,
@@ -128,8 +128,9 @@ export const getReferenceLineRuleMark = (
   const stroke = secondary
     ? { value: getSecondaryStrokeColor(size, colorScheme) }
     : { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
-  const strokeWidth =
-    size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
+  const strokeWidth = secondary
+    ? { value: REFERENCE_LINE_SECONDARY_STROKE_WIDTH }
+    : size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
   const primaryXStart =
     size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
   const xStart = secondary ? { value: 0 } : primaryXStart;
@@ -243,7 +244,7 @@ export const getReferenceLineEndCapMark = (
  * Label is below the line, right-aligned, with S2 typography.
  */
 export const getReferenceLineTextMark = (
-  { colorScheme, label, name, secondary }: ReferenceLineSpecOptions,
+  { colorScheme, label, name, secondary, size }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): TextMark[] => {
   if (!label) return [];
@@ -283,7 +284,7 @@ export const getReferenceLineTextMark = (
       encode: {
         enter: {
           ...sharedEnter,
-          fill: { value: secondary ? getS2ColorValue(REFERENCE_LINE_SECONDARY_LABEL_COLOR, colorScheme) : getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) },
+          fill: { value: secondary ? getSecondaryStrokeColor(size, colorScheme) : getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) },
         },
         update: sharedUpdate,
       },

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
@@ -128,9 +128,9 @@ export const getReferenceLineRuleMark = (
   const stroke = secondary
     ? { value: getSecondaryStrokeColor(size, colorScheme) }
     : { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
-  const strokeWidth = secondary
-    ? { value: REFERENCE_LINE_SECONDARY_STROKE_WIDTH }
-    : size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
+  const primaryStrokeWidth =
+    size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
+  const strokeWidth = secondary ? { value: REFERENCE_LINE_SECONDARY_STROKE_WIDTH } : primaryStrokeWidth;
   const primaryXStart =
     size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
   const xStart = secondary ? { value: 0 } : primaryXStart;

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
@@ -25,12 +25,15 @@ import {
   REFERENCE_LINE_LABEL_OFFSET_FROM_LINE,
   REFERENCE_LINE_RULE_X2_OFFSET,
   REFERENCE_LINE_RULE_X_START,
+  REFERENCE_LINE_SECONDARY_COLORS,
+  REFERENCE_LINE_SECONDARY_LABEL_COLOR,
   REFERENCE_LINE_SIZE_STROKE_WIDTHS,
   REFERENCE_LINE_START_CAP_PATHS,
+  ReferenceLineSize,
 } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
-import { AxisSpecOptions, ReferenceLineOptions, ReferenceLineSpecOptions } from '../types';
+import { AxisSpecOptions, ColorScheme, ReferenceLineOptions, ReferenceLineSpecOptions } from '../types';
 import { isVerticalAxis } from './axisUtils';
 
 export const getReferenceLines = (axisOptions: AxisSpecOptions): ReferenceLineSpecOptions[] => {
@@ -108,33 +111,45 @@ const getCapTierOpacitySignal = (tier: 'S' | 'M' | 'L'): string => {
   return `rscContainerWidth(width) >= ${CHART_SIZE_BREAKPOINTS.M} && rscContainerWidth(width) < ${CHART_SIZE_BREAKPOINTS.L} ? 1 : 0`;
 };
 
+// Returns the stroke color for a secondary reference line.
+// Auto mode has no XS tier, so treat as M (gray-800). Explicit XS → gray-600.
+const getSecondaryStrokeColor = (size: ReferenceLineSize | undefined, colorScheme: ColorScheme): string =>
+  getS2ColorValue(REFERENCE_LINE_SECONDARY_COLORS[size ?? 'M'], colorScheme);
+
 /**
  * Horizontal rule line — spans from caret tip to the right cap, with x-start adapting to caret size.
  * In auto mode (no explicit size) both stroke width and x-start react to chart width via signals.
  */
 export const getReferenceLineRuleMark = (
   { colorScheme }: AxisSpecOptions,
-  { name, size }: ReferenceLineSpecOptions,
+  { name, secondary, size }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): RuleMark => {
+  const stroke = secondary
+    ? { value: getSecondaryStrokeColor(size, colorScheme) }
+    : { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
   const strokeWidth =
     size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
-  const xStart =
-    size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
+  const xStart = secondary
+    ? { value: 0 }
+    : size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
+  const x2 = secondary
+    ? { signal: 'width' }
+    : size === undefined ? { signal: getRuleX2Signal() } : { signal: `width - ${REFERENCE_LINE_RULE_X2_OFFSET[size]}` };
   return {
     name,
     type: 'rule',
     interactive: false,
     encode: {
       enter: {
-        stroke: { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) },
+        stroke,
         strokeWidth,
         strokeCap: { value: 'round' },
         strokeJoin: { value: 'round' },
       },
       update: {
         x: xStart,
-        x2: size === undefined ? { signal: getRuleX2Signal() } : { signal: `width - ${REFERENCE_LINE_RULE_X2_OFFSET[size]}` },
+        x2,
         y: positionEncoding as NumericValueRef,
       },
     },
@@ -148,9 +163,10 @@ export const getReferenceLineRuleMark = (
  */
 export const getReferenceLineStartCapMark = (
   _axisOptions: AxisSpecOptions,
-  { colorScheme, name, size }: ReferenceLineSpecOptions,
+  { colorScheme, name, secondary, size }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): PathMark[] => {
+  if (secondary) return [];
   const fill = { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
   const sharedUpdate = { x: { value: 5 }, y: positionEncoding as NumericValueRef };
 
@@ -186,9 +202,10 @@ export const getReferenceLineStartCapMark = (
  */
 export const getReferenceLineEndCapMark = (
   _axisOptions: AxisSpecOptions,
-  { colorScheme, name, size }: ReferenceLineSpecOptions,
+  { colorScheme, name, secondary, size }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): PathMark[] => {
+  if (secondary) return [];
   const fill = { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
 
   if (size === undefined) {
@@ -226,7 +243,7 @@ export const getReferenceLineEndCapMark = (
  * Label is below the line, right-aligned, with S2 typography.
  */
 export const getReferenceLineTextMark = (
-  { colorScheme, label, name }: ReferenceLineSpecOptions,
+  { colorScheme, label, name, secondary }: ReferenceLineSpecOptions,
   positionEncoding: ProductionRule<NumericValueRef> | SignalRef
 ): TextMark[] => {
   if (!label) return [];
@@ -266,7 +283,7 @@ export const getReferenceLineTextMark = (
       encode: {
         enter: {
           ...sharedEnter,
-          fill: { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) },
+          fill: { value: secondary ? getS2ColorValue(REFERENCE_LINE_SECONDARY_LABEL_COLOR, colorScheme) : getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) },
         },
         update: sharedUpdate,
       },

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
@@ -130,12 +130,12 @@ export const getReferenceLineRuleMark = (
     : { value: getS2ColorValue(DEFAULT_FONT_COLOR, colorScheme) };
   const strokeWidth =
     size === undefined ? { signal: CHART_SIZE_STROKE_WIDTH } : { value: REFERENCE_LINE_SIZE_STROKE_WIDTHS[size] };
-  const xStart = secondary
-    ? { value: 0 }
-    : size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
-  const x2 = secondary
-    ? { signal: 'width' }
-    : size === undefined ? { signal: getRuleX2Signal() } : { signal: `width - ${REFERENCE_LINE_RULE_X2_OFFSET[size]}` };
+  const primaryXStart =
+    size === undefined ? { signal: getRuleXStartSignal() } : { value: REFERENCE_LINE_RULE_X_START[size] };
+  const xStart = secondary ? { value: 0 } : primaryXStart;
+  const primaryX2 =
+    size === undefined ? { signal: getRuleX2Signal() } : { signal: `width - ${REFERENCE_LINE_RULE_X2_OFFSET[size]}` };
+  const x2 = secondary ? { signal: 'width' } : primaryX2;
   return {
     name,
     type: 'rule',

--- a/packages/vega-spec-builder-s2/src/types/axis/referenceLineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/axis/referenceLineSpec.types.ts
@@ -24,6 +24,8 @@ export interface ReferenceLineOptions {
   label?: string;
   /** Size variant controlling stroke weight and caret triangle dimensions. When omitted, stroke width reacts to chart size automatically. */
   size?: ReferenceLineSize;
+  /** When true, renders a lighter secondary style: no caret caps, and a lighter stroke color for XS size. */
+  secondary?: boolean;
 }
 
 export interface ReferenceLineSpecOptions extends ReferenceLineOptions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds secondary?: boolean to the S2 <ReferenceLine> component (AN-450459). Secondary lines are a lighter-emphasis variant intended for contextual values (averages, baselines) that should visually recede behind a primary target line.

Visual differences vs. primary:

- No caret caps (start and end triangles omitted)
- Rule spans full chart width (no cap-clearance offsets on either side)
- Stroke and label color is size-dependent: gray-600 at XS, gray-800 for S/M/L and auto mode

Stroke weight always 1px. 

LineReferenceLine.story.tsx — adds SecondaryBasic, WithSecondary, and PrimaryAndSecondary stories

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
