### PR TITLE
feat: adding displayOnHoverTrigger prop to Trendline and MetricRange

### DIFF
--- a/packages/docs/docs/api/analysis/MetricRange.md
+++ b/packages/docs/docs/api/analysis/MetricRange.md
@@ -45,6 +45,12 @@ The `MetricRange` component is used to add a custom area mark onto visualization
             <td>Controls which parts of the metric range are visible only on hover. <code>true</code>: both the metric line and range area are hidden until hover. <code>'metric'</code>: only the metric line is hidden until hover; the range area is always visible. <code>'range'</code>: only the range area is hidden until hover; the metric line is always visible. <code>false</code>: both are always visible.</td>
         </tr>
         <tr>
+            <td>displayOnHoverTrigger</td>
+            <td>'nearest' | 'item' | 'dimension'</td>
+            <td>–</td>
+            <td>Restricts which hover interaction reveals the metric range when <code>displayOnHover</code> is set, independent of the parent <code>Line</code>'s <code>interactionMode</code>. For example, a line using <code>interactionMode="dimension"</code> can still set <code>displayOnHoverTrigger="item"</code> on its metric range so it only appears when hovering near an actual point, not anywhere along the dimension strip. Has no effect unless <code>displayOnHover</code> is set; if undefined, the metric range reveals on any active hover.</td>
+        </tr>
+        <tr>
             <td>hoverPoint</td>
             <td>boolean</td>
             <td>false</td>

--- a/packages/docs/docs/api/analysis/Trendline.md
+++ b/packages/docs/docs/api/analysis/Trendline.md
@@ -112,6 +112,12 @@ For this example, the granularity of the data would be in days.
             <td>Whether the trendline should only be visible when hovering over the parent line.</td>
         </tr>
         <tr>
+            <td>displayOnHoverTrigger</td>
+            <td>'nearest' | 'item' | 'dimension'</td>
+            <td>–</td>
+            <td>Restricts which hover interaction reveals the trendline when <code>displayOnHover</code> is set, independent of the parent <code>Line</code>'s <code>interactionMode</code>. For example, a line using <code>interactionMode="dimension"</code> can still set <code>displayOnHoverTrigger="item"</code> on its trendline so it only appears when hovering near an actual point, not anywhere along the dimension strip. Has no effect unless <code>displayOnHover</code> is set; if undefined, the trendline reveals on any active hover.</td>
+        </tr>
+        <tr>
             <td>excludeDataKeys</td>
             <td>string[]</td>
             <td>-</td>

--- a/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
@@ -10,17 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import React, { ReactElement } from 'react';
-
-
-
 import { StoryFn } from '@storybook/react';
-
-
-
 import { Content } from '@adobe/react-spectrum';
-
-
-
 import { Chart } from '../../../Chart';
 import { Axis, ChartPopover, ChartTooltip, Legend, Line, MetricRange, Trendline } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';

--- a/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/MetricRange/MetricRange.story.tsx
@@ -11,9 +11,15 @@
  */
 import React, { ReactElement } from 'react';
 
+
+
 import { StoryFn } from '@storybook/react';
 
+
+
 import { Content } from '@adobe/react-spectrum';
+
+
 
 import { Chart } from '../../../Chart';
 import { Axis, ChartPopover, ChartTooltip, Legend, Line, MetricRange, Trendline } from '../../../components';
@@ -21,6 +27,7 @@ import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
 import { workspaceTrendsDataWithAnomalies, workspaceTrendsDataWithBoundaryMetricRange, workspaceTrendsDataWithExtremeMetricRange, workspaceTrendsDataWithForecast, workspaceTrendsDataWithNullsInMetricRange, workspaceTrendsDataWithOutOfDomainMetricRange } from '../../data/data';
+
 
 export default {
   title: 'RSC/MetricRange',
@@ -280,6 +287,20 @@ DisplayOnHoverDimension.args = {
   displayOnHover: true,
 };
 
+// Line is in dimension mode (interactionMode="dimension").
+// displayOnHoverTrigger="item" (reveals only when hovering near an actual point).
+const DisplayOnHoverItemTrigger = bindWithProps(MetricRangeWithTooltipDimensionStory);
+DisplayOnHoverItemTrigger.args = {
+  lineType: 'shortDash',
+  lineWidth: 'S',
+  rangeOpacity: 0.2,
+  metricEnd: 'metricEnd',
+  metricStart: 'metricStart',
+  metric: 'metric',
+  displayOnHover: true,
+  displayOnHoverTrigger: 'item',
+};
+
 const DisplayOnHoverTrendlineDimension = bindWithProps(MetricRangeWithTrendlineAndDimensionStory);
 DisplayOnHoverTrendlineDimension.args = {
   lineType: 'shortDash',
@@ -424,6 +445,7 @@ export {
   Basic,
   DisplayOnHover,
   DisplayOnHoverDimension,
+  DisplayOnHoverItemTrigger,
   DisplayOnHoverTrendlineDimension,
   DisplayOnHoverLinearWithTrendline,
   DisplayOnHoverControlled,

--- a/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
@@ -11,10 +11,16 @@
  */
 import { ReactElement } from 'react';
 
+
+
 import { StoryFn } from '@storybook/react';
+
+
 
 import { TRENDLINE_VALUE } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder';
+
+
 
 import { Chart } from '../../../Chart';
 import { Axis, Bar, ChartPopover, ChartTooltip, Legend, Line, Scatter, Title, Trendline } from '../../../components';
@@ -24,6 +30,7 @@ import { characterData } from '../../../stories/data/marioKartData';
 import { bindWithProps } from '../../../test-utils/bindWithProps';
 import { ChartProps } from '../../../types';
 import { barSeriesData } from '../Bar/data';
+
 
 export default {
   title: 'RSC/Trendline',
@@ -195,6 +202,21 @@ const BothTooltipsWithDisplayOnHoverStory: StoryFn<typeof Trendline> = (args): R
   );
 };
 
+// Line is in dimension mode (interactionMode="dimension").
+const TrendlineWithDimensionStory: StoryFn<typeof Trendline> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series" interactionMode="dimension">
+        <Trendline {...args} />
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
 // Trendlines are always displayed (no displayOnHover). Hovering a line point fades the
 // trendlines of the other series via `line0_hoveredItem`. Hovering the matching legend entry
 // is supposed to produce the same fade via `legend0_hoveredSeries`, but currently does not.
@@ -344,6 +366,18 @@ DisplayOnHoverBothTooltips.args = {
   highlightRawPoint: true,
 };
 
+// Line is in dimension mode (interactionMode="dimension").
+// displayOnHoverTrigger="item" (reveals only when hovering near an actual point).
+const DisplayOnHoverItemTrigger = bindWithProps(TrendlineWithDimensionStory);
+DisplayOnHoverItemTrigger.args = {
+  displayOnHover: true,
+  displayOnHoverTrigger: 'item',
+  method: 'linear',
+  lineType: 'solid',
+  lineWidth: 'S',
+  color: 'gray-600',
+};
+
 const LegendHoverOpacity = bindWithProps(LegendHoverOpacityStory);
 LegendHoverOpacity.args = {
   method: 'linear',
@@ -394,6 +428,7 @@ export {
   DimensionRange,
   DisplayOnHover,
   DisplayOnHoverBothTooltips,
+  DisplayOnHoverItemTrigger,
   DisplayOnHoverTrendlineOnly,
   ExcludeSeriesFromTrendline,
   HidePartialWindows,

--- a/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Trendline/Trendline.story.tsx
@@ -10,18 +10,9 @@
  * governing permissions and limitations under the License.
  */
 import { ReactElement } from 'react';
-
-
-
 import { StoryFn } from '@storybook/react';
-
-
-
 import { TRENDLINE_VALUE } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder';
-
-
-
 import { Chart } from '../../../Chart';
 import { Axis, Bar, ChartPopover, ChartTooltip, Legend, Line, Scatter, Title, Trendline } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';

--- a/packages/vega-spec-builder/src/area/areaUtils.test.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.test.ts
@@ -305,6 +305,44 @@ describe('getAreaOpacity', () => {
     expect(opacity).toHaveLength(5);
   });
 
+  test('displayOnHoverTrigger "item" excludes the dimension rule in fade mode (displayOnHover: true)', () => {
+    const opacity = getAreaOpacity({
+      ...baseMetricRangeOptions,
+      displayOnHover: true,
+      displayOnHoverTrigger: 'item',
+      interactionMode: 'dimension',
+      hoverContext: getHoverContext(interactiveDimLineOpts),
+    });
+    // no dimension rule up front; first rule is now the item-hover fade rule
+    expect(JSON.stringify(opacity)).not.toContain('dimensionHoverArea');
+    expect(JSON.stringify(opacity?.[0])).toContain(`line0_${HOVERED_ITEM}`);
+  });
+
+  test('displayOnHoverTrigger "item" excludes dimension from the combined show-mode test (displayOnHover: "range")', () => {
+    const opacity = getAreaOpacity({
+      ...baseMetricRangeOptions,
+      displayOnHover: 'range',
+      displayOnHoverTrigger: 'item',
+      interactionMode: 'dimension',
+      hoverContext: getHoverContext(interactiveDimLineOpts),
+    });
+    expect(JSON.stringify(opacity?.[0])).not.toContain('dimensionHoverArea');
+    expect(JSON.stringify(opacity?.[0])).toContain(`line0_${HOVERED_ITEM}`);
+  });
+
+  test('displayOnHoverTrigger "dimension" excludes item-series-match rule (displayOnHover: "range")', () => {
+    const opacity = getAreaOpacity({
+      ...baseMetricRangeOptions,
+      displayOnHover: 'range',
+      displayOnHoverTrigger: 'dimension',
+      interactionMode: 'dimension',
+      hoverContext: getHoverContext(interactiveDimLineOpts),
+    });
+    const test = (opacity?.[0] as { test?: string })?.test;
+    expect(test).toContain('dimensionHoverArea');
+    expect(test).not.toContain(`line0_${HOVERED_ITEM}.`);
+  });
+
   test('returns default opacity rule when displayOnHover is false for a metric range', () => {
     const opacity = getAreaOpacity({ ...baseMetricRangeOptions, displayOnHover: false });
     expect(opacity).toEqual([DEFAULT_OPACITY_RULE]);

--- a/packages/vega-spec-builder/src/area/areaUtils.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.ts
@@ -35,6 +35,7 @@ import {
   ChartTooltipOptions,
   ColorFacet,
   ColorScheme,
+  DisplayOnHoverTrigger,
   HighlightedItem,
   InteractionMode,
   ScaleType,
@@ -45,6 +46,8 @@ export interface AreaMarkOptions {
   colorScheme: ColorScheme;
   dimension: string;
   displayOnHover?: boolean | 'metric' | 'range';
+  /** Restricts which hover trigger reveals `displayOnHover` content. Undefined matches any active hover (legacy behavior). */
+  displayOnHoverTrigger?: DisplayOnHoverTrigger;
   highlightedItem?: HighlightedItem;
   /** Resolved hover context — required when isMetricRange && displayOnHover is set. */
   hoverContext?: HoverContext;
@@ -113,16 +116,17 @@ export function getAreaOpacity(areaOptions: AreaMarkOptions): ProductionRule<Num
     chartPopovers,
     displayOnHover,
     hoverContext,
+    displayOnHoverTrigger,
     isHighlightedByGroup,
     isMetricRange,
     highlightedItem,
     name,
   } = areaOptions;
   if (isMetricRange && displayOnHover === 'range' && hoverContext) {
-    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'show');
+    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'show', displayOnHoverTrigger);
   }
   if (isMetricRange && (displayOnHover === true || displayOnHover === 'metric') && hoverContext) {
-    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'fade');
+    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'fade', displayOnHoverTrigger);
   }
 
   if (!isInteractive(areaOptions) && !highlightedItem) {

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -332,6 +332,47 @@ describe('getLineOpacity()', () => {
     expect(opacityRule[1]).toEqual({ value: 0 });
   });
 
+  test('displayOnHoverTrigger "item" excludes dimension hover rule even when interactionMode is dimension', () => {
+    const ctx = getHoverContext({
+      ...defaultLineOptions,
+      chartTooltips: [{}],
+      interactiveMarkName: 'line0',
+      interactionMode: 'dimension',
+    });
+    const opacityRule = getLineOpacity({
+      ...defaultLineMarkOptions,
+      interactiveMarkName: 'line0',
+      displayOnHover: true,
+      displayOnHoverTrigger: 'item',
+      interactionMode: 'dimension',
+      isMetricRange: true,
+      hoverContext: ctx,
+    });
+    expect(JSON.stringify(opacityRule[0])).not.toContain('dimensionHoverArea');
+    expect(JSON.stringify(opacityRule[0])).toContain(`line0_${HOVERED_ITEM}`);
+  });
+
+  test('displayOnHoverTrigger "dimension" excludes item-series-match rule even though item hover is active', () => {
+    const ctx = getHoverContext({
+      ...defaultLineOptions,
+      chartTooltips: [{}],
+      interactiveMarkName: 'line0',
+      interactionMode: 'dimension',
+    });
+    const opacityRule = getLineOpacity({
+      ...defaultLineMarkOptions,
+      interactiveMarkName: 'line0',
+      displayOnHover: true,
+      displayOnHoverTrigger: 'dimension',
+      interactionMode: 'dimension',
+      isMetricRange: true,
+      hoverContext: ctx,
+    });
+    const test = (opacityRule[0] as { test?: string })?.test;
+    expect(test).toContain('dimensionHoverArea');
+    expect(test).not.toContain(`line0_${HOVERED_ITEM}.`);
+  });
+
   test('returns opacity rules when displayOnHover is "metric" to show the line on hover', () => {
     const ctx = getHoverContext({
       ...defaultLineOptions,

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -133,6 +133,7 @@ export const getLineOpacity = ({
   displayOnHover,
   comboSiblingNames,
   hoverContext,
+  displayOnHoverTrigger,
   interactiveMarkName,
   interactionMode,
   isMetricRange,
@@ -148,7 +149,7 @@ export const getLineOpacity = ({
     hoverContext &&
     highlightedItem === undefined
   ) {
-    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'show');
+    return getMetricRangeHoverVisibilityOpacityRules(hoverContext, 'show', displayOnHoverTrigger);
   }
 
   if ((!interactiveMarkName || displayOnHover === true) && highlightedItem === undefined) {

--- a/packages/vega-spec-builder/src/line/lineUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineUtils.ts
@@ -15,6 +15,7 @@ import {
   ChartTooltipOptions,
   ColorFacet,
   ColorScheme,
+  DisplayOnHoverTrigger,
   DonutSummaryOptions,
   HighlightedItem,
   InteractionMode,
@@ -64,6 +65,8 @@ export interface LineMarkOptions {
   comboSiblingNames?: string[];
   dimension: string;
   displayOnHover?: boolean | 'metric' | 'range';
+  /** Restricts which hover trigger reveals `displayOnHover` content. Undefined matches any active hover (legacy behavior). */
+  displayOnHoverTrigger?: DisplayOnHoverTrigger;
   donutSummaries?: DonutSummaryOptions[];
   dualMetricAxis?: boolean;
   hasOnClick?: boolean;

--- a/packages/vega-spec-builder/src/marks/hoverContext.test.ts
+++ b/packages/vega-spec-builder/src/marks/hoverContext.test.ts
@@ -34,7 +34,14 @@ import { MARK_ID } from '@spectrum-charts/constants';
 
 import { defaultLineOptions } from '../trendline/trendlineTestUtils';
 import { LineSpecOptions } from '../types';
-import { HoverContext, getHoverContext, getItemHoverPredicate, getSeriesHoverPredicate } from './hoverContext';
+import {
+  HoverContext,
+  getHoverContext,
+  getItemHoverPredicate,
+  getSeriesHoverPredicate,
+  shouldIncludeDimensionHoverClauses,
+  shouldIncludeItemHoverClauses,
+} from './hoverContext';
 
 type Cell = 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
 
@@ -379,5 +386,59 @@ describe('getHoverContext — empty (no interactivity)', () => {
     expect(expr).not.toContain('hoveredItem');
     expect(expr).toContain('controlledHighlightedTable');
     expect(expr).toContain('controlledHighlightedSeries');
+  });
+});
+
+describe('getSeriesHoverPredicate — displayOnHoverTrigger scoping', () => {
+  // Cell D has both item and dimension prefixes for both the parent and the trendline,
+  // so it's the only cell where trigger-based scoping is actually observable.
+  const ctx = buildCtx('D');
+
+  test('trigger undefined (legacy) includes both item and dimension clauses', () => {
+    const expr = getSeriesHoverPredicate(ctx);
+    expect(expr).toContain('line0_hoveredItem');
+    expect(expr).toContain('line0Trendline_hoveredItem');
+    expect(expr).toContain('line0_dimensionHoverArea_hoveredItem');
+    expect(expr).toContain('line0Trendline_dimensionHoverArea_hoveredItem');
+  });
+
+  test('trigger "item" includes only item clauses, excludes dimension clauses', () => {
+    const expr = getSeriesHoverPredicate(ctx, 'item');
+    expect(expr).toContain('line0_hoveredItem');
+    expect(expr).toContain('line0Trendline_hoveredItem');
+    expect(expr).not.toContain('dimensionHoverArea');
+  });
+
+  test('trigger "nearest" behaves identically to "item"', () => {
+    expect(getSeriesHoverPredicate(ctx, 'nearest')).toBe(getSeriesHoverPredicate(ctx, 'item'));
+  });
+
+  test('trigger "dimension" includes only dimension clauses, excludes item-series-match clauses', () => {
+    const expr = getSeriesHoverPredicate(ctx, 'dimension');
+    expect(expr).toContain('line0_dimensionHoverArea_hoveredItem');
+    expect(expr).toContain('line0Trendline_dimensionHoverArea_hoveredItem');
+    expect(expr).not.toContain('line0_hoveredItem.rscSeriesId');
+    expect(expr).not.toContain('line0Trendline_hoveredItem.rscSeriesId');
+  });
+
+  test('controlled/selection clauses are present regardless of trigger', () => {
+    for (const trigger of [undefined, 'nearest', 'item', 'dimension'] as const) {
+      const expr = getSeriesHoverPredicate(ctx, trigger);
+      expect(expr).toContain('selectedSeries');
+      expect(expr).toContain('controlledHighlightedTable');
+      expect(expr).toContain('controlledHighlightedSeries');
+    }
+  });
+});
+
+describe('shouldIncludeItemHoverClauses / shouldIncludeDimensionHoverClauses', () => {
+  test.each([
+    [undefined, true, true],
+    ['nearest', true, false],
+    ['item', true, false],
+    ['dimension', false, true],
+  ] as const)('trigger=%s → includeItem=%s, includeDimension=%s', (trigger, includeItem, includeDimension) => {
+    expect(shouldIncludeItemHoverClauses(trigger)).toBe(includeItem);
+    expect(shouldIncludeDimensionHoverClauses(trigger)).toBe(includeDimension);
   });
 });

--- a/packages/vega-spec-builder/src/marks/hoverContext.ts
+++ b/packages/vega-spec-builder/src/marks/hoverContext.ts
@@ -9,24 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { CONTROLLED_HIGHLIGHTED_ITEM, CONTROLLED_HIGHLIGHTED_SERIES, CONTROLLED_HIGHLIGHTED_TABLE, DIMENSION_HOVER_AREA, GROUP_ID, HOVERED_ITEM, INTERACTION_MODE, SELECTED_ITEM, SELECTED_SERIES, SERIES_ID } from '@spectrum-charts/constants';
 
-import {
-  CONTROLLED_HIGHLIGHTED_ITEM,
-  CONTROLLED_HIGHLIGHTED_SERIES,
-  CONTROLLED_HIGHLIGHTED_TABLE,
-  DIMENSION_HOVER_AREA,
-  GROUP_ID,
-  HOVERED_ITEM,
-  INTERACTION_MODE,
-  SELECTED_ITEM,
-  SELECTED_SERIES,
-  SERIES_ID,
-} from '@spectrum-charts/constants';
+
 
 import { isHighlightedByGroup } from '../chartTooltip/chartTooltipUtils';
 import { getDimensionField } from '../line/lineDataUtils';
-import { LineSpecOptions } from '../types';
+import { DisplayOnHoverTrigger, LineSpecOptions } from '../types';
 import { hasPopover, hasTooltip, isInteractive } from './markUtils';
+
 
 export interface HoverContext {
   /** Mark namespaces that have an active `<prefix>_hoveredItem` signal (point-level hover). */
@@ -85,19 +76,38 @@ export const getHoverContext = (markOptions: LineSpecOptions): HoverContext => {
 
 const isTrendlinePrefix = (prefix: string): boolean => prefix.endsWith('Trendline');
 
-export const getSeriesHoverPredicate = (ctx: HoverContext): string => {
-  const clauses: string[] = [];
+/** Whether item-level (`nearest`/`item`) hover clauses should be included for the given trigger. */
+export const shouldIncludeItemHoverClauses = (trigger?: DisplayOnHoverTrigger): boolean => trigger !== 'dimension';
 
-  for (const prefix of ctx.itemPrefixes) {
-    const useGroup = isTrendlinePrefix(prefix) ? ctx.isHighlightedByGroupTrendline : ctx.isHighlightedByGroupParent;
-    const matchField = useGroup ? GROUP_ID : SERIES_ID;
-    clauses.push(
-      `isValid(${prefix}_${HOVERED_ITEM}) && ${prefix}_${HOVERED_ITEM}.${matchField} === datum.${matchField}`
-    );
+/** Whether dimension-level hover clauses should be included for the given trigger. */
+export const shouldIncludeDimensionHoverClauses = (trigger?: DisplayOnHoverTrigger): boolean =>
+  trigger === undefined || trigger === 'dimension';
+
+/**
+ * Builds the "is this datum's series hovered" predicate used to gate `displayOnHover` visibility.
+ * @param ctx resolved hover context for the parent mark
+ * @param scope optional hover trigger to restrict the predicate to. When omitted, both item-level
+ * (`nearest`/`item`) and dimension-level hover signals are included, matching legacy `displayOnHover: true` behavior.
+ */
+export const getSeriesHoverPredicate = (ctx: HoverContext, scope?: DisplayOnHoverTrigger): string => {
+  const clauses: string[] = [];
+  const includeItemClauses = shouldIncludeItemHoverClauses(scope);
+  const includeDimensionClauses = shouldIncludeDimensionHoverClauses(scope);
+
+  if (includeItemClauses) {
+    for (const prefix of ctx.itemPrefixes) {
+      const useGroup = isTrendlinePrefix(prefix) ? ctx.isHighlightedByGroupTrendline : ctx.isHighlightedByGroupParent;
+      const matchField = useGroup ? GROUP_ID : SERIES_ID;
+      clauses.push(
+        `isValid(${prefix}_${HOVERED_ITEM}) && ${prefix}_${HOVERED_ITEM}.${matchField} === datum.${matchField}`
+      );
+    }
   }
 
-  for (const prefix of ctx.dimensionPrefixes) {
-    clauses.push(`isValid(${prefix}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM})`);
+  if (includeDimensionClauses) {
+    for (const prefix of ctx.dimensionPrefixes) {
+      clauses.push(`isValid(${prefix}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM})`);
+    }
   }
 
   if (ctx.hasSelection) {

--- a/packages/vega-spec-builder/src/marks/hoverNamespaceMatrix.test.ts
+++ b/packages/vega-spec-builder/src/marks/hoverNamespaceMatrix.test.ts
@@ -45,7 +45,7 @@ import { getHoverContext } from './hoverContext';
 import { defaultLineOptions } from '../trendline/trendlineTestUtils';
 import { getTrendlineData, getTrendlineDisplayOnHoverData } from '../trendline/trendlineDataUtils';
 import { setTrendlineSignals } from '../trendline/trendlineSignalUtils';
-import { LineSpecOptions } from '../types';
+import { DisplayOnHoverTrigger, LineSpecOptions } from '../types';
 
 type Cell = 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
 
@@ -87,10 +87,10 @@ const trendlineHighlightExpr = (cell: Cell): string => {
 };
 
 /** Returns the filter expr for the metricRange displayOnHover data (cell-agnostic; uses parent). */
-const metricRangeDisplayOnHoverExpr = (cell: Cell): string => {
+const metricRangeDisplayOnHoverExpr = (cell: Cell, displayOnHoverTrigger?: DisplayOnHoverTrigger): string => {
   const opts: LineSpecOptions = {
     ...buildOptions(cell),
-    metricRanges: [{ metricStart: 'low', metricEnd: 'high', displayOnHover: true }],
+    metricRanges: [{ metricStart: 'low', metricEnd: 'high', displayOnHover: true, displayOnHoverTrigger }],
   };
   const data = getMetricRangeData(opts);
   const transform = data[0]?.transform?.[0];
@@ -99,10 +99,10 @@ const metricRangeDisplayOnHoverExpr = (cell: Cell): string => {
 };
 
 /** Returns the filter expr for displayOnHover trendline data (cell-aware, but only valid when trendline owns). */
-const trendlineDisplayOnHoverExpr = (cell: Cell): string => {
+const trendlineDisplayOnHoverExpr = (cell: Cell, displayOnHoverTrigger?: DisplayOnHoverTrigger): string => {
   const opts = buildOptions(cell);
   const ctx = getHoverContext(opts);
-  const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx);
+  const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx, displayOnHoverTrigger);
   return (data.transform?.[0] as { expr: string }).expr;
 };
 
@@ -268,5 +268,69 @@ describe('hover namespace matrix — opacity rules', () => {
     expect(JSON.stringify(rules)).toContain(ITEM_HOVER_TRENDLINE);
     expect(rules).toHaveLength(2);
     expect(rules[rules.length - 1]).toEqual({ value: 0 });
+  });
+
+  describe('displayOnHoverTrigger scoping (cell D — all four namespaces active)', () => {
+    test('trigger "item" restricts the combined test to item-hover signals only', () => {
+      const ctx = getHoverContext(buildOptions('D'));
+      const rules = getMetricRangeHoverVisibilityOpacityRules(
+        ctx,
+        'show',
+        'item'
+      ) as Array<{ test?: string; value?: number }>;
+      const flat = JSON.stringify(rules);
+      expect(flat).toContain(ITEM_HOVER_LINE);
+      expect(flat).toContain(ITEM_HOVER_TRENDLINE);
+      expect(flat).not.toContain(DIMENSION_HOVER_AREA);
+    });
+
+    test('trigger "dimension" restricts the combined test to dimension-strip signals only', () => {
+      const ctx = getHoverContext(buildOptions('D'));
+      const rules = getMetricRangeHoverVisibilityOpacityRules(
+        ctx,
+        'show',
+        'dimension'
+      ) as Array<{ test?: string; value?: number }>;
+      const flat = JSON.stringify(rules);
+      expect(flat).toContain(DIM_HOVER_LINE);
+      expect(flat).toContain(DIM_HOVER_TRENDLINE);
+      expect(flat).not.toContain(`${ITEM_HOVER_LINE}.`);
+      expect(flat).not.toContain(`${ITEM_HOVER_TRENDLINE}.`);
+    });
+
+    test('metricRange displayOnHover filter honors trigger "item" (excludes dimension signal)', () => {
+      const expr = metricRangeDisplayOnHoverExpr('D', 'item');
+      expect(expr).toContain(ITEM_HOVER_LINE);
+      expect(expr).toContain(ITEM_HOVER_TRENDLINE);
+      expect(expr).not.toContain(DIMENSION_HOVER_AREA);
+    });
+
+    test('metricRange displayOnHover filter honors trigger "dimension" (excludes item-series-match signal)', () => {
+      const expr = metricRangeDisplayOnHoverExpr('D', 'dimension');
+      expect(expr).toContain(DIM_HOVER_LINE);
+      expect(expr).toContain(DIM_HOVER_TRENDLINE);
+      expect(expr).not.toContain(`${ITEM_HOVER_LINE}.`);
+      expect(expr).not.toContain(`${ITEM_HOVER_TRENDLINE}.`);
+    });
+
+    test('trendline displayOnHover filter honors trigger "item" (excludes dimension signal)', () => {
+      const expr = trendlineDisplayOnHoverExpr('D', 'item');
+      expect(expr).toContain(ITEM_HOVER_LINE);
+      expect(expr).toContain(ITEM_HOVER_TRENDLINE);
+      expect(expr).not.toContain(DIMENSION_HOVER_AREA);
+    });
+
+    test('trendline displayOnHover filter honors trigger "dimension" (excludes item-series-match signal)', () => {
+      const expr = trendlineDisplayOnHoverExpr('D', 'dimension');
+      expect(expr).toContain(DIM_HOVER_LINE);
+      expect(expr).toContain(DIM_HOVER_TRENDLINE);
+      expect(expr).not.toContain(`${ITEM_HOVER_LINE}.`);
+      expect(expr).not.toContain(`${ITEM_HOVER_TRENDLINE}.`);
+    });
+
+    test('trigger undefined (legacy) still includes all four namespaces, matching prior D-cell behavior', () => {
+      expect(metricRangeDisplayOnHoverExpr('D')).toContain(DIMENSION_HOVER_AREA);
+      expect(trendlineDisplayOnHoverExpr('D')).toContain(DIMENSION_HOVER_AREA);
+    });
   });
 });

--- a/packages/vega-spec-builder/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.ts
@@ -50,7 +50,12 @@ import {
 import { getColorValue } from '@spectrum-charts/themes';
 
 import { addHoveredItemOpacityRules } from '../chartTooltip/chartTooltipUtils';
-import { HoverContext, getSeriesHoverPredicate } from './hoverContext';
+import {
+  HoverContext,
+  getSeriesHoverPredicate,
+  shouldIncludeDimensionHoverClauses,
+  shouldIncludeItemHoverClauses,
+} from './hoverContext';
 import { LineMarkOptions } from '../line/lineUtils';
 import { getScaleName } from '../scale/scaleSpecBuilder';
 import {
@@ -64,6 +69,7 @@ import {
   ChartTooltipOptions,
   ColorFacet,
   ColorScheme,
+  DisplayOnHoverTrigger,
   DonutSpecOptions,
   DualFacet,
   HighlightedItem,
@@ -138,27 +144,32 @@ export type MetricRangeHoverVisibility = 'show' | 'fade';
 
 export const getMetricRangeHoverVisibilityOpacityRules = (
   ctx: HoverContext,
-  visibility: MetricRangeHoverVisibility
+  visibility: MetricRangeHoverVisibility,
+  trigger?: DisplayOnHoverTrigger
 ): ProductionRule<NumericValueRef> => {
   const rules: Array<{ test?: string; signal?: string; value?: number }> = [];
 
   if (visibility === 'show') {
-    const showTest = getSeriesHoverPredicate(ctx);
+    const showTest = getSeriesHoverPredicate(ctx, trigger);
     rules.push({ test: showTest, value: 1 }, { value: 0 });
     return rules;
   }
 
-  for (const prefix of ctx.dimensionPrefixes) {
-    rules.push({ test: `isValid(${prefix}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM})`, value: 1 });
+  if (shouldIncludeDimensionHoverClauses(trigger)) {
+    for (const prefix of ctx.dimensionPrefixes) {
+      rules.push({ test: `isValid(${prefix}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM})`, value: 1 });
+    }
   }
-  for (const prefix of ctx.itemPrefixes) {
-    const isHoveredSeries = `${prefix}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;
-    const isControlledTableSeries = `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'), '${SERIES_ID}'), datum.${SERIES_ID}) > -1`;
-    const isControlledSeries = `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`;
-    rules.push({
-      test: `isValid(${prefix}_${HOVERED_ITEM})`,
-      signal: `${isHoveredSeries} || ${isControlledTableSeries} || ${isControlledSeries} ? 1 : ${FADE_FACTOR}`,
-    });
+  if (shouldIncludeItemHoverClauses(trigger)) {
+    for (const prefix of ctx.itemPrefixes) {
+      const isHoveredSeries = `${prefix}_${HOVERED_ITEM}.${SERIES_ID} === datum.${SERIES_ID}`;
+      const isControlledTableSeries = `indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'), '${SERIES_ID}'), datum.${SERIES_ID}) > -1`;
+      const isControlledSeries = `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) && ${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID}`;
+      rules.push({
+        test: `isValid(${prefix}_${HOVERED_ITEM})`,
+        signal: `${isHoveredSeries} || ${isControlledTableSeries} || ${isControlledSeries} ? 1 : ${FADE_FACTOR}`,
+      });
+    }
   }
   rules.push({
     test: `length(data('${CONTROLLED_HIGHLIGHTED_TABLE}'))`,

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
@@ -258,6 +258,26 @@ describe('getMetricRangeMark', () => {
         `isValid(line0_dimensionHoverArea_${HOVERED_ITEM})`
       );
     });
+
+    test('displayOnHoverTrigger "item" excludes dimension hover signals even in dimension mode', () => {
+      const [lineMark, areaMark] = getMetricRangeMark(
+        { ...interactiveLineOptions, interactionMode: 'dimension' },
+        { ...defaultMetricRangeSpecOptions, displayOnHover: true, displayOnHoverTrigger: 'item' }
+      );
+      expect(JSON.stringify(lineMark.encode?.update?.opacity?.[0])).not.toContain('dimensionHoverArea');
+      expect(JSON.stringify(lineMark.encode?.update?.opacity?.[0])).toContain(`line0_${HOVERED_ITEM}`);
+      expect(JSON.stringify(areaMark.encode?.update?.opacity)).not.toContain('dimensionHoverArea');
+    });
+
+    test('displayOnHoverTrigger "dimension" excludes item-series-match signals even though item hover is active', () => {
+      const [lineMark] = getMetricRangeMark(
+        { ...interactiveLineOptions, interactionMode: 'dimension' },
+        { ...defaultMetricRangeSpecOptions, displayOnHover: true, displayOnHoverTrigger: 'dimension' }
+      );
+      const test = (lineMark.encode?.update?.opacity?.[0] as { test?: string })?.test;
+      expect(test).toContain('dimensionHoverArea');
+      expect(test).not.toContain(`line0_${HOVERED_ITEM}.`);
+    });
   });
 
   describe('defined encoding (creates gaps when metric values are null/undefined)', () => {
@@ -406,6 +426,32 @@ describe('getMetricRangeData', () => {
     });
     expect(data).toHaveLength(1);
     expect(data[0]).toHaveProperty('name', 'line0MetricRange0_highlightedData');
+  });
+
+  test('_highlightedData filter honors displayOnHoverTrigger "item" in dimension mode (excludes dimension signal)', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      chartTooltips: [{}],
+      interactiveMarkName: 'line0',
+      interactionMode: 'dimension',
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: true, displayOnHoverTrigger: 'item' }],
+    });
+    const expr = (data[0].transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain(`line0_${HOVERED_ITEM}`);
+    expect(expr).not.toContain('dimensionHoverArea');
+  });
+
+  test('_highlightedData filter honors displayOnHoverTrigger "dimension" in dimension mode (excludes item-series-match signal)', () => {
+    const data = getMetricRangeData({
+      ...defaultLineOptions,
+      chartTooltips: [{}],
+      interactiveMarkName: 'line0',
+      interactionMode: 'dimension',
+      metricRanges: [{ ...defaultMetricRangeOptions, displayOnHover: true, displayOnHoverTrigger: 'dimension' }],
+    });
+    const expr = (data[0].transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain('dimensionHoverArea');
+    expect(expr).not.toContain(`line0_${HOVERED_ITEM}.`);
   });
 
   test('does not create _highlightedData when displayOnHover is "metric"', () => {

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
@@ -200,6 +200,7 @@ export const getMetricRangeMark = (
     isMetricRange: true,
     parentName: lineMarkOptions.name,
     displayOnHover: metricRangeOptions.displayOnHover,
+    displayOnHoverTrigger: metricRangeOptions.displayOnHoverTrigger,
     hoverContext,
     interactiveMarkName: lineMarkOptions.interactiveMarkName,
     interactionMode: lineMarkOptions.interactionMode,
@@ -215,6 +216,7 @@ export const getMetricRangeMark = (
     lineType: { value: metricRangeOptions.lineType },
     lineWidth: { value: metricRangeOptions.lineWidth },
     displayOnHover: metricRangeOptions.displayOnHover,
+    displayOnHoverTrigger: metricRangeOptions.displayOnHoverTrigger,
     opacity: metricRangeOptions.lineOpacity ? metricRangeOptions.lineOpacity : { value: 1 },
     hoverContext,
     interactiveMarkName,
@@ -237,7 +239,7 @@ export const getMetricRangeData = (markOptions: LineSpecOptions): SourceData[] =
 
   const ctx = getHoverContext(markOptions);
   for (const metricRangeOptions of metricRanges) {
-    const { displayOnHover, hoverPoint, metric, name } = metricRangeOptions;
+    const { displayOnHover, displayOnHoverTrigger, hoverPoint, metric, name } = metricRangeOptions;
     // if hoverPoint is true and the line is interactive, add a filtered data source to rows where the
     // MetricRange metric is valid. This prevents hover marks from being created at NaN y positions
     // for rows where the metric is null.
@@ -249,7 +251,7 @@ export const getMetricRangeData = (markOptions: LineSpecOptions): SourceData[] =
       data.push({
         name: `${name}_highlightedData`,
         source: FILTERED_TABLE,
-        transform: [{ type: 'filter', expr: getSeriesHoverPredicate(ctx) }],
+        transform: [{ type: 'filter', expr: getSeriesHoverPredicate(ctx, displayOnHoverTrigger) }],
       });
     }
   }

--- a/packages/vega-spec-builder/src/trendline/trendlineDataUtils.test.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineDataUtils.test.ts
@@ -15,17 +15,21 @@ import {
   DEFAULT_COLOR,
   DEFAULT_TIME_DIMENSION,
   FILTERED_TABLE,
+  HOVERED_ITEM,
   MS_PER_DAY,
   SERIES_ID,
   TRENDLINE_VALUE,
 } from '@spectrum-charts/constants';
 
+import { getHoverContext } from '../marks/hoverContext';
 import { baseData } from '../specUtils';
+import { LineSpecOptions } from '../types';
 import {
   addTableDataTransforms,
   addTrendlineData,
   getAggregateTrendlineData,
   getRegressionTrendlineData,
+  getTrendlineDisplayOnHoverData,
   getTrendlineStatisticalTransforms,
 } from './trendlineDataUtils';
 import { defaultLineOptions, defaultTrendlineOptions } from './trendlineTestUtils';
@@ -278,6 +282,62 @@ describe('addTrendlineData()', () => {
     const powData = getDefaultData();
     addTrendlineData(powData, { ...defaultLineOptions, trendlines: [{ method: 'power' }] });
     expect(powData[2].transform?.[0]).toStrictEqual({ type: 'filter', expr: 'isValid(datum["value"])' });
+  });
+
+  test('displayOnHoverTrigger on a trendline restricts its _highlightedData filter to that hover scope', () => {
+    const dimensionOptions: LineSpecOptions = {
+      ...defaultLineOptions,
+      chartTooltips: [{}],
+      interactiveMarkName: 'line0',
+      interactionMode: 'dimension',
+      trendlines: [{ method: 'linear', chartTooltips: [{}], displayOnHover: true, displayOnHoverTrigger: 'item' }],
+    };
+    const trendlineData = getDefaultData();
+    addTrendlineData(trendlineData, dimensionOptions);
+    const highlighted = trendlineData.find((d) => d.name === 'line0Trendline0_highlightedData');
+    const expr = (highlighted?.transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain(`line0_${HOVERED_ITEM}`);
+    expect(expr).not.toContain('dimensionHoverArea');
+  });
+});
+
+describe('getTrendlineDisplayOnHoverData()', () => {
+  const dimensionOptions: LineSpecOptions = {
+    ...defaultLineOptions,
+    chartTooltips: [{}],
+    interactiveMarkName: 'line0',
+    interactionMode: 'dimension',
+    trendlines: [{ method: 'linear', chartTooltips: [{}] }],
+  };
+  const ctx = getHoverContext(dimensionOptions);
+
+  test('defaults (no trigger) reference both item and dimension hover signals', () => {
+    const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx);
+    const expr = (data.transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain(`line0_${HOVERED_ITEM}`);
+    expect(expr).toContain('dimensionHoverArea');
+  });
+
+  test('trigger "item" excludes dimension hover signals', () => {
+    const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx, 'item');
+    const expr = (data.transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain(`line0_${HOVERED_ITEM}`);
+    expect(expr).not.toContain('dimensionHoverArea');
+  });
+
+  test('trigger "dimension" excludes item-series-match signals', () => {
+    const data = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx, 'dimension');
+    const expr = (data.transform?.[0] as { expr: string }).expr;
+    expect(expr).toContain('dimensionHoverArea');
+    expect(expr).not.toContain(`line0_${HOVERED_ITEM}.`);
+  });
+
+  test('uses _data as source for window methods, _highResolutionData otherwise', () => {
+    const windowData = getTrendlineDisplayOnHoverData('line0Trendline0', 'movingAverage-3', ctx);
+    expect(windowData.source).toBe('line0Trendline0_data');
+
+    const regressionData = getTrendlineDisplayOnHoverData('line0Trendline0', 'linear', ctx);
+    expect(regressionData.source).toBe('line0Trendline0_highResolutionData');
   });
 });
 

--- a/packages/vega-spec-builder/src/trendline/trendlineDataUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineDataUtils.ts
@@ -19,7 +19,7 @@ import { getUniqueDimensionData } from '../line/lineDataUtils';
 import { isInteractive } from '../marks/markUtils';
 import { HoverContext, getHoverContext, getItemHoverPredicate, getSeriesHoverPredicate } from '../marks/hoverContext';
 import { getFacetsFromOptions } from '../specUtils';
-import { LineSpecOptions, TrendlineMethod, TrendlineSpecOptions } from '../types';
+import { DisplayOnHoverTrigger, LineSpecOptions, TrendlineMethod, TrendlineSpecOptions } from '../types';
 import {
   getAggregateTransform,
   getMetricFilterTransform,
@@ -83,7 +83,7 @@ export const getTrendlineData = (markOptions: TrendlineParentOptions): SourceDat
   }
 
   for (const trendlineOptions of trendlines) {
-    const { displayOnHover, method, name } = trendlineOptions;
+    const { displayOnHover, displayOnHoverTrigger, method, name } = trendlineOptions;
     const { facets } = getFacetsFromOptions({ color, lineType });
 
     if (isRegressionMethod(method)) {
@@ -94,7 +94,7 @@ export const getTrendlineData = (markOptions: TrendlineParentOptions): SourceDat
       data.push(getWindowTrendlineData(markOptions, trendlineOptions));
     }
     if (displayOnHover) {
-      data.push(getTrendlineDisplayOnHoverData(name, method, ctx));
+      data.push(getTrendlineDisplayOnHoverData(name, method, ctx, displayOnHoverTrigger));
     }
     if (isInteractive(trendlineOptions)) {
       concatenatedTrendlineData.source.push(`${name}_data`);
@@ -326,16 +326,18 @@ export const addTableDataTransforms = produce<Transforms[], [TrendlineParentOpti
 /**
  * Gets the data source and transforms for displaying the trendline on hover.
  * Uses HoverContext so all active signal namespaces (parent + trendline, item + dimension)
- * are included in the filter expression.
+ * are included in the filter expression, unless restricted by `displayOnHoverTrigger`.
  * @param trendlineName
  * @param method
  * @param ctx
+ * @param displayOnHoverTrigger restricts the filter to a specific hover scope (see `TrendlineOptions.displayOnHoverTrigger`)
  * @returns SourceData
  */
 export const getTrendlineDisplayOnHoverData = (
   trendlineName: string,
   method: TrendlineMethod,
-  ctx: HoverContext
+  ctx: HoverContext,
+  displayOnHoverTrigger?: DisplayOnHoverTrigger
 ): SourceData => {
   const source = isWindowMethod(method) ? `${trendlineName}_data` : `${trendlineName}_highResolutionData`;
   return {
@@ -344,7 +346,7 @@ export const getTrendlineDisplayOnHoverData = (
     transform: [
       {
         type: 'filter',
-        expr: getSeriesHoverPredicate(ctx),
+        expr: getSeriesHoverPredicate(ctx, displayOnHoverTrigger),
       },
     ],
   };

--- a/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/metricRangeSpec.types.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { ChartTooltipOptions } from '../../dialogs/chartTooltipSpec.types';
-import { LineType, LineWidth, PartiallyRequired, OpacityFacet } from '../../specUtil.types';
+import { DisplayOnHoverTrigger, LineType, LineWidth, PartiallyRequired, OpacityFacet } from '../../specUtil.types';
 import { SpectrumColor } from '../../spectrumVizColor.types';
 
 export interface MetricRangeOptions {
@@ -38,6 +38,13 @@ export interface MetricRangeOptions {
    * - `false` (default): both are always visible
    */
   displayOnHover?: boolean | 'metric' | 'range';
+  /**
+   * Restricts which hover trigger reveals `displayOnHover` content. Independent of the parent line's `interactionMode`.
+   * e.g. a line with `interactionMode="dimension"` can still have a metric range with `displayOnHoverTrigger="item"`,
+   * so it only appears when hovering near an actual point, not anywhere along the dimension strip.
+   * Has no effect unless `displayOnHover` is set. Undefined (default) matches any active hover signal (legacy behavior).
+   */
+  displayOnHoverTrigger?: DisplayOnHoverTrigger;
   /** Whether to show a hover point on the metric range line when the parent line is interactive */
   hoverPoint?: boolean;
   /** Boolean indicating whether or not the y-axis should expand to include the entire metric range (if necessary). */

--- a/packages/vega-spec-builder/src/types/marks/supplemental/trendlineSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/trendlineSpec.types.ts
@@ -11,7 +11,15 @@
  */
 import { ColorScheme } from '../../chartSpec.types';
 import { ChartTooltipOptions } from '../../dialogs/chartTooltipSpec.types';
-import { ColorFacet, LineType, LineWidth, Orientation, PartiallyRequired, ScaleType } from '../../specUtil.types';
+import {
+  ColorFacet,
+  DisplayOnHoverTrigger,
+  LineType,
+  LineWidth,
+  Orientation,
+  PartiallyRequired,
+  ScaleType,
+} from '../../specUtil.types';
 import { SpectrumColor } from '../../spectrumVizColor.types';
 import { TrendlineAnnotationOptions } from './trendlineAnnotationSpec.types';
 
@@ -50,6 +58,13 @@ export interface TrendlineOptions {
   dimensionRange?: [number | null, number | null];
   /** Whether the trendline should only be visible when hovering over the parent line */
   displayOnHover?: boolean;
+  /**
+   * Restricts which hover trigger reveals `displayOnHover` content. Independent of the parent line's `interactionMode`.
+   * e.g. a line with `interactionMode="dimension"` can still have a trendline with `displayOnHoverTrigger="item"`,
+   * so the trendline only appears when hovering near an actual point, not anywhere along the dimension strip.
+   * Has no effect unless `displayOnHover` is set. Undefined (default) matches any active hover signal (legacy behavior).
+   */
+  displayOnHoverTrigger?: DisplayOnHoverTrigger;
   /** Data points where these keys have truthy values will not be included in the trendline calculation */
   excludeDataKeys?: string[];
   /** If there is a tooltip on this trendline, then this will highlight the raw point in addition to the hovered trendline point. */

--- a/packages/vega-spec-builder/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder/src/types/specUtil.types.ts
@@ -71,6 +71,7 @@ export type Datum = object & {
 };
 
 export type HoverType = 'point' | 'dimension';
+export type DisplayOnHoverTrigger = 'nearest' | 'item' | 'dimension';
 export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | string;
 export type Orientation = 'vertical' | 'horizontal';
 export type Position = 'left' | 'right' | 'top' | 'bottom';


### PR DESCRIPTION
## Description

This changes allows the display on hover trigger for Trendline and MetricRange be independent to whatever `interactionMode` is set on the parent Line component. 

`displayOnHoverTrigger: 'nearest' | 'item' | 'dimension';` - follows the same type as `interactionMode`

## Related Issue

## Motivation and Context

Handle display on hover functionality independent to the Line's interaction mode. 

## How Has This Been Tested?

Unit tests and storybook 

## Screenshots (if appropriate):

<img width="892" height="449" alt="Screenshot 2026-07-24 at 4 52 46 PM" src="https://github.com/user-attachments/assets/70e6efe9-5e0b-4c62-87c2-ed6a7cf96a51" />
<img width="882" height="450" alt="Screenshot 2026-07-24 at 4 53 11 PM" src="https://github.com/user-attachments/assets/a7c4ede7-0f4d-4051-96ce-99c9d38d8cc9" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
