### PR TITLE
fix: truncate axis labels using the axis band scale instead of hardcoded xBand

### DIFF
--- a/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.test.ts
@@ -162,6 +162,17 @@ describe('getLabelFormat()', () => {
     expect(labelEncodings).toHaveLength(2);
     expect(labelEncodings[1].signal).toContain('truncateText');
   });
+  test('should truncate to the band scale of the axis', () => {
+    expect(getLabelFormat({ ...defaultAxisOptions, truncateLabels: true }, 'xBand')[1].signal).toContain(
+      'bandwidth("xBand")'
+    );
+    expect(
+      getLabelFormat(
+        { ...defaultAxisOptions, truncateLabels: true, position: 'left', labelOrientation: 'vertical' },
+        'yBand'
+      )[1].signal
+    ).toContain('bandwidth("yBand")');
+  });
   test('should not include text truncation if the scale name does not include band', () => {
     expect(getLabelFormat({ ...defaultAxisOptions, truncateLabels: true }, 'xLinear')[1].signal).not.toContain(
       'truncateText'

--- a/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.ts
@@ -259,7 +259,7 @@ export const getLabelFormat = (
   return [
     ...getTextNumberFormat(numberFormat, undefined, currencyLocale, currencyCode),
     ...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
-      ? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
+      ? [{ signal: `truncateText(datum.value, bandwidth("${scaleName}")/(1- paddingInner), "normal", 14)` }]
       : [{ signal: 'datum.value' }]),
   ];
 };

--- a/packages/vega-spec-builder/src/axis/axisLabelUtils.test.ts
+++ b/packages/vega-spec-builder/src/axis/axisLabelUtils.test.ts
@@ -162,6 +162,17 @@ describe('getLabelFormat()', () => {
     expect(labelEncodings).toHaveLength(2);
     expect(labelEncodings[1].signal).toContain('truncateText');
   });
+  test('should truncate to the band scale of the axis', () => {
+    expect(getLabelFormat({ ...defaultAxisOptions, truncateLabels: true }, 'xBand')[1].signal).toContain(
+      'bandwidth("xBand")'
+    );
+    expect(
+      getLabelFormat(
+        { ...defaultAxisOptions, truncateLabels: true, position: 'left', labelOrientation: 'vertical' },
+        'yBand'
+      )[1].signal
+    ).toContain('bandwidth("yBand")');
+  });
   test('should not include text truncation if the scale name does not include band', () => {
     expect(getLabelFormat({ ...defaultAxisOptions, truncateLabels: true }, 'xLinear')[1].signal).not.toContain(
       'truncateText'

--- a/packages/vega-spec-builder/src/axis/axisLabelUtils.ts
+++ b/packages/vega-spec-builder/src/axis/axisLabelUtils.ts
@@ -259,7 +259,7 @@ export const getLabelFormat = (
   return [
     ...getTextNumberFormat(numberFormat, undefined, currencyLocale, currencyCode),
     ...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
-      ? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
+      ? [{ signal: `truncateText(datum.value, bandwidth("${scaleName}")/(1- paddingInner), "normal", 14)` }]
       : [{ signal: 'datum.value' }]),
   ];
 };


### PR DESCRIPTION
## Description

`getLabelFormat()` gates label truncation on the axis's band scale (`scaleName.includes('Band')`), but the emitted Vega expression hardcodes `bandwidth("xBand")`. On a horizontal bar chart the category axis uses the `yBand` scale, so the spec references a scale that doesn't exist — Vega's `bandwidth()` returns 0 for unknown scales, `truncateText` can never fit any text within the resulting width, and it falls back to returning the full label. As a result, `truncateLabels` silently has no effect on left/right band axes with `labelOrientation="vertical"`.

This PR emits `bandwidth("${scaleName}")` using the scale name that is already passed into `getLabelFormat()`. For bottom/top axes (`xBand`) the generated signal is byte-for-byte identical to before, so existing charts are unaffected; vertical band axes now truncate against the correct scale. Fixed in both `vega-spec-builder` (S1) and `vega-spec-builder-s2` for parity.

Changes:
- `axisLabelUtils.ts` (S1 + S2): use the axis's own band scale in the `truncateText` signal instead of hardcoded `xBand`
- `axisLabelUtils.test.ts` (S1 + S2): regression test asserting the truncation signal references `xBand` for bottom axes and `yBand` for left axes with vertical labels

## Related Issue

N/A — found while working with truncated labels on horizontal bar charts.

## Motivation and Context

`truncateLabels` is documented for band axes generally, and `getLabelFormat()` already accepts the correct scale name; long category labels on horizontal bar charts currently overflow with no way to truncate them.

## How Has This Been Tested?

New regression tests fail on `main` and pass with the fix. Full `vega-spec-builder` and `vega-spec-builder-s2` suites pass (123 suites, 2497 tests). Lint and prettier are clean, and `tsc` reports no errors in the changed files.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
