### PR TITLE
feat: S2 bar - added bar selection outline

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.story.tsx
@@ -16,7 +16,7 @@ import { StoryFn } from '@storybook/react';
 import { SpectrumColor } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../Chart';
-import { Axis, Bar, Legend } from '../../../components';
+import { Axis, Bar, ChartInspect, ChartPopover, Legend } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { BarProps } from '../../../types';
@@ -76,6 +76,29 @@ const NegativeBarStory: StoryFn<typeof Bar> = (args): ReactElement => {
   );
 };
 
+const dialogContent = (datum) => (
+  <div>
+    <div>Operating system: {datum.operatingSystem}</div>
+    <div>Browser: {datum.browser}</div>
+    <div>Downloads: {datum.value}</div>
+  </div>
+);
+
+const StackedBarPopoverStory: StoryFn<typeof Bar> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: barSeriesData, colors, width: 800, height: 600 });
+  return (
+    <Chart {...chartProps}>
+      <Axis position={args.orientation === 'horizontal' ? 'left' : 'bottom'} baseline title="Browser" />
+      <Axis position={args.orientation === 'horizontal' ? 'bottom' : 'left'} grid title="Downloads" />
+      <Bar {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+        <ChartPopover width={200}>{dialogContent}</ChartPopover>
+      </Bar>
+      <Legend title="Operating system" />
+    </Chart>
+  );
+};
+
 const defaultProps: BarProps = {
   dimension: 'browser',
   order: 'order',
@@ -85,6 +108,11 @@ const defaultProps: BarProps = {
 
 const Basic = bindWithProps(BarStory);
 Basic.args = {
+  ...defaultProps,
+};
+
+const Popover = bindWithProps(StackedBarPopoverStory);
+Popover.args = {
   ...defaultProps,
 };
 
@@ -123,4 +151,12 @@ InspectOnDimensionArea.args = {
   ...defaultProps,
 };
 
-export { Basic, NegativeStack, OnClick, StackedBarWithUTCDatetimeFormat, InspectOnDimensionArea, WithBarLabels };
+export {
+  Basic,
+  NegativeStack,
+  OnClick,
+  Popover,
+  StackedBarWithUTCDatetimeFormat,
+  InspectOnDimensionArea,
+  WithBarLabels,
+};

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
@@ -661,6 +661,38 @@ describe('barUtils', () => {
       expect(update.y2.signal).toContain(`scale('yLinearSecondary', datum.${DEFAULT_METRIC})`);
       expect(update.y2.signal).toContain(`scale('yLinearPrimary', datum.${DEFAULT_METRIC})`);
     });
+
+    test('widens the stacked bar per-corner radius rules by the gap', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'stacked' };
+      const dimensionEncodings: RectEncodeEntry = {
+        x: { scale: 'xBand', field: DEFAULT_CATEGORICAL_DIMENSION },
+        width: { scale: 'xBand', band: 1 },
+      };
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      const enter = ring.encode?.enter as RectEncodeEntry;
+
+      // the ring reuses the bar's stacked corner-radius production rules (including the
+      // data('..._stacks') test strings), each branch's value widened by the 2px gap
+      const barCorners = getStackedCornerRadiusEncodings(options);
+      const widenBranches = (rule: RectEncodeEntry['cornerRadiusTopLeft']) =>
+        (rule as { test?: string; value: number }[]).map((branch) => ({ ...branch, value: branch.value + 2 }));
+      expect(enter.cornerRadiusTopLeft).toStrictEqual(widenBranches(barCorners.cornerRadiusTopLeft));
+      expect(enter.cornerRadiusBottomRight).toStrictEqual(widenBranches(barCorners.cornerRadiusBottomRight));
+    });
+
+    test('backdrop and outline ring share identical position and corner-radius encodings', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      const dimensionEncodings = getDodgedDimensionEncodings(options);
+      const backdrop = getBarItemSelectionBackdrop(options, FILTERED_TABLE, dimensionEncodings);
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      const backdropEnter = backdrop.encode?.enter as RectEncodeEntry;
+      const ringEnter = ring.encode?.enter as RectEncodeEntry;
+
+      // the two marks must stay geometrically aligned — they differ only in fill/stroke
+      expect(backdrop.encode?.update).toStrictEqual(ring.encode?.update);
+      expect(backdropEnter.cornerRadiusTopLeft).toStrictEqual(ringEnter.cornerRadiusTopLeft);
+      expect(backdropEnter.cornerRadiusBottomRight).toStrictEqual(ringEnter.cornerRadiusBottomRight);
+    });
   });
 
   describe('getStrokeDash()', () => {

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
@@ -12,15 +12,18 @@
 import { RectEncodeEntry } from 'vega';
 
 import {
+  BACKGROUND_COLOR,
   COLOR_SCALE,
   DEFAULT_CATEGORICAL_DIMENSION,
   DEFAULT_COLOR,
   DEFAULT_METRIC,
   FILTERED_TABLE,
+  LAST_RSC_SERIES_ID,
   MARK_ID,
   PADDING_RATIO,
   SELECTED_GROUP,
   SELECTED_ITEM,
+  SERIES_ID,
   STACK_ID,
 } from '@spectrum-charts/constants';
 
@@ -38,6 +41,8 @@ import {
   getBarDimensionAreaPositionEncodings,
   getBarDimensionHoverArea,
   getBarFillEncoding,
+  getBarItemSelectionBackdrop,
+  getBarItemSelectionRing,
   getBarPadding,
   getBaseBarEnterEncodings,
   getBaseScaleName,
@@ -52,6 +57,7 @@ import {
   getStroke,
   getStrokeDash,
   getStrokeWidth,
+  shouldShowItemSelectionRing,
 } from './barUtils';
 
 const defaultDodgedXEncodings: RectEncodeEntry = {
@@ -501,6 +507,159 @@ describe('barUtils', () => {
         name: 'bar0_selectionRing',
         type: 'rect',
       });
+    });
+  });
+
+  describe('shouldShowItemSelectionRing()', () => {
+    test('returns false when there are no popovers', () => {
+      expect(shouldShowItemSelectionRing(defaultBarOptions)).toBe(false);
+    });
+    test('returns true for a default (item) popover', () => {
+      expect(shouldShowItemSelectionRing({ ...defaultBarOptions, chartPopovers: [{}] })).toBe(true);
+    });
+    test('returns false when the popover highlights by dimension', () => {
+      expect(
+        shouldShowItemSelectionRing({ ...defaultBarOptions, chartPopovers: [{ UNSAFE_highlightBy: 'dimension' }] })
+      ).toBe(false);
+    });
+    test('returns true for a series popover', () => {
+      expect(
+        shouldShowItemSelectionRing({ ...defaultBarOptions, chartPopovers: [{ UNSAFE_highlightBy: 'series' }] })
+      ).toBe(true);
+    });
+    test('returns true for an array (custom keys) popover', () => {
+      expect(
+        shouldShowItemSelectionRing({ ...defaultBarOptions, chartPopovers: [{ UNSAFE_highlightBy: ['operatingSystem'] }] })
+      ).toBe(true);
+    });
+    test('returns false when any popover highlights by dimension', () => {
+      expect(
+        shouldShowItemSelectionRing({
+          ...defaultBarOptions,
+          chartPopovers: [{}, { UNSAFE_highlightBy: 'dimension' }],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('getBarItemSelectionBackdrop()', () => {
+    test('returns an opaque, stroke-less rect outset from the bar to fill the selection gap', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      const dimensionEncodings = getDodgedDimensionEncodings(options);
+      const backdrop = getBarItemSelectionBackdrop(options, FILTERED_TABLE, dimensionEncodings);
+      expect(backdrop).toStrictEqual({
+        name: 'bar0_itemSelectionBackdrop',
+        type: 'rect',
+        from: { data: FILTERED_TABLE },
+        interactive: false,
+        encode: {
+          enter: {
+            cornerRadiusBottomLeft: [{ test: 'datum.value < 0', value: 6 }, { value: 2 }],
+            cornerRadiusBottomRight: [{ test: 'datum.value < 0', value: 6 }, { value: 2 }],
+            cornerRadiusTopLeft: [{ test: 'datum.value > 0', value: 6 }, { value: 2 }],
+            cornerRadiusTopRight: [{ test: 'datum.value > 0', value: 6 }, { value: 2 }],
+            fill: { signal: BACKGROUND_COLOR },
+          },
+          update: {
+            y: { signal: `min(scale('yLinear', 0), scale('yLinear', datum.${DEFAULT_METRIC})) - 3` },
+            y2: { signal: `max(scale('yLinear', 0), scale('yLinear', datum.${DEFAULT_METRIC})) + 3` },
+            x: { signal: `scale('bar0_position', datum.bar0_dodgeGroup) - 3` },
+            width: { signal: `bandwidth('bar0_position') * 1 + 6` },
+            opacity: [
+              { test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.${MARK_ID}`, value: 1 },
+              { value: 0 },
+            ],
+          },
+        },
+      });
+    });
+  });
+
+  describe('getBarItemSelectionRing()', () => {
+    test('returns a stroke-only rect (transparent fill) outset from the bar with a concentric corner radius', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      const dimensionEncodings = getDodgedDimensionEncodings(options);
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      expect(ring).toStrictEqual({
+        name: 'bar0_itemSelectionRing',
+        type: 'rect',
+        from: { data: FILTERED_TABLE },
+        interactive: false,
+        encode: {
+          enter: {
+            cornerRadiusBottomLeft: [{ test: 'datum.value < 0', value: 6 }, { value: 2 }],
+            cornerRadiusBottomRight: [{ test: 'datum.value < 0', value: 6 }, { value: 2 }],
+            cornerRadiusTopLeft: [{ test: 'datum.value > 0', value: 6 }, { value: 2 }],
+            cornerRadiusTopRight: [{ test: 'datum.value > 0', value: 6 }, { value: 2 }],
+            fill: { value: 'transparent' },
+            stroke: { value: '#4B75FF' },
+            strokeWidth: { value: 2 },
+          },
+          update: {
+            y: { signal: `min(scale('yLinear', 0), scale('yLinear', datum.${DEFAULT_METRIC})) - 3` },
+            y2: { signal: `max(scale('yLinear', 0), scale('yLinear', datum.${DEFAULT_METRIC})) + 3` },
+            x: { signal: `scale('bar0_position', datum.bar0_dodgeGroup) - 3` },
+            width: { signal: `bandwidth('bar0_position') * 1 + 6` },
+            opacity: [
+              { test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.${MARK_ID}`, value: 1 },
+              { value: 0 },
+            ],
+          },
+        },
+      });
+    });
+
+    test('outsets along the metric (x) and dimension (y) axes when the bar is horizontal', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged', orientation: 'horizontal' };
+      const dimensionEncodings = getDodgedDimensionEncodings(options);
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      // metric axis is x for a horizontal bar; the ring outsets x/x2 and the dimension band on y
+      expect(ring.encode?.update).toStrictEqual({
+        x: { signal: `min(scale('xLinear', 0), scale('xLinear', datum.${DEFAULT_METRIC})) - 3` },
+        x2: { signal: `max(scale('xLinear', 0), scale('xLinear', datum.${DEFAULT_METRIC})) + 3` },
+        y: { signal: `scale('bar0_position', datum.bar0_dodgeGroup) - 3` },
+        height: { signal: `bandwidth('bar0_position') * 1 + 6` },
+        opacity: [
+          { test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.${MARK_ID}`, value: 1 },
+          { value: 0 },
+        ],
+      });
+    });
+
+    test('flattens the stacked bar metric production rule (test/signal branches) into a ternary', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'stacked' };
+      const dimensionEncodings: RectEncodeEntry = {
+        x: { scale: 'xBand', field: DEFAULT_CATEGORICAL_DIMENSION },
+        width: { scale: 'xBand', band: 1 },
+      };
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      const update = ring.encode?.update as { y: { signal: string }; y2: { signal: string } } & RectEncodeEntry;
+
+      // dimension axis (x) collapses the band-scale encodings, outset by the ring padding
+      expect(update.x).toStrictEqual({ signal: `scale('xBand', datum.${DEFAULT_CATEGORICAL_DIMENSION}) - 3` });
+      expect(update.width).toStrictEqual({ signal: `bandwidth('xBand') * 1 + 6` });
+      // metric axis (y) flattens the 3-branch stacked rule into a nested ternary, then outsets by padding
+      expect(update.y.signal).toMatch(/^min\(/);
+      expect(update.y.signal).toContain(' ? ');
+      expect(update.y.signal).toContain(`max(scale('yLinear', datum.${DEFAULT_METRIC}0) - 1.5`);
+      expect(update.y.signal).toContain(`min(scale('yLinear', datum.${DEFAULT_METRIC}0) + 1.5`);
+      expect(update.y.signal.endsWith(' - 3')).toBe(true);
+      expect(update.y2.signal.startsWith('max(')).toBe(true);
+      expect(update.y2.signal.endsWith(' + 3')).toBe(true);
+    });
+
+    test('flattens the dual-metric-axis metric production rule (series-id branches) without throwing', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged', dualMetricAxis: true };
+      const dimensionEncodings = getDodgedDimensionEncodings(options);
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, dimensionEncodings);
+      const update = ring.encode?.update as { y: { signal: string }; y2: { signal: string } };
+
+      // the dual-axis metric rules branch on SERIES_ID and reference the primary + secondary scales
+      expect(update.y.signal).toContain(`datum.${SERIES_ID} === ${LAST_RSC_SERIES_ID}`);
+      expect(update.y.signal).toContain(`scale('yLinearSecondary', 0)`);
+      expect(update.y.signal).toContain(`scale('yLinearPrimary', 0)`);
+      expect(update.y2.signal).toContain(`scale('yLinearSecondary', datum.${DEFAULT_METRIC})`);
+      expect(update.y2.signal).toContain(`scale('yLinearPrimary', datum.${DEFAULT_METRIC})`);
     });
   });
 

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
@@ -693,6 +693,37 @@ describe('barUtils', () => {
       expect(backdropEnter.cornerRadiusTopLeft).toStrictEqual(ringEnter.cornerRadiusTopLeft);
       expect(backdropEnter.cornerRadiusBottomRight).toStrictEqual(ringEnter.cornerRadiusBottomRight);
     });
+
+    test('serializes a plain value-ref dimension encoding into a numeric outset expression', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      // a value-based (non-scaled) dimension encoding still resolves to a numeric outset
+      const ring = getBarItemSelectionRing(options, FILTERED_TABLE, { x: { value: 7 }, width: { value: 20 } });
+      const update = ring.encode?.update as RectEncodeEntry;
+      expect(update.x).toStrictEqual({ signal: '7 - 3' });
+      expect(update.width).toStrictEqual({ signal: '20 + 6' });
+    });
+
+    test('throws on unsupported value-ref shapes rather than emitting invalid Vega', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      // no signal/scale/value at all
+      expect(() => getBarItemSelectionRing(options, FILTERED_TABLE, { x: {}, width: { value: 20 } })).toThrow(
+        'unsupported numeric production rule'
+      );
+      // a scale ref with no field/band/value to resolve
+      expect(() =>
+        getBarItemSelectionRing(options, FILTERED_TABLE, {
+          x: { scale: 'xBand' },
+          width: { value: 20 },
+        } as RectEncodeEntry)
+      ).toThrow('unsupported numeric production rule');
+    });
+
+    test('throws on an empty production-rule array', () => {
+      const options: BarSpecOptions = { ...defaultBarOptions, type: 'dodged' };
+      expect(() => getBarItemSelectionRing(options, FILTERED_TABLE, { x: [], width: { value: 20 } })).toThrow(
+        'empty production rule array'
+      );
+    });
   });
 
   describe('getStrokeDash()', () => {

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -339,22 +339,6 @@ const SELECTION_RING_STROKE_WIDTH = 2;
 // exactly at the gap boundary, so the rendered border spans [gap, gap + strokeWidth] from the bar's edge.
 const SELECTION_RING_PADDING = SELECTION_RING_GAP + SELECTION_RING_STROKE_WIDTH / 2;
 
-interface NumericRule {
-  test?: string;
-  value?: number;
-  signal?: string;
-  scale?: string;
-  field?: string;
-  band?: number;
-}
-
-const CORNER_RADIUS_KEYS = [
-  'cornerRadiusTopLeft',
-  'cornerRadiusTopRight',
-  'cornerRadiusBottomLeft',
-  'cornerRadiusBottomRight',
-] as const;
-
 /**
  * The selection ring's corner radius matches the bar's own per-corner radius (already
  * orientation/sign-aware via {@link getCornerRadiusEncodings}), widened by the ring's gap to the bar
@@ -364,15 +348,20 @@ const CORNER_RADIUS_KEYS = [
  */
 const getSelectionRingCornerRadiusEncodings = (options: BarSpecOptions): RectEncodeEntry => {
   const barCornerRadius = getCornerRadiusEncodings(options);
-  // each corner is a plain-numeric production rule; widen every branch by the gap
+  // each corner is a plain-numeric production rule; widen every branch's value by the gap
   const widen = (rule: ProductionRule<NumericValueRef>): ProductionRule<NumericValueRef> => {
-    const add = (r: NumericRule): NumericRule => ({ ...r, value: (r.value as number) + SELECTION_RING_GAP });
-    const rules = rule as unknown as NumericRule | NumericRule[];
-    return (Array.isArray(rules) ? rules.map(add) : add(rules)) as ProductionRule<NumericValueRef>;
+    const add = (branch: NumericValueRef): NumericValueRef => ({
+      ...branch,
+      value: (branch as { value: number }).value + SELECTION_RING_GAP,
+    });
+    return (Array.isArray(rule) ? rule.map(add) : add(rule)) as ProductionRule<NumericValueRef>;
   };
-  return Object.fromEntries(
-    CORNER_RADIUS_KEYS.map((key) => [key, widen(barCornerRadius[key] as ProductionRule<NumericValueRef>)])
-  ) as RectEncodeEntry;
+  return {
+    cornerRadiusTopLeft: widen(barCornerRadius.cornerRadiusTopLeft as ProductionRule<NumericValueRef>),
+    cornerRadiusTopRight: widen(barCornerRadius.cornerRadiusTopRight as ProductionRule<NumericValueRef>),
+    cornerRadiusBottomLeft: widen(barCornerRadius.cornerRadiusBottomLeft as ProductionRule<NumericValueRef>),
+    cornerRadiusBottomRight: widen(barCornerRadius.cornerRadiusBottomRight as ProductionRule<NumericValueRef>),
+  };
 };
 
 /**
@@ -380,31 +369,32 @@ const getSelectionRingCornerRadiusEncodings = (options: BarSpecOptions): RectEnc
  * Vega expression string, e.g. `test1 ? expr1 : test2 ? expr2 : exprFallback`.
  */
 const productionRuleToExpr = (rule: ProductionRule<NumericValueRef>): string => {
-  const numericRuleToExpr = ({ test: _test, ...valueRef }: NumericRule): string => {
+  const valueRefToExpr = (valueRef: NumericValueRef): string => {
     if ('signal' in valueRef) return valueRef.signal as string;
     if ('scale' in valueRef) {
       const scaleName = valueRef.scale as string;
       if ('field' in valueRef) return `scale('${scaleName}', datum.${valueRef.field as string})`;
-      if ('band' in valueRef) return `bandwidth('${scaleName}') * ${valueRef.band}`;
+      if ('band' in valueRef) return `bandwidth('${scaleName}') * ${valueRef.band as number}`;
       if ('value' in valueRef) return `scale('${scaleName}', ${JSON.stringify(valueRef.value)})`;
     } else if ('value' in valueRef) {
-      return `${valueRef.value}`;
+      return `${valueRef.value as number}`;
     }
     // Fail fast on any production-rule shape this helper wasn't built to serialize, rather than
     // silently emitting an invalid Vega expression like `scale('x', undefined)` or `undefined`.
     throw new Error(`getBarItemSelectionRing: unsupported numeric production rule ${JSON.stringify(valueRef)}`);
   };
 
-  if (!Array.isArray(rule)) return numericRuleToExpr(rule as unknown as NumericRule);
+  if (!Array.isArray(rule)) return valueRefToExpr(rule);
 
-  const rules = rule as unknown as NumericRule[];
-  const fallbackRule = rules.at(-1);
+  // array form = conditional rules, each an optional `test` plus a value ref
+  const branches = rule as ({ test?: string } & NumericValueRef)[];
+  const fallbackRule = branches.at(-1);
   if (fallbackRule === undefined) {
     throw new Error('getBarItemSelectionRing: empty production rule array');
   }
-  let expr = numericRuleToExpr(fallbackRule);
-  for (let i = rules.length - 2; i >= 0; i--) {
-    expr = `${rules[i].test} ? ${numericRuleToExpr(rules[i])} : ${expr}`;
+  let expr = valueRefToExpr(fallbackRule);
+  for (let i = branches.length - 2; i >= 0; i--) {
+    expr = `${branches[i].test} ? ${valueRefToExpr(branches[i])} : ${expr}`;
   }
   return expr;
 };

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -21,6 +21,7 @@ import {
 } from 'vega';
 
 import {
+  BACKGROUND_COLOR,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
   LAST_RSC_SERIES_ID,
@@ -317,6 +318,179 @@ export const getStroke = (options: BarSpecOptions): ProductionRule<ColorValueRef
     defaultProductionRule,
   ];
 };
+
+/**
+ * Determines whether the per-item selection ring should be added for this mark.
+ * Mutually exclusive with the dimension-level {@link getDimensionSelectionRing}, which
+ * already provides its own group-spanning ring for `UNSAFE_highlightBy: 'dimension'` popovers.
+ */
+export const shouldShowItemSelectionRing = (options: BarSpecOptions): boolean => {
+  const { chartPopovers, name } = options;
+  const popovers = getPopovers(chartPopovers, name);
+  return popovers.length > 0 && !popovers.some(({ UNSAFE_highlightBy }) => UNSAFE_highlightBy === 'dimension');
+};
+
+// gap, in pixels, between the bar's own edge and the selection ring's stroke (matches Figma's `padding: 2px`)
+const SELECTION_RING_GAP = 2;
+// matches Figma's `border: 2px solid`
+const SELECTION_RING_STROKE_WIDTH = 2;
+// Vega centers a rect's stroke on its path, but the Figma spec draws the border fully outside the
+// padding box. Offsetting the path by gap + half the stroke width makes the stroke's inner edge land
+// exactly at the gap boundary, so the rendered border spans [gap, gap + strokeWidth] from the bar's edge.
+const SELECTION_RING_PADDING = SELECTION_RING_GAP + SELECTION_RING_STROKE_WIDTH / 2;
+
+interface NumericRule {
+  test?: string;
+  value?: number;
+  signal?: string;
+  scale?: string;
+  field?: string;
+  band?: number;
+}
+
+const CORNER_RADIUS_KEYS = [
+  'cornerRadiusTopLeft',
+  'cornerRadiusTopRight',
+  'cornerRadiusBottomLeft',
+  'cornerRadiusBottomRight',
+] as const;
+
+/**
+ * The selection ring's corner radius matches the bar's own per-corner radius (already
+ * orientation/sign-aware via {@link getCornerRadiusEncodings}), widened by the ring's gap to the bar
+ * so the ring's corners stay visually concentric with the bar's own corners. Per the Figma spec
+ * (`border-radius: 2px … 6px`) the outset here is the gap only (bar radius 0/4 → ring 2/6), not the
+ * position padding — the extra half-stroke used for positioning would over-round each corner by 1px.
+ */
+const getSelectionRingCornerRadiusEncodings = (options: BarSpecOptions): RectEncodeEntry => {
+  const barCornerRadius = getCornerRadiusEncodings(options);
+  // each corner is a plain-numeric production rule; widen every branch by the gap
+  const widen = (rule: ProductionRule<NumericValueRef>): ProductionRule<NumericValueRef> => {
+    const add = (r: NumericRule): NumericRule => ({ ...r, value: (r.value as number) + SELECTION_RING_GAP });
+    const rules = rule as unknown as NumericRule | NumericRule[];
+    return (Array.isArray(rules) ? rules.map(add) : add(rules)) as ProductionRule<NumericValueRef>;
+  };
+  return Object.fromEntries(
+    CORNER_RADIUS_KEYS.map((key) => [key, widen(barCornerRadius[key] as ProductionRule<NumericValueRef>)])
+  ) as RectEncodeEntry;
+};
+
+/**
+ * Collapses a (possibly multi-branch, conditional) numeric production rule into a single
+ * Vega expression string, e.g. `test1 ? expr1 : test2 ? expr2 : exprFallback`.
+ */
+const productionRuleToExpr = (rule: ProductionRule<NumericValueRef>): string => {
+  const numericRuleToExpr = ({ test: _test, ...valueRef }: NumericRule): string => {
+    if ('signal' in valueRef) return valueRef.signal as string;
+    if ('scale' in valueRef) {
+      const scaleName = valueRef.scale as string;
+      if ('field' in valueRef) return `scale('${scaleName}', datum.${valueRef.field as string})`;
+      if ('band' in valueRef) return `bandwidth('${scaleName}') * ${valueRef.band}`;
+      if ('value' in valueRef) return `scale('${scaleName}', ${JSON.stringify(valueRef.value)})`;
+    } else if ('value' in valueRef) {
+      return `${valueRef.value}`;
+    }
+    // Fail fast on any production-rule shape this helper wasn't built to serialize, rather than
+    // silently emitting an invalid Vega expression like `scale('x', undefined)` or `undefined`.
+    throw new Error(`getBarItemSelectionRing: unsupported numeric production rule ${JSON.stringify(valueRef)}`);
+  };
+
+  if (!Array.isArray(rule)) return numericRuleToExpr(rule as unknown as NumericRule);
+
+  const rules = rule as unknown as NumericRule[];
+  let expr = numericRuleToExpr(rules[rules.length - 1]);
+  for (let i = rules.length - 2; i >= 0; i--) {
+    expr = `${rules[i].test} ? ${numericRuleToExpr(rules[i])} : ${expr}`;
+  }
+  return expr;
+};
+
+/**
+ * Shared position/size/visibility (`update`) encodings for the two selection-ring marks. The rect is
+ * outset from the bar's bounds by {@link SELECTION_RING_PADDING} on every side and is only visible
+ * (opacity 1) for the bar whose mark ID matches the {@link SELECTED_ITEM} signal.
+ */
+const getSelectionRingUpdateEncodings = (
+  options: BarSpecOptions,
+  dimensionEncodings: RectEncodeEntry
+): RectEncodeEntry => {
+  const { idKey, orientation } = options;
+  const { metricAxis, dimensionAxis, dimensionSizeSignal } = getOrientationProperties(orientation);
+  const metricEndKey = `${metricAxis}2`;
+
+  const metricEncodings = getMetricEncodings(options);
+  const metricStartExpr = productionRuleToExpr(metricEncodings[metricAxis] as ProductionRule<NumericValueRef>);
+  const metricEndExpr = productionRuleToExpr(metricEncodings[metricEndKey] as ProductionRule<NumericValueRef>);
+
+  const dimensionPosExpr = productionRuleToExpr(dimensionEncodings[dimensionAxis] as ProductionRule<NumericValueRef>);
+  const dimensionSizeExpr = productionRuleToExpr(
+    dimensionEncodings[dimensionSizeSignal] as ProductionRule<NumericValueRef>
+  );
+
+  return {
+    [metricAxis]: { signal: `min(${metricStartExpr}, ${metricEndExpr}) - ${SELECTION_RING_PADDING}` },
+    [metricEndKey]: { signal: `max(${metricStartExpr}, ${metricEndExpr}) + ${SELECTION_RING_PADDING}` },
+    [dimensionAxis]: { signal: `${dimensionPosExpr} - ${SELECTION_RING_PADDING}` },
+    [dimensionSizeSignal]: { signal: `${dimensionSizeExpr} + ${2 * SELECTION_RING_PADDING}` },
+    opacity: [
+      { test: `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.${idKey}`, value: 1 },
+      { value: 0 },
+    ],
+  };
+};
+
+/**
+ * Opaque backdrop for the selection ring, drawn UNDERNEATH the bar. It is outset from the bar and
+ * filled with the chart's background color so the gap between the bar and the stroke reads as an
+ * opaque halo (elements behind the bar aren't visible through it) rather than showing gridlines or
+ * other marks. It carries no stroke — the visible outline is {@link getBarItemSelectionRing}, drawn
+ * on top. Kept separate so the stroke can render above the bars while the fill stays below (an opaque
+ * fill drawn on top would cover the bar itself).
+ */
+export const getBarItemSelectionBackdrop = (
+  options: BarSpecOptions,
+  dataSource: string,
+  dimensionEncodings: RectEncodeEntry
+): RectMark => ({
+  name: `${options.name}_itemSelectionBackdrop`,
+  type: 'rect',
+  from: { data: dataSource },
+  interactive: false,
+  encode: {
+    enter: {
+      ...getSelectionRingCornerRadiusEncodings(options),
+      fill: { signal: BACKGROUND_COLOR },
+    },
+    update: getSelectionRingUpdateEncodings(options, dimensionEncodings),
+  },
+});
+
+/**
+ * The visible selection outline: a stroke-only rect drawn ON TOP of the bar marks so it is never
+ * occluded. This matters for stacked bars, where adjacent segments (drawn after) would paint over a
+ * ring drawn underneath. Its fill is transparent so it doesn't cover the bar; the opaque gap is
+ * provided by {@link getBarItemSelectionBackdrop}, drawn underneath. Only visible for the bar whose
+ * mark ID matches the {@link SELECTED_ITEM} signal.
+ */
+export const getBarItemSelectionRing = (
+  options: BarSpecOptions,
+  dataSource: string,
+  dimensionEncodings: RectEncodeEntry
+): RectMark => ({
+  name: `${options.name}_itemSelectionRing`,
+  type: 'rect',
+  from: { data: dataSource },
+  interactive: false,
+  encode: {
+    enter: {
+      ...getSelectionRingCornerRadiusEncodings(options),
+      fill: { value: 'transparent' },
+      stroke: { value: getS2ColorValue('blue-800', options.colorScheme) },
+      strokeWidth: { value: SELECTION_RING_STROKE_WIDTH },
+    },
+    update: getSelectionRingUpdateEncodings(options, dimensionEncodings),
+  },
+});
 
 export const getDimensionSelectionRing = (options: BarSpecOptions): RectMark => {
   const { name, colorScheme, paddingRatio, orientation } = options;

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -398,7 +398,11 @@ const productionRuleToExpr = (rule: ProductionRule<NumericValueRef>): string => 
   if (!Array.isArray(rule)) return numericRuleToExpr(rule as unknown as NumericRule);
 
   const rules = rule as unknown as NumericRule[];
-  let expr = numericRuleToExpr(rules[rules.length - 1]);
+  const fallbackRule = rules.at(-1);
+  if (fallbackRule === undefined) {
+    throw new Error('getBarItemSelectionRing: empty production rule array');
+  }
+  let expr = numericRuleToExpr(fallbackRule);
   for (let i = rules.length - 2; i >= 0; i--) {
     expr = `${rules[i].test} ? ${numericRuleToExpr(rules[i])} : ${expr}`;
   }

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -348,14 +348,13 @@ const SELECTION_RING_PADDING = SELECTION_RING_GAP + SELECTION_RING_STROKE_WIDTH 
  */
 const getSelectionRingCornerRadiusEncodings = (options: BarSpecOptions): RectEncodeEntry => {
   const barCornerRadius = getCornerRadiusEncodings(options);
-  // each corner is a plain-numeric production rule; widen every branch's value by the gap
-  const widen = (rule: ProductionRule<NumericValueRef>): ProductionRule<NumericValueRef> => {
-    const add = (branch: NumericValueRef): NumericValueRef => ({
+  // every corner from getCornerRadiusEncodings is a conditional array of plain-numeric branches;
+  // widen each branch's value by the gap so the ring's corners stay concentric with the bar's
+  const widen = (rule: ProductionRule<NumericValueRef>): ProductionRule<NumericValueRef> =>
+    (rule as ({ test?: string; value: number } & NumericValueRef)[]).map((branch) => ({
       ...branch,
-      value: (branch as { value: number }).value + SELECTION_RING_GAP,
-    });
-    return (Array.isArray(rule) ? rule.map(add) : add(rule)) as ProductionRule<NumericValueRef>;
-  };
+      value: branch.value + SELECTION_RING_GAP,
+    })) as ProductionRule<NumericValueRef>;
   return {
     cornerRadiusTopLeft: widen(barCornerRadius.cornerRadiusTopLeft as ProductionRule<NumericValueRef>),
     cornerRadiusTopRight: widen(barCornerRadius.cornerRadiusTopRight as ProductionRule<NumericValueRef>),

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
@@ -244,5 +244,28 @@ describe('dodgedBarUtils', () => {
       expect(marks[0].name).toEqual('bar0_dimensionHoverArea');
       expect(marks[1].name).toEqual('bar0_group');
     });
+    test('adds the selection backdrop under the bars and the outline ring on top when an item popover exists', () => {
+      const marks = getDodgedMarks({
+        ...defaultDodgedOptions,
+        chartPopovers: [{}],
+      });
+      const mark = marks[0] as GroupMark;
+      expect(mark.marks).toHaveLength(4);
+      // backdrop is drawn first (underneath) to fill the gap; the outline ring is drawn last (on top)
+      expect(mark.marks?.[0].name).toEqual('bar0_itemSelectionBackdrop');
+      expect(mark.marks?.[1].name).toEqual('bar0_background');
+      expect(mark.marks?.[2].name).toEqual('bar0');
+      expect(mark.marks?.[3].name).toEqual('bar0_itemSelectionRing');
+    });
+    test('does not add the item selection marks when the popover highlights by dimension', () => {
+      const marks = getDodgedMarks({
+        ...defaultDodgedOptions,
+        chartPopovers: [{ UNSAFE_highlightBy: 'dimension' }],
+      });
+      const mark = marks[0] as GroupMark;
+      const names = mark.marks?.map((ringMark) => ringMark.name);
+      expect(names).not.toContain('bar0_itemSelectionBackdrop');
+      expect(names).not.toContain('bar0_itemSelectionRing');
+    });
   });
 });

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
@@ -20,19 +20,28 @@ import { getAnnotationMarks } from './barAnnotationUtils';
 import {
   getBarDimensionHoverArea,
   getBarEnterEncodings,
+  getBarItemSelectionBackdrop,
+  getBarItemSelectionRing,
   getBarUpdateEncodings,
   getBaseBarEnterEncodings,
   getDodgedDimensionEncodings,
   getDodgedGroupMark,
+  shouldShowItemSelectionRing,
 } from './barUtils';
 
 export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[] => {
   const { name } = options;
+  const showItemSelectionRing = shouldShowItemSelectionRing(options);
+  const ringDimensionEncodings = getDodgedDimensionEncodings(options);
 
   const marks: (GroupMark | RectMark)[] = [
     {
       ...getDodgedGroupMark(options),
       marks: [
+        // opaque backdrop drawn underneath the bar so the gap around the selected bar reads as an opaque halo
+        ...(showItemSelectionRing
+          ? [getBarItemSelectionBackdrop(options, `${name}_facet`, ringDimensionEncodings)]
+          : []),
         // background bars
         {
           name: `${name}_background`,
@@ -67,6 +76,10 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
           },
         },
         ...getAnnotationMarks(options, `${name}_facet`, `${name}_position`, `${name}_dodgeGroup`),
+        // visible outline drawn on top of the bars so it is never occluded by adjacent marks
+        ...(showItemSelectionRing
+          ? [getBarItemSelectionRing(options, `${name}_facet`, ringDimensionEncodings)]
+          : []),
       ],
     },
   ];

--- a/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.test.ts
@@ -96,6 +96,39 @@ describe('stackedBarUtils', () => {
       expect(marks[1].name).toEqual('bar0_background');
       expect(marks[2].name).toEqual('bar0');
     });
+    test('adds the selection backdrop under the bars and the outline ring on top when an item popover exists', () => {
+      const marks = getStackedBarMarks({
+        ...defaultBarOptions,
+        chartPopovers: [{}],
+      });
+      expect(marks).toHaveLength(4);
+      // backdrop is drawn first (underneath) to fill the gap; the outline ring is drawn last (on top)
+      // so it is never occluded by adjacent stack segments
+      expect(marks[0].name).toEqual('bar0_itemSelectionBackdrop');
+      expect(marks[1].name).toEqual('bar0_background');
+      expect(marks[2].name).toEqual('bar0');
+      expect(marks[3].name).toEqual('bar0_itemSelectionRing');
+    });
+    test('does not add the item selection marks when the popover highlights by dimension', () => {
+      const marks = getStackedBarMarks({
+        ...defaultBarOptions,
+        chartPopovers: [{ UNSAFE_highlightBy: 'dimension' }],
+      });
+      const names = marks.map((mark) => mark.name);
+      expect(names).not.toContain('bar0_itemSelectionBackdrop');
+      expect(names).not.toContain('bar0_itemSelectionRing');
+    });
+    test('sources the item selection marks from the trellis facet when trellised', () => {
+      const marks = getStackedBarMarks({
+        ...defaultBarOptions,
+        trellis: 'event',
+        chartPopovers: [{}],
+      });
+      const backdrop = marks.find((mark) => mark.name === 'bar0_itemSelectionBackdrop');
+      const ring = marks.find((mark) => mark.name === 'bar0_itemSelectionRing');
+      expect(backdrop?.from).toStrictEqual({ data: 'bar0_trellis' });
+      expect(ring?.from).toStrictEqual({ data: 'bar0_trellis' });
+    });
   });
 
   describe('getDodgedAndStackedBarMark()', () => {
@@ -108,6 +141,20 @@ describe('stackedBarUtils', () => {
       expect(mark.marks).toHaveLength(2);
       expect(mark.marks?.[0].name).toEqual('bar0_background');
       expect(mark.marks?.[1].name).toEqual('bar0');
+    });
+
+    test('adds the selection backdrop under the bars and the outline ring on top when an item popover exists', () => {
+      const mark = getDodgedAndStackedBarMark({
+        ...defaultBarOptions,
+        chartPopovers: [{}],
+      });
+
+      expect(mark.marks).toHaveLength(4);
+      // backdrop underneath, outline ring on top
+      expect(mark.marks?.[0].name).toEqual('bar0_itemSelectionBackdrop');
+      expect(mark.marks?.[1].name).toEqual('bar0_background');
+      expect(mark.marks?.[2].name).toEqual('bar0');
+      expect(mark.marks?.[3].name).toEqual('bar0_itemSelectionRing');
     });
 
     test('should return mark with dodged and stacked marks, with annotation', () => {

--- a/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.ts
@@ -20,12 +20,15 @@ import { getAnnotationMarks } from './barAnnotationUtils';
 import {
   getBarDimensionHoverArea,
   getBarEnterEncodings,
+  getBarItemSelectionBackdrop,
+  getBarItemSelectionRing,
   getBarUpdateEncodings,
   getBaseBarEnterEncodings,
   getDodgedDimensionEncodings,
   getDodgedGroupMark,
   getOrientationProperties,
   isDodgedAndStacked,
+  shouldShowItemSelectionRing,
 } from './barUtils';
 import { getTrellisProperties, isTrellised } from './trellisedBarUtils';
 
@@ -34,6 +37,15 @@ export const getStackedBarMarks = (options: BarSpecOptions): Mark[] => {
 
   if (hasInspectWithDimensionAreaTarget(options.chartInspects)) {
     marks.push(getBarDimensionHoverArea(options, 'stacked'));
+  }
+
+  const showItemSelectionRing = shouldShowItemSelectionRing(options);
+  const ringDataSource = getBaseDataSourceName(options);
+  const ringDimensionEncodings = getStackedDimensionEncodings(options);
+
+  // opaque backdrop drawn underneath the bar so the gap around the selected bar reads as an opaque halo
+  if (showItemSelectionRing) {
+    marks.push(getBarItemSelectionBackdrop(options, ringDataSource, ringDimensionEncodings));
   }
 
   marks.push(
@@ -51,11 +63,24 @@ export const getStackedBarMarks = (options: BarSpecOptions): Mark[] => {
     )
   );
 
+  // visible outline drawn on top of the bars so it is never occluded (e.g. by adjacent stack segments)
+  if (showItemSelectionRing) {
+    marks.push(getBarItemSelectionRing(options, ringDataSource, ringDimensionEncodings));
+  }
+
   return marks;
 };
 
 export const getDodgedAndStackedBarMark = (options: BarSpecOptions): GroupMark => {
   const marks: Mark[] = [];
+  const showItemSelectionRing = shouldShowItemSelectionRing(options);
+  const ringDataSource = `${options.name}_facet`;
+  const ringDimensionEncodings = getStackedDimensionEncodings(options);
+
+  if (showItemSelectionRing) {
+    marks.push(getBarItemSelectionBackdrop(options, ringDataSource, ringDimensionEncodings));
+  }
+
   marks.push(
     // add background marks
     getStackedBackgroundBar(options),
@@ -64,6 +89,10 @@ export const getDodgedAndStackedBarMark = (options: BarSpecOptions): GroupMark =
     // add annotation marks
     ...getAnnotationMarks(options, `${options.name}_facet`, `${options.name}_position`, `${options.name}_dodgeGroup`)
   );
+
+  if (showItemSelectionRing) {
+    marks.push(getBarItemSelectionRing(options, ringDataSource, ringDimensionEncodings));
+  }
 
   return { ...getDodgedGroupMark(options), marks };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a per-item selection outline to the S2 `Bar` mark. When a bar with a
`<ChartPopover>` (default `item` highlight) is selected, a ring renders around
that bar: an opaque backdrop fills the gap so nothing shows through, and a blue
stroke outlines it. Applies to stacked, dodged, dodged-and-stacked, trellised,
and dual-metric-axis bars.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

click any bar to see the selection outline. Sidebar path prefix: 
React Spectrum Charts 2 → Bar → Features → Dodged Bar → Popover
React Spectrum Charts 2 → Bar → Features → Stacked Bar → Popover
React Spectrum Charts 2 → Bar → Features → Dual Metric Axis → Basic 
React Spectrum Charts 2 → Bar → Features → Trellis → Dodged


## Screenshots (if appropriate):
<img width="260" height="432" alt="Screenshot 2026-07-17 at 1 08 41 PM" src="https://github.com/user-attachments/assets/ad293e26-4cba-48fb-bae2-0d5ecf939d5f" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
