### PR TITLE
feat: added Bar DirectLabel number format, D3 format

### DIFF
--- a/packages/docs/docs/spectrum2/bar.md
+++ b/packages/docs/docs/spectrum2/bar.md
@@ -52,7 +52,7 @@ The same component works for horizontal bar charts. Labels appear to the right o
 
 ### BarDirectLabel props
 
-The label text is derived automatically from the parent Bar's metric, dimension, and orientation. Additional options (custom format, prefix, etc.) will be added in future releases.
+The label text is derived automatically from the parent Bar's metric, dimension, and orientation.
 
 <table>
     <thead>
@@ -69,6 +69,12 @@ The label text is derived automatically from the parent Bar's metric, dimension,
             <td>'start' | 'middle' | 'end' | 'end-outside'</td>
             <td>'end-outside'</td>
             <td>Where to place the label relative to the bar. <code>'end-outside'</code> places it outside the bar tip; <code>'end'</code> places it inside the bar, 8px from the tip; <code>'middle'</code> centers it within the bar; <code>'start'</code> places it inside the bar, 8px from the baseline edge.</td>
+        </tr>
+        <tr>
+            <td>format</td>
+            <td>'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string</td>
+            <td>',.2~f'</td>
+            <td>Number format for the label value. Accepts a named preset or a custom d3-format specifier string (e.g. <code>'.1f'</code>).</td>
         </tr>
     </tbody>
 </table>

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarDirectLabel.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarDirectLabel.story.tsx
@@ -88,6 +88,19 @@ const BarDirectLabelStory: StoryFn<BarDirectLabelProps> = (args): ReactElement =
   );
 };
 
+const PercentageBarDirectLabelStory: StoryFn<BarDirectLabelProps> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: barData, width: 600, height: 400 });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline title="Browser" />
+      <Axis position="left" grid title="Share" labelFormat="percentage" />
+      <Bar dimension="browser" metric="share">
+        <BarDirectLabel {...args} />
+      </Bar>
+    </Chart>
+  );
+};
+
 const HorizontalBarDirectLabelStory: StoryFn<BarDirectLabelProps> = (args): ReactElement => {
   const chartProps = useChartProps({ data: barData, width: 600, height: 400 });
   return (
@@ -225,7 +238,23 @@ Position.args = { ...defaultProps, position: 'middle' };
 const PositionHorizontal = bindWithProps(HorizontalBarDirectLabelStory);
 PositionHorizontal.args = { ...defaultProps, position: 'start' };
 
+const PercentageFormat = bindWithProps(PercentageBarDirectLabelStory);
+PercentageFormat.args = { ...defaultProps, format: 'percentage' };
+
+const CustomFormat = bindWithProps(BarDirectLabelStory);
+CustomFormat.args = { ...defaultProps, format: '.1f' };
+
 const SizeScaling = bindWithProps(BarDirectLabelSizeScalingStory);
 SizeScaling.args = { ...defaultProps };
 
-export { Default, Horizontal, MixedValues, MixedValuesHorizontal, Position, PositionHorizontal, SizeScaling };
+export {
+  Default,
+  Horizontal,
+  MixedValues,
+  MixedValuesHorizontal,
+  Position,
+  PositionHorizontal,
+  PercentageFormat,
+  CustomFormat,
+  SizeScaling,
+};

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/data.ts
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/data.ts
@@ -11,11 +11,11 @@
  */
 
 export const barData = [
-  { browser: 'Chrome', downloads: 27000, percentLabel: '53.1%' },
-  { browser: 'Firefox', downloads: 8000, percentLabel: '15.7%' },
-  { browser: 'Safari', downloads: 7750, percentLabel: '15.2%' },
-  { browser: 'Edge', downloads: 7600, percentLabel: '14.9%' },
-  { browser: 'Explorer', downloads: 500, percentLabel: '1.0%' },
+  { browser: 'Chrome', downloads: 27000, percentLabel: '53.1%', share: 0.531 },
+  { browser: 'Firefox', downloads: 8000, percentLabel: '15.7%', share: 0.157 },
+  { browser: 'Safari', downloads: 7750, percentLabel: '15.2%', share: 0.152 },
+  { browser: 'Edge', downloads: 7600, percentLabel: '14.9%', share: 0.149 },
+  { browser: 'Explorer', downloads: 500, percentLabel: '1.0%', share: 0.01 },
 ];
 
 export const barDataLongLabels = [

--- a/packages/react-spectrum-charts-s2/src/types/marks/supplemental/barDirectLabel.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/supplemental/barDirectLabel.types.ts
@@ -11,6 +11,8 @@
  */
 import { JSXElementConstructor, ReactElement } from 'react';
 
+import { NumberFormat } from '@spectrum-charts/vega-spec-builder-s2';
+
 export type BarDirectLabelPosition = 'start' | 'middle' | 'end' | 'end-outside';
 
 export interface BarDirectLabelProps {
@@ -23,6 +25,8 @@ export interface BarDirectLabelProps {
    * @default 'end-outside'
    */
   position?: BarDirectLabelPosition;
+  /** Number format for the label value — a named preset or custom d3-format specifier. @default ',.2~f' */
+  format?: NumberFormat;
 }
 
 export type BarDirectLabelElement = ReactElement<

--- a/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.test.ts
@@ -37,6 +37,15 @@ describe('getBarDirectLabelSpecOptions()', () => {
     const options = getBarDirectLabelSpecOptions({ position: 'middle' }, 0, defaultBarOptions);
     expect(options.position).toBe('middle');
   });
+
+  it('defaults format to an empty string when not provided', () => {
+    expect(defaultSpecOptions.format).toBe('');
+  });
+
+  it('respects a provided format', () => {
+    const options = getBarDirectLabelSpecOptions({ format: 'percentage' }, 0, defaultBarOptions);
+    expect(options.format).toBe('percentage');
+  });
 });
 
 
@@ -208,5 +217,53 @@ describe('getBarDirectLabelMarks()', () => {
   it('marks source directly from FILTERED_TABLE', () => {
     const marks = getBarDirectLabelMarks(defaultSpecOptions, defaultBarOptions);
     marks.forEach(mark => expect((mark as TextMark).from?.data).toBe(FILTERED_TABLE));
+  });
+
+  describe('format', () => {
+    it('falls back to the default d3 spec when format is not provided', () => {
+      const [, main] = getBarDirectLabelMarks(defaultSpecOptions, defaultBarOptions);
+      expect((main as TextMark).encode?.enter?.text).toHaveProperty(
+        'signal',
+        `format(datum["${defaultBarOptions.metric}"], ",.2~f")`
+      );
+    });
+
+    it('resolves the "percentage" preset to the ~% d3 spec', () => {
+      const options = getBarDirectLabelSpecOptions({ format: 'percentage' }, 0, defaultBarOptions);
+      const [, main] = getBarDirectLabelMarks(options, defaultBarOptions);
+      expect((main as TextMark).encode?.enter?.text).toHaveProperty(
+        'signal',
+        `format(datum["${defaultBarOptions.metric}"], "~%")`
+      );
+    });
+
+    it('resolves the "currency" preset to the $,.2f d3 spec', () => {
+      const options = getBarDirectLabelSpecOptions({ format: 'currency' }, 0, defaultBarOptions);
+      const [, main] = getBarDirectLabelMarks(options, defaultBarOptions);
+      expect((main as TextMark).encode?.enter?.text).toHaveProperty(
+        'signal',
+        `format(datum["${defaultBarOptions.metric}"], "$,.2f")`
+      );
+    });
+
+    it('passes a custom d3-format specifier string straight through', () => {
+      const options = getBarDirectLabelSpecOptions({ format: '.1f' }, 0, defaultBarOptions);
+      const [, main] = getBarDirectLabelMarks(options, defaultBarOptions);
+      expect((main as TextMark).encode?.enter?.text).toHaveProperty(
+        'signal',
+        `format(datum["${defaultBarOptions.metric}"], ".1f")`
+      );
+    });
+
+    it('escapes embedded quotes and backslashes so the generated expression stays a single well-formed call', () => {
+      const maliciousFormat = '.1f\\"'; // ends with a literal backslash followed by a quote
+      const options = getBarDirectLabelSpecOptions({ format: maliciousFormat }, 0, defaultBarOptions);
+      const [, main] = getBarDirectLabelMarks(options, defaultBarOptions);
+      const { signal } = (main as TextMark).encode?.enter?.text as { signal: string };
+      const match = signal.match(/^format\(datum\["[^"]*"\], "(.*)"\)$/);
+      expect(match).not.toBeNull();
+      const [, escapedSpec] = match as RegExpMatchArray;
+      expect(JSON.parse(`"${escapedSpec}"`)).toEqual(maliciousFormat);
+    });
   });
 });

--- a/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.ts
@@ -15,6 +15,7 @@ import { BACKGROUND_COLOR, DIRECT_LABEL_BACKGROUND_STROKE_WIDTH, DIRECT_LABEL_FO
 
 import { getOrientationProperties } from '../bar/barUtils';
 import { getColorProductionRule, getDirectLabelFontSizeProductionRule, getMarkOpacity } from '../marks/markUtils';
+import { escapeD3FormatSpecifier, getD3FormatSpecifierFromNumberFormat } from '../specUtils';
 import { BarDirectLabelOptions, BarDirectLabelPositionType, BarDirectLabelSpecOptions, BarSpecOptions } from '../types';
 
 // Pixel gap between the bar tip and the label (end-outside)
@@ -98,7 +99,7 @@ export const getBarDirectLabelPositionEncodings = (
  * No separate data source is needed — each row in FILTERED_TABLE is already one bar.
  */
 export const getBarDirectLabelMarks = (labelOptions: BarDirectLabelSpecOptions, barOptions: BarSpecOptions): Mark[] => {
-  const { barName, color, colorOverride, colorScheme, dimension, index, metric, metricAxis, orientation, position } =
+  const { barName, color, colorOverride, colorScheme, dimension, format, index, metric, metricAxis, orientation, position } =
     labelOptions;
 
   const { metricScaleKey, dimensionScaleKey } = getOrientationProperties(orientation, metricAxis);
@@ -111,7 +112,9 @@ export const getBarDirectLabelMarks = (labelOptions: BarDirectLabelSpecOptions, 
   const fontSizeEncoding = getDirectLabelFontSizeProductionRule();
 
   // Label text computed inline — no derived dataset needed
-  const textSignal = `format(datum["${metric}"], "${DEFAULT_NUMBER_FORMAT}")`;
+  const resolvedFormat = format || DEFAULT_NUMBER_FORMAT;
+  const d3Spec = getD3FormatSpecifierFromNumberFormat(resolvedFormat);
+  const textSignal = `format(datum["${metric}"], "${escapeD3FormatSpecifier(d3Spec)}")`;
 
   // Dimension axis: center of the bar's band
   const dimensionBandCenter = { scale: dimensionScaleKey, field: dimension, band: 0.5 };
@@ -193,6 +196,7 @@ export const getBarDirectLabelSpecOptions = (
   colorOverride: barOptions.colorOverride,
   colorScheme: barOptions.colorScheme,
   dimension: barOptions.dimension,
+  format: labelOptions.format ?? '',
   index,
   metric: barOptions.metric,
   metricAxis: barOptions.metricAxis,

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -294,6 +294,19 @@ describe('getLineDirectLabelData', () => {
 		expect((formula as { expr: string }).expr).toContain('\\"');
 	});
 
+	test('escapes quotes and backslashes so the generated expression stays a single well-formed call', () => {
+		const maliciousFormat = '.1f\\"'; // ends with a literal backslash followed by a quote
+		const opts = { ...defaultLabelSpecOptions, format: maliciousFormat };
+		const data = getLineDirectLabelData('line0', opts, defaultLineOptions);
+		const transforms = getTransforms(data);
+		const formula = transforms.find((t) => t.type === 'formula' && 'as' in t && t.as === 'directLabel_text');
+		const { expr } = formula as { expr: string };
+		const match = expr.match(/^format\(datum\["[^"]*"\], "(.*)"\)$/);
+		expect(match).not.toBeNull();
+		const [, escapedSpec] = match as RegExpMatchArray;
+		expect(JSON.parse(`"${escapedSpec}"`)).toEqual(maliciousFormat);
+	});
+
 	test('includes dimension filter expression', () => {
 		const data = getLineDirectLabelData('line0', defaultLabelSpecOptions, defaultLineOptions);
 		const transforms = getTransforms(data);

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -20,7 +20,7 @@ import { getPrimarySeriesOtherExpr } from '../line/lineDataUtils';
 import { getLineOpacity } from '../line/lineMarkUtils';
 import { getColorProductionRule, getDirectLabelFontSizeProductionRule } from '../marks/markUtils';
 import { getScaleName } from '../scale/scaleSpecBuilder';
-import { getDimensionField, getFacetsFromOptions } from '../specUtils';
+import { escapeD3FormatSpecifier, getDimensionField, getFacetsFromOptions } from '../specUtils';
 import { LineDirectLabelOptions, LineDirectLabelSpecOptions, LineSpecOptions, LabelValue } from '../types';
 
 /**
@@ -98,7 +98,7 @@ const DEFAULT_NUMBER_FORMAT = ',.2~f';
 
 function getEscapedFormat(formatSpec?: string): string {
 	const resolved = formatSpec || DEFAULT_NUMBER_FORMAT;
-	return '"' + resolved.replaceAll('"', String.raw`\"`) + '"';
+	return '"' + escapeD3FormatSpecifier(resolved) + '"';
 }
 
 function getLabelValueExpr(value: LabelValue, metric: string, colorField?: string, formatSpec?: string): string {

--- a/packages/vega-spec-builder-s2/src/specUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   addUserMetaInteractiveMark,
   addUserMetaAnimatedMark,
+  escapeD3FormatSpecifier,
   getChartConfig,
   getD3FormatSpecifierFromNumberFormat,
   getDimensionField,
@@ -193,7 +194,25 @@ describe('getD3FormatSpecifierFromNumberFormat()', () => {
   test('should return proper formats', () => {
     expect(getD3FormatSpecifierFromNumberFormat('currency')).toEqual('$,.2f');
     expect(getD3FormatSpecifierFromNumberFormat('standardNumber')).toEqual(',');
+    expect(getD3FormatSpecifierFromNumberFormat('percentage')).toEqual('~%');
     expect(getD3FormatSpecifierFromNumberFormat(',.2f')).toEqual(',.2f');
+  });
+});
+
+describe('escapeD3FormatSpecifier()', () => {
+  test('escapes embedded double quotes', () => {
+    expect(escapeD3FormatSpecifier('foo"bar')).toEqual('foo\\"bar');
+  });
+
+  test('escapes embedded backslashes', () => {
+    expect(escapeD3FormatSpecifier('foo\\bar')).toEqual('foo\\\\bar');
+  });
+
+  test('escapes backslashes before quotes so a trailing backslash-quote cannot terminate the outer string early', () => {
+    const input = '\\"'; // backslash followed by a quote
+    const escaped = escapeD3FormatSpecifier(input);
+    // JSON string-escaping rules match Vega's, so this doubles as a round-trip proof
+    expect(JSON.parse(`"${escaped}"`)).toEqual(input);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/specUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.ts
@@ -298,7 +298,7 @@ export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat 
 
 /** Backslashes must be escaped before quotes — otherwise a trailing backslash-quote can terminate the outer Vega expression string early. */
 export const escapeD3FormatSpecifier = (formatSpec: string): string =>
-  formatSpec.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  formatSpec.replaceAll('\\', String.raw`\\`).replaceAll('"', String.raw`\"`);
 
 /**
  * Merges the provided config with the Spectrum Vega config

--- a/packages/vega-spec-builder-s2/src/specUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.ts
@@ -289,10 +289,16 @@ export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat 
       return '$,.2f'; // currency format
     case 'standardNumber':
       return ','; // standard number format
+    case 'percentage':
+      return '~%'; // percentage format
     default:
       return numberFormat;
   }
 };
+
+/** Backslashes must be escaped before quotes — otherwise a trailing backslash-quote can terminate the outer Vega expression string early. */
+export const escapeD3FormatSpecifier = (formatSpec: string): string =>
+  formatSpec.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 
 /**
  * Merges the provided config with the Spectrum Vega config

--- a/packages/vega-spec-builder-s2/src/specUtils.ts
+++ b/packages/vega-spec-builder-s2/src/specUtils.ts
@@ -283,7 +283,7 @@ export const getDimensionField = (dimension: string, scaleType?: ScaleType) => {
  * @param numberFormat
  * @returns
  */
-export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | string): string => {
+export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat): string => {
   switch (numberFormat) {
     case 'currency':
       return '$,.2f'; // currency format

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/barDirectLabelSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/barDirectLabelSpec.types.ts
@@ -10,13 +10,15 @@
  * governing permissions and limitations under the License.
  */
 import { ColorScheme } from '../../chartSpec.types';
-import { ColorFacet, Orientation } from '../../specUtil.types';
+import { ColorFacet, NumberFormat, Orientation } from '../../specUtil.types';
 import { DualFacet } from '../barSpec.types';
 
 export type BarDirectLabelPositionType = 'start' | 'middle' | 'end' | 'end-outside';
 
 export interface BarDirectLabelOptions {
   position?: BarDirectLabelPositionType;
+  /** Number format for the label value — a named preset or custom d3-format specifier. @default ',.2~f' */
+  format?: NumberFormat;
 }
 
 export interface BarDirectLabelSpecOptions extends BarDirectLabelOptions {
@@ -25,6 +27,7 @@ export interface BarDirectLabelSpecOptions extends BarDirectLabelOptions {
   colorOverride?: string;
   colorScheme: ColorScheme;
   dimension: string;
+  format: NumberFormat;
   index: number;
   metric: string;
   metricAxis?: string;

--- a/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
@@ -73,7 +73,7 @@ export type Datum = object & {
   [key: string]: any;
 };
 
-export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | string;
+export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string;
 export type Orientation = 'vertical' | 'horizontal';
 export type Position = 'left' | 'right' | 'top' | 'bottom';
 export type ScaleType = 'linear' | 'point' | 'time' | 'band';

--- a/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
@@ -73,7 +73,13 @@ export type Datum = object & {
   [key: string]: any;
 };
 
-export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string;
+export type NumberFormat =
+  | 'currency'
+  | 'shortCurrency'
+  | 'shortNumber'
+  | 'standardNumber'
+  | 'percentage'
+  | (string & NonNullable<unknown>);
 export type Orientation = 'vertical' | 'horizontal';
 export type Position = 'left' | 'right' | 'top' | 'bottom';
 export type ScaleType = 'linear' | 'point' | 'time' | 'band';

--- a/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
@@ -73,13 +73,7 @@ export type Datum = object & {
   [key: string]: any;
 };
 
-export type NumberFormat =
-  | 'currency'
-  | 'shortCurrency'
-  | 'shortNumber'
-  | 'standardNumber'
-  | 'percentage'
-  | (string & NonNullable<unknown>);
+export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string; // NOSONAR
 export type Orientation = 'vertical' | 'horizontal';
 export type Position = 'left' | 'right' | 'top' | 'bottom';
 export type ScaleType = 'linear' | 'point' | 'time' | 'band';

--- a/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/specUtil.types.ts
@@ -73,7 +73,7 @@ export type Datum = object & {
   [key: string]: any;
 };
 
-export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string; // NOSONAR
+export type NumberFormat = 'currency' | 'shortCurrency' | 'shortNumber' | 'standardNumber' | 'percentage' | string;
 export type Orientation = 'vertical' | 'horizontal';
 export type Position = 'left' | 'right' | 'top' | 'bottom';
 export type ScaleType = 'linear' | 'point' | 'time' | 'band';

--- a/packages/vega-spec-builder/src/specUtils.ts
+++ b/packages/vega-spec-builder/src/specUtils.ts
@@ -281,7 +281,8 @@ export const getDimensionField = (dimension: string, scaleType?: ScaleType) => {
  * @param numberFormat
  * @returns
  */
-export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | string): string => {  switch (numberFormat) {
+export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat): string => {
+  switch (numberFormat) {
     case 'currency':
       return '$,.2f'; // currency format
     case 'standardNumber':

--- a/packages/vega-spec-builder/src/specUtils.ts
+++ b/packages/vega-spec-builder/src/specUtils.ts
@@ -281,7 +281,7 @@ export const getDimensionField = (dimension: string, scaleType?: ScaleType) => {
  * @param numberFormat
  * @returns
  */
-export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | (string &  NonNullable<unknown>)): string => {  switch (numberFormat) {
+export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | string): string => {  switch (numberFormat) {
     case 'currency':
       return '$,.2f'; // currency format
     case 'standardNumber':

--- a/packages/vega-spec-builder/src/specUtils.ts
+++ b/packages/vega-spec-builder/src/specUtils.ts
@@ -281,8 +281,7 @@ export const getDimensionField = (dimension: string, scaleType?: ScaleType) => {
  * @param numberFormat
  * @returns
  */
-export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | string): string => {
-  switch (numberFormat) {
+export const getD3FormatSpecifierFromNumberFormat = (numberFormat: NumberFormat | (string &  NonNullable<unknown>)): string => {  switch (numberFormat) {
     case 'currency':
       return '$,.2f'; // currency format
     case 'standardNumber':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

[AN-461051](https://jira.corp.adobe.com/browse/AN-461051) — Bar DirectLabel number format

## Motivation and Context

BarDirectLabel (S2) had no format prop — its label text was hardcoded to the ,.2~f d3 spec. This ticket asks for two things on top of that: a percentage display option, and a way to pass a custom d3-format specifier string, matching the NumberFormat-style preset pattern already used by Legend, Donut, and Bullet.

## How Has This Been Tested?
Manually verified in storybook:s2 (RSC/Bar/BarDirectLabel) that PercentageFormat renders 53.1%/15.7%/15.2%/14.9%/1% and CustomFormat (.1f) renders one-decimal values correctly.

## Screenshots (if appropriate):
<img width="656" height="333" alt="Screenshot 2026-07-29 at 1 35 27 PM" src="https://github.com/user-attachments/assets/b7f48fa8-a47c-446e-9f05-6f10e45b0f10" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
