### PR TITLE
fix: line point annotation background halo alignment 

### DIFF
--- a/packages/vega-spec-builder-s2/src/line/directLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/directLabelUtils.ts
@@ -155,7 +155,10 @@ export const getLabelTransformTextMarks = (
     interactive: false,
     from: { data: backgroundMarkName },
     encode: {
-      enter: { fill: getDirectLabelForegroundFill(colorScheme, foregroundFillOverride) },
+      enter: {
+        fill: getDirectLabelForegroundFill(colorScheme, foregroundFillOverride),
+        fontSize: { signal: CHART_SIZE_FONT_SIZE },
+      },
       update: {
         text: { field: 'text' },
         x: { field: 'x' },

--- a/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, LINE_POINT_ANNOTATION_OFFSET } from '@spectrum-charts/constants';
+import { BACKGROUND_COLOR, CHART_SIZE_FONT_SIZE, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FONT_WEIGHT, LINE_POINT_ANNOTATION_OFFSET } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { defaultLineOptions } from '../lineTestUtils';
@@ -139,6 +139,10 @@ describe('getLinePointAnnotationMarks', () => {
 			expect(getBackgroundMark().encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
 		});
 
+		test('uses chart size font size signal', () => {
+			expect(getBackgroundMark().encode?.enter).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
+		});
+
 		test('has label transform', () => {
 			const transform = getBackgroundMark().transform;
 			expect(transform).toHaveLength(1);
@@ -236,6 +240,25 @@ describe('getLinePointAnnotationMarks', () => {
 
 		test('applies font weight in update encoding', () => {
 			expect(getForegroundMark().encode?.update).toHaveProperty('fontWeight', { value: DIRECT_LABEL_FONT_WEIGHT });
+		});
+
+		test('uses chart size font size signal', () => {
+			expect(getForegroundMark().encode?.enter).toHaveProperty('fontSize', { signal: CHART_SIZE_FONT_SIZE });
+		});
+	});
+
+	describe('background and foreground alignment', () => {
+		// The foreground mark renders the visible text; the background mark renders the halo and
+		// runs the label transform that positions both. If their fontSize or fontWeight ever drift
+		// apart, the halo stops matching the glyph size and visibly misaligns from the text.
+		test('background and foreground share the same fontSize', () => {
+			const [backgroundMark, foregroundMark] = getLinePointAnnotationMarks(lineOptionsWithAnnotations);
+			expect(backgroundMark.encode?.enter?.fontSize).toEqual(foregroundMark.encode?.enter?.fontSize);
+		});
+
+		test('background and foreground share the same fontWeight', () => {
+			const [backgroundMark, foregroundMark] = getLinePointAnnotationMarks(lineOptionsWithAnnotations);
+			expect(backgroundMark.encode?.update?.fontWeight).toEqual(foregroundMark.encode?.update?.fontWeight);
 		});
 	});
 


### PR DESCRIPTION
## Description

add fontSize to background halo so it aligns with the foreground mark

## Related Issue

## Motivation and Context

Background halo mark was not aligning with the foreground mark on line point annotations because the font size was changed to scale with the chart size, but the background halo mark was not. 

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
