### PR TITLE
fix: render gray empty state ring for donut with zero or empty data

### DIFF
--- a/packages/docs/docs/api/visualizations/Donut.md
+++ b/packages/docs/docs/api/visualizations/Donut.md
@@ -23,6 +23,10 @@ It is also possible to label each series using a legend just like you would on a
 
 You should not use direct labels and a legend at the same time as the information is redundant.
 
+## Empty state
+
+If there isn't any data to display (there are no data points or all metric values are 0), the donut will render as a light gray (gray-200) ring and all direct labels will be dropped. If a `DonutSummary` is present, the metric total (0) will still be displayed in the center of the donut.
+
 ## Examples
 
 ### Donut

--- a/packages/react-spectrum-charts-s2/src/stories/components/Donut/Donut.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Donut/Donut.story.tsx
@@ -18,10 +18,10 @@ import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
 import { Chart } from '../../../Chart';
 import { ChartPopover, ChartInspect, Legend } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
-import { Donut, DonutSummary } from '../../../rc';
+import { Donut, DonutSummary, SegmentLabel } from '../../../rc';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps, DonutProps } from '../../../types';
-import { basicDonutData, booleanDonutData } from './data';
+import { basicDonutData, booleanDonutData, zeroDonutData } from './data';
 
 export default {
   title: 'React Spectrum Charts 2/Donut/Features',
@@ -46,6 +46,16 @@ const DonutStory: StoryFn<DonutProps & { width?: number; height?: number }> = (a
 
 const DonutLegendStory: StoryFn<typeof Donut> = (args): ReactElement => {
   const chartProps = useChartProps({ ...defaultChartProps, width: 400 });
+  return (
+    <Chart {...chartProps}>
+      <Donut {...args} />
+      <Legend title="Browsers" position={'right'} highlight isToggleable />
+    </Chart>
+  );
+};
+
+const EmptyStateStory: StoryFn<typeof Donut> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: zeroDonutData, width: 400 });
   return (
     <Chart {...chartProps}>
       <Donut {...args} />
@@ -126,6 +136,15 @@ BooleanDonut.args = {
   isBoolean: true,
 };
 
+// all metric values are 0, so the donut renders the empty state ring with 0 displayed in the center
+const EmptyState = bindWithProps(EmptyStateStory);
+EmptyState.args = {
+  metric: 'count',
+  color: 'browser',
+  holeRatio: 0.8,
+  children: [<DonutSummary label="Visitors" key={0} />, <SegmentLabel percent value key={1} />],
+};
+
 const Supreme = bindWithProps(DonutLegendStory);
 Supreme.args = {
   metric: 'count',
@@ -134,4 +153,4 @@ Supreme.args = {
   children: [...interactiveChildren, <DonutSummary label="Visitors" key={0} />],
 };
 
-export { Basic, BooleanDonut, Supreme, WithLegend, WithPopover };
+export { Basic, BooleanDonut, EmptyState, Supreme, WithLegend, WithPopover };

--- a/packages/react-spectrum-charts-s2/src/stories/components/Donut/Donut.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Donut/Donut.test.tsx
@@ -9,9 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { spectrum2Colors } from '@spectrum-charts/themes';
+
 import { Donut } from '../../../rc/components/Donut';
-import { findAllMarksByGroupName, findChart, render } from '../../../test-utils';
-import { Basic } from './Donut.story';
+import { allElementsHaveAttributeValue, findAllMarksByGroupName, findChart, render, screen } from '../../../test-utils';
+import { Basic, EmptyState } from './Donut.story';
 
 describe('Donut', () => {
   // Donut is not a real React component. This is test just provides test coverage for sonarqube
@@ -27,5 +29,32 @@ describe('Donut', () => {
     // donut data has 7 segments
     const bars = await findAllMarksByGroupName(chart, 'donut0');
     expect(bars.length).toEqual(7);
+
+    // empty state ring should be hidden since there is data
+    const emptyStateRings = await findAllMarksByGroupName(chart, 'donut0_emptyState');
+    expect(allElementsHaveAttributeValue(emptyStateRings, 'opacity', '0')).toBe(true);
+  });
+
+  test('EmptyState renders a gray ring with the value in the center when all values are 0', async () => {
+    render(<EmptyState {...EmptyState.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // the empty state ring should be visible and gray-200
+    const emptyStateRings = await findAllMarksByGroupName(chart, 'donut0_emptyState');
+    expect(emptyStateRings.length).toEqual(1);
+    expect(emptyStateRings[0]).toHaveAttribute('fill', spectrum2Colors.light['gray-200']);
+    expect(emptyStateRings[0]).toHaveAttribute('opacity', '1');
+
+    // the donut segments should be hidden
+    const segments = await findAllMarksByGroupName(chart, 'donut0');
+    expect(allElementsHaveAttributeValue(segments, 'opacity', '0')).toBe(true);
+
+    // the summary value should display 0
+    expect(await screen.findByText('0')).toBeInTheDocument();
+    expect(screen.getByText('Visitors')).toBeInTheDocument();
+
+    // no NaN segment labels should be displayed
+    expect(screen.queryAllByText(/NaN/)).toHaveLength(0);
   });
 });

--- a/packages/react-spectrum-charts-s2/src/stories/components/Donut/data.ts
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Donut/data.ts
@@ -42,3 +42,9 @@ export const booleanDonutData = [
   { id: '1', value: 0.68 },
   { id: '2', value: 0.32 },
 ];
+
+export const zeroDonutData = [
+  { count: 0, browser: 'Chrome' },
+  { count: 0, browser: 'Firefox' },
+  { count: 0, browser: 'Safari' },
+];

--- a/packages/react-spectrum-charts/src/stories/components/Donut/Donut.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Donut/Donut.story.tsx
@@ -19,10 +19,10 @@ import { Datum } from '@spectrum-charts/vega-spec-builder';
 import { Chart } from '../../../Chart';
 import { ChartPopover, ChartTooltip, Legend } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
-import { Donut, DonutSummary } from '../../../rc';
+import { Donut, DonutSummary, SegmentLabel } from '../../../rc';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps, DonutProps } from '../../../types';
-import { basicDonutData, booleanDonutData } from './data';
+import { basicDonutData, booleanDonutData, zeroDonutData } from './data';
 
 export default {
   title: 'RSC/Donut',
@@ -47,6 +47,16 @@ const DonutStory: StoryFn<DonutProps & { width?: number; height?: number }> = (a
 
 const DonutLegendStory: StoryFn<typeof Donut> = (args): ReactElement => {
   const chartProps = useChartProps({ ...defaultChartProps, width: 400 });
+  return (
+    <Chart {...chartProps}>
+      <Donut {...args} />
+      <Legend title="Browsers" position={'right'} highlight isToggleable />
+    </Chart>
+  );
+};
+
+const EmptyStateStory: StoryFn<typeof Donut> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: zeroDonutData, width: 400 });
   return (
     <Chart {...chartProps}>
       <Donut {...args} />
@@ -127,6 +137,15 @@ BooleanDonut.args = {
   isBoolean: true,
 };
 
+// all metric values are 0, so the donut renders the empty state ring with 0 displayed in the center
+const EmptyState = bindWithProps(EmptyStateStory);
+EmptyState.args = {
+  metric: 'count',
+  color: 'browser',
+  holeRatio: 0.8,
+  children: [<DonutSummary label="Visitors" key={0} />, <SegmentLabel percent value key={1} />],
+};
+
 const Supreme = bindWithProps(DonutLegendStory);
 Supreme.args = {
   metric: 'count',
@@ -135,4 +154,4 @@ Supreme.args = {
   children: [...interactiveChildren, <DonutSummary label="Visitors" key={0} />],
 };
 
-export { Basic, BooleanDonut, Supreme, WithLegend, WithPopover };
+export { Basic, BooleanDonut, EmptyState, Supreme, WithLegend, WithPopover };

--- a/packages/react-spectrum-charts/src/stories/components/Donut/Donut.test.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Donut/Donut.test.tsx
@@ -9,9 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { spectrumColors } from '@spectrum-charts/themes';
+
 import { Donut } from '../../../rc/components/Donut';
-import { findAllMarksByGroupName, findChart, render } from '../../../test-utils';
-import { Basic } from './Donut.story';
+import { allElementsHaveAttributeValue, findAllMarksByGroupName, findChart, render, screen } from '../../../test-utils';
+import { Basic, EmptyState } from './Donut.story';
 
 describe('Donut', () => {
   // Donut is not a real React component. This is test just provides test coverage for sonarqube
@@ -27,5 +29,32 @@ describe('Donut', () => {
     // donut data has 7 segments
     const bars = await findAllMarksByGroupName(chart, 'donut0');
     expect(bars.length).toEqual(7);
+
+    // empty state ring should be hidden since there is data
+    const emptyStateRings = await findAllMarksByGroupName(chart, 'donut0_emptyState');
+    expect(allElementsHaveAttributeValue(emptyStateRings, 'opacity', '0')).toBe(true);
+  });
+
+  test('EmptyState renders a gray ring with the value in the center when all values are 0', async () => {
+    render(<EmptyState {...EmptyState.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // the empty state ring should be visible and gray-200
+    const emptyStateRings = await findAllMarksByGroupName(chart, 'donut0_emptyState');
+    expect(emptyStateRings.length).toEqual(1);
+    expect(emptyStateRings[0]).toHaveAttribute('fill', spectrumColors.light['gray-200']);
+    expect(emptyStateRings[0]).toHaveAttribute('opacity', '1');
+
+    // the donut segments should be hidden
+    const segments = await findAllMarksByGroupName(chart, 'donut0');
+    expect(allElementsHaveAttributeValue(segments, 'opacity', '0')).toBe(true);
+
+    // the summary value should display 0
+    expect(await screen.findByText('0')).toBeInTheDocument();
+    expect(screen.getByText('Visitors')).toBeInTheDocument();
+
+    // no NaN segment labels should be displayed
+    expect(screen.queryAllByText(/NaN/)).toHaveLength(0);
   });
 });

--- a/packages/react-spectrum-charts/src/stories/components/Donut/data.ts
+++ b/packages/react-spectrum-charts/src/stories/components/Donut/data.ts
@@ -42,3 +42,9 @@ export const booleanDonutData = [
   { id: '1', value: 0.68 },
   { id: '2', value: 0.32 },
 ];
+
+export const zeroDonutData = [
+  { count: 0, browser: 'Chrome' },
+  { count: 0, browser: 'Firefox' },
+  { count: 0, browser: 'Safari' },
+];

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.test.ts
@@ -20,7 +20,7 @@ describe('addData', () => {
   test('should add data correctly for boolean donut', () => {
     const data = addData(initializeSpec().data ?? [], { ...defaultDonutOptions, isBoolean: true });
 
-    expect(data).toHaveLength(3);
+    expect(data).toHaveLength(4);
     expect(data[2].transform).toHaveLength(2);
     expect(data[2].transform?.[0].type).toBe('window');
     expect(data[2].transform?.[1].type).toBe('filter');
@@ -28,12 +28,22 @@ describe('addData', () => {
 
   test('should add data correctly for non-boolean donut', () => {
     const data = addData(initializeSpec().data ?? [], defaultDonutOptions);
-    expect(data).toHaveLength(2);
+    expect(data).toHaveLength(3);
     expect(data[1].transform).toHaveLength(4);
     expect(data[1].transform?.[0].type).toBe('pie');
     expect(data[1].transform?.[1]).toHaveProperty('as', 'testName_arcTheta');
     expect(data[1].transform?.[2]).toHaveProperty('as', 'testName_arcLength');
     expect(data[1].transform?.[3]).toHaveProperty('as', 'testName_arcPercent');
+  });
+
+  test('should add the sum data used to detect the empty state', () => {
+    const data = addData(initializeSpec().data ?? [], defaultDonutOptions);
+    const sumData = data.find((d) => d.name === 'testName_sumData');
+    expect(sumData).toBeDefined();
+    expect(sumData?.transform).toHaveLength(1);
+    expect(sumData?.transform?.[0]).toHaveProperty('type', 'aggregate');
+    expect(sumData?.transform?.[0]).toHaveProperty('fields', ['testMetric']);
+    expect(sumData?.transform?.[0]).toHaveProperty('ops', ['sum']);
   });
 });
 
@@ -62,6 +72,16 @@ describe('addSignals()', () => {
     expect(hoveredItemSignal?.on?.[0]).toHaveProperty('events', '@testName:mouseover');
     expect(hoveredItemSignal?.on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum');
     expect(hoveredItemSignal?.on?.[1]).toHaveProperty('events', '@testName:mouseout');
+  });
+});
+
+describe('addMarks()', () => {
+  test('should add the empty state ring before the arc mark', () => {
+    const marks = addMarks([], defaultDonutOptions);
+    expect(marks).toHaveLength(2);
+    expect(marks[0]).toHaveProperty('name', 'testName_emptyState');
+    expect(marks[0]).toHaveProperty('type', 'arc');
+    expect(marks[1]).toHaveProperty('name', 'testName');
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -32,7 +32,7 @@ import {
   getDonutSummaryScales,
   getDonutSummarySignals,
 } from './donutSummaryUtils';
-import { getArcMark } from './donutUtils';
+import { getArcMark, getEmptyStateArcMark, getSumData } from './donutUtils';
 import { getSegmentLabelMarks } from './segmentLabelUtils';
 
 export const addDonut = produce<
@@ -117,6 +117,8 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
       ],
     });
   }
+  // used to detect the empty state (no data or all metric values are 0)
+  data.push(getSumData(options));
   data.push(...getDonutSummaryData(options));
 });
 
@@ -152,7 +154,12 @@ export const addScales = produce<Scale[], [DonutSpecOptions]>((scales, options) 
 });
 
 export const addMarks = produce<Mark[], [DonutSpecOptions]>((marks, options) => {
-  marks.push(getArcMark(options), ...getDonutSummaryMarks(options), ...getSegmentLabelMarks(options));
+  marks.push(
+    getEmptyStateArcMark(options),
+    getArcMark(options),
+    ...getDonutSummaryMarks(options),
+    ...getSegmentLabelMarks(options)
+  );
 });
 
 export const addSignals = produce<Signal[], [DonutSpecOptions]>((signals, options) => {

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FILTERED_TABLE } from '@spectrum-charts/constants';
+import { spectrum2Colors } from '@spectrum-charts/themes';
+
+import { defaultDonutOptions } from './donutTestUtils';
+import { getArcMark, getDonutEmptyStateTest, getEmptyStateArcMark, getSumData } from './donutUtils';
+
+describe('getDonutEmptyStateTest()', () => {
+  test('should test for empty data and a metric sum of 0', () => {
+    const test = getDonutEmptyStateTest('testName');
+    expect(test).toBe(`length(data('${FILTERED_TABLE}')) === 0 || !data('testName_sumData')[0]['sum']`);
+  });
+});
+
+describe('getSumData()', () => {
+  test('should aggregate the sum of the metric from the filtered table', () => {
+    const sumData = getSumData(defaultDonutOptions);
+    expect(sumData).toHaveProperty('name', 'testName_sumData');
+    expect(sumData).toHaveProperty('source', FILTERED_TABLE);
+    expect(sumData.transform).toEqual([
+      {
+        type: 'aggregate',
+        fields: ['testMetric'],
+        ops: ['sum'],
+        as: ['sum'],
+      },
+    ]);
+  });
+});
+
+describe('getArcMark()', () => {
+  test('should hide the arcs when the donut is in the empty state', () => {
+    const arcMark = getArcMark(defaultDonutOptions);
+    const opacity = arcMark.encode?.update?.opacity;
+    expect(opacity).toHaveLength(2);
+    expect(opacity?.[0]).toEqual({ test: getDonutEmptyStateTest('testName'), value: 0 });
+  });
+});
+
+describe('getEmptyStateArcMark()', () => {
+  test('should return a gray-200 ring', () => {
+    const emptyStateMark = getEmptyStateArcMark(defaultDonutOptions);
+    expect(emptyStateMark).toHaveProperty('name', 'testName_emptyState');
+    expect(emptyStateMark).toHaveProperty('type', 'arc');
+    expect(emptyStateMark).toHaveProperty('interactive', false);
+    expect(emptyStateMark.encode?.enter?.fill).toEqual({ value: spectrum2Colors.light['gray-200'] });
+    expect(emptyStateMark.encode?.enter?.startAngle).toEqual({ value: 0 });
+    expect(emptyStateMark.encode?.enter?.endAngle).toEqual({ signal: '2 * PI' });
+  });
+  test('should only be visible when the donut is in the empty state', () => {
+    const emptyStateMark = getEmptyStateArcMark(defaultDonutOptions);
+    expect(emptyStateMark.encode?.update?.opacity).toEqual([
+      { test: getDonutEmptyStateTest('testName'), value: 1 },
+      { value: 0 },
+    ]);
+  });
+});

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
@@ -9,13 +9,41 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ArcMark } from 'vega';
+import { ArcMark, SourceData } from 'vega';
 
 import { DONUT_RADIUS, FILTERED_TABLE, SELECTED_ITEM } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getColorProductionRule, getCursor, getMarkOpacity, getInspectEncoding } from '../marks/markUtils';
 import { DonutSpecOptions } from '../types';
+
+/**
+ * Gets the test expression that is true when the donut has no data or all metric values sum to 0.
+ * When the metric sum is 0, the vega pie transform produces NaN angles which cannot be rendered.
+ * @param name donut name
+ * @returns vega expression string
+ */
+export const getDonutEmptyStateTest = (name: string): string =>
+  `length(data('${FILTERED_TABLE}')) === 0 || !data('${name}_sumData')[0]['sum']`;
+
+/**
+ * Gets the data source that aggregates the sum of the metric.
+ * Used to detect the empty state (no data or all metric values are 0).
+ * @param donutOptions
+ * @returns SourceData
+ */
+export const getSumData = ({ metric, name }: DonutSpecOptions): SourceData => ({
+  name: `${name}_sumData`,
+  source: FILTERED_TABLE,
+  transform: [
+    {
+      type: 'aggregate',
+      fields: [metric],
+      ops: ['sum'],
+      as: ['sum'],
+    },
+  ],
+});
 
 export const getArcMark = (options: DonutSpecOptions): ArcMark => {
   const { chartPopovers, chartInspects, color, colorScheme, holeRatio, idKey, name } = options;
@@ -38,9 +66,40 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
         padAngle: { value: 0.01 },
         innerRadius: { signal: `${holeRatio} * ${DONUT_RADIUS}` },
         outerRadius: { signal: DONUT_RADIUS },
-        opacity: getMarkOpacity(options),
+        // hide the segments when there isn't any data to display, the empty state ring is shown instead
+        opacity: [{ test: getDonutEmptyStateTest(name), value: 0 }, ...getMarkOpacity(options)],
         cursor: getCursor(chartPopovers),
         strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${idKey}`, value: 2 }, { value: 0 }],
+      },
+    },
+  };
+};
+
+/**
+ * Gets the empty state arc mark. This is a light gray ring that is only visible
+ * when the donut has no data or all metric values sum to 0.
+ * @param donutOptions
+ * @returns ArcMark
+ */
+export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
+  const { colorScheme, holeRatio, name } = options;
+  return {
+    type: 'arc',
+    name: `${name}_emptyState`,
+    description: `${name}_emptyState`,
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { value: getS2ColorValue('gray-200', colorScheme) },
+        x: { signal: 'width / 2' },
+        y: { signal: 'height / 2' },
+        startAngle: { value: 0 },
+        endAngle: { signal: '2 * PI' },
+      },
+      update: {
+        innerRadius: { signal: `${holeRatio} * ${DONUT_RADIUS}` },
+        outerRadius: { signal: DONUT_RADIUS },
+        opacity: [{ test: getDonutEmptyStateTest(name), value: 1 }, { value: 0 }],
       },
     },
   };

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -11,6 +11,7 @@
  */
 import { DonutSpecOptions, SegmentLabelSpecOptions } from '../types';
 import { defaultDonutOptions } from './donutTestUtils';
+import { getDonutEmptyStateTest } from './donutUtils';
 import {
   getSegmentLabelMarks,
   getSegmentLabelTextMark,
@@ -124,6 +125,14 @@ describe('getSegmentLabelTextMark()', () => {
   test('should not define dy if value and percent are false', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     expect(mark.encode?.enter?.dy).toBeUndefined();
+  });
+  test('should hide labels when the donut is in the empty state', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    expect(mark.encode?.enter?.fontSize).toEqual([
+      { test: getDonutEmptyStateTest('testName'), value: 0 },
+      { test: `datum['testName_arcLength'] < 0.3`, value: 0 },
+      { value: 14 },
+    ]);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -16,6 +16,7 @@ import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, SegmentLabelOptions, SegmentLabelSpecOptions } from '../types';
+import { getDonutEmptyStateTest } from './donutUtils';
 
 /**
  * Gets the SegmentLabel component from the children if one exists
@@ -89,7 +90,8 @@ export const getSegmentLabelTextMark = ({
     encode: {
       enter: {
         ...getBaseSegmentLabelEnterEncode(name),
-        text: { field: labelKey ?? color },
+        // drop all labels when there isn't any data to display, the empty state ring is shown instead
+        text: [{ test: getDonutEmptyStateTest(name), value: '' }, { field: labelKey ?? color }],
         fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
         dy:
           value || percent
@@ -112,6 +114,8 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
   if (!options.value && !options.percent) return [];
   const { donutOptions } = options;
   const baseFontSize = 16; // S2 base font size
+  const valueText = getSegmentLabelValueText(options) ?? [];
+  const valueTextRules = Array.isArray(valueText) ? valueText : [valueText];
 
   return [
     {
@@ -121,7 +125,8 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
       encode: {
         enter: {
           ...getBaseSegmentLabelEnterEncode(donutOptions.name, baseFontSize),
-          text: getSegmentLabelValueText(options),
+          // drop all labels when there isn't any data to display, the empty state ring is shown instead
+          text: [{ test: getDonutEmptyStateTest(donutOptions.name), value: '' }, ...valueTextRules],
           fontWeight: { value: 'bold' },
           fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
           dy: {
@@ -202,5 +207,10 @@ const getSegmentLabelFontSize = (name: string, baseFontSize: number = 14): Produ
   // need to use radians for this. 0.3 radians is about 17 degrees
   // if we used arc length, then showing a label could shrink the overall donut size which could make the arc to small
   // that would hide the label which would make the arc bigger which would show the label and so on
-  return [{ test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 }, { value: baseFontSize }];
+  return [
+    // hide all labels when there isn't any data to display, the empty state ring is shown instead
+    { test: getDonutEmptyStateTest(name), value: 0 },
+    { test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 },
+    { value: baseFontSize },
+  ];
 };

--- a/packages/vega-spec-builder/src/donut/donutSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/donut/donutSpecBuilder.test.ts
@@ -20,7 +20,7 @@ describe('addData', () => {
   test('should add data correctly for boolean donut', () => {
     const data = addData(initializeSpec().data ?? [], { ...defaultDonutOptions, isBoolean: true });
 
-    expect(data).toHaveLength(3);
+    expect(data).toHaveLength(4);
     expect(data[2].transform).toHaveLength(2);
     expect(data[2].transform?.[0].type).toBe('window');
     expect(data[2].transform?.[1].type).toBe('filter');
@@ -28,12 +28,22 @@ describe('addData', () => {
 
   test('should add data correctly for non-boolean donut', () => {
     const data = addData(initializeSpec().data ?? [], defaultDonutOptions);
-    expect(data).toHaveLength(2);
+    expect(data).toHaveLength(3);
     expect(data[1].transform).toHaveLength(4);
     expect(data[1].transform?.[0].type).toBe('pie');
     expect(data[1].transform?.[1]).toHaveProperty('as', 'testName_arcTheta');
     expect(data[1].transform?.[2]).toHaveProperty('as', 'testName_arcLength');
     expect(data[1].transform?.[3]).toHaveProperty('as', 'testName_arcPercent');
+  });
+
+  test('should add the sum data used to detect the empty state', () => {
+    const data = addData(initializeSpec().data ?? [], defaultDonutOptions);
+    const sumData = data.find((d) => d.name === 'testName_sumData');
+    expect(sumData).toBeDefined();
+    expect(sumData?.transform).toHaveLength(1);
+    expect(sumData?.transform?.[0]).toHaveProperty('type', 'aggregate');
+    expect(sumData?.transform?.[0]).toHaveProperty('fields', ['testMetric']);
+    expect(sumData?.transform?.[0]).toHaveProperty('ops', ['sum']);
   });
 });
 
@@ -62,6 +72,16 @@ describe('addSignals()', () => {
     expect(hoveredItemSignal?.on?.[0]).toHaveProperty('events', '@testName:mouseover');
     expect(hoveredItemSignal?.on?.[0]).toHaveProperty('update', '(datum.excludeFromTooltip) ? null : datum');
     expect(hoveredItemSignal?.on?.[1]).toHaveProperty('events', '@testName:mouseout');
+  });
+});
+
+describe('addMarks()', () => {
+  test('should add the empty state ring before the arc mark', () => {
+    const marks = addMarks([], defaultDonutOptions);
+    expect(marks).toHaveLength(2);
+    expect(marks[0]).toHaveProperty('name', 'testName_emptyState');
+    expect(marks[0]).toHaveProperty('type', 'arc');
+    expect(marks[1]).toHaveProperty('name', 'testName');
   });
 });
 

--- a/packages/vega-spec-builder/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/donut/donutSpecBuilder.ts
@@ -32,7 +32,7 @@ import {
   getDonutSummaryScales,
   getDonutSummarySignals,
 } from './donutSummaryUtils';
-import { getArcMark } from './donutUtils';
+import { getArcMark, getEmptyStateArcMark, getSumData } from './donutUtils';
 import { getSegmentLabelMarks } from './segmentLabelUtils';
 
 export const addDonut = produce<
@@ -120,6 +120,8 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
       ],
     });
   }
+  // used to detect the empty state (no data or all metric values are 0)
+  data.push(getSumData(options));
   data.push(...getDonutSummaryData(options));
 });
 
@@ -155,7 +157,12 @@ export const addScales = produce<Scale[], [DonutSpecOptions]>((scales, options) 
 });
 
 export const addMarks = produce<Mark[], [DonutSpecOptions]>((marks, options) => {
-  marks.push(getArcMark(options), ...getDonutSummaryMarks(options), ...getSegmentLabelMarks(options));
+  marks.push(
+    getEmptyStateArcMark(options),
+    getArcMark(options),
+    ...getDonutSummaryMarks(options),
+    ...getSegmentLabelMarks(options)
+  );
 });
 
 export const addSignals = produce<Signal[], [DonutSpecOptions]>((signals, options) => {

--- a/packages/vega-spec-builder/src/donut/donutUtils.test.ts
+++ b/packages/vega-spec-builder/src/donut/donutUtils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FILTERED_TABLE } from '@spectrum-charts/constants';
+import { spectrumColors } from '@spectrum-charts/themes';
+
+import { defaultDonutOptions } from './donutTestUtils';
+import { getArcMark, getDonutEmptyStateTest, getEmptyStateArcMark, getSumData } from './donutUtils';
+
+describe('getDonutEmptyStateTest()', () => {
+  test('should test for empty data and a metric sum of 0', () => {
+    const test = getDonutEmptyStateTest('testName');
+    expect(test).toBe(`length(data('${FILTERED_TABLE}')) === 0 || !data('testName_sumData')[0]['sum']`);
+  });
+});
+
+describe('getSumData()', () => {
+  test('should aggregate the sum of the metric from the filtered table', () => {
+    const sumData = getSumData(defaultDonutOptions);
+    expect(sumData).toHaveProperty('name', 'testName_sumData');
+    expect(sumData).toHaveProperty('source', FILTERED_TABLE);
+    expect(sumData.transform).toEqual([
+      {
+        type: 'aggregate',
+        fields: ['testMetric'],
+        ops: ['sum'],
+        as: ['sum'],
+      },
+    ]);
+  });
+});
+
+describe('getArcMark()', () => {
+  test('should hide the arcs when the donut is in the empty state', () => {
+    const arcMark = getArcMark(defaultDonutOptions);
+    const opacity = arcMark.encode?.update?.opacity;
+    expect(opacity).toHaveLength(2);
+    expect(opacity?.[0]).toEqual({ test: getDonutEmptyStateTest('testName'), value: 0 });
+  });
+});
+
+describe('getEmptyStateArcMark()', () => {
+  test('should return a gray-200 ring', () => {
+    const emptyStateMark = getEmptyStateArcMark(defaultDonutOptions);
+    expect(emptyStateMark).toHaveProperty('name', 'testName_emptyState');
+    expect(emptyStateMark).toHaveProperty('type', 'arc');
+    expect(emptyStateMark).toHaveProperty('interactive', false);
+    expect(emptyStateMark.encode?.enter?.fill).toEqual({ value: spectrumColors.light['gray-200'] });
+    expect(emptyStateMark.encode?.enter?.startAngle).toEqual({ value: 0 });
+    expect(emptyStateMark.encode?.enter?.endAngle).toEqual({ signal: '2 * PI' });
+  });
+  test('should only be visible when the donut is in the empty state', () => {
+    const emptyStateMark = getEmptyStateArcMark(defaultDonutOptions);
+    expect(emptyStateMark.encode?.update?.opacity).toEqual([
+      { test: getDonutEmptyStateTest('testName'), value: 1 },
+      { value: 0 },
+    ]);
+  });
+});

--- a/packages/vega-spec-builder/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder/src/donut/donutUtils.ts
@@ -9,13 +9,41 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ArcMark } from 'vega';
+import { ArcMark, SourceData } from 'vega';
 
 import { DONUT_RADIUS, FILTERED_TABLE, SELECTED_ITEM } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
 
 import { getColorProductionRule, getCursor, getMarkOpacity, getTooltip } from '../marks/markUtils';
 import { DonutSpecOptions } from '../types';
+
+/**
+ * Gets the test expression that is true when the donut has no data or all metric values sum to 0.
+ * When the metric sum is 0, the vega pie transform produces NaN angles which cannot be rendered.
+ * @param name donut name
+ * @returns vega expression string
+ */
+export const getDonutEmptyStateTest = (name: string): string =>
+  `length(data('${FILTERED_TABLE}')) === 0 || !data('${name}_sumData')[0]['sum']`;
+
+/**
+ * Gets the data source that aggregates the sum of the metric.
+ * Used to detect the empty state (no data or all metric values are 0).
+ * @param donutOptions
+ * @returns SourceData
+ */
+export const getSumData = ({ metric, name }: DonutSpecOptions): SourceData => ({
+  name: `${name}_sumData`,
+  source: FILTERED_TABLE,
+  transform: [
+    {
+      type: 'aggregate',
+      fields: [metric],
+      ops: ['sum'],
+      as: ['sum'],
+    },
+  ],
+});
 
 export const getArcMark = (options: DonutSpecOptions): ArcMark => {
   const { chartPopovers, chartTooltips, color, colorScheme, holeRatio, idKey, name } = options;
@@ -38,9 +66,40 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
         padAngle: { value: 0.01 },
         innerRadius: { signal: `${holeRatio} * ${DONUT_RADIUS}` },
         outerRadius: { signal: DONUT_RADIUS },
-        opacity: getMarkOpacity(options),
+        // hide the segments when there isn't any data to display, the empty state ring is shown instead
+        opacity: [{ test: getDonutEmptyStateTest(name), value: 0 }, ...getMarkOpacity(options)],
         cursor: getCursor(chartPopovers),
         strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${idKey}`, value: 2 }, { value: 0 }],
+      },
+    },
+  };
+};
+
+/**
+ * Gets the empty state arc mark. This is a light gray ring that is only visible
+ * when the donut has no data or all metric values sum to 0.
+ * @param donutOptions
+ * @returns ArcMark
+ */
+export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
+  const { colorScheme, holeRatio, name } = options;
+  return {
+    type: 'arc',
+    name: `${name}_emptyState`,
+    description: `${name}_emptyState`,
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { value: getColorValue('gray-200', colorScheme) },
+        x: { signal: 'width / 2' },
+        y: { signal: 'height / 2' },
+        startAngle: { value: 0 },
+        endAngle: { signal: '2 * PI' },
+      },
+      update: {
+        innerRadius: { signal: `${holeRatio} * ${DONUT_RADIUS}` },
+        outerRadius: { signal: DONUT_RADIUS },
+        opacity: [{ test: getDonutEmptyStateTest(name), value: 1 }, { value: 0 }],
       },
     },
   };

--- a/packages/vega-spec-builder/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder/src/donut/segmentLabelUtils.test.tsx
@@ -11,6 +11,7 @@
  */
 import { DonutSpecOptions, SegmentLabelSpecOptions } from '../types';
 import { defaultDonutOptions } from './donutTestUtils';
+import { getDonutEmptyStateTest } from './donutUtils';
 import {
   getSegmentLabelMarks,
   getSegmentLabelTextMark,
@@ -124,6 +125,14 @@ describe('getSegmentLabelTextMark()', () => {
   test('should not define dy if value and percent are false', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     expect(mark.encode?.enter?.dy).toBeUndefined();
+  });
+  test('should hide labels when the donut is in the empty state', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    expect(mark.encode?.enter?.fontSize).toEqual([
+      { test: getDonutEmptyStateTest('testName'), value: 0 },
+      { test: `datum['testName_arcLength'] < 0.3`, value: 0 },
+      { value: 14 },
+    ]);
   });
 });
 

--- a/packages/vega-spec-builder/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder/src/donut/segmentLabelUtils.ts
@@ -16,6 +16,7 @@ import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, SegmentLabelOptions, SegmentLabelSpecOptions } from '../types';
+import { getDonutEmptyStateTest } from './donutUtils';
 
 /**
  * Gets the SegmentLabel component from the children if one exists
@@ -89,7 +90,8 @@ export const getSegmentLabelTextMark = ({
     encode: {
       enter: {
         ...getBaseSegmentLabelEnterEncode(name),
-        text: { field: labelKey ?? color },
+        // drop all labels when there isn't any data to display, the empty state ring is shown instead
+        text: [{ test: getDonutEmptyStateTest(name), value: '' }, { field: labelKey ?? color }],
         ...(!donutOptions.s2 && { fontWeight: { value: 'bold' } }),
         ...(donutOptions.s2 && {
           fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
@@ -115,6 +117,8 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
   if (!options.value && !options.percent) return [];
   const { donutOptions } = options;
   const baseFontSize = donutOptions.s2 ? 16 : 14;
+  const valueText = getSegmentLabelValueText(options) ?? [];
+  const valueTextRules = Array.isArray(valueText) ? valueText : [valueText];
 
   return [
     {
@@ -124,7 +128,8 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
       encode: {
         enter: {
           ...getBaseSegmentLabelEnterEncode(donutOptions.name, baseFontSize),
-          text: getSegmentLabelValueText(options),
+          // drop all labels when there isn't any data to display, the empty state ring is shown instead
+          text: [{ test: getDonutEmptyStateTest(donutOptions.name), value: '' }, ...valueTextRules],
           ...(donutOptions.s2 && {
             fontWeight: { value: 'bold' },
             fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
@@ -207,5 +212,10 @@ const getSegmentLabelFontSize = (name: string, baseFontSize: number = 14): Produ
   // need to use radians for this. 0.3 radians is about 17 degrees
   // if we used arc length, then showing a label could shrink the overall donut size which could make the arc to small
   // that would hide the label which would make the arc bigger which would show the label and so on
-  return [{ test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 }, { value: baseFontSize }];
+  return [
+    // hide all labels when there isn't any data to display, the empty state ring is shown instead
+    { test: getDonutEmptyStateTest(name), value: 0 },
+    { test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 },
+    { value: baseFontSize },
+  ];
 };


### PR DESCRIPTION
## Description

When every metric value in a donut is zero, Vega's pie transform divides each value by a zero sum and emits NaN start and end angles. The downstream formulas (`arcTheta`, `arcLength`, `arcPercent`) become NaN as well, so the chart renders broken arcs and stacked "NaN%" segment labels.

This PR implements the empty state proposed in the issue thread: the donut renders a static gray-200 ring, the summary shows 0 in the center, and segment labels are suppressed. The behavior is implemented in both `vega-spec-builder` (S1) and `vega-spec-builder-s2` for parity.

Changes:

- `donutUtils.ts`: adds `getSumData()` (aggregate data source summing the metric), `getDonutEmptyStateTest()` (Vega expression: table empty or sum falsy), and `getEmptyStateArcMark()` (a non-interactive gray-200 ring shown only in the empty state); `getArcMark()` now hides segments when the empty state is active
- `donutSpecBuilder.ts`: wires in the sum data source and the empty-state ring mark
- `segmentLabelUtils.ts`: segment label and label-value marks render empty text in the empty state, so no hidden NaN text remains in the DOM
- New `EmptyState` story in both the `react-spectrum-charts` and `react-spectrum-charts-s2` Donut story files, plus `zeroDonutData` fixtures
- Unit tests for the new utils, updated spec-builder and segment-label tests, and end-to-end story tests asserting the rendered SVG shows the gray ring, hidden segments, a centered "0", and zero NaN text
- Docs: adds an "Empty state" section to the Donut API docs

`DonutSummary` needed no change; its sum aggregate already yields 0 for the center display.

## Related Issue

Closes #357

## Motivation and Context

An all-zero dataset is a normal state for the metrics a donut displays (for example, no visitors yet in the current period). Today that state renders NaN labels and unusable arcs. With this change it renders a readable empty chart that matches the design proposed by the maintainers in the issue.

## How Has This Been Tested?

Full test suite passes (238 suites, 3529 tests), including the new unit tests in both spec-builder packages and the end-to-end story tests. `yarn lint` is clean, and `yarn tsc` output is identical to the `main` baseline with no new errors. I also verified the empty state visually through the new `EmptyState` story in Storybook.

## Screenshots (if appropriate):

<!-- TODO: add a screenshot of the EmptyState story before submitting -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
