### PR TITLE
feat: scale reference line labels with size

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/ReferenceLine/LineReferenceLine.story.tsx
@@ -189,6 +189,7 @@ const AutoDetectSizeStory = (): ReactElement => {
           <Chart data={workspaceTrendsData} width={width} height={CHART_HEIGHT}>
             <Axis position="left" grid title="Users">
               <ReferenceLine value={referenceValue} label="Target" />
+              <ReferenceLine value={Math.round(referenceValue * 0.7)} label="Minimum" secondary />
             </Axis>
             <Axis position="bottom" labelFormat="time" baseline ticks />
             <Line dimension="datetime" metric="users" color="series" scaleType="time" />

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.test.ts
@@ -11,6 +11,7 @@
  */
 import {
   CHART_SIZE_BREAKPOINTS,
+  CHART_SIZE_FONT_SIZE,
   CHART_SIZE_STROKE_WIDTH,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_FONT_COLOR,
@@ -361,14 +362,13 @@ describe('getReferenceLineTextMark() — S2 direct label pattern', () => {
     expect(marks[1].encode?.enter?.stroke).toBeUndefined();
   });
 
-  test('both marks inherit font, fontSize, lineHeight from theme (no explicit overrides)', () => {
+  test('both marks inherit font, lineHeight from theme (no explicit overrides)', () => {
     const marks = getReferenceLineTextMark(
       { ...defaultReferenceLineOptions, label: 'Target' },
       defaultYPositionEncoding
     );
     for (const mark of marks) {
       expect(mark.encode?.enter?.font).toBeUndefined();
-      expect(mark.encode?.enter?.fontSize).toBeUndefined();
       expect(mark.encode?.enter?.lineHeight).toBeUndefined();
     }
   });
@@ -381,6 +381,20 @@ describe('getReferenceLineTextMark() — S2 direct label pattern', () => {
     for (const mark of marks) {
       expect(mark.encode?.update?.fontWeight).toBeDefined();
       expect((mark.encode?.update?.fontWeight as { value: number }).value).toBe(REFERENCE_LINE_LABEL_FONT_WEIGHT);
+    }
+  });
+
+  test('fontSize uses the same CHART_SIZE_FONT_SIZE signal regardless of explicit size tier or secondary', () => {
+    for (const size of ['XS', 'S', 'M', 'L'] as const) {
+      for (const secondary of [false, true]) {
+        const marks = getReferenceLineTextMark(
+          { ...defaultReferenceLineOptions, label: 'Target', size, secondary },
+          defaultYPositionEncoding
+        );
+        for (const mark of marks) {
+          expect(mark.encode?.update?.fontSize).toStrictEqual({ signal: CHART_SIZE_FONT_SIZE });
+        }
+      }
     }
   });
 

--- a/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisReferenceLineUtils.ts
@@ -13,6 +13,7 @@ import { Mark, NumericValueRef, PathMark, ProductionRule, RuleMark, ScaleType, S
 
 import {
   CHART_SIZE_BREAKPOINTS,
+  CHART_SIZE_FONT_SIZE,
   CHART_SIZE_STROKE_WIDTH,
   DEFAULT_FONT_COLOR,
   REFERENCE_LINE_AUTO_RULE_X2_OFFSET,
@@ -260,6 +261,7 @@ export const getReferenceLineTextMark = (
 
   const sharedUpdate = {
     fontWeight: { value: REFERENCE_LINE_LABEL_FONT_WEIGHT },
+    fontSize: { signal: CHART_SIZE_FONT_SIZE },
   };
 
   return [


### PR DESCRIPTION
## Description

Scale reference line label with chart size. 

## Related Issue

## Motivation and Context

Size scaling. 

## How Has This Been Tested?

Added unit tests, and storybook 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
