### PR TITLE
feat: legend pagination

### DIFF
--- a/packages/react-spectrum-charts/src/components/Legend/Legend.tsx
+++ b/packages/react-spectrum-charts/src/components/Legend/Legend.tsx
@@ -25,6 +25,7 @@ const Legend: FC<LegendProps> = ({
   isToggleable = false,
   legendLabels,
   _labelWrap,
+  _maxRows,
   titleLimit,
   lineType,
   lineWidth,

--- a/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Legend/Legend.story.tsx
@@ -9,10 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ReactElement } from 'react';
+import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { View } from '@adobe/react-spectrum';
+import { Button, Flex, Text, View } from '@adobe/react-spectrum';
 import { StoryFn } from '@storybook/react';
+import { View as VegaView } from 'vega';
 
 import { Chart } from '../../../Chart';
 import { Axis, ChartPopover, Legend, Line } from '../../../components';
@@ -261,6 +262,87 @@ PreferredColumnsWithWrap.args = {
   highlight: true,
 };
 
+type LegendPage = { columns: number; start: number; end: number };
+
+const arePagesEqual = (a: LegendPage[], b: LegendPage[]): boolean =>
+  a.length === b.length && a.every((p, i) => p.columns === b[i].columns && p.start === b[i].start && p.end === b[i].end);
+
+const PreferredColumnsWithPaginationStory: StoryFn<typeof Legend> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: legendColumns20SeriesData, width: 700, height: 300 });
+  const [pages, setPages] = useState<LegendPage[]>([]);
+  const [pageIndex, setPageIndex] = useState(0);
+
+  // A ref lets us attach the listener without ever triggering a render just because a view became ready.
+  const viewRef = useRef<VegaView | undefined>(undefined);
+  const listenerRef = useRef<(() => void) | undefined>(undefined);
+
+  const handleVegaViewReady = useCallback((newView: VegaView) => {
+    if (viewRef.current && listenerRef.current) {
+      viewRef.current.removeSignalListener('legend0_pages', listenerRef.current);
+    }
+    viewRef.current = newView;
+
+    const updatePages = () => {
+      const next: LegendPage[] = newView.signal('legend0_pages') ?? [];
+      // Only update state when the content actually changed, so once the page plan settles React
+      // can bail out of rendering entirely rather than cascading into another spec rebuild.
+      setPages((prev) => (arePagesEqual(prev, next) ? prev : next));
+    };
+    listenerRef.current = updatePages;
+    updatePages();
+    newView.addSignalListener('legend0_pages', updatePages);
+  }, []);
+
+  useEffect(() => {
+    if (pageIndex > pages.length - 1) setPageIndex(0);
+  }, [pages, pageIndex]);
+
+  const hiddenEntries = useMemo(() => {
+    const page = pages[pageIndex];
+    if (!page) return [];
+    const visibleSeries = twentySeriesNames.slice(page.start, page.end + 1);
+    return twentySeriesNames.filter((series) => !visibleSeries.includes(series));
+  }, [pages, pageIndex]);
+
+  return (
+    <Flex direction="column" gap="size-100">
+      <Chart {...chartProps} onVegaViewReady={handleVegaViewReady}>
+        <Axis position="left" grid />
+        <Axis position="bottom" labelFormat="time" baseline ticks />
+        <Line color="series" dimension="datetime" metric="value" scaleType="time" />
+        <Legend {...args} hiddenEntries={hiddenEntries} />
+      </Chart>
+      <Flex gap="size-100" alignItems="center">
+        <Button
+          variant="secondary"
+          onPress={() => setPageIndex((i) => Math.max(0, i - 1))}
+          isDisabled={pageIndex === 0}
+        >
+          Previous
+        </Button>
+        <Text>
+          Page {pages.length ? pageIndex + 1 : 0} of {pages.length}
+        </Text>
+        <Button
+          variant="secondary"
+          onPress={() => setPageIndex((i) => Math.min(pages.length - 1, i + 1))}
+          isDisabled={pageIndex >= pages.length - 1}
+        >
+          Next
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+const PreferredColumnsWithPagination = bindWithProps(PreferredColumnsWithPaginationStory);
+PreferredColumnsWithPagination.args = {
+  _preferredColumns: [5, 3],
+  _maxRows: 2,
+  _labelWrap: 2,
+  highlight: true,
+};
+
 export {
   Basic,
   Descriptions,
@@ -282,4 +364,5 @@ export {
   PreferredColumnsLadder,
   PreferredColumnsLongLabel,
   PreferredColumnsWithWrap,
+  PreferredColumnsWithPagination,
 };

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.test.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.test.ts
@@ -15,6 +15,7 @@ import { Locale, TimeLocale } from 'vega';
 
 import {
   LabelDatum,
+  LegendLabelWidthDatum,
   expressionFunctions,
   getLocaleCode,
   formatHorizontalTimeAxisLabels,
@@ -227,6 +228,81 @@ describe('wrapTruncates()', () => {
     expect(expressionFunctions.wrapTruncates('hello world', 12, 3)).toBe(false);
     const lines = expressionFunctions.wrapLabelText('hello world', 12, 3);
     expect(lines.some((line) => line.endsWith('…'))).toBe(false);
+  });
+});
+
+describe('getLegendColumnLayout()', () => {
+  const item = (legendIndex: number, labelWidth = 40): LegendLabelWidthDatum => ({
+    legendIndex,
+    displayLabel: `Item ${legendIndex}`,
+    labelWidth,
+  });
+
+  test('picks the largest candidate that fits at full width', () => {
+    const items = [item(1), item(2), item(3), item(4), item(5)];
+    const layout = expressionFunctions.getLegendColumnLayout(items, 600, [5, 3]);
+    expect(layout.columns).toBe(5);
+    // a non-last candidate fitting means labelLimit is unlimited
+    expect(layout.labelLimit).toBe(0);
+  });
+
+  test('falls back to a smaller candidate when the larger one does not fit', () => {
+    const items = [item(1, 300), item(2), item(3), item(4), item(5)];
+    const layout = expressionFunctions.getLegendColumnLayout(items, 200, [5, 3]);
+    expect(layout.columns).toBe(3);
+  });
+
+  test('falls back to the last candidate and uses its fair-share labelLimit when nothing fits', () => {
+    const items = [item(1, 300), item(2, 300), item(3, 300)];
+    const layout = expressionFunctions.getLegendColumnLayout(items, 140, [5, 3]);
+    expect(layout.columns).toBe(3);
+    expect(layout.labelLimit).toBeGreaterThan(0);
+  });
+
+  test('with labelWrap, a candidate that only fits once wrapped is chosen with labelLimit 0', () => {
+    const displayLabel = 'Supercalifragilisticexpialidocious is quite long';
+    const items = [
+      { legendIndex: 1, displayLabel, labelWidth: expressionFunctions.getLabelWidth(displayLabel, 'normal', 14) },
+    ];
+    const layout = expressionFunctions.getLegendColumnLayout(items, 100, [1], 2);
+    expect(layout.labelLimit).toBe(0);
+    expect(layout.wrapWidth).toBeGreaterThan(0);
+  });
+});
+
+describe('getLegendPages()', () => {
+  const items = (n: number, labelWidth = 40): LegendLabelWidthDatum[] =>
+    Array.from({ length: n }, (_, i) => ({ legendIndex: i + 1, displayLabel: `Item ${i}`, labelWidth }));
+
+  test('returns a single page when everything fits within columns * maxRows', () => {
+    const pages = expressionFunctions.getLegendPages(items(4), 600, [5, 3], 2);
+    expect(pages).toEqual([{ columns: 5, start: 0, end: 3 }]);
+  });
+
+  test('splits into multiple pages with inclusive, contiguous start/end bounds', () => {
+    const pages = expressionFunctions.getLegendPages(items(16), 600, [5, 3], 2);
+    expect(pages).toEqual([
+      { columns: 5, start: 0, end: 9 },
+      { columns: 5, start: 10, end: 15 },
+    ]);
+  });
+
+  // Regression: a long label destined for a later page must not shrink an earlier page's column
+  // count (see planning/research/legend-pagination-columns-mismatch.md).
+  test('a long label past a page boundary does not affect an earlier page column count', () => {
+    const list = items(16);
+    list[11] = { ...list[11], labelWidth: 300 };
+    const pages = expressionFunctions.getLegendPages(list, 600, [5, 3], 2);
+
+    expect(pages[0]).toEqual({ columns: 5, start: 0, end: 9 });
+    const pageWithLongLabel = pages.find((p) => p.start <= 11 && p.end >= 11);
+    expect(pageWithLongLabel?.columns).toBe(3);
+  });
+
+  test('guards against a non-positive maxRows looping forever', () => {
+    const pages = expressionFunctions.getLegendPages(items(3), 600, [5, 3], 0);
+    expect(pages.every((p) => p.end >= p.start)).toBe(true);
+    expect(pages[pages.length - 1].end).toBe(2);
   });
 });
 

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
@@ -420,6 +420,37 @@ const fitsWhenWrapped = (
 };
 
 /**
+ * Builds the layout for a candidate `n` that qualifies (fits, at full width or wrapped), or
+ * `undefined` if it doesn't. Isolates the fit test and the resulting labelLimit/wrapWidth
+ * computation so `getLegendColumnLayout`'s loop body stays a single, flat check.
+ */
+const getColumnLayoutForCandidate = (
+  items: LegendLabelWidthDatum[],
+  width: number,
+  n: number,
+  lastCandidate: number,
+  useWrap: boolean,
+  labelWrap: number
+): LegendColumnLayout | undefined => {
+  const fullWidthFits = fitsAtFullWidth(items, width, n);
+  const wrapFits = useWrap && !fullWidthFits && fitsWhenWrapped(items, width, n, labelWrap);
+  if (!fullWidthFits && !wrapFits) return undefined;
+
+  if (useWrap) {
+    return { columns: n, labelLimit: 0, wrapWidth: fullWidthFits ? width : getFairShareWidth(width, n) };
+  }
+  const isLast = n === lastCandidate;
+  return { columns: n, labelLimit: isLast ? getFairShareWidth(width, lastCandidate) : 0, wrapWidth: 0 };
+};
+
+/** Layout used when no candidate fits: force the last (smallest) candidate, truncating to its fair share. */
+const getFallbackColumnLayout = (width: number, lastCandidate: number, useWrap: boolean): LegendColumnLayout => ({
+  columns: lastCandidate,
+  labelLimit: useWrap ? 0 : getFairShareWidth(width, lastCandidate),
+  wrapWidth: useWrap ? getFairShareWidth(width, lastCandidate) : 0,
+});
+
+/**
  * Picks the largest candidate column count whose labels fit the available width, falling back to
  * the last (smallest) candidate if none fit. This is the single source of truth for the
  * `_preferredColumns` layout decision: it drives both the legend's actual rendered `columns`/
@@ -441,23 +472,14 @@ const getLegendColumnLayout = (
   if (lastCandidate === undefined) return { columns: 1, labelLimit: 0, wrapWidth: 0 };
   const useWrap = labelWrap > 1;
 
-  for (let i = 0; i < candidates.length; i++) {
-    const n = candidates[i];
-    const isLast = i === candidates.length - 1;
-    const fullWidthFits = fitsAtFullWidth(items, width, n);
-    if (fullWidthFits || (useWrap && fitsWhenWrapped(items, width, n, labelWrap))) {
-      if (useWrap) {
-        return { columns: n, labelLimit: 0, wrapWidth: fullWidthFits ? width : getFairShareWidth(width, n) };
-      }
-      return { columns: n, labelLimit: isLast ? getFairShareWidth(width, lastCandidate) : 0, wrapWidth: 0 };
+  for (const n of candidates) {
+    const layout = getColumnLayoutForCandidate(items, width, n, lastCandidate, useWrap, labelWrap);
+    if (layout) {
+      return layout;
     }
   }
 
-  return {
-    columns: lastCandidate,
-    labelLimit: useWrap ? 0 : getFairShareWidth(width, lastCandidate),
-    wrapWidth: useWrap ? getFairShareWidth(width, lastCandidate) : 0,
-  };
+  return getFallbackColumnLayout(width, lastCandidate, useWrap);
 };
 
 /**

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
@@ -12,6 +12,7 @@
 import { FormatLocaleDefinition, formatLocale } from 'd3-format';
 import { FontWeight, Locale, NumberLocale, TimeLocale } from 'vega';
 
+import { DEFAULT_FONT_SIZE, DEFAULT_LEGEND_COLUMN_PADDING } from '@spectrum-charts/constants';
 import { LocaleCode, NumberLocaleCode, TimeLocaleCode, getLocale, numberLocales } from '@spectrum-charts/locales';
 import { ADOBE_CLEAN_FONT } from '@spectrum-charts/themes';
 
@@ -21,6 +22,26 @@ export interface LabelDatum {
   index: number;
   label: string;
   value: string | number;
+}
+
+export interface LegendLabelWidthDatum {
+  legendIndex: number;
+  displayLabel: string;
+  labelWidth: number;
+}
+
+export interface LegendColumnLayout {
+  columns: number;
+  /** 0 means unlimited, matching Vega's own labelLimit convention */
+  labelLimit: number;
+  /** dynamic wrap width for the chosen column count; only meaningful when labelWrap > 1 */
+  wrapWidth: number;
+}
+
+export interface LegendPage {
+  columns: number;
+  start: number;
+  end: number;
 }
 
 export const getExpressionFunctions = (
@@ -41,6 +62,9 @@ export const getExpressionFunctions = (
     formatVerticalAxisTimeLabels: formatVerticalAxisTimeLabels(),
     formatVerticalAxisTimeLabelTooltips: formatVerticalAxisTimeLabelTooltips(dateLocaleCode),
     getLabelWidth,
+
+    getLegendColumnLayout,
+    getLegendPages,
     truncateText,
     wrapLabelText,
     wrapTruncates,
@@ -357,12 +381,153 @@ const wrapTruncates = (
   return false;
 };
 
+// Rendered width of the default size-250 circle legend symbol (2 * sqrt(250 / PI)), plus the gap
+// Vega's theme leaves at its default (labelOffset), used as the per-item chrome in every column.
+const LEGEND_SYMBOL_RENDERED_WIDTH = 18;
+const LEGEND_LABEL_OFFSET = 4;
+const LEGEND_ITEM_BASE = LEGEND_SYMBOL_RENDERED_WIDTH + LEGEND_LABEL_OFFSET;
+// Safety margin added only to the full-width fit estimate (not the fair-share wrap width, which must
+// stay exact) to match Vega's own per-column Math.ceil and symbol stroke overhang.
+const LEGEND_COLUMN_FIT_MARGIN = 2;
+
+const getFairShareWidth = (width: number, columns: number): number =>
+  (width - (columns - 1) * DEFAULT_LEGEND_COLUMN_PADDING) / columns - LEGEND_ITEM_BASE;
+
+// Matches Vega's per-entry column assignment (column = index % columns) and per-column sizing
+// (align: 'each', each column sized to its own widest label).
+const fitsAtFullWidth = (items: LegendLabelWidthDatum[], width: number, columns: number): boolean => {
+  if (!items.length) return true;
+  const colWidths = new Array(columns).fill(0);
+  items.forEach((item, i) => {
+    const col = i % columns;
+    colWidths[col] = Math.max(colWidths[col], item.labelWidth);
+  });
+  const totalWidth = colWidths.reduce(
+    (sum, w) => sum + Math.ceil(w) + LEGEND_ITEM_BASE + LEGEND_COLUMN_FIT_MARGIN,
+    0
+  );
+  return totalWidth + (columns - 1) * DEFAULT_LEGEND_COLUMN_PADDING <= width;
+};
+
+const fitsWhenWrapped = (
+  items: LegendLabelWidthDatum[],
+  width: number,
+  columns: number,
+  labelWrap: number
+): boolean => {
+  const wrapWidth = getFairShareWidth(width, columns);
+  return items.every((item) => !wrapTruncates(item.displayLabel, wrapWidth, labelWrap, 'normal', DEFAULT_FONT_SIZE));
+};
+
+/**
+ * Picks the largest candidate column count whose labels fit the available width, falling back to
+ * the last (smallest) candidate if none fit. This is the single source of truth for the
+ * `_preferredColumns` layout decision: it drives both the legend's actual rendered `columns`/
+ * `labelLimit` (via a signal referencing this function) and, via `getLegendPages`, upfront
+ * pagination planning outside of Vega — both call this exact same logic against the same measured
+ * label widths, so they can never disagree about how a given set of items would lay out.
+ * @param items ordered legend entries with their measured label widths (see `${name}_labelWidths`)
+ * @param width available width for the legend
+ * @param candidates ordered list of candidate column counts, e.g. [5, 3]
+ * @param labelWrap max lines a label may wrap onto before truncating; 1 (default) disables wrapping
+ */
+const getLegendColumnLayout = (
+  items: LegendLabelWidthDatum[],
+  width: number,
+  candidates: number[],
+  labelWrap = 1
+): LegendColumnLayout => {
+  const lastCandidate = candidates.at(-1);
+  if (lastCandidate === undefined) return { columns: 1, labelLimit: 0, wrapWidth: 0 };
+  const useWrap = labelWrap > 1;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const n = candidates[i];
+    const isLast = i === candidates.length - 1;
+    const fullWidthFits = fitsAtFullWidth(items, width, n);
+    if (fullWidthFits || (useWrap && fitsWhenWrapped(items, width, n, labelWrap))) {
+      if (useWrap) {
+        return { columns: n, labelLimit: 0, wrapWidth: fullWidthFits ? width : getFairShareWidth(width, n) };
+      }
+      return { columns: n, labelLimit: isLast ? getFairShareWidth(width, lastCandidate) : 0, wrapWidth: 0 };
+    }
+  }
+
+  return {
+    columns: lastCandidate,
+    labelLimit: useWrap ? 0 : getFairShareWidth(width, lastCandidate),
+    wrapWidth: useWrap ? getFairShareWidth(width, lastCandidate) : 0,
+  };
+};
+
+/**
+ * Picks the column count for a page starting at the front of `remaining`, testing each candidate
+ * `n` against only the `n * rows` items that would actually land on the page if `n` wins — not the
+ * full `remaining` tail. A label further down the list (destined for a later page) must never
+ * influence this page's column count; testing against the whole tail let a long label past the page
+ * boundary fail a larger candidate's fit test even though that label never renders on this page.
+ */
+const getPageColumnCount = (
+  remaining: LegendLabelWidthDatum[],
+  width: number,
+  candidates: number[],
+  rows: number,
+  labelWrap: number
+): number => {
+  const lastCandidate = candidates.at(-1);
+  if (lastCandidate === undefined) return 1;
+  const useWrap = labelWrap > 1;
+
+  for (const n of candidates) {
+    const pageItems = remaining.slice(0, n * rows);
+    const fullWidthFits = fitsAtFullWidth(pageItems, width, n);
+    if (fullWidthFits || (useWrap && fitsWhenWrapped(pageItems, width, n, labelWrap))) {
+      return n;
+    }
+  }
+  return lastCandidate;
+};
+
+/**
+ * Splits the full ordered legend entry list into pages of at most `columns * maxRows` items each,
+ * recomputing `columns` from scratch for each page's own labels via `getPageColumnCount` (so a page
+ * of short labels can use a wider candidate than a page with one long label) — bounded to just the
+ * items that would land on that page, so a label on a later page can never affect this page's
+ * column count. Exposed via the `${name}_pages` signal for pagination UIs built outside RSC.
+ * @param items ordered legend entries with their measured label widths (see `${name}_labelWidths`)
+ * @param width available width for the legend
+ * @param candidates ordered list of candidate column counts, e.g. [5, 3]
+ * @param maxRows maximum rows of entries allowed per page
+ * @param labelWrap max lines a label may wrap onto before truncating; 1 (default) disables wrapping
+ */
+const getLegendPages = (
+  items: LegendLabelWidthDatum[],
+  width: number,
+  candidates: number[],
+  maxRows: number,
+  labelWrap = 1
+): LegendPage[] => {
+  const rows = Math.max(1, maxRows);
+  const pages: LegendPage[] = [];
+  let start = 0;
+  while (start < items.length) {
+    const remaining = items.slice(start);
+    const columns = getPageColumnCount(remaining, width, candidates, rows, labelWrap);
+    const pageSize = Math.max(1, Math.min(remaining.length, columns * rows));
+    pages.push({ columns, start, end: start + pageSize - 1 });
+    start += pageSize;
+  }
+  return pages;
+};
+
 export const expressionFunctions = {
   consoleLog,
   formatHorizontalTimeAxisLabels: formatHorizontalTimeAxisLabels(),
   formatVerticalAxisTimeLabels: formatVerticalAxisTimeLabels(),
   formatVerticalAxisTimeLabelTooltips: formatVerticalAxisTimeLabelTooltips(),
   getLabelWidth,
+  getLegendColumnLayout,
+  getLegendPages,
   truncateText,
   wrapLabelText,
   wrapTruncates,

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
@@ -350,29 +350,80 @@ describe('addLegend()', () => {
       expect(addLegend(defaultSpec, { _labelWrap: 1 }).legends?.[0].encode).toStrictEqual(defaultLegend.encode);
     });
 
-    test('should set labelLimit to 0 when both _preferredColumns and _labelWrap are provided', () => {
+    test('should reference the columnLayout signal for labelLimit when both _preferredColumns and _labelWrap are provided', () => {
       const legend = addLegend(defaultSpec, { _preferredColumns: [5, 3], _labelWrap: 2 }).legends?.[0];
-      expect(legend?.labelLimit).toBe(0);
+      // getLegendColumnLayout resolves this to 0 (unlimited) at runtime when labelWrap is set
+      expect(legend?.labelLimit).toEqual({ signal: 'legend0_columnLayout.labelLimit' });
     });
 
-    test('should use fit-or-wrap branches for columns when both _preferredColumns and _labelWrap are provided', () => {
+    test('should reference the columnLayout signal for columns when both _preferredColumns and _labelWrap are provided', () => {
       const legend = addLegend(defaultSpec, { _preferredColumns: [5, 3], _labelWrap: 2 }).legends?.[0];
-      expect((legend?.columns as { signal: string }).signal).toContain("data('legend0_wrapfit_5')");
+      expect(legend?.columns).toEqual({ signal: 'legend0_columnLayout.columns' });
     });
 
     test('should wrap labels at the dynamic preferred wrap width when both _preferredColumns and _labelWrap are provided', () => {
       const text = addLegend(defaultSpec, { _preferredColumns: [5, 3], _labelWrap: 2 }).legends?.[0].encode?.labels
         ?.update?.text as { signal: string };
-      // dynamic width references the fit/wrapfit data sources rather than the static labelLimit
-      expect(text.signal.startsWith('wrapLabelText(datum.value, ')).toBe(true);
-      expect(text.signal).toContain("data('legend0_wrapfit_5')");
+      // dynamic width references the columnLayout signal rather than the static labelLimit
+      expect(text.signal).toStrictEqual("wrapLabelText(datum.value, legend0_columnLayout.wrapWidth, 2, 'normal', 14)");
     });
 
-    test('should emit wrapfit data sources when both _preferredColumns and _labelWrap are provided', () => {
-      const data = addLegend(defaultSpec, { _preferredColumns: [5, 3], _labelWrap: 2 }).data;
-      expect(data?.map((d) => d.name)).toEqual(
-        expect.arrayContaining(['legend0_wrapfit_5', 'legend0_wrapfit_3'])
-      );
+    test('should emit the columnLayout signal when both _preferredColumns and _labelWrap are provided', () => {
+      const signals = addLegend(defaultSpec, { _preferredColumns: [5, 3], _labelWrap: 2 }).signals;
+      const columnLayoutSignal = signals?.find((s) => 'name' in s && s.name === 'legend0_columnLayout');
+      expect(columnLayoutSignal).toEqual({
+        name: 'legend0_columnLayout',
+        update: "getLegendColumnLayout(data('legend0_labelWidths'), width, [5,3], 2)",
+      });
+    });
+
+    describe('_maxRows', () => {
+      test('should not emit legend0_pages or legend0AggregateAll when _maxRows is not set', () => {
+        const legendSpec = addLegend(defaultSpec, { _preferredColumns: [5, 3] });
+        expect(legendSpec.signals?.some((s) => 'name' in s && s.name === 'legend0_pages')).toBe(false);
+        expect(legendSpec.data?.some((d) => d.name === 'legend0AggregateAll')).toBe(false);
+      });
+
+      test('should not emit legend0_pages when _maxRows is set without _preferredColumns', () => {
+        const legendSpec = addLegend(defaultSpec, { _maxRows: 2 });
+        expect(legendSpec.signals?.some((s) => 'name' in s && s.name === 'legend0_pages')).toBe(false);
+      });
+
+      test('should emit the legend0_pages signal referencing legend0_pagesLabelWidths when _maxRows and _preferredColumns are both set', () => {
+        const signals = addLegend(defaultSpec, { _preferredColumns: [5, 3], _maxRows: 2 }).signals;
+        const pagesSignal = signals?.find((s) => 'name' in s && s.name === 'legend0_pages');
+        expect(pagesSignal).toEqual({
+          name: 'legend0_pages',
+          update: "getLegendPages(data('legend0_pagesLabelWidths'), width, [5,3], 2, 1)",
+        });
+      });
+
+      // Regression: legend0_pages must plan against every entry, not the hiddenEntries-filtered set
+      test('should source legend0AggregateAll from the unaggregated table, without the hiddenEntries filter, even when hiddenEntries is set', () => {
+        const data = addLegend(defaultSpec, {
+          _preferredColumns: [5, 3],
+          _maxRows: 2,
+          hiddenEntries: ['red'],
+        }).data;
+
+        const aggregateAll = data?.find((d) => d.name === 'legend0AggregateAll');
+        expect(aggregateAll).toBeDefined();
+        expect(aggregateAll?.transform?.some((t) => t.type === 'filter')).toBe(false);
+
+        // the live-render aggregate must still carry the hiddenEntries filter
+        const aggregate = data?.find((d) => d.name === 'legend0Aggregate');
+        expect(aggregate?.transform?.some((t) => t.type === 'filter')).toBe(true);
+      });
+
+      test('should source legend0_pagesLabelWidths from legend0AggregateAll, not legend0_labelWidths from the filtered aggregate', () => {
+        const data = addLegend(defaultSpec, { _preferredColumns: [5, 3], _maxRows: 2 }).data;
+
+        const pagesLabelWidths = data?.find((d) => d.name === 'legend0_pagesLabelWidths');
+        expect(pagesLabelWidths).toMatchObject({ source: 'legend0AggregateAll' });
+
+        const labelWidths = data?.find((d) => d.name === 'legend0_labelWidths');
+        expect(labelWidths).toMatchObject({ source: 'legend0Aggregate' });
+      });
     });
 
     test('should add titleLimit if provided', () => {

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { produce } from 'immer';
-import { Data, Legend, Mark, Scale, Signal, SignalRef } from 'vega';
+import { Data, Legend, Mark, Scale, Signal } from 'vega';
 
 import {
   COLOR_SCALE,
@@ -47,13 +47,15 @@ import { getFacets, getFacetsFromKeys } from './legendFacetUtils';
 import { setHoverOpacityForMarks } from './legendHighlightUtils';
 import {
   Facet,
+  getColumnLayoutExpr,
   getColumns,
   getDisplayLabelExpr,
   getEncodings,
   getHiddenEntriesFilter,
-  getPreferredColumns,
-  getPreferredColumnsData,
-  getPreferredLabelLimit,
+  getLabelWidthsData,
+  getPagesExpr,
+  getPagesLabelWidthsData,
+  getRowCappedAggregateData,
   getSymbolType,
 } from './legendUtils';
 
@@ -137,12 +139,21 @@ export const addLegend = produce<
 
     // if there are any categorical facets, add the legend and supporting data, signals and marks
     if (ordinalFacets.length) {
+      // When _maxRows is set alongside _preferredColumns on a horizontal legend, render from the
+      // row-capped aggregate so the legend itself never exceeds the row cap (see
+      // getRowCappedAggregateData) — otherwise it's a pure passthrough of every visible entry.
+      const usesRowCap =
+        legendOptions._maxRows !== undefined &&
+        legendOptions._preferredColumns !== undefined &&
+        legendOptions._preferredColumns.length > 0 &&
+        ['top', 'bottom'].includes(legendOptions.position);
+
       // add the legendEntries scale
       // this scale is used to generate every combination of the catergorical facets
       spec.scales.push({
         name: `${name}Entries`,
         type: 'ordinal',
-        domain: { data: `${name}Aggregate`, field: `${name}Entries` },
+        domain: { data: usesRowCap ? `${name}AggregateCapped` : `${name}Aggregate`, field: `${name}Entries` },
       });
 
       // just want the unique fields
@@ -226,25 +237,16 @@ const getCategoricalLegend = (facets: Facet[], options: LegendSpecOptions, userM
   // _preferredColumns only applies to horizontal legends, matching getColumns returning undefined for left/right
   const usePreferredColumns =
     _preferredColumns !== undefined && _preferredColumns.length > 0 && ['top', 'bottom'].includes(position);
-  // When both are set, _preferredColumns owns truncation and uses wrapping as a lever; labelLimit
-  // becomes the chosen candidate's dynamic wrap width (see getPreferredWrapWidth).
-  const usePreferredWrap = usePreferredColumns && Boolean(_labelWrap && _labelWrap > 1);
-  let preferredLabelLimit: SignalRef | number | undefined = labelLimit;
-  // In combined mode wrapLabelText already wraps/ellipsizes at the dynamic width, so leave Vega's
-  // labelLimit unlimited (0). Setting it to the fair-share width caused a hairline band where Vega's
-  // text rendering truncated a line our canvas measurement had fit — truncation before wrapping.
-  if (usePreferredWrap) preferredLabelLimit = 0;
-  else if (usePreferredColumns) preferredLabelLimit = getPreferredLabelLimit(name, _preferredColumns as number[]);
+  // columns/labelLimit/wrapWidth are all resolved together by the ${name}_columnLayout signal (see
+  // addSignals)
   const legend: Legend = {
     fill: `${name}Entries`,
     direction: ['top', 'bottom'].includes(position) ? 'horizontal' : 'vertical',
     orient: position,
     title,
     encode: getEncodings(facets, options, userMeta),
-    columns: usePreferredColumns
-      ? getPreferredColumns(name, _preferredColumns as number[], _labelWrap)
-      : getColumns(position, name, labelLimit),
-    labelLimit: preferredLabelLimit,
+    columns: usePreferredColumns ? { signal: `${name}_columnLayout.columns` } : getColumns(position, name, labelLimit),
+    labelLimit: usePreferredColumns ? { signal: `${name}_columnLayout.labelLimit` } : labelLimit,
   };
   if (titleLimit !== undefined) legend.titleLimit = titleLimit;
   if (_labelWrap && _labelWrap > 1) {
@@ -312,7 +314,7 @@ const addMarks = produce<Mark[], [LegendSpecOptions]>((marks, { highlight, keys,
  * Each unique combination gets joined with a pipe to create a single string to use as legend entries
  */
 export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }]>(
-  (data, { facets, hiddenEntries, keys, name, position, _preferredColumns, _labelWrap }) => {
+  (data, { facets, hiddenEntries, keys, name, position, _preferredColumns, _maxRows }) => {
     // expression for combining all the facets into a single key
     const expr = facets.map((facet) => `datum.${facet}`).join(' + " | " + ');
     data.push(
@@ -357,10 +359,30 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
       }
     );
 
-    // When _preferredColumns is set on a horizontal legend, emit the per-candidate fit data sources
-    // that the columns/labelLimit signals use to pick the largest count that fits without truncation.
+    // When _preferredColumns is set on a horizontal legend, emit the per-entry label-width data that
+    // the ${name}_columnLayout signal uses to pick the largest count that fits the currently visible
+    // (hiddenEntries-filtered) entries.
     if (_preferredColumns?.length && ['top', 'bottom'].includes(position)) {
-      data.push(...getPreferredColumnsData(name, _preferredColumns, _labelWrap));
+      data.push(getLabelWidthsData(name));
+    }
+
+    // ${name}_pages needs to plan every entry up front, unaffected by hiddenEntries — otherwise
+    // applying one page's hiddenEntries would shrink the  data the next page plan is computed
+    // from. ${name}AggregateAll mirrors ${name}Aggregate without the hiddenEntries filter step.
+    if (_maxRows !== undefined && _preferredColumns?.length && ['top', 'bottom'].includes(position)) {
+      data.push(
+        {
+          name: `${name}AggregateAll`,
+          source: 'table',
+          transform: [
+            { type: 'aggregate', groupby: facets },
+            { type: 'formula', as: `${name}Entries`, expr },
+          ],
+        },
+        getPagesLabelWidthsData(name),
+        // Enforces _maxRows at render time so the legend never visibly wraps past its row cap during resize
+        getRowCappedAggregateData(name, _maxRows)
+      );
     }
 
     if (keys?.length) {
@@ -386,7 +408,7 @@ export const addData = produce<Data[], [LegendSpecOptions & { facets: string[] }
 );
 
 export const addSignals = produce<Signal[], [LegendSpecOptions]>(
-  (signals, { hiddenSeries, highlight, isToggleable, keys, legendLabels, name }) => {
+  (signals, { hiddenSeries, highlight, isToggleable, keys, legendLabels, name, position, _preferredColumns, _labelWrap, _maxRows }) => {
     if (highlight) {
       addHighlightSignalLegendHoverEvents(signals, name, Boolean(isToggleable || hiddenSeries), keys);
     }
@@ -394,5 +416,17 @@ export const addSignals = produce<Signal[], [LegendSpecOptions]>(
     // Always emit _labels so the _maxLabelWidth data transform can safely reference it.
     // Defaults to [] when no legendLabels prop is set; the lookup falls through to datum.${name}Entries.
     signals.push(getGenericValueSignal(`${name}_labels`, legendLabels ?? []));
+
+    // _preferredColumns only applies to horizontal legends, matching getColumns returning undefined for left/right
+    const usePreferredColumns =
+      _preferredColumns !== undefined && _preferredColumns.length > 0 && ['top', 'bottom'].includes(position);
+    if (usePreferredColumns) {
+      signals.push({ name: `${name}_columnLayout`, update: getColumnLayoutExpr(name, _preferredColumns, _labelWrap) });
+      // ${name}_pages is only useful for external pagination once _maxRows is set; it's not needed
+      // to render the legend itself, so it's skipped otherwise.
+      if (_maxRows !== undefined) {
+        signals.push({ name: `${name}_pages`, update: getPagesExpr(name, _preferredColumns, _maxRows, _labelWrap) });
+      }
+    }
   }
 );

--- a/packages/vega-spec-builder/src/legend/legendUtils.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.test.ts
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { SourceData } from 'vega';
-
 import { DEFAULT_LEGEND_COLUMN_PADDING, DEFAULT_LEGEND_LABEL_LIMIT, DEFAULT_LEGEND_SYMBOL_WIDTH, FILTERED_TABLE } from '@spectrum-charts/constants';
 import { spectrumColors } from '@spectrum-charts/themes';
 
@@ -18,12 +16,7 @@ import { defaultLegendOptions } from './legendTestUtils';
 import {
   getClickEncodings,
   getColumns,
-  getDisplayLabelExpr,
   getHiddenSeriesColorRule,
-  getPreferredColumns,
-  getPreferredColumnsData,
-  getPreferredLabelLimit,
-  getPreferredWrapWidth,
   getSymbolEncodings,
   getSymbolType,
   mergeLegendEncodings,
@@ -178,141 +171,3 @@ describe('getColumns()', () => {
   });
 });
 
-// Mirrors getFitExpr in legendUtils.ts: (n - 1) * DEFAULT_LEGEND_COLUMN_PADDING (20) inter-column padding
-const getExpectedFitExpr = (name: string, n: number) => {
-  const interColumnPadding = (n - 1) * DEFAULT_LEGEND_COLUMN_PADDING;
-  return `length(data('${name}_fit_${n}')) > 0 && (data('${name}_fit_${n}')[0].totalWidth + ${interColumnPadding} <= width)`;
-};
-
-// Mirrors getWrapFitExpr in legendUtils.ts
-const getExpectedWrapFitExpr = (name: string, n: number) =>
-  `length(data('${name}_wrapfit_${n}')) > 0 && data('${name}_wrapfit_${n}')[0].anyTruncated === 0`;
-
-// Mirrors getFairShareExpr in legendUtils.ts: 22 = 18 swatch + 4 labelOffset
-const getExpectedFairShare = (n: number) => `(width - ${(n - 1) * DEFAULT_LEGEND_COLUMN_PADDING}) / ${n} - 22`;
-
-describe('getPreferredColumns()', () => {
-  test('should chain candidates in order and fall back to the last value', () => {
-    expect(getPreferredColumns('legend0', [5, 3])).toEqual({
-      signal: `${getExpectedFitExpr('legend0', 5)} ? 5 : ${getExpectedFitExpr('legend0', 3)} ? 3 : 3`,
-    });
-  });
-
-  test('should use the legend name in the data reference', () => {
-    expect(getPreferredColumns('myLegend', [4])).toEqual({
-      signal: `${getExpectedFitExpr('myLegend', 4)} ? 4 : 4`,
-    });
-  });
-
-  test('should also accept a candidate that fits once wrapped when labelWrap is set', () => {
-    expect(getPreferredColumns('legend0', [5, 3], 2)).toEqual({
-      signal:
-        `(${getExpectedFitExpr('legend0', 5)} || ${getExpectedWrapFitExpr('legend0', 5)}) ? 5 : ` +
-        `(${getExpectedFitExpr('legend0', 3)} || ${getExpectedWrapFitExpr('legend0', 3)}) ? 3 : 3`,
-    });
-  });
-
-  test('should not add wrap conditions when labelWrap is 1 or less', () => {
-    expect(getPreferredColumns('legend0', [5, 3], 1)).toEqual({
-      signal: `${getExpectedFitExpr('legend0', 5)} ? 5 : ${getExpectedFitExpr('legend0', 3)} ? 3 : 3`,
-    });
-  });
-});
-
-describe('getPreferredWrapWidth()', () => {
-  test('should wrap at full width when a candidate fits unwrapped, else its fair-share width', () => {
-    expect(getPreferredWrapWidth('legend0', [5, 3])).toEqual({
-      signal:
-        `(${getExpectedFitExpr('legend0', 5)} || ${getExpectedWrapFitExpr('legend0', 5)}) ? ` +
-        `(${getExpectedFitExpr('legend0', 5)} ? width : ${getExpectedFairShare(5)}) : ` +
-        `(${getExpectedFitExpr('legend0', 3)} || ${getExpectedWrapFitExpr('legend0', 3)}) ? ` +
-        `(${getExpectedFitExpr('legend0', 3)} ? width : ${getExpectedFairShare(3)}) : ` +
-        `${getExpectedFairShare(3)}`,
-    });
-  });
-});
-
-describe('getPreferredLabelLimit()', () => {
-  test('should emit 0 only while a non-last candidate fits, else the fair-share width for the last count', () => {
-    // last value n=3 fair share: (width - (3-1)*20) / 3 - (18 swatch + 4 labelOffset)
-    expect(getPreferredLabelLimit('legend0', [5, 3])).toEqual({
-      signal: `(${getExpectedFitExpr('legend0', 5)}) ? 0 : (width - 40) / 3 - 22`,
-    });
-  });
-
-  test('should always emit the fair-share width when there is a single candidate', () => {
-    expect(getPreferredLabelLimit('legend0', [3])).toEqual({ signal: '(width - 40) / 3 - 22' });
-  });
-});
-
-describe('getPreferredColumnsData()', () => {
-  test('should emit an indexed label-widths source plus one fit source per candidate', () => {
-    const data = getPreferredColumnsData('legend0', [5, 3]);
-    expect(data.map((d) => d.name)).toEqual(['legend0_labelWidths', 'legend0_fit_5', 'legend0_fit_3']);
-  });
-
-  test('should index entries with a row_number window matching Vega entry order', () => {
-    const [labelWidths] = getPreferredColumnsData('legend0', [5, 3]);
-    expect((labelWidths as SourceData).source).toEqual('legend0Aggregate');
-    expect(labelWidths.transform).toContainEqual({ type: 'window', ops: ['row_number'], as: ['legendIndex'] });
-    expect(labelWidths.transform).toContainEqual({
-      type: 'formula',
-      as: 'displayLabel',
-      expr: getDisplayLabelExpr('legend0'),
-    });
-  });
-
-  test('should assign each entry to column = index % N per candidate', () => {
-    const [, fit5, fit3] = getPreferredColumnsData('legend0', [5, 3]);
-    expect(fit5.transform?.[0]).toEqual({ type: 'formula', as: 'col', expr: '(datum.legendIndex - 1) % 5' });
-    expect(fit3.transform?.[0]).toEqual({ type: 'formula', as: 'col', expr: '(datum.legendIndex - 1) % 3' });
-  });
-
-  test('should size each column to its widest label then sum the column totals', () => {
-    const [, fit5] = getPreferredColumnsData('legend0', [5, 3]);
-    expect(fit5.transform).toContainEqual({
-      type: 'aggregate',
-      groupby: ['col'],
-      fields: ['labelWidth'],
-      ops: ['max'],
-      as: ['colWidth'],
-    });
-    // per-column chrome: 18 swatch + 4 labelOffset + 2 fit margin, label width ceiled to match Vega
-    expect(fit5.transform).toContainEqual({ type: 'formula', as: 'colTotal', expr: 'ceil(datum.colWidth) + 24' });
-    expect(fit5.transform).toContainEqual({
-      type: 'aggregate',
-      fields: ['colTotal'],
-      ops: ['sum'],
-      as: ['totalWidth'],
-    });
-  });
-
-  test('should not emit wrapfit sources when labelWrap is absent', () => {
-    const data = getPreferredColumnsData('legend0', [5, 3]);
-    expect(data.some((d) => d.name.includes('_wrapfit_'))).toBe(false);
-  });
-
-  test('should emit one wrapfit source per candidate when labelWrap > 1', () => {
-    const data = getPreferredColumnsData('legend0', [5, 3], 2);
-    expect(data.map((d) => d.name)).toEqual([
-      'legend0_labelWidths',
-      'legend0_fit_5',
-      'legend0_fit_3',
-      'legend0_wrapfit_5',
-      'legend0_wrapfit_3',
-    ]);
-  });
-
-  test('should flag any label truncating after wrapping at the candidate fair-share width', () => {
-    const data = getPreferredColumnsData('legend0', [5, 3], 2);
-    const wrapfit5 = data.find((d) => d.name === 'legend0_wrapfit_5');
-    expect(wrapfit5?.transform).toEqual([
-      {
-        type: 'formula',
-        as: 'truncated',
-        expr: `wrapTruncates(datum.displayLabel, ${getExpectedFairShare(5)}, 2, 'normal', 14) ? 1 : 0`,
-      },
-      { type: 'aggregate', fields: ['truncated'], ops: ['max'], as: ['anyTruncated'] },
-    ]);
-  });
-});

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -84,192 +84,82 @@ export const getColumns = (position: Position, name: string, labelLimit?: number
 };
 
 /**
- * Vega's default legend `labelOffset` (gap between symbol and label). The spectrum theme overrides
- * `columnPadding` but not `labelOffset`, so Vega's default of 4 applies.
- */
-const LEGEND_LABEL_OFFSET = 4;
-
-/**
- * True rendered width of a legend symbol. The default legend symbol is a size-250 circle, which
- * renders ~17.8px wide (2 * sqrt(250 / PI)). `DEFAULT_LEGEND_SYMBOL_WIDTH` (16) rounds this down; the
- * shortfall is paid per column, so the summed prediction under-counts and the last-fitting layout
- * clips on its right edge just before the column count steps down. Use the true width here.
- * Nudge this up a hair if any clipping remains during manual testing.
- */
-const LEGEND_SYMBOL_RENDERED_WIDTH = 18;
-
-/**
- * Per-column chrome added to a label's own width: the symbol swatch plus the symbol-to-label gap.
- * Used both when measuring each column's total width and when computing the fair-share truncation
- * width for the last-column labelLimit.
- */
-const LEGEND_ITEM_BASE = LEGEND_SYMBOL_RENDERED_WIDTH + LEGEND_LABEL_OFFSET;
-
-/**
- * Per-column safety margin added to the full-width fit estimate ONLY (not the fair-share wrap width,
- * which must stay exact). Vega ceils each column's right edge (`Math.ceil(b.x2)` in grid.js) and the
- * symbol stroke overhangs slightly, so the summed float estimate runs a few px light — worst at the
- * largest column count. This margin makes `fitsFull` hand off to the exact wrap/step-down path just
- * before the layout would actually overrun `width`.
- */
-const LEGEND_COLUMN_FIT_MARGIN = 2;
-
-/**
  * Expression that resolves an entry's display label: the custom legendLabel if one exists for the
  * series, otherwise the raw entry value. Shared by the max-label-width and preferred-columns data.
  */
 export const getDisplayLabelExpr = (name: string): string =>
   `indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries) > -1 ? ${name}_labels[indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries)].label : datum.${name}Entries`;
 
-/**
- * Boolean expression testing whether candidate column count `n` fits the available `width` at full
- * label width. `${name}_fit_${n}` holds the summed per-column width (label + item chrome); the
- * inter-column padding `(n - 1) * columnPadding` is added here since it is a build-time constant.
- */
-const getFitExpr = (name: string, n: number): string => {
-  const interColumnPadding = (n - 1) * DEFAULT_LEGEND_COLUMN_PADDING;
-  return `length(data('${name}_fit_${n}')) > 0 && (data('${name}_fit_${n}')[0].totalWidth + ${interColumnPadding} <= width)`;
-};
+const getLabelWidthTransforms = (name: string): Data['transform'] => [
+  { type: 'formula', as: 'displayLabel', expr: getDisplayLabelExpr(name) },
+  { type: 'formula', as: 'labelWidth', expr: "getLabelWidth(datum.displayLabel, 'normal', 14)" },
+  { type: 'window', ops: ['row_number'], as: ['legendIndex'] },
+];
 
 /**
- * Per-column fair-share width expression for candidate `n`: the reactive `width` split into `n` equal
- * columns, minus inter-column padding and per-item chrome. Used as both the wrap width and the
- * fallback truncation width so the fit test and the rendered wrap agree.
+ * Data source backing the live `_preferredColumns` layout decision: one row per *currently visible*
+ * legend entry with its measured label width and a stable order index
+ * Consumed by `getLegendColumnLayout` (see expressionFunctions.ts) via the
+ * `${name}_columnLayout` signal, which drives the legend's actual rendered columns/labelLimit — this
+ * is deliberately scoped to whatever's currently shown, so a page of short labels can use a wider
+ * column count than a page with one long label.
  */
-const getFairShareExpr = (n: number): string => {
-  const interColumnPadding = (n - 1) * DEFAULT_LEGEND_COLUMN_PADDING;
-  return `(width - ${interColumnPadding}) / ${n} - ${LEGEND_ITEM_BASE}`;
-};
-
-/**
- * Boolean expression testing whether candidate column count `n` fits when labels are wrapped (up to
- * `_labelWrap` lines) at `n`'s fair-share width with no label truncating. Backed by
- * `${name}_wrapfit_${n}` (see getPreferredColumnsData).
- */
-const getWrapFitExpr = (name: string, n: number): string =>
-  `length(data('${name}_wrapfit_${n}')) > 0 && data('${name}_wrapfit_${n}')[0].anyTruncated === 0`;
-
-/**
- * Builds the data sources backing the `_preferredColumns` layout decision:
- * - `${name}_labelWidths`: one row per legend entry with its measured label width and stable order index
- * - `${name}_fit_${n}`: for each candidate `n`, the summed width of the `n`-column layout, sized
- *   per-column to that column's widest label (matching Vega's `align: 'each'` grid).
- * - `${name}_wrapfit_${n}` (only when `labelWrap > 1`): for each candidate `n`, whether any label
- *   would still truncate after wrapping to `labelWrap` lines at `n`'s fair-share width.
- */
-export const getPreferredColumnsData = (name: string, preferredColumns: number[], labelWrap?: number): Data[] => {
-  const labelWidths: Data = {
-    name: `${name}_labelWidths`,
-    source: `${name}Aggregate`,
-    transform: [
-      { type: 'formula', as: 'displayLabel', expr: getDisplayLabelExpr(name) },
-      { type: 'formula', as: 'labelWidth', expr: "getLabelWidth(datum.displayLabel, 'normal', 14)" },
-      { type: 'window', ops: ['row_number'], as: ['legendIndex'] },
-    ],
-  };
-
-  const fitSources: Data[] = preferredColumns.map((n) => ({
-    name: `${name}_fit_${n}`,
-    source: `${name}_labelWidths`,
-    transform: [
-      // matches Vega's per-entry column assignment: column = index % ncols (0-based index)
-      { type: 'formula', as: 'col', expr: `(datum.legendIndex - 1) % ${n}` },
-      // each column is sized to its own widest label (align: 'each')
-      { type: 'aggregate', groupby: ['col'], fields: ['labelWidth'], ops: ['max'], as: ['colWidth'] },
-      // ceil the label width to match Vega's per-column Math.ceil, plus a small overhang margin
-      {
-        type: 'formula',
-        as: 'colTotal',
-        expr: `ceil(datum.colWidth) + ${LEGEND_ITEM_BASE + LEGEND_COLUMN_FIT_MARGIN}`,
-      },
-      { type: 'aggregate', fields: ['colTotal'], ops: ['sum'], as: ['totalWidth'] },
-    ],
-  }));
-
-  const sources = [labelWidths, ...fitSources];
-
-  // When wrapping is available, add a per-candidate source that flags whether wrapping to labelWrap
-  // lines at that candidate's fair-share width still truncates any label. `width` is reactive, so
-  // these recompute on resize alongside the fit sources.
-  if (labelWrap && labelWrap > 1) {
-    const wrapFitSources: Data[] = preferredColumns.map((n) => ({
-      name: `${name}_wrapfit_${n}`,
-      source: `${name}_labelWidths`,
-      transform: [
-        {
-          type: 'formula',
-          as: 'truncated',
-          expr: `wrapTruncates(datum.displayLabel, ${getFairShareExpr(n)}, ${labelWrap}, 'normal', ${DEFAULT_FONT_SIZE}) ? 1 : 0`,
-        },
-        { type: 'aggregate', fields: ['truncated'], ops: ['max'], as: ['anyTruncated'] },
-      ],
-    }));
-    sources.push(...wrapFitSources);
-  }
-
-  return sources;
-};
-
-/**
- * Emits the `columns` signal for a `_preferredColumns` legend: walks the candidate list in order and
- * picks the first count that fits at full label width, falling back to the last (smallest) count.
- */
-export const getPreferredColumns = (name: string, preferredColumns: number[], labelWrap?: number): SignalRef => {
-  const useWrap = Boolean(labelWrap && labelWrap > 1);
-  const lastValue = preferredColumns.at(-1) ?? 1;
-  const branches = preferredColumns.map((n) => {
-    // With wrapping, a candidate also qualifies if it fits once labels wrap without truncating.
-    const condition = useWrap ? `(${getFitExpr(name, n)} || ${getWrapFitExpr(name, n)})` : getFitExpr(name, n);
-    return `${condition} ? ${n}`;
-  });
-  return { signal: `${branches.join(' : ')} : ${lastValue}` };
-};
-
-/**
- * Raw expression (not wrapped in a SignalRef) for the wrap width of the chosen candidate in a
- * combined `_preferredColumns` + `_labelWrap` legend. For each candidate: `width` when it fit at full
- * single-line width (so labels stay on one line), otherwise the candidate's fair-share width. The
- * last candidate always uses fair-share, allowing truncation. Shared by the label text/dy signals
- * (via getLegendLabelsEncodings) and the legend labelLimit so all three stay in sync.
- */
-export const getPreferredWrapWidthExpr = (name: string, preferredColumns: number[]): string => {
-  const lastValue = preferredColumns.at(-1) ?? 1;
-  const branches = preferredColumns.map((n) => {
-    const qualifies = `(${getFitExpr(name, n)} || ${getWrapFitExpr(name, n)})`;
-    const chosenWidth = `(${getFitExpr(name, n)} ? width : ${getFairShareExpr(n)})`;
-    return `${qualifies} ? ${chosenWidth}`;
-  });
-  return `${branches.join(' : ')} : ${getFairShareExpr(lastValue)}`;
-};
-
-/**
- * SignalRef wrapper around getPreferredWrapWidthExpr, used for the legend `labelLimit` in combined
- * `_preferredColumns` + `_labelWrap` mode.
- */
-export const getPreferredWrapWidth = (name: string, preferredColumns: number[]): SignalRef => ({
-  signal: getPreferredWrapWidthExpr(name, preferredColumns),
+export const getLabelWidthsData = (name: string): Data => ({
+  name: `${name}_labelWidths`,
+  source: `${name}Aggregate`,
+  transform: getLabelWidthTransforms(name),
 });
 
 /**
- * Emits the `labelLimit` signal for a `_preferredColumns` legend.
- *
- * `0` (unlimited) whenever a non-last candidate fits. Once the layout drops to the last (smallest)
- * candidate `n`, the fair-share truncation width `(width - padding) / n - itemBase` is applied
- * unconditionally — even while `n` still fits at full width. This keeps the last-column state
- * consistent: labels shrink continuously as the container narrows instead of snapping from full
- * width to the fair share the instant `n` stops fitting.
+ * Data source backing `${name}_pages`: the same per-entry label-width measurement as
+ * `${name}_labelWidths`, but sourced from the *unfiltered* `${name}AggregateAll` instead of the
+ * `hiddenEntries`-filtered `${name}Aggregate`. needed to plan the full pagination sequence up front, over every entry
  */
-export const getPreferredLabelLimit = (name: string, preferredColumns: number[]): SignalRef => {
-  const n = preferredColumns.at(-1) ?? 1;
-  const fairShareLimit = getFairShareExpr(n);
+export const getPagesLabelWidthsData = (name: string): Data => ({
+  name: `${name}_pagesLabelWidths`,
+  source: `${name}AggregateAll`,
+  transform: getLabelWidthTransforms(name),
+});
 
-  // With a single candidate the last count is the only count, so always use the fair-share limit.
-  const nonLastCandidates = preferredColumns.slice(0, -1);
-  if (!nonLastCandidates.length) return { signal: fairShareLimit };
+/**
+ * Data source that caps the live-rendered legend entries at `columns * maxRows`, referencing the
+ * live `${name}_columnLayout.columns` signal so the cap tracks whatever Vega just resolved for the
+ * current width — not a value from a prior render.
+ *
+ * Only the legend's own `${name}Entries` scale domain points at this when `_maxRows` is set
+ */
+export const getRowCappedAggregateData = (name: string, maxRows: number): Data => ({
+  name: `${name}AggregateCapped`,
+  source: `${name}Aggregate`,
+  transform: [
+    { type: 'window', ops: ['row_number'], as: [`${name}RowIndex`] },
+    { type: 'filter', expr: `datum.${name}RowIndex <= ${name}_columnLayout.columns * ${maxRows}` },
+  ],
+});
 
-  const anyNonLastFits = nonLastCandidates.map((c) => `(${getFitExpr(name, c)})`).join(' || ');
-  return { signal: `${anyNonLastFits} ? 0 : ${fairShareLimit}` };
-};
+/**
+ * Expression for the `${name}_columnLayout` signal: resolves the chosen column count, labelLimit,
+ * and (when `_labelWrap` is combined with `_preferredColumns`) dynamic wrap width, via the
+ * `getLegendColumnLayout` expression function.
+ */
+export const getColumnLayoutExpr = (name: string, preferredColumns: number[], labelWrap?: number): string =>
+  `getLegendColumnLayout(data('${name}_labelWidths'), width, ${JSON.stringify(preferredColumns)}, ${
+    labelWrap ?? 1
+  })`;
+
+/**
+ * Expression for the `${name}_pages` signal: the full pagination plan for every legend entry
+ * Only emitted when `_maxRows` is set.
+ */
+export const getPagesExpr = (
+  name: string,
+  preferredColumns: number[],
+  maxRows: number,
+  labelWrap?: number
+): string =>
+  `getLegendPages(data('${name}_pagesLabelWidths'), width, ${JSON.stringify(preferredColumns)}, ${maxRows}, ${
+    labelWrap ?? 1
+  })`;
 
 /**
  * Gets the filter transform for hidden entries
@@ -301,9 +191,7 @@ export const getEncodings = (facets: Facet[], legendOptions: LegendSpecOptions, 
   const usePreferredColumns =
     _preferredColumns !== undefined && _preferredColumns.length > 0 && ['top', 'bottom'].includes(position);
   const wrapWidthExpr =
-    usePreferredColumns && _labelWrap && _labelWrap > 1
-      ? getPreferredWrapWidthExpr(name, _preferredColumns)
-      : undefined;
+    usePreferredColumns && _labelWrap && _labelWrap > 1 ? `${name}_columnLayout.wrapWidth` : undefined;
   const legendLabelsEncodings = getLegendLabelsEncodings(name, legendLabels, labelLimit, _labelWrap, wrapWidthExpr);
   const showHideEncodings = getShowHideEncodings(legendOptions);
   const clickEncodings = getClickEncodings(legendOptions);

--- a/packages/vega-spec-builder/src/types/legendSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/legendSpec.types.ts
@@ -87,6 +87,17 @@ export interface LegendOptions {
    * behavior outside that use case is not guaranteed. Use at your own risk.
    */
   _preferredColumns?: number[];
+  /**
+   * Maximum rows of legend entries the legend will render, and the row budget used to compute the
+   * `${name}_pages` signal for pagination UIs built outside RSC. Requires `_preferredColumns` to
+   * also be set. The legend itself is capped at `columns * _maxRows` entries. Entries
+   * beyond the cap are dropped from rendering, not just hidden by `hiddenEntries` semantics.
+   *
+   * NOTE: The leading underscore marks this as a targeted, internal-use property. It exists to support
+   * a specific horizontal-legend layout requirement and is not a generally supported prop — its
+   * behavior outside that use case is not guaranteed. Use at your own risk.
+   */
+  _maxRows?: number;
   /** customize the legend symbol shape */
   symbolShape?: SymbolShapeFacet;
   /** legend title */


### PR DESCRIPTION
## Description

Adding a `legend0_pages` signal, that calls a getLegendPages expression function. 

`getLegendPages()` walks the entire legend entry list, splits them into pages with `{ column, start, end }` information per page. 

Adds a new `_maxRows` prop. Requires the `_preferredColumns` prop to also be set. Caps the amount of legend rows rendered. 

## Related Issue

## Motivation and Context

Expose vega signal for external apps to apply legend pagination. 

## How Has This Been Tested?

Unit testing and storybook 

## Screenshots (if appropriate):

<img width="774" height="395" alt="Screenshot 2026-07-21 at 10 11 25 AM" src="https://github.com/user-attachments/assets/6fa0e260-f7c6-45ad-bacb-3c3ab499b564" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
