### PR TITLE
feat: hover animations legend opacity implementation

### DIFF
--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -199,6 +199,7 @@ const ChartDialog = ({ popover, setIsPopoverOpen, targetElement, idKey, specSign
   return (
     <>
       <button
+        type="button"
         id={`${name}-${rightClick ? 'contextmenu' : 'popover'}-button`}
         aria-hidden="true"
         tabIndex={-1}

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Line.test.tsx
@@ -147,11 +147,14 @@ describe('Line', () => {
     expect(entries.length).toEqual(4);
     await hoverNthElement(entries, 0);
 
-    // symbol opacity should be reduced for all but the first symbol (legend opacity is not yet wired
-    // into the hover-animation system, so this stays an instant, synchronous check)
+    // symbol opacity should be reduced for all but the first symbol. Legend opacity is now driven by
+    // the same animated fraction data as the line for animated marks, so it settles asynchronously
+    // rather than flipping instantly — hence the waitFor rather than a direct synchronous assertion.
     let symbols = getAllLegendSymbols(chart);
-    expect(symbols[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(symbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    await waitFor(() => {
+      expect(symbols[0]).toHaveAttribute('opacity', '1');
+      expect(allElementsHaveAttributeValue(symbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    });
 
     await waitForMarksByGroupName(chart, 'line0', (lines) => {
       expect(lines[0]).toHaveAttribute('opacity', '1');
@@ -163,8 +166,10 @@ describe('Line', () => {
 
     // symbol opacity should be reduced for all but the last symbol
     symbols = getAllLegendSymbols(chart);
-    expect(allElementsHaveAttributeValue(symbols.slice(0, 3), 'opacity', FADE_FACTOR)).toBeTruthy();
-    expect(symbols[3]).toHaveAttribute('opacity', '1');
+    await waitFor(() => {
+      expect(allElementsHaveAttributeValue(symbols.slice(0, 3), 'opacity', FADE_FACTOR)).toBeTruthy();
+      expect(symbols[3]).toHaveAttribute('opacity', '1');
+    });
 
     // line opacity should be reduced for all but the last line
     await waitForMarksByGroupName(chart, 'line0', (lines) => {

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
@@ -90,6 +90,7 @@ const defaultBarOptions: BarOptions = { markType: 'bar', dimension: 'browser', m
 jest.mock('./legend/legendHighlightUtils', () => {
   return {
     getLegendHighlightSignals: jest.fn().mockReturnValue([]),
+    injectLegendHoverIntoData: jest.fn(),
     setHoverOpacityForMarks: jest.fn(),
     setHoverStrokeWidthForMarks: jest.fn(),
   };

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -213,7 +213,7 @@ export function buildSpec({
 
   // add signals and update marks for controlled highlighting if there isn't a legend with highlight enabled
   if (highlightedSeries) {
-    setHoverOpacityForMarks('', spec.marks ?? [], undefined, true);
+    setHoverOpacityForMarks('', spec.marks ?? [], undefined, true, spec.usermeta?.animatedMarks ?? []);
     setHoverStrokeWidthForMarks('', spec.marks ?? [], undefined, true);
   }
 

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { Mark } from 'vega';
+import { AggregateTransform, Data, FormulaTransform, LookupTransform, Mark } from 'vega';
 
 import {
   CHART_SIZE_HOVER_STROKE_WIDTH,
@@ -18,6 +18,8 @@ import {
   DEFAULT_OPACITY_RULE,
   DEFAULT_STROKE_WIDTH_RULE,
   FADE_FACTOR,
+  FILTERED_TABLE,
+  GROUP_ID,
   HOVERED_SERIES,
   SERIES_ID,
 } from '@spectrum-charts/constants';
@@ -26,6 +28,7 @@ import {
   encodingUsesScale,
   getHighlightOpacityRule,
   getHighlightStrokeWidthRule,
+  injectLegendHoverIntoData,
   setHoverOpacityForMarks,
   setHoverStrokeWidthForMarks,
 } from './legendHighlightUtils';
@@ -77,6 +80,107 @@ const defaultOpacityEncoding = {
     },
   ],
 };
+
+const hoverTargetData: Data = {
+  name: 'line0_hoverTargetData',
+  source: FILTERED_TABLE,
+  transform: [
+    { type: 'aggregate', groupby: [SERIES_ID] },
+    { type: 'formula', as: 'hoveredMatch', expr: `isValid(hoveredItem) ? 1 : null` },
+    { type: 'formula', as: 'target', expr: `isValid(datum.hoveredMatch) ? datum.hoveredMatch : 0.5` },
+  ],
+};
+
+const hoverFractionData: Data = {
+  name: 'line0_hoverFractionData',
+  source: 'line0_hoverAnimStateData',
+  transform: [{ type: 'formula', as: 'fraction', expr: 'lerp(...)' }],
+};
+
+const getExpectedLegendHoverFormulas = (legendName: string, matchExpr: string): FormulaTransform[] => [
+  {
+    type: 'formula',
+    as: 'legendHoverMatch',
+    expr: `(isValid(${legendName}_${HOVERED_SERIES})) ? ((${matchExpr}) ? 1 : 0) : null`,
+  },
+  {
+    type: 'formula',
+    as: 'target',
+    expr: `isValid(datum.hoveredMatch) ? datum.hoveredMatch : isValid(datum.legendHoverMatch) ? datum.legendHoverMatch : datum.conditions`,
+  },
+];
+
+describe('injectLegendHoverIntoData()', () => {
+  test('renames the existing target formula to conditions and appends the legendHoverMatch/target formulas', () => {
+    const data = JSON.parse(JSON.stringify([hoverTargetData]));
+    injectLegendHoverIntoData('legend0', data);
+
+    const transform = data[0].transform as FormulaTransform[];
+    expect(transform).toHaveLength(5);
+    expect(transform[2]).toHaveProperty('as', 'conditions');
+    expect(transform.slice(-2)).toEqual(
+      getExpectedLegendHoverFormulas('legend0', `legend0_${HOVERED_SERIES} === datum.${SERIES_ID} ? 1 : 0`)
+    );
+  });
+
+  test('uses the legend group match expression and extends the aggregate groupby when keys are provided', () => {
+    const data = JSON.parse(JSON.stringify([hoverTargetData]));
+    injectLegendHoverIntoData('legend0', data, ['category']);
+
+    const transform = data[0].transform as (AggregateTransform | FormulaTransform)[];
+    expect(transform[0]).toHaveProperty('groupby', [SERIES_ID, `legend0_${GROUP_ID}`]);
+    expect(transform.slice(-2)).toEqual(
+      getExpectedLegendHoverFormulas('legend0', `legend0_${HOVERED_SERIES} === datum.legend0_${GROUP_ID} ? 1 : 0`)
+    );
+  });
+
+  test('adds a grouped fraction data source and lookup transform when keys are provided and a _hoverFractionData source exists', () => {
+    const data = JSON.parse(JSON.stringify([hoverTargetData, hoverFractionData]));
+    injectLegendHoverIntoData('legend0', data, ['category']);
+
+    const fractionTransform = data[1].transform as LookupTransform[];
+    expect(fractionTransform).toHaveLength(2);
+    expect(fractionTransform[1]).toEqual({
+      type: 'lookup',
+      from: 'line0_hoverTargetData',
+      key: SERIES_ID,
+      fields: [SERIES_ID],
+      values: [`legend0_${GROUP_ID}`],
+      as: [`legend0_${GROUP_ID}`],
+    });
+
+    const groupFractionData = data.find((d: Data) => d.name === 'line0_hoverGroupFractionData');
+    expect(groupFractionData).toEqual({
+      name: 'line0_hoverGroupFractionData',
+      source: 'line0_hoverFractionData',
+      transform: [
+        {
+          type: 'aggregate',
+          groupby: [`legend0_${GROUP_ID}`],
+          fields: ['fraction'],
+          ops: ['max'],
+          as: ['fraction'],
+        },
+      ],
+    });
+  });
+
+  test('does not touch _hoverFractionData when keys are not provided', () => {
+    const data = JSON.parse(JSON.stringify([hoverTargetData, hoverFractionData]));
+    injectLegendHoverIntoData('legend0', data);
+
+    expect(data).toHaveLength(2);
+    expect(data[1].transform).toEqual(hoverFractionData.transform);
+  });
+
+  test('leaves data sources that are not hover target/fraction data untouched', () => {
+    const otherData: Data = { name: 'table', source: 'table', transform: [{ type: 'identifier', as: 'id' }] };
+    const data = JSON.parse(JSON.stringify([otherData]));
+    injectLegendHoverIntoData('legend0', data);
+
+    expect(data).toEqual([otherData]);
+  });
+});
 
 describe('getHighlightOpacityRule()', () => {
   test('should use HIGHLIGHTED_SERIES in test if there are not any keys', () => {
@@ -155,6 +259,29 @@ describe('setHoverOpacityForMarks()', () => {
       expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
     });
   });
+  describe('mark using the new hover animation system', () => {
+    const animatedLineMark: Mark = {
+      ...defaultMark,
+      name: 'line0',
+      encode: {
+        ...defaultMark.encode,
+        update: { opacity: { signal: `0.2 + (1 - 0.2) * clamp(0.5 / 0.5, 0, 1)` } },
+      },
+    };
+
+    test('is left untouched when its name is in animatedMarks', () => {
+      const marks = JSON.parse(JSON.stringify([animatedLineMark]));
+      setHoverOpacityForMarks('legend0', marks, undefined, false, ['line0']);
+      expect(marks[0].encode.update.opacity).toEqual(animatedLineMark.encode?.update?.opacity);
+    });
+
+    test('still gets the legend-hover opacity rule spliced in when its name is not in animatedMarks', () => {
+      const marks = JSON.parse(JSON.stringify([animatedLineMark]));
+      setHoverOpacityForMarks('legend0', marks, undefined, false, ['line1']);
+      expect(marks[0].encode.update.opacity[0]).toEqual(getHighlightOpacityRule('legend0', false));
+    });
+  });
+
   describe('trendline hover-support mark sharing the trendline name prefix', () => {
     // Named like `<parent>Trendline_hoverRule` — shares the "Trendline" prefix with the
     // trendline's own line mark, but isn't the trendline mark itself. Its non-array opacity

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
+import { AggregateTransform, Data, FormulaTransform, GroupMark, Mark, NumericValueRef, ProductionRule } from 'vega';
 
 import {
   CHART_SIZE_HOVER_STROKE_WIDTH,
@@ -29,16 +29,128 @@ export const getLegendHighlightSignals = (legends: LegendOptions[]): string[] =>
     .filter((legend) => legend.highlight)
     .map((legend) => `${legend.name}_${HOVERED_SERIES}`);
 
+type DataTransforms = NonNullable<Data['transform']>;
+
+/**
+ * Merges a legend hover match rule into an existing `_hoverTargetData` source's `target` formula,
+ * and (for grouped legends) adds the legend's group field to the aggregate's groupby.
+ */
+const injectLegendHoverIntoTargetData = (
+  transform: DataTransforms,
+  legendName: string,
+  matchExpr: string,
+  groupIdField: string,
+  keys?: string[]
+): void => {
+  if (keys?.length) {
+    // Add legend group field to aggregate's groupby
+    const aggregateTransform = transform.find((t): t is AggregateTransform => t.type === 'aggregate');
+    if (aggregateTransform && Array.isArray(aggregateTransform.groupby)) {
+      aggregateTransform.groupby.push(groupIdField);
+    }
+  }
+
+  // Change the old target's name to conditions
+  const targetTransform = transform.find((t): t is FormulaTransform => t.type === 'formula' && t.as === 'target');
+  if (targetTransform) {
+    targetTransform.as = 'conditions';
+  }
+
+  // Add the legend hover match formula, then combine it with the prior target into a new target formula
+  transform.push(
+    {
+      type: 'formula' as const,
+      as: `legendHoverMatch`,
+      expr: `(isValid(${legendName}_${HOVERED_SERIES})) ? ((${matchExpr}) ? 1 : 0) : null`,
+    },
+    {
+      type: 'formula' as const,
+      as: `target`,
+      expr: `isValid(datum.hoveredMatch) ? datum.hoveredMatch : isValid(datum.legendHoverMatch) ? datum.legendHoverMatch : datum.conditions`,
+    }
+  );
+};
+
+/**
+ * For grouped legends, brings the group field into an existing `_hoverFractionData` source via
+ * lookup, then adds a `_hoverGroupFractionData` source that aggregates fractions by group (max).
+ */
+const addGroupedFractionData = (
+  fractionDataName: string,
+  transform: DataTransforms,
+  data: Data[],
+  groupIdField: string
+): void => {
+  const markName = fractionDataName.replace('_hoverFractionData', '');
+  transform.push({
+    type: 'lookup' as const,
+    from: `${markName}_hoverTargetData`,
+    key: SERIES_ID,
+    fields: [SERIES_ID],
+    values: [groupIdField],
+    as: [groupIdField]
+  });
+
+  data.push({
+    name: `${markName}_hoverGroupFractionData`,
+    source: `${markName}_hoverFractionData`,
+    transform: [
+      {
+        type: 'aggregate' as const,
+        groupby: [groupIdField],
+        fields: ['fraction'],
+        ops: ['max'],
+        as: ['fraction']
+      },
+    ],
+  });
+};
+
+/**
+ * Injects a legend hover rule into the hover target data for the chart.
+ */
+export const injectLegendHoverIntoData = (legendName: string, data: Data[], keys?: string[]): void => {
+  const groupIdField = `${legendName}_${GROUP_ID}`;
+  // The ungrouped branch matches on SERIES_ID, not the animated mark's own identity field, so legend
+  // hover matches at the series level even for marks whose animation identity is finer-grained (e.g. a
+  // future bar mark keyed by rscMarkId). This requires every animated mark's own `_hoverTargetData`
+  // aggregate to include SERIES_ID in its groupby regardless of its animation keyField — see the design
+  // doc §11 ("Extending to other marks") for that contract.
+  const matchExpr = keys?.length
+    ? `${legendName}_${HOVERED_SERIES} === datum.${legendName}_${GROUP_ID} ? 1 : 0`
+    : `${legendName}_${HOVERED_SERIES} === datum.${SERIES_ID} ? 1 : 0`;
+
+  for (const source of data) {
+    const { name, transform } = source;
+    if (!Array.isArray(transform) || typeof name !== 'string') continue;
+    if (name.endsWith('_hoverTargetData')) {
+      injectLegendHoverIntoTargetData(transform, legendName, matchExpr, groupIdField, keys);
+    }
+    if (name.endsWith('_hoverFractionData') && keys?.length) {
+      addGroupedFractionData(name, transform, data, groupIdField);
+    }
+  }
+};
+
 /**
  * Adds opacity tests for marks whose fill/stroke is driven by the color scale, and for marks
  * that are already per-series (e.g. trendlines, which facet by series regardless of their own
  * color encoding — a trendline with an overridden literal color still needs to fade on legend hover).
  */
-export const setHoverOpacityForMarks = (legendName: string, marks: Mark[], keys?: string[], controlled = false) => {
+export const setHoverOpacityForMarks = (
+  legendName: string,
+  marks: Mark[],
+  keys?: string[],
+  controlled = false,
+  animatedMarks: string[] = []
+) => {
   if (!marks.length) return;
   const flatMarks = flattenMarks(marks);
   const seriesMarks = flatMarks.filter(markIsSeriesAware);
   seriesMarks.forEach((mark) => {
+    // Skip marks on the new hover-animation system
+    if (mark.name && animatedMarks.includes(mark.name)) return;
+
     // need to drill down to the prop we need to set and add missing properties if needed
     if (!mark.encode) {
       mark.encode = { update: {} };

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -111,11 +111,6 @@ const addGroupedFractionData = (
  */
 export const injectLegendHoverIntoData = (legendName: string, data: Data[], keys?: string[]): void => {
   const groupIdField = `${legendName}_${GROUP_ID}`;
-  // The ungrouped branch matches on SERIES_ID, not the animated mark's own identity field, so legend
-  // hover matches at the series level even for marks whose animation identity is finer-grained (e.g. a
-  // future bar mark keyed by rscMarkId). This requires every animated mark's own `_hoverTargetData`
-  // aggregate to include SERIES_ID in its groupby regardless of its animation keyField — see the design
-  // doc §11 ("Extending to other marks") for that contract.
   const matchExpr = keys?.length
     ? `${legendName}_${HOVERED_SERIES} === datum.${legendName}_${GROUP_ID} ? 1 : 0`
     : `${legendName}_${HOVERED_SERIES} === datum.${SERIES_ID} ? 1 : 0`;

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.test.ts
@@ -17,9 +17,11 @@ import {
   DEFAULT_COLOR,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_SECONDARY_COLOR,
+  FILTERED_TABLE,
   GROUP_ID,
   HOVERED_SERIES,
   LINEAR_COLOR_SCALE,
+  SERIES_ID,
   TABLE,
 } from '@spectrum-charts/constants';
 
@@ -416,6 +418,38 @@ describe('addData()', () => {
       keys: ['key1', 'key2'],
     });
     expect(data[0].transform).toHaveLength(1);
+  });
+
+  const hoverTargetData: Data = {
+    name: 'line0_hoverTargetData',
+    source: FILTERED_TABLE,
+    transform: [
+      { type: 'aggregate', groupby: [SERIES_ID] },
+      { type: 'formula', as: 'hoveredMatch', expr: 'isValid(hoveredItem) ? 1 : null' },
+      { type: 'formula', as: 'target', expr: 'isValid(datum.hoveredMatch) ? datum.hoveredMatch : 0.5' },
+    ],
+  };
+
+  test('injects legend hover into _hoverTargetData sources when highlight is true', () => {
+    const data = addData([...baseData, hoverTargetData], {
+      ...defaultLegendOptions,
+      facets: [DEFAULT_COLOR],
+      highlight: true,
+    });
+    const targetData = data.find((d) => d.name === 'line0_hoverTargetData');
+    expect(targetData?.transform).toHaveLength(5);
+    expect(targetData?.transform?.[2]).toHaveProperty('as', 'conditions');
+    expect(targetData?.transform?.[4]).toHaveProperty('as', 'target');
+  });
+
+  test('does not inject legend hover into _hoverTargetData sources when highlight is false', () => {
+    const data = addData([...baseData, hoverTargetData], {
+      ...defaultLegendOptions,
+      facets: [DEFAULT_COLOR],
+      highlight: false,
+    });
+    const targetData = data.find((d) => d.name === 'line0_hoverTargetData');
+    expect(targetData?.transform).toStrictEqual(hoverTargetData.transform);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendSpecBuilder.ts
@@ -44,7 +44,7 @@ import {
   UserMeta,
 } from '../types';
 import { getFacets, getFacetsFromKeys } from './legendFacetUtils';
-import { setHoverOpacityForMarks, setHoverStrokeWidthForMarks } from './legendHighlightUtils';
+import { injectLegendHoverIntoData, setHoverOpacityForMarks, setHoverStrokeWidthForMarks } from './legendHighlightUtils';
 import { Facet, getColumns, getEncodings, getHiddenEntriesFilter, getSymbolType } from './legendUtils';
 
 export const addLegend = produce<
@@ -140,7 +140,7 @@ export const addLegend = produce<
 
       spec.data = addData(spec.data ?? [], { ...legendOptions, facets: uniqueFacetFields });
       spec.signals = addSignals(spec.signals ?? [], legendOptions);
-      spec.marks = addMarks(spec.marks ?? [], legendOptions);
+      spec.marks = addMarks(spec.marks ?? [], legendOptions, spec.usermeta?.animatedMarks ?? []);
 
       // add the legend
       legends.push(getCategoricalLegend(ordinalFacets, legendOptions, spec.usermeta));
@@ -272,9 +272,9 @@ const addScales = produce<Scale[], [LegendSpecOptions]>((scales, { color, lineTy
   addFieldToFacetScaleDomain(scales, SYMBOL_SHAPE_SCALE, symbolShape);
 });
 
-const addMarks = produce<Mark[], [LegendSpecOptions]>((marks, { highlight, keys, name }) => {
+const addMarks = produce<Mark[], [LegendSpecOptions, string[]]>((marks, { highlight, keys, name }, animatedMarks) => {
   if (highlight) {
-    setHoverOpacityForMarks(name, marks, keys);
+    setHoverOpacityForMarks(name, marks, keys, undefined, animatedMarks);
     setHoverStrokeWidthForMarks(name, marks, keys);
   }
 });
@@ -285,7 +285,7 @@ const addMarks = produce<Mark[], [LegendSpecOptions]>((marks, { highlight, keys,
  * Each unique combination gets joined with a pipe to create a single string to use as legend entries
  */
 export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }]>(
-  (data, { facets, hiddenEntries, keys, name }) => {
+  (data, { facets, hiddenEntries, highlight, keys, name }) => {
     // expression for combining all the facets into a single key
     const expr = facets.map((facet) => `datum.${facet}`).join(' + " | " + ');
     data.push({
@@ -348,6 +348,10 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
       if (data.transform?.[0] && 'expr' in data.transform[0]) {
         data.transform[0].expr += ` || datum.${SERIES_ID} === ${name}_${HOVERED_SERIES}`;
       }
+    }
+
+    if (highlight) {
+      injectLegendHoverIntoData(name, data, keys);
     }
   }
 );

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
@@ -9,14 +9,28 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_LABEL_LIMIT, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE, GROUP_ID, ROUNDED_SQUARE_PATH, VISIBILITY_OFF_PATH } from '@spectrum-charts/constants';
+import {
+  DEFAULT_LEGEND_COLUMN_PADDING,
+  DEFAULT_LEGEND_LABEL_LIMIT,
+  DEFAULT_LEGEND_SYMBOL_WIDTH,
+  DEFAULT_OPACITY_RULE,
+  FADE_FACTOR,
+  FILTERED_TABLE,
+  GROUP_ID,
+  ROUNDED_SQUARE_PATH,
+  SERIES_ID,
+  VISIBILITY_OFF_PATH,
+} from '@spectrum-charts/constants';
 import { spectrum2Colors } from '@spectrum-charts/themes';
 
+import { getDeemphasisRamp } from '../marks/hoverAnimationUtils';
 import { defaultLegendOptions } from './legendTestUtils';
 import {
   getClickEncodings,
   getColumns,
   getHiddenSeriesColorRule,
+  getLegendOpacity,
+  getOpacityEncoding,
   getShowHideEncodings,
   getSymbolEncodings,
   getSymbolType,
@@ -232,5 +246,52 @@ describe('getColumns()', () => {
 
   test('should use legend name in the data reference', () => {
     expect(getColumns('top', 'myLegend', 100)).toEqual(getExpectedColumnsSignal('myLegend', 100));
+  });
+});
+
+describe('getLegendOpacity()', () => {
+  test('falls back to getOpacityEncoding when userMeta has no animatedMarks', () => {
+    const options = { ...defaultLegendOptions, highlight: true };
+    expect(getLegendOpacity(options, {})).toStrictEqual(getOpacityEncoding(options, {}));
+  });
+
+  test('falls back to getOpacityEncoding when animatedMarks is empty', () => {
+    const options = { ...defaultLegendOptions, highlight: true };
+    expect(getLegendOpacity(options, { animatedMarks: [] })).toStrictEqual(getOpacityEncoding(options, {}));
+  });
+
+  test('builds a per-series animated rule for an ungrouped legend', () => {
+    const fractionData = `data('line0_hoverFractionData')`;
+    const fraction = `(${fractionData}[indexof(pluck(${fractionData}, '${SERIES_ID}'), datum.value)] || {fraction: ${FADE_FACTOR}}).fraction`;
+    const ramp = getDeemphasisRamp(fraction);
+
+    expect(getLegendOpacity(defaultLegendOptions, { animatedMarks: ['line0'] })).toStrictEqual([
+      {
+        test: `length(${fractionData})`,
+        signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}`,
+      },
+      DEFAULT_OPACITY_RULE,
+    ]);
+  });
+
+  test('uses the group fraction data and legend group id field when keys are provided', () => {
+    const options = { ...defaultLegendOptions, keys: ['category'] };
+    const fractionData = `data('line0_hoverGroupFractionData')`;
+    const fraction = `(${fractionData}[indexof(pluck(${fractionData}, '${options.name}_${GROUP_ID}'), datum.value)] || {fraction: ${FADE_FACTOR}}).fraction`;
+    const ramp = getDeemphasisRamp(fraction);
+
+    expect(getLegendOpacity(options, { animatedMarks: ['line0'] })).toStrictEqual([
+      {
+        test: `length(${fractionData})`,
+        signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}`,
+      },
+      DEFAULT_OPACITY_RULE,
+    ]);
+  });
+
+  test('adds one rule per registered animated mark, plus the fallback rule', () => {
+    const result = getLegendOpacity(defaultLegendOptions, { animatedMarks: ['line0', 'line1'] });
+    expect(Array.isArray(result) && result).toHaveLength(3);
+    expect(Array.isArray(result) && result[2]).toEqual(DEFAULT_OPACITY_RULE);
   });
 });

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
@@ -61,6 +61,7 @@ import {
   SecondaryFacetType,
   UserMeta,
 } from '../types';
+import { getDeemphasisRamp } from '../marks/hoverAnimationUtils';
 
 export interface Facet {
   facetType: FacetType | SecondaryFacetType;
@@ -154,12 +155,12 @@ const getHoverEncodings = (options: LegendSpecOptions, userMeta: UserMeta): Lege
       },
       labels: {
         update: {
-          opacity: getOpacityEncoding(options, userMeta),
+          opacity: getLegendOpacity(options, userMeta),
         },
       },
       symbols: {
         update: {
-          opacity: getOpacityEncoding(options, userMeta),
+          opacity: getLegendOpacity(options, userMeta),
         },
       },
     };
@@ -177,6 +178,32 @@ const getHoverEncodings = (options: LegendSpecOptions, userMeta: UserMeta): Lege
 
   return {};
 };
+
+export const getLegendOpacity = (options: LegendSpecOptions, userMeta: UserMeta): ProductionRule<NumericValueRef> | undefined => {
+  const rules: ProductionRule<NumericValueRef> = [];
+
+  for (const markName of userMeta.animatedMarks || []) {
+    const isGrouped = !!options.keys?.length;
+    const fractionData = isGrouped ? `data('${markName}_hoverGroupFractionData')` : `data('${markName}_hoverFractionData')`;
+    const lookupField = isGrouped ? `${options.name}_${GROUP_ID}` : SERIES_ID;
+    const seriesLookup = `indexof(pluck(${fractionData}, '${lookupField}'), datum.value)`;
+    // default to the neutral emphasis level when a legend entry has no animation row
+    const fraction = `(${fractionData}[${seriesLookup}] || {fraction: ${FADE_FACTOR}}).fraction`;
+    // fade deemphasized entries to FADE_FACTOR; neutral and emphasized both stay fully opaque
+    const ramp = getDeemphasisRamp(fraction);
+    rules.push({
+      test: `length(${fractionData})`,
+      signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}`,
+    });
+  }
+
+  if (rules.length) {
+    return [...rules, DEFAULT_OPACITY_RULE];
+  }
+
+  // Fall back to old rules if no animated marks are present (not using hover animation system)
+  return getOpacityEncoding(options, userMeta);
+}
 
 const getLegendDescriptionEncoding = (descriptions: LegendDescription[] | undefined, name: string) => {
   if (descriptions?.length) {

--- a/planning/research/hover-animation-system/hover-animation-system.md
+++ b/planning/research/hover-animation-system/hover-animation-system.md
@@ -369,6 +369,13 @@ yet — see above). The `!Array.isArray` guards in `setHoverOpacityForMarks` / `
 then re-engage (array ⇒ old legend-hover path applies), so the entire old system is restored coherently by
 flipping one prop.
 
+**`setHoverOpacityForMarks` skips animated marks explicitly.** When animated, `update.opacity` is a single
+`{ signal: ... }` ref (not an array), and legend hover for that mark is already delivered through the
+animation pipeline (`injectLegendHoverIntoData`, §7). `setHoverOpacityForMarks` takes an `animatedMarks:
+string[]` param (`usermeta.animatedMarks`, §7) and returns early for any mark whose name is in it, before
+touching `update.opacity`. `setHoverStrokeWidthForMarks` has no such guard — stroke width isn't animated
+yet (§1).
+
 **Why resolve-once-and-thread rather than each function recomputing?** Two reasons:
 1. **Type visibility.** The encoding functions are typed on `LineMarkOptions`, which historically didn't
    carry `legendHighlightSignals`, so if they recomputed the gate themselves they couldn't see the legend
@@ -404,7 +411,7 @@ sequential builder calls operating on the same spec.
 Flow:
 1. `addLine` registers the mark: `addUserMetaAnimatedMark(spec.usermeta, lineName)` (gated by
    `usesHoverAnimation`, so the list truthfully reflects marks that have `_hoverFractionData`).
-2. `addLegend` runs **after** the marks. `injectLegendHoverIntoHoverData(legendName, data, keys)` mutates
+2. `addLegend` runs **after** the marks. `injectLegendHoverIntoData(legendName, data, keys)` mutates
    each `*_hoverTargetData`: renames the existing `target` formula to `conditions`, adds a
    `legendHoverMatch` formula, and rebuilds `target` as
    `hoveredMatch ?? legendHoverMatch ?? conditions`. For grouped legends it also aggregates a
@@ -453,7 +460,7 @@ one shared row for the whole chart (§3f).
 | `vega-spec-builder-s2/src/line/lineSpecBuilder.ts` | `usesHoverAnimation` gate; wires data/signals/registration in `addData`/`addSignals`/`addLine` |
 | `vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts` | `getLineMarkOptions` — sets `isAnimate: false` for trendline marks (§6 overlay exception) |
 | `vega-spec-builder-s2/src/metricRange/metricRangeUtils.ts` | `getMetricRangeMark` — sets `isAnimate: false` for the boundary line (§6 overlay exception) |
-| `vega-spec-builder-s2/src/legend/legendHighlightUtils.ts` | `injectLegendHoverIntoHoverData`, `getLegendHighlightSignals` |
+| `vega-spec-builder-s2/src/legend/legendHighlightUtils.ts` | `injectLegendHoverIntoData`, `getLegendHighlightSignals` |
 | `vega-spec-builder-s2/src/legend/legendUtils.ts` | `getLegendOpacity` (legend consumer) |
 | `vega-spec-builder-s2/src/specUtils.ts` + `types/specUtil.types.ts` | `addUserMetaAnimatedMark`, `animatedMarks` on `UserMeta` |
 
@@ -518,13 +525,16 @@ mark could pass `rscMarkId` (bar) etc. — see §11.
 3. Write the mark's match rules (`getLineHoverRules` analog).
 4. Write consumers (opacity, stroke width, …) that map `getHoverFractionSignal` via the ramps.
 5. Add the `usesHoverAnimation` gate and wire data/signals/registration + gate the encodings in lockstep.
-6. Legend: `animatedMarks` UserMeta registry, `injectLegendHoverIntoHoverData`, `getLegendOpacity`.
+6. Legend: `animatedMarks` UserMeta registry, `injectLegendHoverIntoData`, `getLegendOpacity`.
 
 **Extending to other marks (e.g. bar):** the engine is reusable. Choose the identity `keyField` = the
 finest independently-animatable unit (series for line; `rscMarkId` for bar). Write mark-specific match
 rules and consumers. For bars, carry both `rscMarkId` (animation identity) and `rscSeriesId`/group in the
 target-data `groupby` so series/legend-level highlights can set the target for all bars of a series.
-Everything downstream of `target` is generic.
+Everything downstream of `target` is generic. This isn't optional: `injectLegendHoverIntoData`'s ungrouped
+match expression hard-codes `datum.${SERIES_ID}` (not the mark's own `keyField`) precisely so legend hover
+matches at the series level regardless of animation identity — skip `rscSeriesId` in a new mark's groupby
+and legend-hover injection silently stops matching (no error, nothing highlights).
 
 **Adding a new animated property:** just add a consumer that maps `getHoverFractionSignal` (via
 `getDeemphasisRamp`, `getEmphasisRamp`, or its own math). No engine change.
@@ -558,4 +568,8 @@ Everything downstream of `target` is generic.
   `isAnimate` field is new in this branch; spreading the parent line's options into a renamed mark
   silently carries it along unless overridden, which is why these two needed the same fix already applied
   to the overlay.)
+- **Legend integration (done)** (§7): `injectLegendHoverIntoData` wired into `addData` (`legendSpecBuilder.ts`)
+  behind `if (highlight)`; `getLegendOpacity` wired into `getHoverEncodings` (`legendUtils.ts`), replacing
+  `getOpacityEncoding` for labels/symbols. `setHoverOpacityForMarks` takes the `animatedMarks` param (§6) so
+  it no longer clobbers animated lines' opacity when a legend's `highlight` triggers it.
 - **Other marks** (bar, area, …) don't use the system yet.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Hooked up legend hovering to the new hover animation system. Now, legend symbols + labels smoothly fade opacity when hovered and when their respective series is hovered. Legend hover animations can also be toggled via the `animations` prop. See [hover-animation-system.md](https://github.com/adobe/react-spectrum-charts/blob/61cf1f2f9bbb9b5065740ec7c4d1f6e35570e375/planning/research/hover-animation-system/hover-animation-system.md) for more detail.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is part 3 of implementing the hover animation system for line charts.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been updated to test the new changes. Storybook stories for legend hover and grouped legend hover are used to manually test the system.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
