### PR TITLE
feat: update stroke dash for dotted line type in s2 to render as circles

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
@@ -115,13 +115,13 @@ describe('Line', () => {
     const lines = await findAllMarksByGroupName(chart, 'line0');
     expect(lines.length).toEqual(4);
     // dotted teal line
-    expect(lines[0].getAttribute('stroke-dasharray')).toEqual('2,3');
+    expect(lines[0].getAttribute('stroke-dasharray')).toEqual('0,4');
     expect(lines[0].getAttribute('stroke')).toEqual('#5424DB'); // S2 categorical-100
     // solid teal line
     expect(lines[1].getAttribute('stroke-dasharray')).toEqual('');
     expect(lines[1].getAttribute('stroke')).toEqual('#5424DB'); // S2 categorical-100
     // dotted purple line
-    expect(lines[2].getAttribute('stroke-dasharray')).toEqual('2,3');
+    expect(lines[2].getAttribute('stroke-dasharray')).toEqual('0,4');
     expect(lines[3].getAttribute('stroke')).toEqual('#D92361'); // S2 categorical-200
     // solid purple line
     expect(lines[3].getAttribute('stroke-dasharray')).toEqual('');

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
@@ -91,7 +91,7 @@ describe('Line', () => {
     expect(lines.length).toEqual(4);
     expect(lines[0].getAttribute('stroke-dasharray')).toEqual('');
     expect(lines[1].getAttribute('stroke-dasharray')).toEqual('7,4');
-    expect(lines[2].getAttribute('stroke-dasharray')).toEqual('2,3');
+    expect(lines[2].getAttribute('stroke-dasharray')).toEqual('0,4');
     expect(lines[3].getAttribute('stroke-dasharray')).toEqual('2,3,7,4');
   });
 

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendSymbol.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendSymbol.test.tsx
@@ -88,7 +88,7 @@ test('Supreme renders correctly', async () => {
   const symbols = getAllLegendSymbols(chart);
   expect(symbols[0].getAttribute('stroke-dasharray')).toEqual('');
   expect(symbols[1].getAttribute('stroke-dasharray')).toEqual('7,4');
-  expect(symbols[2].getAttribute('stroke-dasharray')).toEqual('2,3');
+  expect(symbols[2].getAttribute('stroke-dasharray')).toEqual('0,4');
 
   expect(symbols[0].getAttribute('stroke-width')).toEqual('1.5');
 

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
@@ -217,7 +217,7 @@ describe('Chart spec builder', () => {
     });
 
     test('should convert line type names', () => {
-      expect(getTwoDimensionalLineTypes([['solid', 'dashed'], ['dotted']])).toStrictEqual([[[], [7, 4]], [[2, 3]]]);
+      expect(getTwoDimensionalLineTypes([['solid', 'dashed'], ['dotted']])).toStrictEqual([[[], [7, 4]], [[0, 4]]]);
     });
   });
 

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.test.ts
@@ -110,7 +110,7 @@ describe('getStrokeDashProductionRule', () => {
   });
 
   test('should return static value and convert preset line type to dash array', () => {
-    expect(getStrokeDashProductionRule({ value: 'dotted' })).toStrictEqual({ value: [2, 3] });
+    expect(getStrokeDashProductionRule({ value: 'dotted' })).toStrictEqual({ value: [0, 4] });
   });
 
   test('should return static value of the dash array provided', () => {

--- a/packages/vega-spec-builder-s2/src/specUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.test.ts
@@ -127,7 +127,7 @@ describe('getStrokeDashFromLineType()', () => {
   test('should convert line type names to their coresponding stroke dash array', () => {
     expect(getStrokeDashFromLineType('solid')).toStrictEqual([]);
     expect(getStrokeDashFromLineType('dashed')).toStrictEqual([7, 4]);
-    expect(getStrokeDashFromLineType('dotted')).toStrictEqual([2, 3]);
+    expect(getStrokeDashFromLineType('dotted')).toStrictEqual([0, 4]);
     expect(getStrokeDashFromLineType('dotDash')).toStrictEqual([2, 3, 7, 4]);
     expect(getStrokeDashFromLineType('shortDash')).toStrictEqual([3, 4]);
     expect(getStrokeDashFromLineType('longDash')).toStrictEqual([11, 4]);

--- a/packages/vega-spec-builder-s2/src/specUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.ts
@@ -117,7 +117,7 @@ export const getStrokeDashFromLineType = (lineType: LineType): number[] => {
     case 'dashed':
       return [7, 4];
     case 'dotted':
-      return [2, 3];
+      return [0, 4];
     case 'dotDash':
       return [2, 3, 7, 4];
     case 'shortDash':


### PR DESCRIPTION
## Description

Updating the dotted stroke dash array to create a circle. [0,4] draws a 0px stroke that renders as a point, with a 4px gap. 

## Related Issue

## Motivation and Context

After applying `lineCap: round` in s2, the dotted line type was rendering each line mark as an oval pill shape, rather than circles. 

## How Has This Been Tested?

Unit tests and visual testing in storybook. 

## Screenshots (if appropriate):

<img width="646" height="434" alt="Screenshot 2026-06-17 at 1 57 38 PM" src="https://github.com/user-attachments/assets/645151c2-d1f0-4b51-9224-174250feeafc" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
