### PR TITLE
fix: trendlines and metric ranges for lines match hover opacity

### DIFF
--- a/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
@@ -195,6 +195,24 @@ const BothTooltipsWithDisplayOnHoverStory: StoryFn<typeof Trendline> = (args): R
   );
 };
 
+// Trendlines are always displayed (no displayOnHover). Hovering a line point fades the
+// trendlines of the other series via `line0_hoveredItem`. Hovering the matching legend entry
+// is supposed to produce the same fade via `legend0_hoveredSeries`, but currently does not.
+const LegendHoverOpacityStory: StoryFn<typeof Trendline> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <ChartTooltip>{(item: Datum) => <div>Line value: {item.value}</div>}</ChartTooltip>
+        <Trendline {...args} />
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
 const ScatterStory: StoryFn<typeof Trendline> = (args): ReactElement => {
   const chartProps = useChartProps({ data: characterData, height: 500, width: 500, lineWidths: [1, 2, 3] });
 
@@ -326,6 +344,13 @@ DisplayOnHoverBothTooltips.args = {
   highlightRawPoint: true,
 };
 
+const LegendHoverOpacity = bindWithProps(LegendHoverOpacityStory);
+LegendHoverOpacity.args = {
+  method: 'linear',
+  lineType: 'dashed',
+  lineWidth: 'S',
+};
+
 const Orientation = bindWithProps(ScatterStory);
 Orientation.args = {
   orientation: 'vertical',
@@ -372,6 +397,7 @@ export {
   DisplayOnHoverTrendlineOnly,
   ExcludeSeriesFromTrendline,
   HidePartialWindows,
+  LegendHoverOpacity,
   Orientation,
   TooltipAndPopover,
   TooltipAndPopoverOnParentLine,

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
@@ -36,6 +36,22 @@ const defaultGroupMark: Mark = {
   marks: [defaultMark],
 };
 
+// Mirrors a metric range's own line mark with an overridden literal color — the only metric
+// range sub-mark whose color is overridable, so it needs the same name-based fallback.
+const metricRangeLineWithOverriddenColorMark: Mark = {
+  name: 'line0MetricRange0_line',
+  type: 'line',
+  from: { data: 'line0MetricRange0_facet' },
+  encode: {
+    enter: {
+      stroke: { value: '#ABC123' },
+    },
+    update: {
+      opacity: [DEFAULT_OPACITY_RULE],
+    },
+  },
+};
+
 // Mirrors a trendline mark whose color has been overridden with a literal value rather than a
 // color scale facet. It's still per-series (faceted by series regardless of its own color), so
 // it should still receive the legend-hover rule based on its name, not its color encoding.
@@ -130,6 +146,35 @@ describe('setHoverOpacityForMarks()', () => {
       const marks = JSON.parse(JSON.stringify([trendlineWithOverriddenColorMark]));
       setHoverOpacityForMarks('legend0', marks);
       expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
+    });
+  });
+  describe('metric range line mark with an overridden (non-scale) color', () => {
+    test('still gets the legend-hover opacity rule spliced in, based on its name rather than its color encoding', () => {
+      const marks = JSON.parse(JSON.stringify([metricRangeLineWithOverriddenColorMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
+    });
+  });
+  describe('trendline hover-support mark sharing the trendline name prefix', () => {
+    // Named like `<parent>Trendline_hoverRule` — shares the "Trendline" prefix with the
+    // trendline's own line mark, but isn't the trendline mark itself. Its non-array opacity
+    // rule is unrelated to series matching (it hides the guide line when something is selected)
+    // and must not be clobbered by the legend-hover splice logic.
+    const trendlineHoverRuleMark: Mark = {
+      name: 'line0Trendline_hoverRule',
+      type: 'rule',
+      encode: {
+        enter: {},
+        update: {
+          opacity: { signal: `length(data('line0Trendline_selectedData')) > 0 ? 0 : 1` },
+        },
+      },
+    };
+
+    test('is left untouched, preserving its non-array opacity rule', () => {
+      const marks = JSON.parse(JSON.stringify([trendlineHoverRuleMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity).toEqual(trendlineHoverRuleMark.encode?.update?.opacity);
     });
   });
 });

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
@@ -36,6 +36,23 @@ const defaultGroupMark: Mark = {
   marks: [defaultMark],
 };
 
+// Mirrors a trendline mark whose color has been overridden with a literal value rather than a
+// color scale facet. It's still per-series (faceted by series regardless of its own color), so
+// it should still receive the legend-hover rule based on its name, not its color encoding.
+const trendlineWithOverriddenColorMark: Mark = {
+  name: 'line0Trendline0',
+  type: 'line',
+  from: { data: 'line0Trendline0_facet' },
+  encode: {
+    enter: {
+      stroke: { value: '#ABC123' },
+    },
+    update: {
+      opacity: [DEFAULT_OPACITY_RULE],
+    },
+  },
+};
+
 const defaultOpacityEncoding = {
   opacity: [
     {
@@ -106,6 +123,13 @@ describe('setHoverOpacityForMarks()', () => {
           marks: [{ ...defaultMark, encode: { ...defaultMark.encode, update: defaultOpacityEncoding } }],
         },
       ]);
+    });
+  });
+  describe('trendline mark with an overridden (non-scale) color', () => {
+    test('still gets the legend-hover opacity rule spliced in, based on its name rather than its color encoding', () => {
+      const marks = JSON.parse(JSON.stringify([trendlineWithOverriddenColorMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
     });
   });
 });

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -30,12 +30,14 @@ export const getLegendHighlightSignals = (legends: LegendOptions[]): string[] =>
     .map((legend) => `${legend.name}_${HOVERED_SERIES}`);
 
 /**
- * Adds opacity tests for the fill and stroke of marks that use the color scale to set the fill or stroke value.
+ * Adds opacity tests for marks whose fill/stroke is driven by the color scale, and for marks
+ * that are already per-series (e.g. trendlines, which facet by series regardless of their own
+ * color encoding — a trendline with an overridden literal color still needs to fade on legend hover).
  */
 export const setHoverOpacityForMarks = (legendName: string, marks: Mark[], keys?: string[], controlled = false) => {
   if (!marks.length) return;
   const flatMarks = flattenMarks(marks);
-  const seriesMarks = flatMarks.filter(markUsesSeriesColorScale);
+  const seriesMarks = flatMarks.filter(markIsSeriesAware);
   seriesMarks.forEach((mark) => {
     // need to drill down to the prop we need to set and add missing properties if needed
     if (!mark.encode) {
@@ -155,6 +157,27 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
   }
   return false;
 };
+
+/**
+ * Determines if the supplied mark is a trendline or metric range mark. These are always
+ * per-series (faceted by series regardless of their own color encoding), so a trendline or
+ * metric range with an overridden literal color still needs to fade on legend hover.
+ * Mirrors the name-based convention in `legendSpecBuilder.ts`'s `addData`, which patches
+ * the analogous `*(Trendline|MetricRange)*highlightedData` data sources for the same reason.
+ * @param mark
+ * @returns boolean
+ */
+const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
+  Boolean(mark.name) && /(Trendline|MetricRange)/.test(mark.name as string);
+
+/**
+ * Determines if a mark should receive a legend-hover opacity rule — either because its own
+ * fill/stroke uses the color scale, or because it's a trendline/metric range mark.
+ * @param mark
+ * @returns boolean
+ */
+export const markIsSeriesAware = (mark: Mark): boolean =>
+  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeMark(mark);
 
 /**
  * Determines if the supplied encoding uses a scale to set the value

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -159,16 +159,20 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
 };
 
 /**
- * Determines if the supplied mark is a trendline or metric range mark. These are always
- * per-series (faceted by series regardless of their own color encoding), so a trendline or
- * metric range with an overridden literal color still needs to fade on legend hover.
- * Mirrors the name-based convention in `legendSpecBuilder.ts`'s `addData`, which patches
- * the analogous `*(Trendline|MetricRange)*highlightedData` data sources for the same reason.
+ * Determines if the supplied mark is the trendline's own line/rule mark, or the metric range's
+ * own line mark. These are always per-series (faceted by series regardless of their own color
+ * encoding), so an overridden literal color still needs to fade on legend hover. Anchored to
+ * these two exact name shapes — `<parent>Trendline<index>` and `<parent>MetricRange<index>_line`
+ * — so it doesn't also match hover-support marks that share the same name prefix (e.g.
+ * `<parent>Trendline_hoverRule`, `_pointBackground`, `_point_highlight`, `_secondaryPoint`).
+ * Those marks are already scoped to a single active item via their (pre-filtered) data source,
+ * not via opacity, and some carry non-series opacity logic of their own that a broader match
+ * would clobber.
  * @param mark
  * @returns boolean
  */
-const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
-  Boolean(mark.name) && /(Trendline|MetricRange)/.test(mark.name as string);
+const isTrendlineOrMetricRangeLineMark = (mark: Mark): boolean =>
+  Boolean(mark.name) && /(Trendline\d+|MetricRange\d+_line)$/.test(mark.name as string);
 
 /**
  * Determines if a mark should receive a legend-hover opacity rule — either because its own
@@ -177,7 +181,7 @@ const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
  * @returns boolean
  */
 export const markIsSeriesAware = (mark: Mark): boolean =>
-  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeMark(mark);
+  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeLineMark(mark);
 
 /**
  * Determines if the supplied encoding uses a scale to set the value

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
@@ -23,6 +23,23 @@ import {
 import { encodingUsesScale, getHighlightOpacityRule, setHoverOpacityForMarks } from './legendHighlightUtils';
 import { defaultMark } from './legendTestUtils';
 
+// Mirrors a trendline mark whose color has been overridden with a literal value rather than a
+// color scale facet. It's still per-series (faceted by series regardless of its own color), so
+// it should still receive the legend-hover rule based on its name, not its color encoding.
+const trendlineWithOverriddenColorMark: Mark = {
+  name: 'line0Trendline0',
+  type: 'line',
+  from: { data: 'line0Trendline0_facet' },
+  encode: {
+    enter: {
+      stroke: { value: '#ABC123' },
+    },
+    update: {
+      opacity: [DEFAULT_OPACITY_RULE],
+    },
+  },
+};
+
 const defaultGroupMark: Mark = {
   type: 'group',
   marks: [defaultMark],
@@ -86,6 +103,13 @@ describe('setHoverOpacityForMarks()', () => {
           },
         },
       ]);
+    });
+  });
+  describe('trendline mark with an overridden (non-scale) color', () => {
+    test('still gets the legend-hover opacity rule spliced in, based on its name rather than its color encoding', () => {
+      const marks = JSON.parse(JSON.stringify([trendlineWithOverriddenColorMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
     });
   });
   describe('group mark initial state', () => {

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.test.ts
@@ -40,6 +40,22 @@ const trendlineWithOverriddenColorMark: Mark = {
   },
 };
 
+// Mirrors a metric range's own line mark with an overridden literal color — the only metric
+// range sub-mark whose color is overridable, so it needs the same name-based fallback.
+const metricRangeLineWithOverriddenColorMark: Mark = {
+  name: 'line0MetricRange0_line',
+  type: 'line',
+  from: { data: 'line0MetricRange0_facet' },
+  encode: {
+    enter: {
+      stroke: { value: '#ABC123' },
+    },
+    update: {
+      opacity: [DEFAULT_OPACITY_RULE],
+    },
+  },
+};
+
 const defaultGroupMark: Mark = {
   type: 'group',
   marks: [defaultMark],
@@ -122,6 +138,35 @@ describe('setHoverOpacityForMarks()', () => {
           marks: [{ ...defaultMark, encode: { ...defaultMark.encode, update: defaultOpacityEncoding } }],
         },
       ]);
+    });
+  });
+  describe('metric range line mark with an overridden (non-scale) color', () => {
+    test('still gets the legend-hover opacity rule spliced in, based on its name rather than its color encoding', () => {
+      const marks = JSON.parse(JSON.stringify([metricRangeLineWithOverriddenColorMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
+    });
+  });
+  describe('trendline hover-support mark sharing the trendline name prefix', () => {
+    // Named like `<parent>Trendline_hoverRule` — shares the "Trendline" prefix with the
+    // trendline's own line mark, but isn't the trendline mark itself. Its non-array opacity
+    // rule is unrelated to series matching (it hides the guide line when something is selected)
+    // and must not be clobbered by the legend-hover splice logic.
+    const trendlineHoverRuleMark: Mark = {
+      name: 'line0Trendline_hoverRule',
+      type: 'rule',
+      encode: {
+        enter: {},
+        update: {
+          opacity: { signal: `length(data('line0Trendline_selectedData')) > 0 ? 0 : 1` },
+        },
+      },
+    };
+
+    test('is left untouched, preserving its non-array opacity rule', () => {
+      const marks = JSON.parse(JSON.stringify([trendlineHoverRuleMark]));
+      setHoverOpacityForMarks('legend0', marks);
+      expect(marks[0].encode.update.opacity).toEqual(trendlineHoverRuleMark.encode?.update?.opacity);
     });
   });
 });

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
@@ -23,12 +23,14 @@ import {
 import { flattenMarks } from '../marks/markUtils';
 
 /**
- * Adds opacity tests for the fill and stroke of marks that use the color scale to set the fill or stroke value.
+ * Adds opacity tests for marks whose fill/stroke is driven by the color scale, and for marks
+ * that are already per-series (e.g. trendlines, which facet by series regardless of their own
+ * color encoding — a trendline with an overridden literal color still needs to fade on legend hover).
  */
 export const setHoverOpacityForMarks = (legendName: string, marks: Mark[], keys?: string[], controlled = false) => {
   if (!marks.length) return;
   const flatMarks = flattenMarks(marks);
-  flatMarks.filter(markUsesSeriesColorScale).forEach((mark) => applyLegendOpacityToMark(mark, legendName, keys, controlled));
+  flatMarks.filter(markIsSeriesAware).forEach((mark) => applyLegendOpacityToMark(mark, legendName, keys, controlled));
 };
 
 const applyLegendOpacityToMark = (mark: Mark, legendName: string, keys?: string[], controlled = false) => {
@@ -101,6 +103,27 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
   }
   return false;
 };
+
+/**
+ * Determines if the supplied mark is a trendline or metric range mark. These are always
+ * per-series (faceted by series regardless of their own color encoding), so a trendline or
+ * metric range with an overridden literal color still needs to fade on legend hover.
+ * Mirrors the name-based convention in `legendSpecBuilder.ts`'s `addData`, which patches
+ * the analogous `*(Trendline|MetricRange)*highlightedData` data sources for the same reason.
+ * @param mark
+ * @returns boolean
+ */
+const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
+  Boolean(mark.name) && /(Trendline|MetricRange)/.test(mark.name as string);
+
+/**
+ * Determines if a mark should receive a legend-hover opacity rule — either because its own
+ * fill/stroke uses the color scale, or because it's a trendline/metric range mark.
+ * @param mark
+ * @returns boolean
+ */
+export const markIsSeriesAware = (mark: Mark): boolean =>
+  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeMark(mark);
 
 /**
  * Determines if the supplied encoding uses a scale to set the value

--- a/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendHighlightUtils.ts
@@ -105,16 +105,20 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
 };
 
 /**
- * Determines if the supplied mark is a trendline or metric range mark. These are always
- * per-series (faceted by series regardless of their own color encoding), so a trendline or
- * metric range with an overridden literal color still needs to fade on legend hover.
- * Mirrors the name-based convention in `legendSpecBuilder.ts`'s `addData`, which patches
- * the analogous `*(Trendline|MetricRange)*highlightedData` data sources for the same reason.
+ * Determines if the supplied mark is the trendline's own line/rule mark, or the metric range's
+ * own line mark. These are always per-series (faceted by series regardless of their own color
+ * encoding), so an overridden literal color still needs to fade on legend hover. Anchored to
+ * these two exact name shapes — `<parent>Trendline<index>` and `<parent>MetricRange<index>_line`
+ * — so it doesn't also match hover-support marks that share the same name prefix (e.g.
+ * `<parent>Trendline_hoverRule`, `_pointBackground`, `_point_highlight`, `_secondaryPoint`).
+ * Those marks are already scoped to a single active item via their (pre-filtered) data source,
+ * not via opacity, and some carry non-series opacity logic of their own that a broader match
+ * would clobber.
  * @param mark
  * @returns boolean
  */
-const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
-  Boolean(mark.name) && /(Trendline|MetricRange)/.test(mark.name as string);
+const isTrendlineOrMetricRangeLineMark = (mark: Mark): boolean =>
+  Boolean(mark.name) && /(Trendline\d+|MetricRange\d+_line)$/.test(mark.name as string);
 
 /**
  * Determines if a mark should receive a legend-hover opacity rule — either because its own
@@ -123,7 +127,7 @@ const isTrendlineOrMetricRangeMark = (mark: Mark): boolean =>
  * @returns boolean
  */
 export const markIsSeriesAware = (mark: Mark): boolean =>
-  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeMark(mark);
+  markUsesSeriesColorScale(mark) || isTrendlineOrMetricRangeLineMark(mark);
 
 /**
  * Determines if the supplied encoding uses a scale to set the value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow trendline opacity hover without depending on series color.

<!--- Describe your changes in detail -->
Added a simple matching function for Metric Range and Trendline to check if they're connected to the highlighted line mark. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Opacity changes for trendlines and metric ranges can occur when highlighting a parent line. This was being done by matching the series color, which doesn't work if either of those elements had a color override. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
