### PR TITLE
feat: legend pagination column layout logic update 

### DIFF
--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.test.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.test.ts
@@ -234,6 +234,7 @@ describe('wrapTruncates()', () => {
 describe('getLegendColumnLayout()', () => {
   const item = (legendIndex: number, labelWidth = 40): LegendLabelWidthDatum => ({
     legendIndex,
+    entryKey: `Item ${legendIndex}`,
     displayLabel: `Item ${legendIndex}`,
     labelWidth,
   });
@@ -262,7 +263,12 @@ describe('getLegendColumnLayout()', () => {
   test('with labelWrap, a candidate that only fits once wrapped is chosen with labelLimit 0', () => {
     const displayLabel = 'Supercalifragilisticexpialidocious is quite long';
     const items = [
-      { legendIndex: 1, displayLabel, labelWidth: expressionFunctions.getLabelWidth(displayLabel, 'normal', 14) },
+      {
+        legendIndex: 1,
+        entryKey: displayLabel,
+        displayLabel,
+        labelWidth: expressionFunctions.getLabelWidth(displayLabel, 'normal', 14),
+      },
     ];
     const layout = expressionFunctions.getLegendColumnLayout(items, 100, [1], 2);
     expect(layout.labelLimit).toBe(0);
@@ -272,7 +278,12 @@ describe('getLegendColumnLayout()', () => {
 
 describe('getLegendPages()', () => {
   const items = (n: number, labelWidth = 40): LegendLabelWidthDatum[] =>
-    Array.from({ length: n }, (_, i) => ({ legendIndex: i + 1, displayLabel: `Item ${i}`, labelWidth }));
+    Array.from({ length: n }, (_, i) => ({
+      legendIndex: i + 1,
+      entryKey: `Item ${i}`,
+      displayLabel: `Item ${i}`,
+      labelWidth,
+    }));
 
   test('returns a single page when everything fits within columns * maxRows', () => {
     const pages = expressionFunctions.getLegendPages(items(4), 600, [5, 3], 2);
@@ -303,6 +314,70 @@ describe('getLegendPages()', () => {
     const pages = expressionFunctions.getLegendPages(items(3), 600, [5, 3], 0);
     expect(pages.every((p) => p.end >= p.start)).toBe(true);
     expect(pages[pages.length - 1].end).toBe(2);
+  });
+});
+
+describe('getLegendColumnLayoutForPage()', () => {
+  const item = (legendIndex: number, entryKey: string, labelWidth = 40): LegendLabelWidthDatum => ({
+    legendIndex,
+    entryKey,
+    displayLabel: entryKey,
+    labelWidth,
+  });
+
+  const fullItems = Array.from({ length: 10 }, (_, i) => item(i + 1, `Series ${i}`));
+  // The plan rejected 5 columns for the original 10-item candidate set (some other item didn't fit)
+  // and landed on 3 columns for a 6-item page. In isolation, these 6 short-labeled items would
+  // trivially satisfy 5 columns too.
+  const visiblePage0Items = fullItems.slice(0, 6);
+
+  test("defers to the plan's column count even when the visible subset could independently satisfy a larger candidate", () => {
+    const pages = [
+      { columns: 3, start: 0, end: 5 },
+      { columns: 3, start: 6, end: 9 },
+    ];
+    const layout = expressionFunctions.getLegendColumnLayoutForPage(
+      visiblePage0Items,
+      fullItems,
+      pages,
+      [5, 3],
+      600,
+      1
+    );
+    expect(layout.columns).toBe(3);
+
+    // sanity check: the independent (non-page-aware) function really would pick 5 for just these 6 —
+    // this is the mismatch getLegendColumnLayoutForPage exists to avoid.
+    const independentLayout = expressionFunctions.getLegendColumnLayout(visiblePage0Items, 600, [5, 3], 1);
+    expect(independentLayout.columns).toBe(5);
+  });
+
+  test("matches the currently-visible page by the first visible entry's position in the full list", () => {
+    const pages = [
+      { columns: 5, start: 0, end: 5 },
+      { columns: 3, start: 6, end: 9 },
+    ];
+    const visiblePage1Items = fullItems.slice(6, 10);
+    const layout = expressionFunctions.getLegendColumnLayoutForPage(visiblePage1Items, fullItems, pages, [5, 3], 600, 1);
+    expect(layout.columns).toBe(3);
+  });
+
+  test('falls back to the last page when the visible entry cannot be matched against the full list', () => {
+    const pages = [
+      { columns: 5, start: 0, end: 5 },
+      { columns: 3, start: 6, end: 9 },
+    ];
+    const unmatchedItem = item(1, 'Not In Full List');
+    const layout = expressionFunctions.getLegendColumnLayoutForPage([unmatchedItem], fullItems, pages, [5, 3], 600, 1);
+    expect(layout.columns).toBe(3);
+  });
+
+  test('returns a safe default when there are no visible items or no pages', () => {
+    expect(expressionFunctions.getLegendColumnLayoutForPage([], fullItems, [], [5, 3], 600, 1)).toEqual({
+      columns: 1,
+      labelLimit: 0,
+      wrapWidth: 0,
+    });
   });
 });
 

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
@@ -26,6 +26,9 @@ export interface LabelDatum {
 
 export interface LegendLabelWidthDatum {
   legendIndex: number;
+  /** the raw entry key (unaffected by any legendLabels override), used to match an entry across
+   * the visible (hiddenEntries-filtered) and full (unfiltered) label-width lists */
+  entryKey: string;
   displayLabel: string;
   labelWidth: number;
 }
@@ -64,6 +67,7 @@ export const getExpressionFunctions = (
     getLabelWidth,
 
     getLegendColumnLayout,
+    getLegendColumnLayoutForPage,
     getLegendPages,
     truncateText,
     wrapLabelText,
@@ -542,6 +546,47 @@ const getLegendPages = (
   return pages;
 };
 
+/**
+ * Resolves the live `${name}_columnLayout` for a paginated legend by deferring to whatever
+ * `getLegendPages` already decided for the page currently visible, instead of independently
+ * re-testing candidates against just the visible subset. That independent re-test is the source of
+ * a real inconsistency: a page can end up with fewer items than a larger candidate would allow
+ * (because a *different* item elsewhere in the original candidate-sized group didn't fit), and that
+ * smaller, "easier" subset can then trivially satisfy a *larger* candidate in isolation — rendering
+ * more columns than the page was actually planned around.
+ *
+ * Finds the currently-visible page by matching the first visible item's `entryKey` against its
+ * position in the full (unfiltered) list, then locating the page whose range starts there.
+ * @param visibleItems the currently-visible (hiddenEntries-filtered) entries — see `${name}_labelWidths`
+ * @param fullItems every entry, unfiltered — see `${name}_pagesLabelWidths`
+ * @param pages the full pagination plan — see `${name}_pages`
+ * @param candidates ordered list of candidate column counts, e.g. [5, 3]
+ * @param width available width for the legend
+ * @param labelWrap max lines a label may wrap onto before truncating; 1 (default) disables wrapping
+ */
+const getLegendColumnLayoutForPage = (
+  visibleItems: LegendLabelWidthDatum[],
+  fullItems: LegendLabelWidthDatum[],
+  pages: LegendPage[],
+  candidates: number[],
+  width: number,
+  labelWrap = 1
+): LegendColumnLayout => {
+  const lastCandidate = candidates.at(-1);
+  if (!visibleItems.length || !pages.length || lastCandidate === undefined) {
+    return { columns: 1, labelLimit: 0, wrapWidth: 0 };
+  }
+
+  const startIndex = fullItems.findIndex((item) => item.entryKey === visibleItems[0].entryKey);
+  const page = pages.find((p) => p.start === startIndex) ?? pages[pages.length - 1];
+
+  const useWrap = labelWrap > 1;
+  return (
+    getColumnLayoutForCandidate(visibleItems, width, page.columns, lastCandidate, useWrap, labelWrap) ??
+    getFallbackColumnLayout(width, lastCandidate, useWrap)
+  );
+};
+
 export const expressionFunctions = {
   consoleLog,
   formatHorizontalTimeAxisLabels: formatHorizontalTimeAxisLabels(),
@@ -549,6 +594,7 @@ export const expressionFunctions = {
   formatVerticalAxisTimeLabelTooltips: formatVerticalAxisTimeLabelTooltips(),
   getLabelWidth,
   getLegendColumnLayout,
+  getLegendColumnLayoutForPage,
   getLegendPages,
   truncateText,
   wrapLabelText,

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
@@ -549,11 +549,7 @@ const getLegendPages = (
 /**
  * Resolves the live `${name}_columnLayout` for a paginated legend by deferring to whatever
  * `getLegendPages` already decided for the page currently visible, instead of independently
- * re-testing candidates against just the visible subset. That independent re-test is the source of
- * a real inconsistency: a page can end up with fewer items than a larger candidate would allow
- * (because a *different* item elsewhere in the original candidate-sized group didn't fit), and that
- * smaller, "easier" subset can then trivially satisfy a *larger* candidate in isolation — rendering
- * more columns than the page was actually planned around.
+ * re-testing candidates against just the visible subset.
  *
  * Finds the currently-visible page by matching the first visible item's `entryKey` against its
  * position in the full (unfiltered) list, then locating the page whose range starts there.

--- a/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
+++ b/packages/vega-spec-builder/src/expressionFunctions/expressionFunctions.ts
@@ -569,12 +569,13 @@ const getLegendColumnLayoutForPage = (
   labelWrap = 1
 ): LegendColumnLayout => {
   const lastCandidate = candidates.at(-1);
-  if (!visibleItems.length || !pages.length || lastCandidate === undefined) {
+  const lastPage = pages.at(-1);
+  if (!visibleItems.length || !lastPage || lastCandidate === undefined) {
     return { columns: 1, labelLimit: 0, wrapWidth: 0 };
   }
 
   const startIndex = fullItems.findIndex((item) => item.entryKey === visibleItems[0].entryKey);
-  const page = pages.find((p) => p.start === startIndex) ?? pages[pages.length - 1];
+  const page = pages.find((p) => p.start === startIndex) ?? lastPage;
 
   const useWrap = labelWrap > 1;
   return (

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.test.ts
@@ -424,6 +424,27 @@ describe('addLegend()', () => {
         const labelWidths = data?.find((d) => d.name === 'legend0_labelWidths');
         expect(labelWidths).toMatchObject({ source: 'legend0Aggregate' });
       });
+
+      // Regression: the live render must defer to whatever ${name}_pages already decided for the
+      // currently-visible page, not independently re-test candidates against just that subset
+      test('should use the page-aware column layout expression when _maxRows is set', () => {
+        const signals = addLegend(defaultSpec, { _preferredColumns: [5, 3], _maxRows: 2 }).signals;
+        const columnLayoutSignal = signals?.find((s) => 'name' in s && s.name === 'legend0_columnLayout');
+        expect(columnLayoutSignal).toEqual({
+          name: 'legend0_columnLayout',
+          update:
+            "getLegendColumnLayoutForPage(data('legend0_labelWidths'), data('legend0_pagesLabelWidths'), legend0_pages, [5,3], width, 1)",
+        });
+      });
+
+      test('should use the original, self-contained column layout expression when _maxRows is not set', () => {
+        const signals = addLegend(defaultSpec, { _preferredColumns: [5, 3] }).signals;
+        const columnLayoutSignal = signals?.find((s) => 'name' in s && s.name === 'legend0_columnLayout');
+        expect(columnLayoutSignal).toEqual({
+          name: 'legend0_columnLayout',
+          update: "getLegendColumnLayout(data('legend0_labelWidths'), width, [5,3], 1)",
+        });
+      });
     });
 
     test('should add titleLimit if provided', () => {

--- a/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/legend/legendSpecBuilder.ts
@@ -12,52 +12,22 @@
 import { produce } from 'immer';
 import { Data, Legend, Mark, Scale, Signal } from 'vega';
 
-import {
-  COLOR_SCALE,
-  DEFAULT_COLOR_SCHEME,
-  GROUP_ID,
-  HOVERED_SERIES,
-  LINEAR_COLOR_SCALE,
-  LINE_TYPE_SCALE,
-  OPACITY_SCALE,
-  SERIES_ID,
-  SYMBOL_SHAPE_SCALE,
-  SYMBOL_SIZE_SCALE,
-} from '@spectrum-charts/constants';
+
+
+import { COLOR_SCALE, DEFAULT_COLOR_SCHEME, GROUP_ID, HOVERED_SERIES, LINEAR_COLOR_SCALE, LINE_TYPE_SCALE, OPACITY_SCALE, SERIES_ID, SYMBOL_SHAPE_SCALE, SYMBOL_SIZE_SCALE } from '@spectrum-charts/constants';
 import { getColorValue } from '@spectrum-charts/themes';
+
+
 
 import { getTableData } from '../data/dataUtils';
 import { addFieldToFacetScaleDomain } from '../scale/scaleSpecBuilder';
 import { addHighlightSignalLegendHoverEvents, getGenericValueSignal } from '../signal/signalSpecBuilder';
 import { getLineWidthPixelsFromLineWidth, getPathFromSymbolShape, getStrokeDashFromLineType } from '../specUtils';
-import {
-  ColorFacet,
-  ColorScheme,
-  FacetRef,
-  HighlightedItem,
-  LegendOptions,
-  LegendSpecOptions,
-  LineTypeFacet,
-  LineWidthFacet,
-  ScSpec,
-  SymbolShapeFacet,
-  UserMeta,
-} from '../types';
+import { ColorFacet, ColorScheme, FacetRef, HighlightedItem, LegendOptions, LegendSpecOptions, LineTypeFacet, LineWidthFacet, ScSpec, SymbolShapeFacet, UserMeta } from '../types';
 import { getFacets, getFacetsFromKeys } from './legendFacetUtils';
 import { setHoverOpacityForMarks } from './legendHighlightUtils';
-import {
-  Facet,
-  getColumnLayoutExpr,
-  getColumns,
-  getDisplayLabelExpr,
-  getEncodings,
-  getHiddenEntriesFilter,
-  getLabelWidthsData,
-  getPagesExpr,
-  getPagesLabelWidthsData,
-  getRowCappedAggregateData,
-  getSymbolType,
-} from './legendUtils';
+import { Facet, getColumnLayoutExpr, getColumns, getDisplayLabelExpr, getEncodings, getHiddenEntriesFilter, getLabelWidthsData, getPagesExpr, getPagesLabelWidthsData, getRowCappedAggregateData, getSymbolType } from './legendUtils';
+
 
 export const addLegend = produce<
   ScSpec,
@@ -421,12 +391,16 @@ export const addSignals = produce<Signal[], [LegendSpecOptions]>(
     const usePreferredColumns =
       _preferredColumns !== undefined && _preferredColumns.length > 0 && ['top', 'bottom'].includes(position);
     if (usePreferredColumns) {
-      signals.push({ name: `${name}_columnLayout`, update: getColumnLayoutExpr(name, _preferredColumns, _labelWrap) });
       // ${name}_pages is only useful for external pagination once _maxRows is set; it's not needed
       // to render the legend itself, so it's skipped otherwise.
       if (_maxRows !== undefined) {
         signals.push({ name: `${name}_pages`, update: getPagesExpr(name, _preferredColumns, _maxRows, _labelWrap) });
       }
+      // compute ${name}_columnLayout AFTER the page layout is computed, to get the correct per page column count decided by ${name}_pages
+      signals.push({
+        name: `${name}_columnLayout`,
+        update: getColumnLayoutExpr(name, _preferredColumns, _labelWrap, _maxRows),
+      });
     }
   }
 );

--- a/packages/vega-spec-builder/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder/src/legend/legendUtils.ts
@@ -91,6 +91,9 @@ export const getDisplayLabelExpr = (name: string): string =>
   `indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries) > -1 ? ${name}_labels[indexof(pluck(${name}_labels, 'seriesName'), datum.${name}Entries)].label : datum.${name}Entries`;
 
 const getLabelWidthTransforms = (name: string): Data['transform'] => [
+  // entryKey is the raw entry value, unaffected by any legendLabels override, so a page-aware
+  // render lookup can match an entry even when displayLabel has been customized.
+  { type: 'formula', as: 'entryKey', expr: `datum.${name}Entries` },
   { type: 'formula', as: 'displayLabel', expr: getDisplayLabelExpr(name) },
   { type: 'formula', as: 'labelWidth', expr: "getLabelWidth(datum.displayLabel, 'normal', 14)" },
   { type: 'window', ops: ['row_number'], as: ['legendIndex'] },
@@ -139,13 +142,26 @@ export const getRowCappedAggregateData = (name: string, maxRows: number): Data =
 
 /**
  * Expression for the `${name}_columnLayout` signal: resolves the chosen column count, labelLimit,
- * and (when `_labelWrap` is combined with `_preferredColumns`) dynamic wrap width, via the
- * `getLegendColumnLayout` expression function.
+ * and (when `_labelWrap` is combined with `_preferredColumns`) dynamic wrap width.
+ *
+ * When `maxRows` is set (pagination active), defers to `getLegendColumnLayoutForPage`, which looks
+ * up whatever `${name}_pages` already decided for the currently-visible page, instead of
+ * independently re-testing candidates against just the visible subset.
  */
-export const getColumnLayoutExpr = (name: string, preferredColumns: number[], labelWrap?: number): string =>
-  `getLegendColumnLayout(data('${name}_labelWidths'), width, ${JSON.stringify(preferredColumns)}, ${
+export const getColumnLayoutExpr = (
+  name: string,
+  preferredColumns: number[],
+  labelWrap?: number,
+  maxRows?: number
+): string => {
+  const candidates = JSON.stringify(preferredColumns);
+  if (maxRows === undefined) {
+    return `getLegendColumnLayout(data('${name}_labelWidths'), width, ${candidates}, ${labelWrap ?? 1})`;
+  }
+  return `getLegendColumnLayoutForPage(data('${name}_labelWidths'), data('${name}_pagesLabelWidths'), ${name}_pages, ${candidates}, width, ${
     labelWrap ?? 1
   })`;
+};
 
 /**
  * Expression for the `${name}_pages` signal: the full pagination plan for every legend entry


### PR DESCRIPTION
## Description

When computing the column layout, look at the column decision from the `_pages` signal, instead of re-computing based off the updated item count for that page. 

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
