### PR TITLE
Fix: highlight area fixes

### DIFF
--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
@@ -568,6 +568,16 @@ describe('barSpecBuilder', () => {
         ).toBeDefined();
       });
 
+      test('should wire the bar mark itself onto the dimension hover area signal, not just the hover area rect', () => {
+        const signals = addSignals(defaultSignals, { ...defaultBarOptions, chartPopovers: [{}] });
+        const signal = signals.find(
+          (signal) => signal.name === `${defaultBarOptions.name}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`
+        );
+        expect(signal?.on).toContainEqual(
+          expect.objectContaining({ events: `@${defaultBarOptions.name}:mouseover` })
+        );
+      });
+
       test('should not add dimension hover area signal if the bar is not interactive', () => {
         const signals = addSignals(defaultSignals, defaultBarOptions);
         expect(

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
@@ -200,6 +200,10 @@ export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options)
   // gated by isInteractive() to match the rect mark and opacity rule that consume this signal
   if (isInteractive(options)) {
     addHoveredItemSignal(signals, `${name}_${DIMENSION_HOVER_AREA}`);
+    // the bar mark sits on top of the dimensionHoverArea rect and occludes it, so also wire the bar's
+    // own hover directly onto this signal - otherwise hovering a bar (rather than the padding around it)
+    // never triggers the dimension fade rule that reads this signal.
+    addHoveredItemSignal(signals, `${name}_${DIMENSION_HOVER_AREA}`, name);
   }
   addInspectSignals(signals, options);
   setTrendlineSignals(signals, options);

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
@@ -882,6 +882,19 @@ describe('getBarDimensionHoverArea()', () => {
       'bar0_groups'
     );
   });
+
+  test('should not set a tooltip when no inspect targets dimensionArea', () => {
+    const mark = getBarDimensionHoverArea({ ...defaultBarOptions, chartInspects: [{ targets: ['item'] }] }, 'stacked');
+    expect(mark.encode?.enter).toHaveProperty('tooltip', undefined);
+  });
+
+  test('should set a tooltip when an inspect targets dimensionArea', () => {
+    const mark = getBarDimensionHoverArea(
+      { ...defaultBarOptions, chartInspects: [{ targets: ['dimensionArea'] }] },
+      'stacked'
+    );
+    expect(mark.encode?.enter?.tooltip).toBeDefined();
+  });
 });
 
 describe('getBarDimensionAreaPositionEncodings()', () => {

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -32,6 +32,7 @@ import {
 } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
+import { hasInspectWithDimensionAreaTarget } from '../chartInspect/chartInspectUtils';
 import { getPopovers } from '../chartPopover/chartPopoverUtils';
 import {
   getColorProductionRule,
@@ -620,7 +621,9 @@ export const getBarDimensionHoverArea = (options: BarSpecOptions, type: 'stacked
     encode: {
       enter: {
         fill: { value: 'transparent' },
-        tooltip: getInspectEncoding(options.chartInspects ?? [], `${barName}_${DIMENSION_HOVER_AREA}`, false, { dimension }),
+        tooltip: hasInspectWithDimensionAreaTarget(options.chartInspects ?? [])
+          ? getInspectEncoding(options.chartInspects ?? [], `${barName}_${DIMENSION_HOVER_AREA}`, false, { dimension })
+          : undefined,
       },
       update: {
         ...getBarDimensionAreaPositionEncodings(options),

--- a/packages/vega-spec-builder-s2/src/chartInspect/chartInspectUtils.ts
+++ b/packages/vega-spec-builder-s2/src/chartInspect/chartInspectUtils.ts
@@ -240,3 +240,8 @@ export const addHoverdDimenstionAreaOpacityRules = (
     signal: `${hoveredItemSignal}.${dimension} === datum.${dimension} ? 1 : ${FADE_FACTOR}`,
   });
 };
+
+/** Whether any inspect on this mark targets the dimension-hover-area rect's own tooltip, rather than just the item mark. */
+export const hasInspectWithDimensionAreaTarget = (chartInspects: ChartInspectOptions[]) => {
+  return chartInspects.some(({ targets }) => targets?.includes('dimensionArea'));
+};

--- a/planning/specs/bar/issues/implemented/s2-bar-axis-label-fade-inconsistent-hover-source.json
+++ b/planning/specs/bar/issues/implemented/s2-bar-axis-label-fade-inconsistent-hover-source.json
@@ -1,0 +1,48 @@
+{
+  "id": "s2-bar-axis-label-fade-inconsistent-hover-source",
+  "title": "S2 Bar Axis Label Fade Only Triggers From Padding Gap, Not the Bar Itself",
+  "chartType": "bar",
+  "kind": "bug",
+  "variant": "s2",
+  "status": "implemented",
+  "lastUpdated": "2026-07-30",
+  "complexity": {
+    "score": 3,
+    "rationale": "Fix adds one extra symmetric mouseover/mouseout wiring onto an existing signal in a single addSignals function; no new mark or scale, but it is signal-wiring logic, not a plain value change."
+  },
+  "summary": "In S2 bar charts, hovering directly on a bar does not fade the other categories' axis labels, while hovering the padding gap around a bar (or the axis label itself) correctly triggers the fade - the dimension fade highlight only responds to some of the ways a user can hover a bar's category, not all of them.",
+  "symptom": "Hovering directly on a bar in an S2 bar chart leaves all axis labels at full opacity. Hovering just outside the same bar, in the padding gap between bars, correctly dims the other (non-hovered) axis labels. The fade should trigger consistently regardless of whether the cursor is over the bar itself or the padding around it.",
+  "rootCause": "packages/vega-spec-builder-s2/src/axis/axisLabelHoverUtils.ts:65-76 (getAxisLabelDimensionFillOpacity) computes axis label opacity purely from the `${name}_dimensionHoverArea_hoveredItem` signal. Before this fix, packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts:189 (addSignals) only ever wired that signal to the transparent dimension-hover-area rect's own mouseover/mouseout via `addHoveredItemSignal(signals, `${name}_${DIMENSION_HOVER_AREA}`)` (targeting `@${name}_dimensionHoverArea:mouseover`), plus axisLabelHoverUtils.ts's own addAxisLabelHoverSignalWiring appending a second source for the axis label mark. That rect (packages/vega-spec-builder-s2/src/bar/barUtils.ts:610, getBarDimensionHoverArea) is added to the marks array before the real bar mark in stackedBarUtils.ts:53-55 (and nested inside the bar's group in dodgedBarUtils.ts), so it is painted underneath the real bar and only ever receives pointer events in the padding gaps where no bar occludes it - never when the cursor is directly over a bar, since the real bar mark (on top, its own `isInteractive` handler already wired to a separate `${name}_hoveredItem` signal) intercepts those events instead. The dimension-hover-area signal therefore only ever reflected gap-hovers and axis-label hovers, never bar-hovers.",
+  "comparison": [
+    {
+      "aspect": "Sources that update the `${name}_dimensionHoverArea_hoveredItem` signal driving axis-label fade",
+      "expected": "Fading other-category axis labels should happen whenever any part of a bar's dimension band is hovered - the bar itself, the padding gap around it, or the axis label.",
+      "actual": "Only the padding-gap rect (barSpecBuilder.ts:189) and the axis label (axisLabelHoverUtils.ts's addAxisLabelHoverSignalWiring) were wired onto the signal. The real bar mark's own mouseover/mouseout never updated it, since the bar visually and interactively occludes the rect within its own footprint."
+    }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": false,
+    "touchesLegendInteraction": false,
+    "touchesTooltipOrPopover": false,
+    "requiresNewSignalOrScale": true,
+    "requiresS1S2Parity": false,
+    "notes": "requiresNewSignalOrScale is true because the fix adds a second symmetric mouseover/mouseout pair onto the existing `${name}_dimensionHoverArea_hoveredItem` signal (not a brand-new signal, but a new set/clear source that must stay paired). requiresS1S2Parity is false because the axis-label-hover feature (packages/vega-spec-builder-s2/src/axis/axisLabelHoverUtils.ts) is s2-only - it was added by commit 7bfc581c365da5070376f2f8fc2e1725d5fe1940 ('feat: AN-456589 Highlight bar on axis label hover') with no corresponding vega-spec-builder (s1) file, so there is no s1 equivalent behavior to check."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts",
+      "change": "In addSignals, after the existing addHoveredItemSignal(signals, `${name}_${DIMENSION_HOVER_AREA}`) call (wired to the rect's own hover), add a second addHoveredItemSignal(signals, `${name}_${DIMENSION_HOVER_AREA}`, name) call - passing the real bar mark's name as the targetName - so the bar's own mouseover/mouseout also updates the same signal.",
+      "lines": "186-190"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts",
+      "change": "Add a regression test asserting the dimension-hover-area signal's `on` array contains an entry for `@${name}:mouseover` (the bar's own mark name), not just `@${name}_dimensionHoverArea:mouseover`.",
+      "lines": "508-515 (inserted alongside the existing dimension-hover-area signal tests)"
+    }
+  ],
+  "openQuestions": [
+    "Fix was verified at the signal-wiring level (unit test) and confirmed type-agnostic (addSignals doesn't branch on stacked vs. dodged), but wasn't separately visually verified for trellised or dodged-and-stacked combo bar charts - worth a manual check if those layouts are in active use with this feature."
+  ],
+  "relatedIssues": ["s2-bar-dimension-hover-blank-tooltip"]
+}

--- a/planning/specs/bar/issues/implemented/s2-bar-dimension-hover-blank-tooltip.json
+++ b/planning/specs/bar/issues/implemented/s2-bar-dimension-hover-blank-tooltip.json
@@ -1,0 +1,53 @@
+{
+  "id": "s2-bar-dimension-hover-blank-tooltip",
+  "title": "S2 Bar Nearest-Hover Highlight Shows Blank Tooltip",
+  "chartType": "bar",
+  "kind": "bug",
+  "variant": "s2",
+  "status": "implemented",
+  "lastUpdated": "2026-07-30",
+  "complexity": {
+    "score": 3,
+    "rationale": "Fix re-gates one existing encode key (a conditional tooltip encode) and restores one small helper function that was deleted; no new mark, signal, or scale is needed since the underlying rect/signal must stay unconditional for a separate intended feature."
+  },
+  "summary": "In S2 bar charts, hovering the padding gap next to a bar correctly triggers the intended nearest-bar highlight, but also populates a tooltip from an aggregate datum missing the metric/series fields the tooltip content needs, so the tooltip renders blank.",
+  "symptom": "Hovering just outside a bar (in the gap between bars) in an S2 bar chart highlights the nearest bar as intended, but shows a tooltip with no value instead of the metric value shown when hovering directly over the bar.",
+  "rootCause": "packages/vega-spec-builder-s2/src/bar/barUtils.ts:610-627 (getBarDimensionHoverArea) sets its `tooltip` encode key via `getInspectEncoding(options.chartInspects ?? [], ..., { dimension })` unconditionally whenever `chartInspects.length > 0` (markUtils.ts:90-115 has no target-based gating). This rect's `from` data source is `${barName}_stacks` / `${barName}_groups` (barSpecBuilder.ts, getStackAggregateData ~234-249 and getDodgedGroupAggregateData ~271-283), which are aggregate sources carrying only grouping/aggregate fields (e.g. an auto-named `min_<metric>1`, or just the dimension for dodged) - not the plain metric/series fields a normal item tooltip's content reads, so the tooltip renders blank. This rect mark is added unconditionally by stackedBarUtils.ts:37 and dodgedBarUtils.ts:86 whenever `isInteractive(options)` is true, which is correct and intentional (needed by the axis-label-hover feature and by the nearest-bar highlight fade rule in chartInspectUtils.ts's addHoverdDimenstionAreaOpacityRules, both of which depend on this mark and its `${name}_dimensionHoverArea_hoveredItem` signal existing for every interactive bar chart) - but its `tooltip` encode key was left ungated when the surrounding mark-creation gate changed. Before commit 7bfc581c365da5070376f2f8fc2e1725d5fe1940 ('feat: AN-456589 Highlight bar on axis label hover', 2026-07-21), the whole mark - and by extension this tooltip - only ever existed when `hasInspectWithDimensionAreaTarget(options.chartInspects)` was true (an inspect explicitly targeting `'dimensionArea'`). That commit deleted `hasInspectWithDimensionAreaTarget` entirely and replaced the mark-creation checks with `isInteractive(options)`, so now any interactive bar chart with only the default item tooltip (`targets: ['item']` per `applyInspectPropDefaults`, chartInspectUtils.ts:62) also gets a tooltip from this rect whenever the nearest-bar-hover behavior fires.",
+  "comparison": [
+    {
+      "aspect": "Gating of the dimension-hover-area rect's tooltip encode",
+      "expected": "S1's packages/vega-spec-builder/src/bar/stackedBarUtils.ts:35 and dodgedBarUtils.ts:74 only ever create getBarDimensionHoverArea (barUtils.ts:448) when hasTooltipWithDimensionAreaTarget(options.chartTooltips) is true, so its own unconditional tooltip encode (barUtils.ts:462) only ever fires for charts that opted into targets: ['dimensionArea'].",
+      "actual": "S2's getBarDimensionHoverArea (barUtils.ts:623) sets a tooltip encode unconditionally whenever chartInspects.length > 0, and the mark itself is now created by stackedBarUtils.ts:37 / dodgedBarUtils.ts:86 whenever isInteractive(options) is true (any tooltip/popover/onClick/trendline), so the tooltip fires even for the default item-target tooltip."
+    }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": false,
+    "touchesLegendInteraction": false,
+    "touchesTooltipOrPopover": true,
+    "requiresNewSignalOrScale": false,
+    "requiresS1S2Parity": false,
+    "notes": "touchesTooltipOrPopover is true because the defect is precisely a tooltip content bug in the interactive-mark/inspect system (getInspectEncoding + isInteractive gating). requiresS1S2Parity is false because S1 does not reproduce this bug - dodgedBarUtils.ts:74 / stackedBarUtils.ts:35 still gate the entire dimensionHoverArea mark behind hasTooltipWithDimensionAreaTarget(options.chartTooltips), so S1's own unconditional tooltip line never fires outside an explicit dimensionArea target. S1's gating function is the reference the S2 fix should restore, but scoped only to the tooltip encode key - not to the mark/signal's existence, which S2 correctly needs unconditional for the axis-label-hover feature (AN-456589) and the nearest-bar highlight fade rule."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder-s2/src/bar/barUtils.ts",
+      "change": "In getBarDimensionHoverArea, gate the `tooltip` encode key so it's only set when an inspect targets 'dimensionArea' (restore the check removed in 7bfc581), instead of unconditionally calling getInspectEncoding whenever chartInspects.length > 0. Leave the rest of the mark (name, from, interactive: true, position encodings) untouched - it must keep existing unconditionally for every interactive bar chart.",
+      "lines": "610-627"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/chartInspect/chartInspectUtils.ts",
+      "change": "Re-add a hasInspectWithDimensionAreaTarget(chartInspects) export (deleted in 7bfc581 alongside the addHoverdDimenstionAreaOpacityRules gate change) for barUtils.ts to import and use only at the tooltip encode site. Do not use it to gate mark or signal creation in stackedBarUtils.ts, dodgedBarUtils.ts, or barSpecBuilder.ts's addSignals - those must stay unconditional on isInteractive(options) for the axis-label-hover and nearest-bar-highlight fade behavior to keep working.",
+      "lines": "~230-243 (near addHoverdDimenstionAreaOpacityRules, where the deleted function used to live)"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/bar/barUtils.test.ts",
+      "change": "Add a regression test asserting getBarDimensionHoverArea's tooltip encode is undefined when chartInspects has no dimensionArea-targeting entry (default item tooltip), and still populated when one does.",
+      "lines": "n/a - new test cases"
+    }
+  ],
+  "openQuestions": [
+    "Is the nearest-bar opacity fade highlight itself (addHoverdDimenstionAreaOpacityRules in chartInspectUtils.ts, gated only on markType === 'bar') intended to apply unconditionally to every interactive bar chart regardless of inspect target, or should it also be scoped to dimensionArea-targeting inspects? This fix assumed the fade highlight is desired as-is (the reporting user described it as 'fine') and scoped the fix to the tooltip content only - still open if that assumption needs revisiting."
+  ],
+  "relatedIssues": ["s2-bar-axis-label-fade-inconsistent-hover-source"]
+}


### PR DESCRIPTION
 ## Description

  Fixes two related S2 bar chart bugs around the dimension-hover-area rect used for "hover near a bar" interactions:

  1. **Blank tooltip on nearest-bar hover** - hovering the padding gap next to a bar (rather than the bar itself) triggered a tooltip, but its content
  came from an aggregate data source lacking the metric/series fields the tooltip needs, so it rendered blank.
  2. **Inconsistent axis label fade** - hovering directly on a bar did not fade the other categories' axis labels, while hovering the padding gap
  around a bar (or the axis label itself) did. The fade should trigger consistently regardless of where within a bar's dimension band the cursor lands.

  ### Changes

  - `barUtils.ts` / `chartInspectUtils.ts`: restored a `hasInspectWithDimensionAreaTarget` gate (removed in a previous commit) scoped specifically to
  the dimension-hover-area rect's `tooltip` encode key, so it only populates a tooltip when a chart explicitly opts in via `targets:
  ['dimensionArea']`. The rect and its hover signal remain unconditional for interactive bars, since axis-label-hover highlighting depends on them.
  - `barSpecBuilder.ts`: wired the real bar mark's own mouseover/mouseout onto the same `${name}_dimensionHoverArea_hoveredItem` signal the axis-label
  fade rule reads. Previously only the transparent hover-area rect (which sits underneath the bar and only receives events in the padding gaps) and the
  axis label itself updated that signal, so hovering a bar directly never triggered the fade.

  ## Related Issue

  Investigated and filed as specs (no pre-existing GitHub issue):
  - `planning/specs/bar/issues/implemented/s2-bar-dimension-hover-blank-tooltip.json`
  - `planning/specs/bar/issues/implemented/s2-bar-axis-label-fade-inconsistent-hover-source.json`

  Both are regressions from commit `7bfc581c` ("feat: AN-456589 Highlight bar on axis label hover"), which removed the tooltip-target gate and only
  partially wired the fade signal.

  ## Motivation and Context

  The axis-label-hover feature made the dimension-hover-area rect unconditional for all interactive bar charts (previously it only existed when a
  tooltip explicitly targeted `dimensionArea`). That change had two side effects that weren't caught at the time: the rect's tooltip encoding started
  firing for default item tooltips with incomplete data, and the new axis-label fade signal was only ever wired to the rect and the axis label, not the
  bar mark itself, since hovering a bar directly is occluded by the bar mark's own layer.

  ## How Has This Been Tested?

  - Added unit tests in `barUtils.test.ts` (tooltip encode gating) and `barSpecBuilder.test.ts` (signal wiring), verifying each new test fails against
  the pre-fix code and passes against the fix.
  - Full `vega-spec-builder-s2` test suite passes (1457/1457).
  - `yarn tsc --noEmit` shows no new errors (pre-existing, unrelated errors in `useChartInspectInteractions.test.tsx` and `Line.story.tsx` confirmed
  present on `main` independent of this change).

  ## Screenshots (if appropriate):

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  Left the CLA/CONTRIBUTING boxes unchecked since I can't confirm those on your behalf. Want me to open the PR on GitHub with this (base generalFixes),
  or are you posting it yourself?