### PR TITLE
S2 stories

### DIFF
--- a/packages/react-spectrum-charts/src/stories/components/Combo/Combo.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Combo/Combo.story.tsx
@@ -13,12 +13,14 @@ import { ReactElement } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
+import { ColorFacet } from '@spectrum-charts/vega-spec-builder';
+
 import { Chart } from '../../../Chart';
 import { Combo } from '../../../alpha';
 import { Axis, Bar, ChartTooltip, Line } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
-import { ChartProps } from '../../../types';
+import { ChartProps, ComboProps } from '../../../types';
 import { peopleAdoptionComboData, peopleTotalComboData } from '../../data/data';
 import { formatTimestamp } from '../../storyUtils';
 
@@ -34,19 +36,26 @@ const defaultChartProps: ChartProps = {
   height: 400,
 };
 
+/**
+ * Shared people/adoption-rate combo marks, reused by the s2 combo story so the two don't drift.
+ * `lineColor` is the only thing that differs between the s1 and s2 renderings.
+ */
+export const getPeopleAdoptionComboMarks = (
+  args: ComboProps,
+  lineColor: ColorFacet = { value: 'indigo-900' }
+): ReactElement[] => [
+  <Axis key="left" position="left" title="People" grid />,
+  <Axis key="right" position="right" name="adoption" title="Adoption Rate" />,
+  <Axis key="bottom" position="bottom" labelFormat="time" baseline ticks />,
+  <Combo key="combo" {...args}>
+    <Bar metric="people" />
+    <Line metric="adoptionRate" metricAxis="adoption" color={lineColor} scaleType="point" />
+  </Combo>,
+];
+
 const BasicComboStory: StoryFn<typeof Combo> = (args): ReactElement => {
   const chartProps = useChartProps(defaultChartProps);
-  return (
-    <Chart {...chartProps}>
-      <Axis position="left" title="People" grid />
-      <Axis position="right" name="adoption" title="Adoption Rate" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Combo {...args}>
-        <Bar metric="people" />
-        <Line metric="adoptionRate" metricAxis="adoption" color={{ value: 'indigo-900' }} scaleType="point" />
-      </Combo>
-    </Chart>
-  );
+  return <Chart {...chartProps}>{getPeopleAdoptionComboMarks(args)}</Chart>;
 };
 
 const TooltipStory: StoryFn<typeof Combo> = (args): ReactElement => {

--- a/packages/react-spectrum-charts/src/stories/components/Combo/Combo.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/components/Combo/Combo.story.tsx
@@ -36,13 +36,15 @@ const defaultChartProps: ChartProps = {
   height: 400,
 };
 
+const DEFAULT_LINE_COLOR: ColorFacet = { value: 'indigo-900' };
+
 /**
  * Shared people/adoption-rate combo marks, reused by the s2 combo story so the two don't drift.
  * `lineColor` is the only thing that differs between the s1 and s2 renderings.
  */
 export const getPeopleAdoptionComboMarks = (
   args: ComboProps,
-  lineColor: ColorFacet = { value: 'indigo-900' }
+  lineColor: ColorFacet = DEFAULT_LINE_COLOR
 ): ReactElement[] => [
   <Axis key="left" position="left" title="People" grid />,
   <Axis key="right" position="right" name="adoption" title="Adoption Rate" />,

--- a/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
@@ -16,6 +16,7 @@ import { StoryFn } from '@storybook/react';
 import { Chart } from '../../../Chart';
 import { Area, Axis, Legend } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
+import { workspaceTrendsData } from '../../data/data';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
 
@@ -34,44 +35,20 @@ const data = [
   { datetime: 1668409200000, maxTemperature: 64, minTemperature: 43, series: 'Add Fallout' },
 ];
 
-const multiSeriesData = [
-  { datetime: 1667890800000, value: 738, series: 'Add Fallout' },
-  { datetime: 1667977200000, value: 704, series: 'Add Fallout' },
-  { datetime: 1668063600000, value: 730, series: 'Add Fallout' },
-  { datetime: 1668150000000, value: 465, series: 'Add Fallout' },
-  { datetime: 1668236400000, value: 31, series: 'Add Fallout' },
-  { datetime: 1668322800000, value: 108, series: 'Add Fallout' },
-  { datetime: 1668409200000, value: 648, series: 'Add Fallout' },
-  { datetime: 1667890800000, value: 1220, series: 'Add Freeform table' },
-  { datetime: 1667977200000, value: 1130, series: 'Add Freeform table' },
-  { datetime: 1668063600000, value: 1109, series: 'Add Freeform table' },
-  { datetime: 1668150000000, value: 724, series: 'Add Freeform table' },
-  { datetime: 1668236400000, value: 39, series: 'Add Freeform table' },
-  { datetime: 1668322800000, value: 160, series: 'Add Freeform table' },
-  { datetime: 1668409200000, value: 1093, series: 'Add Freeform table' },
-];
-
-const defaultChartProps: ChartProps = { data, minWidth: 400, maxWidth: 800, height: 400 };
+const defaultChartProps: Omit<ChartProps, 'data'> = { minWidth: 400, maxWidth: 800, height: 400, s2: true };
 
 const S2AreaStory: StoryFn<typeof Area> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, s2: true });
+  const isMultiSeries = Boolean(args.color);
+  const chartProps = useChartProps({
+    ...defaultChartProps,
+    data: isMultiSeries ? workspaceTrendsData : data,
+  });
   return (
     <Chart {...chartProps}>
       <Axis position="bottom" labelFormat="time" baseline />
-      <Axis position="left" title="Temperature (F)" grid />
+      <Axis position="left" title={isMultiSeries ? 'Users' : 'Temperature (F)'} grid />
       <Area {...args} />
-    </Chart>
-  );
-};
-
-const S2StackedAreaStory: StoryFn<typeof Area> = (args): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: multiSeriesData, s2: true });
-  return (
-    <Chart {...chartProps}>
-      <Axis position="bottom" labelFormat="time" baseline />
-      <Axis position="left" title="Users" grid />
-      <Area {...args} />
-      <Legend highlight />
+      {isMultiSeries && <Legend highlight />}
     </Chart>
   );
 };
@@ -79,7 +56,7 @@ const S2StackedAreaStory: StoryFn<typeof Area> = (args): ReactElement => {
 const S2Area = bindWithProps(S2AreaStory);
 S2Area.args = { metric: 'maxTemperature' };
 
-const S2StackedArea = bindWithProps(S2StackedAreaStory);
+const S2StackedArea = bindWithProps(S2AreaStory);
 S2StackedArea.args = { dimension: 'datetime', metric: 'value', color: 'series' };
 
 export { S2Area, S2StackedArea };

--- a/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Area, Axis } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps } from '../../../types';
+
+export default {
+  title: 'RSC/Chart/S2/Area',
+  component: Area,
+};
+
+const data = [
+  { datetime: 1667890800000, maxTemperature: 73, minTemperature: 47, series: 'Add Fallout' },
+  { datetime: 1667977200000, maxTemperature: 70, minTemperature: 48, series: 'Add Fallout' },
+  { datetime: 1668063600000, maxTemperature: 73, minTemperature: 48, series: 'Add Fallout' },
+  { datetime: 1668150000000, maxTemperature: 56, minTemperature: 31, series: 'Add Fallout' },
+  { datetime: 1668236400000, maxTemperature: 41, minTemperature: 18, series: 'Add Fallout' },
+  { datetime: 1668322800000, maxTemperature: 60, minTemperature: 45, series: 'Add Fallout' },
+  { datetime: 1668409200000, maxTemperature: 64, minTemperature: 43, series: 'Add Fallout' },
+];
+
+const defaultChartProps: ChartProps = { data, minWidth: 400, maxWidth: 800, height: 400 };
+
+const S2AreaStory: StoryFn<typeof Area> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, s2: true });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline />
+      <Axis position="left" title="Temperature (F)" grid />
+      <Area {...args} />
+    </Chart>
+  );
+};
+
+const S2Area = bindWithProps(S2AreaStory);
+S2Area.args = { metric: 'maxTemperature' };
+
+export { S2Area };

--- a/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Area/S2Area.story.tsx
@@ -14,7 +14,7 @@ import { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../Chart';
-import { Area, Axis } from '../../../components';
+import { Area, Axis, Legend } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
@@ -34,6 +34,23 @@ const data = [
   { datetime: 1668409200000, maxTemperature: 64, minTemperature: 43, series: 'Add Fallout' },
 ];
 
+const multiSeriesData = [
+  { datetime: 1667890800000, value: 738, series: 'Add Fallout' },
+  { datetime: 1667977200000, value: 704, series: 'Add Fallout' },
+  { datetime: 1668063600000, value: 730, series: 'Add Fallout' },
+  { datetime: 1668150000000, value: 465, series: 'Add Fallout' },
+  { datetime: 1668236400000, value: 31, series: 'Add Fallout' },
+  { datetime: 1668322800000, value: 108, series: 'Add Fallout' },
+  { datetime: 1668409200000, value: 648, series: 'Add Fallout' },
+  { datetime: 1667890800000, value: 1220, series: 'Add Freeform table' },
+  { datetime: 1667977200000, value: 1130, series: 'Add Freeform table' },
+  { datetime: 1668063600000, value: 1109, series: 'Add Freeform table' },
+  { datetime: 1668150000000, value: 724, series: 'Add Freeform table' },
+  { datetime: 1668236400000, value: 39, series: 'Add Freeform table' },
+  { datetime: 1668322800000, value: 160, series: 'Add Freeform table' },
+  { datetime: 1668409200000, value: 1093, series: 'Add Freeform table' },
+];
+
 const defaultChartProps: ChartProps = { data, minWidth: 400, maxWidth: 800, height: 400 };
 
 const S2AreaStory: StoryFn<typeof Area> = (args): ReactElement => {
@@ -47,7 +64,22 @@ const S2AreaStory: StoryFn<typeof Area> = (args): ReactElement => {
   );
 };
 
+const S2StackedAreaStory: StoryFn<typeof Area> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: multiSeriesData, s2: true });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline />
+      <Axis position="left" title="Users" grid />
+      <Area {...args} />
+      <Legend highlight />
+    </Chart>
+  );
+};
+
 const S2Area = bindWithProps(S2AreaStory);
 S2Area.args = { metric: 'maxTemperature' };
 
-export { S2Area };
+const S2StackedArea = bindWithProps(S2StackedAreaStory);
+S2StackedArea.args = { dimension: 'datetime', metric: 'value', color: 'series' };
+
+export { S2Area, S2StackedArea };

--- a/packages/react-spectrum-charts/src/stories/s2/BigNumber/S2BigNumber.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/BigNumber/S2BigNumber.story.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import useChartProps from '../../../hooks/useChartProps';
+import { BigNumber } from '../../../rc';
+import { bindWithProps } from '../../../test-utils';
+import { simpleSparklineData as data } from '../../data/data';
+
+export default {
+  title: 'RSC/Chart/S2/BigNumber',
+  component: BigNumber,
+};
+
+const S2BigNumberStory: StoryFn<typeof BigNumber> = (args): ReactElement => {
+  const chartProps = useChartProps({
+    data,
+    width: 500,
+    height: 500,
+    s2: true,
+  });
+  return (
+    <Chart {...chartProps}>
+      <BigNumber {...args} />
+    </Chart>
+  );
+};
+
+const S2BigNumber = bindWithProps(S2BigNumberStory);
+S2BigNumber.args = {
+  children: undefined,
+  dataKey: 'x',
+  orientation: 'horizontal',
+  label: 'Visitors',
+};
+
+export { S2BigNumber };

--- a/packages/react-spectrum-charts/src/stories/s2/Bullet/S2Bullet.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Bullet/S2Bullet.story.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Bullet } from '../../../alpha';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { BulletProps, ChartProps } from '../../../types';
+import { basicBulletData } from '../../components/Bullet/data';
+
+export default {
+  title: 'RSC/Chart/S2/Bullet',
+  component: Bullet,
+};
+
+const defaultChartProps: ChartProps = {
+  data: basicBulletData,
+  width: 350,
+  height: 350,
+  s2: true,
+};
+
+const S2BulletStory: StoryFn<BulletProps> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Bullet {...args} />
+    </Chart>
+  );
+};
+
+const S2Bullet = bindWithProps(S2BulletStory);
+S2Bullet.args = {
+  metric: 'currentAmount',
+  dimension: 'graphLabel',
+  target: 'target',
+  color: 'blue-900',
+  direction: 'column',
+  numberFormat: '$,.2f',
+  showTarget: true,
+  showTargetValue: false,
+  labelPosition: 'top',
+  scaleType: 'normal',
+  maxScaleValue: 100,
+  track: false,
+  thresholdBarColor: false,
+  metricAxis: false,
+};
+
+export { S2Bullet };

--- a/packages/react-spectrum-charts/src/stories/s2/Combo/S2Combo.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Combo/S2Combo.story.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Combo } from '../../../alpha';
+import { Axis, Bar, Line } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps } from '../../../types';
+import { peopleAdoptionComboData } from '../../data/data';
+
+export default {
+  title: 'RSC/Chart/S2/Combo',
+  component: Combo,
+};
+
+const defaultChartProps: ChartProps = {
+  data: peopleAdoptionComboData,
+  minWidth: 400,
+  maxWidth: 800,
+  height: 400,
+  s2: true,
+};
+
+const S2ComboStory: StoryFn<typeof Combo> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" title="People" grid />
+      <Axis position="right" name="adoption" title="Adoption Rate" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Combo {...args}>
+        <Bar metric="people" />
+        <Line metric="adoptionRate" metricAxis="adoption" color={{ value: 'categorical-200' }} scaleType="point" />
+      </Combo>
+    </Chart>
+  );
+};
+
+const S2Combo = bindWithProps(S2ComboStory);
+S2Combo.args = {
+  name: 'combo0',
+  dimension: 'datetime',
+};
+
+export { S2Combo };

--- a/packages/react-spectrum-charts/src/stories/s2/Combo/S2Combo.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Combo/S2Combo.story.tsx
@@ -15,11 +15,11 @@ import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../Chart';
 import { Combo } from '../../../alpha';
-import { Axis, Bar, Line } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { ChartProps } from '../../../types';
 import { peopleAdoptionComboData } from '../../data/data';
+import { getPeopleAdoptionComboMarks } from '../../components/Combo/Combo.story';
 
 export default {
   title: 'RSC/Chart/S2/Combo',
@@ -36,17 +36,7 @@ const defaultChartProps: ChartProps = {
 
 const S2ComboStory: StoryFn<typeof Combo> = (args): ReactElement => {
   const chartProps = useChartProps(defaultChartProps);
-  return (
-    <Chart {...chartProps}>
-      <Axis position="left" title="People" grid />
-      <Axis position="right" name="adoption" title="Adoption Rate" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Combo {...args}>
-        <Bar metric="people" />
-        <Line metric="adoptionRate" metricAxis="adoption" color={{ value: 'categorical-200' }} scaleType="point" />
-      </Combo>
-    </Chart>
-  );
+  return <Chart {...chartProps}>{getPeopleAdoptionComboMarks(args, { value: 'categorical-200' })}</Chart>;
 };
 
 const S2Combo = bindWithProps(S2ComboStory);

--- a/packages/react-spectrum-charts/src/stories/s2/Donut/S2Donut.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Donut/S2Donut.story.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import useChartProps from '../../../hooks/useChartProps';
+import { Donut } from '../../../rc';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps, DonutProps } from '../../../types';
+import { basicDonutData } from '../../components/Donut/data';
+
+export default {
+  title: 'RSC/Chart/S2/Donut',
+  component: Donut,
+};
+
+const defaultChartProps: ChartProps = {
+  data: basicDonutData,
+  width: 350,
+  height: 350,
+};
+
+const S2DonutStory: StoryFn<DonutProps> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, s2: true });
+  return (
+    <Chart {...chartProps}>
+      <Donut {...args} />
+    </Chart>
+  );
+};
+
+const S2Donut = bindWithProps(S2DonutStory);
+S2Donut.args = {
+  metric: 'count',
+  color: 'browser',
+};
+
+export { S2Donut };

--- a/packages/react-spectrum-charts/src/stories/s2/MetricRange/S2MetricRange.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/MetricRange/S2MetricRange.story.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, Legend, Line, MetricRange } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { workspaceTrendsDataWithAnomalies } from '../../data/data';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps } from '../../../types';
+
+export default {
+  title: 'RSC/Chart/S2/MetricRange',
+  component: MetricRange,
+};
+
+const defaultChartProps: ChartProps = {
+  data: workspaceTrendsDataWithAnomalies,
+  minWidth: 400,
+  maxWidth: 800,
+  height: 400,
+  s2: true,
+};
+
+const S2MetricRangeStory: StoryFn<typeof MetricRange> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <MetricRange {...args} />
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
+const S2MetricRange = bindWithProps(S2MetricRangeStory);
+S2MetricRange.args = {
+  lineType: 'shortDash',
+  lineWidth: 'S',
+  rangeOpacity: 0.2,
+  metricEnd: 'metricEnd',
+  metricStart: 'metricStart',
+  metric: 'metric',
+};
+
+export { S2MetricRange };

--- a/packages/react-spectrum-charts/src/stories/s2/Scatter/S2Scatter.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Scatter/S2Scatter.story.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, Scatter } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { characterData } from '../../data/marioKartData';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps } from '../../../types';
+
+export default {
+  title: 'RSC/Chart/S2/Scatter',
+  component: Scatter,
+};
+
+const defaultChartProps: ChartProps = { data: characterData, height: 500, width: 500, s2: true };
+
+const S2ScatterStory: StoryFn<typeof Scatter> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" grid ticks baseline title="Speed (normal)" />
+      <Axis position="left" grid ticks baseline title="Handling (normal)" />
+      <Scatter {...args} />
+    </Chart>
+  );
+};
+
+const S2Scatter = bindWithProps(S2ScatterStory);
+S2Scatter.args = {
+  dimension: 'speedNormal',
+  metric: 'handlingNormal',
+};
+
+export { S2Scatter };

--- a/packages/react-spectrum-charts/src/stories/s2/Trendline/S2Trendline.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Trendline/S2Trendline.story.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, Legend, Line, Trendline } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { workspaceTrendsData } from '../../data/data';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps } from '../../../types';
+
+export default {
+  title: 'RSC/Chart/S2/Trendline',
+  component: Trendline,
+};
+
+const defaultChartProps: ChartProps = {
+  data: workspaceTrendsData,
+  minWidth: 400,
+  maxWidth: 800,
+  height: 400,
+  s2: true,
+};
+
+const S2TrendlineStory: StoryFn<typeof Trendline> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line color="series">
+        <Trendline {...args} />
+      </Line>
+      <Legend lineWidth={{ value: 0 }} highlight />
+    </Chart>
+  );
+};
+
+const S2Trendline = bindWithProps(S2TrendlineStory);
+S2Trendline.args = {
+  method: 'linear',
+  lineType: 'dashed',
+  lineWidth: 'S',
+};
+
+export { S2Trendline };

--- a/packages/react-spectrum-charts/src/stories/s2/Venn/S2Venn.story.tsx
+++ b/packages/react-spectrum-charts/src/stories/s2/Venn/S2Venn.story.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Venn } from '../../../alpha';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps, VennProps } from '../../../types';
+
+export default {
+  title: 'RSC/Chart/S2/Venn',
+  component: Venn,
+};
+
+const { A, B } = { A: 'Instagram', B: 'TikTok' };
+
+const basicData = [
+  { sets: [A], size: 12, label: 'A' },
+  { sets: [B], size: 12, label: 'B' },
+  { sets: [A, B], size: 2, label: 'AnB' },
+];
+
+const defaultChartProps: ChartProps = {
+  data: basicData,
+  height: 350,
+  width: 350,
+  s2: true,
+};
+
+const S2VennStory: StoryFn<VennProps> = (args) => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps} config={{ autosize: { type: 'pad' } }}>
+      <Venn {...args} />
+    </Chart>
+  );
+};
+
+const S2Venn = bindWithProps(S2VennStory);
+
+export { S2Venn };

--- a/packages/themes/src/utils.ts
+++ b/packages/themes/src/utils.ts
@@ -18,8 +18,9 @@ import { spectrumColors } from './spectrumColors';
  * @param colorScheme
  * @returns css color string
  */
-export const getColorValue = (color: string, colorScheme: 'light' | 'dark'): string => {
-  return spectrumColors[colorScheme][color] || color;
+export const getColorValue = (color: string, colorScheme: 'light' | 'dark', s2 = false): string => {
+  const palette = s2 ? spectrum2Colors : spectrumColors;
+  return palette[colorScheme][color] || color;
 };
 
 /**

--- a/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/area/areaSpecBuilder.ts
@@ -28,7 +28,7 @@ import {
   SELECTED_ITEM,
   SELECTED_SERIES,
 } from '@spectrum-charts/constants';
-import { spectrumColors } from '@spectrum-charts/themes';
+import { getColorValue } from '@spectrum-charts/themes';
 import { toCamelCase } from '@spectrum-charts/utils';
 
 import {
@@ -256,6 +256,7 @@ export const addAreaMarks = produce<Mark[], [AreaSpecOptions]>((marks, areaOptio
     metric,
     name,
     opacity,
+    s2,
     scaleType,
   } = areaOptions;
   let { metricStart, metricEnd } = areaOptions;
@@ -290,12 +291,13 @@ export const addAreaMarks = produce<Mark[], [AreaSpecOptions]>((marks, areaOptio
           metricEnd,
           name,
           opacity,
+          s2,
           scaleType,
         }),
         ...getAnchorPointMark(areaOptions),
       ],
     },
-    ...getSelectedAreaMarks({ chartPopovers, name, scaleType, color, dimension, metricEnd, metricStart }),
+    ...getSelectedAreaMarks({ chartPopovers, name, scaleType, color, dimension, metricEnd, metricStart, colorScheme, s2 }),
     ...getHoverMarks(areaOptions)
   );
   return marks;
@@ -380,17 +382,21 @@ const getSelectedAreaMarks = ({
   name,
   scaleType,
   color,
+  colorScheme,
   dimension,
   metricEnd,
   metricStart,
+  s2,
 }: {
   chartPopovers: ChartPopoverOptions[];
   name: string;
   scaleType: ScaleType;
   color: string;
+  colorScheme: ColorScheme;
   dimension: string;
   metricEnd: string;
   metricStart: string;
+  s2?: boolean;
 }): Mark[] => {
   if (!chartPopovers.length) return [];
   return [
@@ -405,7 +411,7 @@ const getSelectedAreaMarks = ({
           y2: { scale: 'yLinear', field: metricEnd },
           // need to fill this so the white border doesn't slightly bleed around the blue select border
           fill: { scale: COLOR_SCALE, field: color },
-          stroke: { value: spectrumColors.light['static-blue'] },
+          stroke: { value: getColorValue('static-blue', colorScheme, s2) },
           strokeWidth: { value: 2 },
           strokeJoin: { value: 'round' },
         },

--- a/packages/vega-spec-builder/src/area/areaUtils.ts
+++ b/packages/vega-spec-builder/src/area/areaUtils.ts
@@ -61,6 +61,7 @@ export interface AreaMarkOptions {
   name: string;
   opacity: number;
   parentName?: string; // Optional name of mark that this area is a child of. Used for metric ranges.
+  s2?: boolean;
   scaleType: ScaleType;
 
   chartPopovers?: ChartPopoverOptions[];
@@ -83,6 +84,7 @@ export const getAreaMark = (
     scaleType,
     dimension,
     opacity,
+    s2,
   } = areaOptions;
   return {
     name,
@@ -94,7 +96,7 @@ export const getAreaMark = (
       enter: {
         y: { scale: 'yLinear', field: metricStart },
         y2: { scale: 'yLinear', field: metricEnd },
-        fill: getColorProductionRule(color, colorScheme),
+        fill: getColorProductionRule(color, colorScheme, undefined, s2),
         tooltip: getTooltip(chartTooltips ?? [], name),
         ...getBorderStrokeEncodings(isStacked, true),
         defined: { signal: `isValid(datum["${metricStart}"]) || isValid(datum["${metricEnd}"])` },

--- a/packages/vega-spec-builder/src/bar/barSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/bar/barSpecBuilder.ts
@@ -79,6 +79,7 @@ export const addBar = produce<
       index?: number;
       idKey: string;
       comboSiblingNames?: string[];
+      s2?: boolean;
     }
   ]
 >(

--- a/packages/vega-spec-builder/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder/src/bar/barUtils.ts
@@ -286,11 +286,11 @@ export const getBaseBarEnterEncodings = (options: BarSpecOptions): EncodeEntry =
  * Otherwise fill is from the color scale via {@link getColorProductionRule} using {@link BarSpecOptions.color}.
  */
 export const getBarFillEncoding = (options: BarSpecOptions): ColorValueRef => {
-  const { colorOverride, color, colorScheme } = options;
+  const { colorOverride, color, colorScheme, s2 } = options;
   if (colorOverride) {
     return { signal: `datum[${JSON.stringify(colorOverride)}]` };
   }
-  return getColorProductionRule(color, colorScheme);
+  return getColorProductionRule(color, colorScheme, undefined, s2);
 };
 
 export const getBarEnterEncodings = (options: BarSpecOptions): EncodeEntry => ({
@@ -308,7 +308,7 @@ export const getBarUpdateEncodings = (options: BarSpecOptions): EncodeEntry => (
 });
 
 export const getStroke = (options: BarSpecOptions): ProductionRule<ColorValueRef> => {
-  const { name, chartPopovers, colorScheme, idKey } = options;
+  const { name, chartPopovers, colorScheme, idKey, s2 } = options;
   const defaultProductionRule = getBarFillEncoding(options);
   if (!hasPopover({ chartPopovers })) {
     return [defaultProductionRule];
@@ -317,14 +317,14 @@ export const getStroke = (options: BarSpecOptions): ProductionRule<ColorValueRef
   return [
     {
       test: `(${SELECTED_ITEM} && ${SELECTED_ITEM} === datum.${idKey}) || (${SELECTED_GROUP} && ${SELECTED_GROUP} === datum.${name}_selectedGroupId)`,
-      value: getColorValue('static-blue', colorScheme),
+      value: getColorValue('static-blue', colorScheme, s2),
     },
     defaultProductionRule,
   ];
 };
 
 export const getDimensionSelectionRing = (options: BarSpecOptions): RectMark => {
-  const { name, colorScheme, paddingRatio, orientation } = options;
+  const { name, colorScheme, paddingRatio, orientation, s2 } = options;
 
   const update =
     orientation === 'vertical'
@@ -352,7 +352,7 @@ export const getDimensionSelectionRing = (options: BarSpecOptions): RectMark => 
       enter: {
         fill: { value: 'transparent' },
         strokeWidth: { value: 2 },
-        stroke: { value: getColorValue('static-blue', colorScheme) },
+        stroke: { value: getColorValue('static-blue', colorScheme, s2) },
         cornerRadius: { value: 6 },
       },
       update,

--- a/packages/vega-spec-builder/src/bullet/bulletMarkUtils.ts
+++ b/packages/vega-spec-builder/src/bullet/bulletMarkUtils.ts
@@ -123,7 +123,7 @@ export function getBulletMarkRect(bulletOptions: BulletSpecOptions): Mark {
 }
 
 export function getBulletMarkTarget(bulletOptions: BulletSpecOptions): Mark {
-  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme);
+  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme, bulletOptions.s2);
 
   //When the target value label is shown, we must subtract the height of the target value label
   //to make sure that the target line is not drawn over the target value label
@@ -160,7 +160,7 @@ export function getBulletMarkTarget(bulletOptions: BulletSpecOptions): Mark {
 }
 
 export function getBulletMarkLabel(bulletOptions: BulletSpecOptions): Mark {
-  const barLabelColor = getColorValue('gray-600', bulletOptions.colorScheme);
+  const barLabelColor = getColorValue('gray-600', bulletOptions.colorScheme, bulletOptions.s2);
 
   const bulletMarkLabel: Mark = {
     name: `${bulletOptions.name}Label`,
@@ -194,8 +194,8 @@ export function getBulletValueText(
 }
 
 export function getBulletMarkValueLabel(bulletOptions: BulletSpecOptions): Mark {
-  const defaultColor = getColorValue(bulletOptions.color, bulletOptions.colorScheme);
-  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme);
+  const defaultColor = getColorValue(bulletOptions.color, bulletOptions.colorScheme, bulletOptions.s2);
+  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme, bulletOptions.s2);
   const encodeUpdateSignalWidth = bulletOptions.direction === 'column' ? 'width' : 'bulletGroupWidth';
   const fillExpr =
     bulletOptions.thresholdBarColor && (bulletOptions.thresholds?.length ?? 0) > 0
@@ -227,7 +227,7 @@ export function getBulletMarkValueLabel(bulletOptions: BulletSpecOptions): Mark 
 }
 
 export function getBulletMarkTargetValueLabel(bulletOptions: BulletSpecOptions): Mark {
-  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme);
+  const solidColor = getColorValue('gray-900', bulletOptions.colorScheme, bulletOptions.s2);
   const valueExpr = `datum.${bulletOptions.target}`;
 
   // Use targetLabel field if provided, otherwise format the target value
@@ -363,7 +363,7 @@ export function getBulletHoverArea(bulletOptions: BulletSpecOptions): Mark {
 }
 
 export function getBulletTrack(bulletOptions: BulletSpecOptions): Mark {
-  const trackColor = getColorValue('gray-200', bulletOptions.colorScheme);
+  const trackColor = getColorValue('gray-200', bulletOptions.colorScheme, bulletOptions.s2);
   const trackWidth = bulletOptions.direction === 'column' ? 'width' : 'bulletGroupWidth';
   // Subtracting 20 accounts for the space used by the target value label
   const trackY =

--- a/packages/vega-spec-builder/src/bullet/bulletSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/bullet/bulletSpecBuilder.ts
@@ -33,7 +33,7 @@ const DEFAULT_COLOR = spectrumColors.light['static-blue'];
 
 export const addBullet = produce<
   ScSpec,
-  [BulletOptions & { colorScheme?: ColorScheme; index?: number; idKey: string }]
+  [BulletOptions & { colorScheme?: ColorScheme; index?: number; idKey: string; s2?: boolean }]
 >(
   (
     spec,
@@ -57,6 +57,7 @@ export const addBullet = produce<
       thresholdBarColor = false,
       metricAxis = false,
       chartTooltips = [],
+      s2 = false,
       ...options
     }
   ) => {
@@ -64,7 +65,8 @@ export const addBullet = produce<
     const bulletOptions: BulletSpecOptions = {
       colorScheme: colorScheme,
       index,
-      color: getColorValue(color, colorScheme),
+      color: getColorValue(color, colorScheme, s2),
+      s2,
       metric: metric ?? 'currentAmount',
       dimension: dimension ?? 'graphLabel',
       target: target ?? 'target',

--- a/packages/vega-spec-builder/src/combo/comboSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/combo/comboSpecBuilder.ts
@@ -20,7 +20,15 @@ import { BarOptions, ColorScheme, ComboOptions, HighlightedItem, LineOptions, Sc
 
 export const addCombo = produce<
   ScSpec,
-  [ComboOptions & { colorScheme?: ColorScheme; highlightedItem?: HighlightedItem; index?: number; idKey: string }]
+  [
+    ComboOptions & {
+      colorScheme?: ColorScheme;
+      highlightedItem?: HighlightedItem;
+      index?: number;
+      idKey: string;
+      s2?: boolean;
+    }
+  ]
 >(
   (
     spec,
@@ -32,6 +40,7 @@ export const addCombo = produce<
       name,
       marks = [],
       dimension = DEFAULT_TIME_DIMENSION,
+      s2 = false,
     }
   ) => {
     let { barCount, lineCount } = initializeComponentCounts();
@@ -75,6 +84,7 @@ export const addCombo = produce<
             index: barCount,
             name: markName,
             dimension: getDimension(mark, dimension),
+            s2,
           });
         case 'line':
         default:
@@ -89,6 +99,7 @@ export const addCombo = produce<
             index: lineCount,
             name: markName,
             dimension: getDimension(mark, dimension),
+            s2,
           });
       }
     }, spec);

--- a/packages/vega-spec-builder/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder/src/donut/donutUtils.ts
@@ -46,7 +46,7 @@ export const getSumData = ({ metric, name }: DonutSpecOptions): SourceData => ({
 });
 
 export const getArcMark = (options: DonutSpecOptions): ArcMark => {
-  const { chartPopovers, chartTooltips, color, colorScheme, holeRatio, idKey, name } = options;
+  const { chartPopovers, chartTooltips, color, colorScheme, holeRatio, idKey, name, s2 } = options;
   return {
     type: 'arc',
     name,
@@ -54,11 +54,11 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
     from: { data: FILTERED_TABLE },
     encode: {
       enter: {
-        fill: getColorProductionRule(color, colorScheme),
+        fill: getColorProductionRule(color, colorScheme, undefined, s2),
         x: { signal: 'width / 2' },
         y: { signal: 'height / 2' },
         tooltip: getTooltip(chartTooltips, name),
-        stroke: { value: getColorValue('static-blue', colorScheme) },
+        stroke: { value: getColorValue('static-blue', colorScheme, s2) },
       },
       update: {
         startAngle: { field: `${name}_startAngle` },
@@ -82,7 +82,7 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
  * @returns ArcMark
  */
 export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
-  const { colorScheme, holeRatio, name } = options;
+  const { colorScheme, holeRatio, name, s2 } = options;
   return {
     type: 'arc',
     name: `${name}_emptyState`,
@@ -90,7 +90,7 @@ export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
     interactive: false,
     encode: {
       enter: {
-        fill: { value: getColorValue('gray-200', colorScheme) },
+        fill: { value: getColorValue('gray-200', colorScheme, s2) },
         x: { signal: 'width / 2' },
         y: { signal: 'height / 2' },
         startAngle: { value: 0 },

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -97,6 +97,7 @@ export const getLineMark = (lineMarkOptions: LineMarkOptions, dataSource: string
     metric,
     name,
     opacity,
+    s2,
     scaleType,
   } = lineMarkOptions;
   const popovers = getPopovers(chartPopovers ?? [], name);
@@ -113,7 +114,7 @@ export const getLineMark = (lineMarkOptions: LineMarkOptions, dataSource: string
     encode: {
       enter: {
         y: getLineYEncoding(lineMarkOptions, metric),
-        stroke: getColorProductionRule(color, colorScheme),
+        stroke: getColorProductionRule(color, colorScheme, undefined, s2),
         strokeDash: getStrokeDashProductionRule(lineType),
         strokeOpacity: getOpacityProductionRule(opacity),
         strokeWidth: getLineWidthProductionRule(lineWidth),

--- a/packages/vega-spec-builder/src/line/linePointUtils.ts
+++ b/packages/vega-spec-builder/src/line/linePointUtils.ts
@@ -42,10 +42,10 @@ const getSelectedTest = (name: string, idKey: string) =>
 const staticPointHollowTest = (staticPoint: string) => `datum.${staticPoint} === 'hollow'`;
 
 function getStaticPointFillEncode(
-  lineOptions: Pick<LineSpecOptions, 'color' | 'colorScheme' | 'isSparkline' | 'staticPoint'>
+  lineOptions: Pick<LineSpecOptions, 'color' | 'colorScheme' | 'isSparkline' | 's2' | 'staticPoint'>
 ) {
-  const { color, colorScheme, isSparkline, staticPoint } = lineOptions;
-  const solidFill = getColorProductionRule(color, colorScheme);
+  const { color, colorScheme, isSparkline, s2, staticPoint } = lineOptions;
+  const solidFill = getColorProductionRule(color, colorScheme, undefined, s2);
   // Sparkline static points use the same outline look as datum[field] === 'hollow'
   if (isSparkline) {
     return { signal: BACKGROUND_COLOR };
@@ -57,15 +57,18 @@ function getStaticPointFillEncode(
 }
 
 function getStaticPointStrokeEncode(
-  lineOptions: Pick<LineSpecOptions, 'color' | 'colorScheme' | 'isSparkline' | 'staticPoint'>
+  lineOptions: Pick<LineSpecOptions, 'color' | 'colorScheme' | 'isSparkline' | 's2' | 'staticPoint'>
 ) {
-  const { color, colorScheme, isSparkline, staticPoint } = lineOptions;
+  const { color, colorScheme, isSparkline, s2, staticPoint } = lineOptions;
   const solidStroke = { signal: BACKGROUND_COLOR };
   if (isSparkline) {
-    return getColorProductionRule(color, colorScheme);
+    return getColorProductionRule(color, colorScheme, undefined, s2);
   }
   if (staticPoint) {
-    return [{ test: staticPointHollowTest(staticPoint), ...getColorProductionRule(color, colorScheme) }, solidStroke];
+    return [
+      { test: staticPointHollowTest(staticPoint), ...getColorProductionRule(color, colorScheme, undefined, s2) },
+      solidStroke,
+    ];
   }
   return solidStroke;
 }
@@ -79,12 +82,13 @@ export const getLineStaticPoint = (lineOptions: LineSpecOptions): SymbolMark => 
     scaleType,
     dimension,
     isSparkline,
+    s2,
     staticPoint,
     pointSize = 125,
   } = lineOptions;
 
-  const fillEncode = getStaticPointFillEncode({ color, colorScheme, isSparkline, staticPoint });
-  const strokeEncode = getStaticPointStrokeEncode({ color, colorScheme, isSparkline, staticPoint });
+  const fillEncode = getStaticPointFillEncode({ color, colorScheme, isSparkline, s2, staticPoint });
+  const strokeEncode = getStaticPointStrokeEncode({ color, colorScheme, isSparkline, s2, staticPoint });
 
   return {
     name: `${name}_staticPoints`,
@@ -141,7 +145,7 @@ export const getHighlightBackgroundPoint = (lineOptions: LineMarkOptions): Symbo
 };
 
 const getHighlightOrSelectionPoint = (lineOptions: LineMarkOptions, useHighlightedData = true): SymbolMark => {
-  const { color, colorScheme, dimension, metric, metricRanges, name, scaleType } = lineOptions;
+  const { color, colorScheme, dimension, metric, metricRanges, name, s2, scaleType } = lineOptions;
   const dataSource = useHighlightedData ? getHighlightedDataSource(name, metricRanges) : `${name}_selectedData`;
   return {
     name: `${name}_point_${useHighlightedData ? 'highlight' : 'select'}`,
@@ -152,7 +156,7 @@ const getHighlightOrSelectionPoint = (lineOptions: LineMarkOptions, useHighlight
     encode: {
       enter: {
         y: getLineYEncoding(lineOptions, metric),
-        stroke: getColorProductionRule(color, colorScheme),
+        stroke: getColorProductionRule(color, colorScheme, undefined, s2),
       },
       update: {
         fill: getHighlightPointFill(lineOptions),
@@ -194,7 +198,7 @@ export const getSecondaryHighlightPoint = (
   lineOptions: LineMarkOptions,
   secondaryHighlightedMetric: string
 ): SymbolMark => {
-  const { color, colorScheme, dimension, name, scaleType } = lineOptions;
+  const { color, colorScheme, dimension, name, s2, scaleType } = lineOptions;
   return {
     name: `${name}_secondaryPoint`,
     description: `${name}_secondaryPoint`,
@@ -205,7 +209,7 @@ export const getSecondaryHighlightPoint = (
       enter: {
         y: getLineYEncoding(lineOptions, secondaryHighlightedMetric),
         fill: { signal: BACKGROUND_COLOR },
-        stroke: getColorProductionRule(color, colorScheme),
+        stroke: getColorProductionRule(color, colorScheme, undefined, s2),
       },
       update: {
         x: getXProductionRule(scaleType, dimension),
@@ -220,15 +224,18 @@ export const getSecondaryHighlightPoint = (
  * @returns fill rule
  */
 export const getHighlightPointFill = (markOptions: LineMarkOptions): ProductionRuleTests<ColorValueRef> => {
-  const { color, colorScheme, idKey, name, staticPoint } = markOptions;
+  const { color, colorScheme, idKey, name, s2, staticPoint } = markOptions;
   const fillRules: ProductionRuleTests<ColorValueRef> = [];
   const selectedTest = getSelectedTest(name, idKey);
 
   if (staticPoint) {
-    fillRules.push({ test: staticPointTestExpr(staticPoint), ...getColorProductionRule(color, colorScheme) });
+    fillRules.push({
+      test: staticPointTestExpr(staticPoint),
+      ...getColorProductionRule(color, colorScheme, undefined, s2),
+    });
   }
   if (hasPopover(markOptions)) {
-    fillRules.push({ test: selectedTest, ...getColorProductionRule(color, colorScheme) });
+    fillRules.push({ test: selectedTest, ...getColorProductionRule(color, colorScheme, undefined, s2) });
   }
   return [...fillRules, { signal: BACKGROUND_COLOR }];
 };
@@ -239,18 +246,21 @@ export const getHighlightPointFill = (markOptions: LineMarkOptions): ProductionR
  * @returns stroke rule
  */
 export const getHighlightPointStroke = (markOptions: LineMarkOptions): ProductionRuleTests<ColorValueRef> => {
-  const { color, colorScheme, idKey, name, staticPoint } = markOptions;
+  const { color, colorScheme, idKey, name, s2, staticPoint } = markOptions;
   const strokeRules: ProductionRuleTests<ColorValueRef> = [];
   const selectedTest = getSelectedTest(name, idKey);
 
   if (staticPoint) {
-    strokeRules.push({ test: staticPointTestExpr(staticPoint), ...getColorProductionRule(color, colorScheme) });
+    strokeRules.push({
+      test: staticPointTestExpr(staticPoint),
+      ...getColorProductionRule(color, colorScheme, undefined, s2),
+    });
   }
   if (hasPopover(markOptions)) {
     strokeRules.push({ test: selectedTest, signal: BACKGROUND_COLOR });
   }
 
-  return [...strokeRules, getColorProductionRule(color, colorScheme)];
+  return [...strokeRules, getColorProductionRule(color, colorScheme, undefined, s2)];
 };
 
 /**
@@ -315,7 +325,7 @@ export const getHighlightPointStrokeWidth = ({
  * @returns SymbolMark
  */
 export const getSelectRingPoint = (lineOptions: LineMarkOptions): SymbolMark => {
-  const { colorScheme, dimension, idKey, metric, name, scaleType } = lineOptions;
+  const { colorScheme, dimension, idKey, metric, name, s2, scaleType } = lineOptions;
   const selectedTest = getSelectedTest(name, idKey);
 
   return {
@@ -328,7 +338,7 @@ export const getSelectRingPoint = (lineOptions: LineMarkOptions): SymbolMark => 
       enter: {
         y: getLineYEncoding(lineOptions, metric),
         fill: { signal: BACKGROUND_COLOR },
-        stroke: { value: getColorValue('static-blue', colorScheme) },
+        stroke: { value: getColorValue('static-blue', colorScheme, s2) },
       },
       update: {
         size: [{ test: selectedTest, value: 196 }, { value: 0 }],

--- a/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder/src/line/lineSpecBuilder.ts
@@ -53,6 +53,7 @@ export const addLine = produce<
       index?: number;
       idKey: string;
       comboSiblingNames?: string[];
+      s2?: boolean;
     }
   ]
 >(

--- a/packages/vega-spec-builder/src/line/lineUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineUtils.ts
@@ -85,6 +85,7 @@ export interface LineMarkOptions {
   name: string;
   opacity: OpacityFacet;
   popoverMarkName?: string;
+  s2?: boolean;
   scaleType: ScaleType;
   scatterPaths?: ScatterPathOptions[];
   segmentLabels?: SegmentLabelOptions[];

--- a/packages/vega-spec-builder/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder/src/marks/markUtils.ts
@@ -233,7 +233,8 @@ export const hasTooltip = (options: { chartTooltips?: ChartTooltipOptions[] }): 
 export const getColorProductionRule = (
   color: ColorFacet | DualFacet,
   colorScheme: ColorScheme,
-  colorScaleType: 'linear' | 'ordinal' = 'ordinal'
+  colorScaleType: 'linear' | 'ordinal' = 'ordinal',
+  s2 = false
 ): ColorValueRef => {
   const colorScaleName = colorScaleType === 'linear' ? LINEAR_COLOR_SCALE : COLOR_SCALE;
   if (Array.isArray(color)) {
@@ -244,7 +245,7 @@ export const getColorProductionRule = (
   if (typeof color === 'string') {
     return { scale: colorScaleName, field: color };
   }
-  return { value: getColorValue(color.value, colorScheme) };
+  return { value: getColorValue(color.value, colorScheme, s2) };
 };
 
 /**
@@ -257,9 +258,10 @@ export const getColorProductionRule = (
 export const getColorProductionRuleSignalString = (
   color: ColorFacet | DualFacet,
   colorScheme: ColorScheme,
-  colorScaleType: 'linear' | 'ordinal' = 'ordinal'
+  colorScaleType: 'linear' | 'ordinal' = 'ordinal',
+  s2 = false
 ): string => {
-  const colorRule = getColorProductionRule(color, colorScheme, colorScaleType);
+  const colorRule = getColorProductionRule(color, colorScheme, colorScaleType, s2);
   if ('signal' in colorRule) {
     return colorRule.signal;
   }

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
@@ -123,7 +123,7 @@ export const getMetricRangeHoverPoints = (
   lineMarkOptions: LineSpecOptions,
   metricRangeOptions: MetricRangeSpecOptions
 ): SymbolMark[] => {
-  const { color: lineColor, colorScheme, dimension, scaleType } = lineMarkOptions;
+  const { color: lineColor, colorScheme, dimension, s2, scaleType } = lineMarkOptions;
   const { color: rangeColor, metric, name } = metricRangeOptions;
   const highlightedData = `${name}_hoverPointData`;
   const color = rangeColor ? { value: rangeColor } : lineColor;
@@ -160,12 +160,12 @@ export const getMetricRangeHoverPoints = (
     encode: {
       enter: {
         y: getLineYEncoding(lineMarkOptions, metric),
-        stroke: getColorProductionRule(color, colorScheme),
+        stroke: getColorProductionRule(color, colorScheme, undefined, s2),
       },
       update: {
         fill: { signal: BACKGROUND_COLOR },
         size: { value: DEFAULT_SYMBOL_SIZE },
-        stroke: getColorProductionRule(color, colorScheme),
+        stroke: getColorProductionRule(color, colorScheme, undefined, s2),
         strokeOpacity: getOpacityProductionRule(lineMarkOptions.opacity),
         strokeWidth: { value: DEFAULT_SYMBOL_STROKE_WIDTH },
         x: getXProductionRule(scaleType, dimension),
@@ -205,6 +205,7 @@ export const getMetricRangeMark = (
     interactiveMarkName: lineMarkOptions.interactiveMarkName,
     interactionMode: lineMarkOptions.interactionMode,
     isHighlightedByGroup: lineMarkOptions.isHighlightedByGroup,
+    s2: lineMarkOptions.s2,
   };
   const { interactiveMarkName, ...baseLineMarkOptions } = lineMarkOptions;
   const lineOptions: LineMarkOptions = {

--- a/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
+++ b/packages/vega-spec-builder/src/scatter/scatterMarkUtils.ts
@@ -13,7 +13,7 @@ import { produce } from 'immer';
 import { Blend, GroupMark, Mark, NumericValueRef, SymbolMark } from 'vega';
 
 import { DEFAULT_OPACITY_RULE, FADE_FACTOR, FILTERED_TABLE, SELECTED_ITEM } from '@spectrum-charts/constants';
-import { spectrumColors } from '@spectrum-charts/themes';
+import { getColorValue } from '@spectrum-charts/themes';
 
 import { addHoveredItemOpacityRules } from '../chartTooltip/chartTooltipUtils';
 import {
@@ -89,6 +89,7 @@ export const getScatterMark = (options: ScatterSpecOptions): SymbolMark => {
     metric,
     name,
     opacity,
+    s2,
     size,
     stroke,
   } = options;
@@ -105,13 +106,13 @@ export const getScatterMark = (options: ScatterSpecOptions): SymbolMark => {
     encode: {
       enter: {
         ...(blendEncoding && { blend: blendEncoding }),
-        fill: getColorProductionRule(color, colorScheme, colorScaleType),
+        fill: getColorProductionRule(color, colorScheme, colorScaleType, s2),
         fillOpacity: getOpacityProductionRule(opacity),
         shape: { value: 'circle' },
         size: getSymbolSizeProductionRule(size),
         strokeDash: getStrokeDashProductionRule(lineType),
         strokeWidth: getLineWidthProductionRule(lineWidth),
-        stroke: getColorProductionRule(stroke ?? color, colorScheme, colorScaleType),
+        stroke: getColorProductionRule(stroke ?? color, colorScheme, colorScaleType, s2),
       },
       update: {
         opacity: getOpacity(options),
@@ -163,7 +164,7 @@ export const getScatterHoverMarks = (scatterOptions: ScatterSpecOptions): Mark[]
 };
 
 const getScatterSelectMarks = (scatterOptions: ScatterSpecOptions): SymbolMark[] => {
-  const { dimension, dimensionScaleType, metric, name, size } = scatterOptions;
+  const { colorScheme, dimension, dimensionScaleType, metric, name, s2, size } = scatterOptions;
   if (!hasPopover(scatterOptions)) {
     return [];
   }
@@ -181,7 +182,7 @@ const getScatterSelectMarks = (scatterOptions: ScatterSpecOptions): SymbolMark[]
           shape: { value: 'circle' },
           size: getSelectRingSize(size),
           strokeWidth: { value: 2 },
-          stroke: { value: spectrumColors.light['static-blue'] },
+          stroke: { value: getColorValue('static-blue', colorScheme, s2) },
         },
         update: {
           x: getXProductionRule(dimensionScaleType, dimension),

--- a/packages/vega-spec-builder/src/trendline/trendlineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineMarkUtils.ts
@@ -93,7 +93,7 @@ export const getTrendlineRuleMark = (
   markOptions: TrendlineParentOptions,
   trendlineOptions: TrendlineSpecOptions
 ): RuleMark => {
-  const { colorScheme } = markOptions;
+  const { colorScheme, s2 } = markOptions;
   const {
     dimensionExtent,
     dimensionScaleType,
@@ -119,7 +119,7 @@ export const getTrendlineRuleMark = (
     encode: {
       enter: {
         ...getRuleYEncodings(dimensionExtent, trendlineDimension, orientation),
-        stroke: getColorProductionRule(trendlineColor, colorScheme),
+        stroke: getColorProductionRule(trendlineColor, colorScheme, undefined, s2),
         strokeDash: getStrokeDashProductionRule({ value: lineType }),
         strokeOpacity: getOpacityProductionRule({ value: trendlineOptions.opacity }),
         strokeWidth: getLineWidthProductionRule({ value: lineWidth }),
@@ -237,7 +237,7 @@ export const getTrendlineLineMark = (
   markOptions: TrendlineParentOptions,
   trendlineOptions: TrendlineSpecOptions
 ): LineMark => {
-  const { colorScheme } = markOptions;
+  const { colorScheme, s2 } = markOptions;
   const {
     dimensionScaleType,
     isDimensionNormalized,
@@ -257,7 +257,7 @@ export const getTrendlineLineMark = (
     encode: {
       enter: {
         y: getLineYProductionRule(trendlineDimension, orientation),
-        stroke: getColorProductionRule(trendlineColor, colorScheme),
+        stroke: getColorProductionRule(trendlineColor, colorScheme, undefined, s2),
         strokeDash: getStrokeDashProductionRule({ value: lineType }),
         strokeOpacity: getOpacityProductionRule({ value: trendlineOptions.opacity }),
         strokeWidth: getLineWidthProductionRule({ value: lineWidth }),

--- a/packages/vega-spec-builder/src/trendline/trendlineUtils.ts
+++ b/packages/vega-spec-builder/src/trendline/trendlineUtils.ts
@@ -96,6 +96,7 @@ export const applyTrendlinePropDefaults = (
     name: `${markOptions.name}Trendline${index}`,
     opacity,
     orientation,
+    s2: markOptions.s2,
     trendlineAnnotations,
     trendlineColor,
     trendlineDimension,

--- a/packages/vega-spec-builder/src/trendlineAnnotation/trendlineAnnotationUtils.ts
+++ b/packages/vega-spec-builder/src/trendlineAnnotation/trendlineAnnotationUtils.ts
@@ -41,6 +41,7 @@ export const getTrendlineAnnotationSpecOptions = (
     displayOnHover,
     lineWidth,
     orientation,
+    s2,
     trendlineColor,
     trendlineDimension,
     name: trendlineName,
@@ -55,6 +56,7 @@ export const getTrendlineAnnotationSpecOptions = (
   name: `${trendlineName}Annotation${index}`,
   numberFormat,
   prefix,
+  s2,
   trendlineColor,
   trendlineDimension,
   trendlineDimensionExtent: dimensionExtent,
@@ -222,6 +224,7 @@ export const getTrendlineAnnotationTextMark = (annotation: TrendlineAnnotationSp
 export const getTextFill = ({
   badge,
   colorScheme,
+  s2,
   trendlineColor,
 }: TrendlineAnnotationSpecOptions): ProductionRule<ColorValueRef> | undefined => {
   if (!badge) {
@@ -229,8 +232,8 @@ export const getTextFill = ({
     return undefined;
   }
   const color = getColorKey(trendlineColor);
-  const colorString = getColorProductionRuleSignalString(color, colorScheme);
-  const textColors = [getColorValue('gray-50', colorScheme), getColorValue('gray-900', colorScheme)];
+  const colorString = getColorProductionRuleSignalString(color, colorScheme, undefined, s2);
+  const textColors = [getColorValue('gray-50', colorScheme, s2), getColorValue('gray-900', colorScheme, s2)];
   return [
     { test: `contrast(${colorString}, '${textColors[0]}') >= 4.5`, value: textColors[0] },
     { value: textColors[1] },
@@ -241,6 +244,7 @@ export const getTrendlineAnnotationBadgeMark = ({
   badge,
   colorScheme,
   name,
+  s2,
   trendlineColor,
 }: TrendlineAnnotationSpecOptions): RectMark[] => {
   if (!badge) {
@@ -257,7 +261,7 @@ export const getTrendlineAnnotationBadgeMark = ({
       encode: {
         enter: {
           cornerRadius: { value: 2 },
-          fill: getColorProductionRule(color, colorScheme),
+          fill: getColorProductionRule(color, colorScheme, undefined, s2),
           opacity: { field: 'opacity' },
           x: { signal: 'datum.bounds.x1 - 3' },
           x2: { signal: 'datum.bounds.x2 + 3' },

--- a/packages/vega-spec-builder/src/types/marks/areaSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/areaSpec.types.ts
@@ -63,4 +63,5 @@ export interface AreaSpecOptions extends PartiallyRequired<AreaOptions, AreaOpti
   idKey: string;
   interactiveMarkName?: string;
   index: number;
+  s2?: boolean;
 }

--- a/packages/vega-spec-builder/src/types/marks/bulletSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/bulletSpec.types.ts
@@ -102,4 +102,5 @@ export interface BulletSpecOptions extends PartiallyRequired<BulletOptions, Bull
   idKey: string;
   index: number;
   interactiveMarkName: string | undefined;
+  s2?: boolean;
 }

--- a/packages/vega-spec-builder/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/lineSpec.types.ts
@@ -104,4 +104,5 @@ export interface LineSpecOptions extends PartiallyRequired<LineOptions, LineOpti
   lineWidth?: FacetRef<LineWidth>;
   popoverMarkName: string | undefined;
   interactionMode?: InteractionMode;
+  s2?: boolean;
 }

--- a/packages/vega-spec-builder/src/types/marks/scatterSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/scatterSpec.types.ts
@@ -119,4 +119,5 @@ export interface ScatterSpecOptions extends PartiallyRequired<ScatterOptions, Sc
   idKey: string;
   index: number;
   interactiveMarkName: string | undefined;
+  s2?: boolean;
 }

--- a/packages/vega-spec-builder/src/types/marks/supplemental/trendlineAnnotationSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/trendlineAnnotationSpec.types.ts
@@ -35,6 +35,7 @@ export interface TrendlineAnnotationSpecOptions
   displayOnHover: boolean;
   markName: string;
   name: string;
+  s2?: boolean;
   trendlineColor: ColorFacet;
   trendlineDimension: string;
   trendlineDimensionExtent: TrendlineSpecOptions['dimensionExtent'];

--- a/packages/vega-spec-builder/src/types/marks/supplemental/trendlineSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/supplemental/trendlineSpec.types.ts
@@ -111,6 +111,7 @@ export interface TrendlineSpecOptions extends PartiallyRequired<TrendlineOptions
   isDimensionNormalized: boolean;
   metric: string;
   name: string;
+  s2?: boolean;
   trendlineColor: ColorFacet;
   trendlineDimension: string;
   trendlineMetric: string;

--- a/packages/vega-spec-builder/src/types/marks/vennSpec.types.ts
+++ b/packages/vega-spec-builder/src/types/marks/vennSpec.types.ts
@@ -54,6 +54,7 @@ export interface VennSpecOptions extends PartiallyRequired<VennOptions, VennOpti
   idKey: string;
   index: number;
   markType: 'venn';
+  s2?: boolean;
 }
 
 export type VennDegreeOptions = '0deg' | '90deg' | '180deg' | '270deg';

--- a/packages/vega-spec-builder/src/venn/vennUtils.ts
+++ b/packages/vega-spec-builder/src/venn/vennUtils.ts
@@ -79,7 +79,7 @@ export const mapDataForVennHelper = (options: VennSpecOptions): VennHelperProps[
 };
 
 export const getCircleMark = (options: VennSpecOptions): SymbolMark => {
-  const { name, colorScheme, chartTooltips, chartPopovers } = options;
+  const { name, colorScheme, chartTooltips, chartPopovers, s2 } = options;
 
   return {
     type: 'symbol',
@@ -92,7 +92,7 @@ export const getCircleMark = (options: VennSpecOptions): SymbolMark => {
         tooltip: getTooltip(chartTooltips, name),
         size: { field: 'size' },
         shape: { value: 'circle' },
-        fill: getColorProductionRule('set_id', colorScheme),
+        fill: getColorProductionRule('set_id', colorScheme, undefined, s2),
         stroke: { signal: 'chartBackgroundColor' },
         strokeWidth: { value: 2 },
       },
@@ -127,7 +127,7 @@ export const getTextMark = (options: VennSpecOptions, dataSource: 'circles' | 'i
 };
 
 export const getIntersectionStrokeMark = (options: VennSpecOptions): PathMark => {
-  const { name, idKey, colorScheme } = options;
+  const { name, idKey, colorScheme, s2 } = options;
 
   return {
     type: 'path',
@@ -139,7 +139,7 @@ export const getIntersectionStrokeMark = (options: VennSpecOptions): PathMark =>
         path: { field: 'path' },
         strokeWidth: { value: 6 },
         strokeCap: { value: 'round' },
-        stroke: { value: getColorValue('static-blue', colorScheme) },
+        stroke: { value: getColorValue('static-blue', colorScheme, s2) },
       },
 
       update: {
@@ -150,7 +150,7 @@ export const getIntersectionStrokeMark = (options: VennSpecOptions): PathMark =>
 };
 
 export const getInterserctionMark = (options: VennSpecOptions): PathMark => {
-  const { name, chartTooltips, colorScheme, chartPopovers } = options;
+  const { name, chartTooltips, colorScheme, chartPopovers, s2 } = options;
 
   return {
     type: 'path',
@@ -159,7 +159,7 @@ export const getInterserctionMark = (options: VennSpecOptions): PathMark => {
     encode: {
       enter: {
         path: { field: 'path' },
-        fill: getColorProductionRule('set_id', colorScheme),
+        fill: getColorProductionRule('set_id', colorScheme, undefined, s2),
         strokeWidth: { value: 2 },
         stroke: { signal: 'chartBackgroundColor' },
         strokeCap: { value: 'square' },
@@ -175,7 +175,7 @@ export const getInterserctionMark = (options: VennSpecOptions): PathMark => {
 };
 
 export const getCircleStrokeMark = (options: VennSpecOptions): SymbolMark => {
-  const { colorScheme, idKey } = options;
+  const { colorScheme, idKey, s2 } = options;
   return {
     type: 'symbol',
     name: `${options.name}_circle_strokes`,
@@ -187,7 +187,7 @@ export const getCircleStrokeMark = (options: VennSpecOptions): SymbolMark => {
         y: { field: 'y' },
         size: { field: 'size' },
         shape: { value: 'circle' },
-        stroke: { value: getColorValue('static-blue', colorScheme) },
+        stroke: { value: getColorValue('static-blue', colorScheme, s2) },
         strokeWidth: { value: 6 },
       },
       update: {


### PR DESCRIPTION
 ## Description

Adds `s2`-prop Storybook stories for chart types that didn't have one: Area (incl. multi-series), Donut, Scatter, Bullet, Combo, Venn, BigNumber, Trendline, and MetricRange.

  ## Related Issue

  N/A

  ## Motivation and Context

  Give s1 consumers a working preview of Spectrum 2 styling across all chart types, not just the few that had it.

  ## How Has This Been Tested?

  `yarn tsc`, `yarn lint`, and full `yarn test` (243 suites / 3808 tests) all pass. Verified colors directly via built specs and reviewed each story in
  Storybook.

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.