### PR TITLE
feat(s2): AxisThumbnail follows the diverging axis to the zero line

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/Diverging.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/Diverging.story.tsx
@@ -14,7 +14,7 @@ import { ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../Chart';
-import { Axis, Bar, BarDirectLabel, Title } from '../../../components';
+import { Axis, AxisThumbnail, Bar, BarDirectLabel, Title } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { bindWithProps } from '../../../test-utils';
 import { BarProps } from '../../../types';
@@ -56,6 +56,33 @@ Horizontal.args = {
   ...defaultProps,
 };
 
+const thumbnails = ['/chrome.png', '/firefox.png', '/safari.png', '/edge.png', '/explorer.png'];
+
+const divergingConversionRateDataWithThumbnails = divergingConversionRateData.map((datum, index) => ({
+  ...datum,
+  thumbnail: thumbnails[index % thumbnails.length],
+}));
+
+/** Same as `Horizontal`, but with an `AxisThumbnail` on the dimension axis instead of a `BarDirectLabel` — thumbnails must move to the zero baseline along with the axis. */
+const HorizontalWithThumbnailStory: StoryFn<typeof Bar> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: divergingConversionRateDataWithThumbnails, width: 700, height: 400 });
+  return (
+    <Chart {...chartProps}>
+      <Title text="Single-series horizontal — axis thumbnails follow the axis to the zero line" fontSize={16} />
+      <Axis position="left" baseline>
+        <AxisThumbnail urlKey="thumbnail" />
+      </Axis>
+      <Axis position="bottom" grid labelFormat="percentage" />
+      <Bar {...args} diverging />
+    </Chart>
+  );
+};
+
+const HorizontalWithThumbnail = bindWithProps(HorizontalWithThumbnailStory);
+HorizontalWithThumbnail.args = {
+  ...defaultProps,
+};
+
 /** Single-series diverging, vertical — dimension on the bottom axis (baseline/dy flip). Value labels forced outside via `position="end-outside"`. */
 const VerticalStory: StoryFn<typeof Bar> = (args): ReactElement => {
   const chartProps = useChartProps({ data: divergingConversionRateData, width: 500, height: 500 });
@@ -73,6 +100,29 @@ const VerticalStory: StoryFn<typeof Bar> = (args): ReactElement => {
 
 const Vertical = bindWithProps(VerticalStory);
 Vertical.args = {
+  dimension: 'channel',
+  metric: 'changeRate',
+  orientation: 'vertical',
+  colorOverride: 'barColor',
+} satisfies BarProps;
+
+/** Same as `Vertical`, but with an `AxisThumbnail` on the dimension axis instead of a `BarDirectLabel` — thumbnails must move to the zero baseline along with the axis. */
+const VerticalWithThumbnailStory: StoryFn<typeof Bar> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: divergingConversionRateDataWithThumbnails, width: 500, height: 500 });
+  return (
+    <Chart {...chartProps}>
+      <Title text="Single-series vertical — axis thumbnails follow the axis to the zero line" fontSize={16} />
+      <Axis position="bottom" baseline>
+        <AxisThumbnail urlKey="thumbnail" />
+      </Axis>
+      <Axis position="left" grid labelFormat="percentage" />
+      <Bar {...args} diverging />
+    </Chart>
+  );
+};
+
+const VerticalWithThumbnail = bindWithProps(VerticalWithThumbnailStory);
+VerticalWithThumbnail.args = {
   dimension: 'channel',
   metric: 'changeRate',
   orientation: 'vertical',
@@ -120,7 +170,9 @@ LongLabels.args = {
 
 export {
   Horizontal,
+  HorizontalWithThumbnail,
   Vertical,
+  VerticalWithThumbnail,
   TimeAxis,
   LongLabels,
 };

--- a/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.ts
@@ -488,7 +488,7 @@ export const addAxes = produce<
     });
   }
 
-  applyAxisThumbnailEncodings(newAxes, axisOptions, position);
+  applyAxisThumbnailEncodings(newAxes, axisOptions, position, divergingContext, opposingScaleType, opposingScaleName);
 
   const axisAnnotations = getAxisAnnotationsFromChildren(axisOptions);
   for (const axisAnnotation of axisAnnotations) {
@@ -603,12 +603,25 @@ function applyAxisLabelEncodings(
 }
 
 /** Split out of `addAxes` to keep cognitive complexity down. */
-function applyAxisThumbnailEncodings(newAxes: Axis[], axisOptions: AxisSpecOptions, position: Position): void {
+function applyAxisThumbnailEncodings(
+  newAxes: Axis[],
+  axisOptions: AxisSpecOptions,
+  position: Position,
+  divergingContext?: DivergingBarContext,
+  opposingScaleType?: string,
+  opposingScaleName?: string
+): void {
   if (!scaleTypeSupportsThumbnails(axisOptions.scaleType)) return;
+
+  // when diverging, the label's thumbnail-clearance offset flips per row to match the thumbnail's side flip
+  const isNegativeBarExpr =
+    divergingContext && opposingScaleType === 'linear' && opposingScaleName
+      ? getDivergingTickIsNegativeTest(divergingContext)
+      : undefined;
 
   const offsetKey = isVerticalAxis(position) ? 'dx' : 'dy';
   for (const axisThumbnail of getAxisThumbnails(axisOptions)) {
-    const thumbnailOffset = getAxisThumbnailLabelOffset(axisThumbnail.name, position)[offsetKey];
+    const thumbnailOffset = getAxisThumbnailLabelOffset(axisThumbnail.name, position, isNegativeBarExpr)[offsetKey];
 
     // apply encodings to all axes
     for (const axis of newAxes) {

--- a/packages/vega-spec-builder-s2/src/axis/axisThumbnailUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisThumbnailUtils.test.ts
@@ -23,6 +23,7 @@ import {
   getAxisThumbnails,
   scaleTypeSupportsThumbnails,
 } from './axisThumbnailUtils';
+import { DivergingBarContext } from './axisUtils';
 
 describe('axisThumbnailUtils', () => {
   describe('getAxisThumbnails', () => {
@@ -208,6 +209,77 @@ describe('axisThumbnailUtils', () => {
       expect(result[1]).toHaveProperty('type', 'image');
       expect(result[1]).toHaveProperty('name', 'testAxisAxisThumbnail1');
     });
+
+    const divergingContext: DivergingBarContext = { dataName: 'table', dimension: 'category', metric: 'value' };
+
+    test('should flip the thumbnail to the opposite side of the zero line per row when diverging is active', () => {
+      const thumbnailOptions: AxisThumbnailOptions = { urlKey: 'customThumbnail' };
+      const axisOptions: AxisSpecOptions & {
+        opposingScaleType?: string;
+        opposingScaleName?: string;
+        divergingContext?: DivergingBarContext;
+      } = {
+        ...defaultAxisOptions,
+        name: 'testAxis',
+        position: 'left',
+        axisThumbnails: [thumbnailOptions],
+        opposingScaleType: 'linear',
+        opposingScaleName: 'yLinear',
+        divergingContext,
+      };
+
+      const result = getAxisThumbnailMarks(axisOptions, 'xScale', 'category');
+
+      expect(result[0].encode?.update).toHaveProperty('x', [
+        { test: "datum['value'] < 0", signal: `scale('yLinear', 0) + ${THUMBNAIL_OFFSET}` },
+        { signal: `scale('yLinear', 0) - ${THUMBNAIL_OFFSET} - testAxisAxisThumbnail0ThumbnailSize` },
+      ]);
+    });
+
+    test('should not flip the thumbnail when opposingScaleType is not linear', () => {
+      const thumbnailOptions: AxisThumbnailOptions = { urlKey: 'customThumbnail' };
+      const axisOptions: AxisSpecOptions & {
+        opposingScaleType?: string;
+        opposingScaleName?: string;
+        divergingContext?: DivergingBarContext;
+      } = {
+        ...defaultAxisOptions,
+        name: 'testAxis',
+        position: 'left',
+        axisThumbnails: [thumbnailOptions],
+        opposingScaleType: 'band',
+        opposingScaleName: 'yBand',
+        divergingContext,
+      };
+
+      const result = getAxisThumbnailMarks(axisOptions, 'xScale', 'category');
+
+      expect(result[0].encode?.update).toHaveProperty('x', {
+        signal: `-${THUMBNAIL_OFFSET} - testAxisAxisThumbnail0ThumbnailSize`,
+      });
+    });
+
+    test('should not flip the thumbnail when divergingContext is absent', () => {
+      const thumbnailOptions: AxisThumbnailOptions = { urlKey: 'customThumbnail' };
+      const axisOptions: AxisSpecOptions & {
+        opposingScaleType?: string;
+        opposingScaleName?: string;
+        divergingContext?: DivergingBarContext;
+      } = {
+        ...defaultAxisOptions,
+        name: 'testAxis',
+        position: 'left',
+        axisThumbnails: [thumbnailOptions],
+        opposingScaleType: 'linear',
+        opposingScaleName: 'yLinear',
+      };
+
+      const result = getAxisThumbnailMarks(axisOptions, 'xScale', 'category');
+
+      expect(result[0].encode?.update).toHaveProperty('x', {
+        signal: `-${THUMBNAIL_OFFSET} - testAxisAxisThumbnail0ThumbnailSize`,
+      });
+    });
   });
 
   describe('getAxisThumbnailPosition', () => {
@@ -244,6 +316,62 @@ describe('axisThumbnailUtils', () => {
       expect(result).toEqual({
         xc: { signal: "scale('xScale', datum.category) + bandwidth('xScale') / 2" },
         y: { signal: `height + ${THUMBNAIL_OFFSET}` },
+      });
+    });
+
+    test('should place a positive-row thumbnail outward and flip a negative-row thumbnail for left axis', () => {
+      const zeroLine = "scale('yLinear', 0)";
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailPosition('xScale', 'category', 'left', 'testThumbnail', { zeroLine, isNegativeBarExpr });
+
+      expect(result).toEqual({
+        x: [
+          { test: isNegativeBarExpr, signal: `${zeroLine} + ${THUMBNAIL_OFFSET}` },
+          { signal: `${zeroLine} - ${THUMBNAIL_OFFSET} - testThumbnailThumbnailSize` },
+        ],
+        yc: { signal: "scale('xScale', datum.category) + bandwidth('xScale') / 2" },
+      });
+    });
+
+    test('should place a positive-row thumbnail outward and flip a negative-row thumbnail for right axis', () => {
+      const zeroLine = "scale('yLinear', 0)";
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailPosition('yScale', 'value', 'right', 'testThumbnail', { zeroLine, isNegativeBarExpr });
+
+      expect(result).toEqual({
+        x: [
+          { test: isNegativeBarExpr, signal: `${zeroLine} - ${THUMBNAIL_OFFSET} - testThumbnailThumbnailSize` },
+          { signal: `${zeroLine} + ${THUMBNAIL_OFFSET}` },
+        ],
+        yc: { signal: "scale('yScale', datum.value) + bandwidth('yScale') / 2" },
+      });
+    });
+
+    test('should place a positive-row thumbnail outward and flip a negative-row thumbnail for top axis', () => {
+      const zeroLine = "scale('xLinear', 0)";
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailPosition('xScale', 'category', 'top', 'testThumbnail', { zeroLine, isNegativeBarExpr });
+
+      expect(result).toEqual({
+        xc: { signal: "scale('xScale', datum.category) + bandwidth('xScale') / 2" },
+        y: [
+          { test: isNegativeBarExpr, signal: `${zeroLine} + ${THUMBNAIL_OFFSET}` },
+          { signal: `${zeroLine} - ${THUMBNAIL_OFFSET} - testThumbnailThumbnailSize` },
+        ],
+      });
+    });
+
+    test('should place a positive-row thumbnail outward and flip a negative-row thumbnail for bottom axis', () => {
+      const zeroLine = "scale('xLinear', 0)";
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailPosition('xScale', 'category', 'bottom', 'testThumbnail', { zeroLine, isNegativeBarExpr });
+
+      expect(result).toEqual({
+        xc: { signal: "scale('xScale', datum.category) + bandwidth('xScale') / 2" },
+        y: [
+          { test: isNegativeBarExpr, signal: `${zeroLine} - ${THUMBNAIL_OFFSET} - testThumbnailThumbnailSize` },
+          { signal: `${zeroLine} + ${THUMBNAIL_OFFSET}` },
+        ],
       });
     });
   });
@@ -288,6 +416,32 @@ describe('axisThumbnailUtils', () => {
       expect(result).toEqual({
         dy: [
           { test: `testThumbnailThumbnailSize < ${MIN_THUMBNAIL_SIZE}`, value: 0 },
+          { signal: 'testThumbnailThumbnailSize' },
+        ],
+      });
+    });
+
+    test('should flip the label offset per row when diverging is active for a vertical axis', () => {
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailLabelOffset('testThumbnail', 'left', isNegativeBarExpr);
+
+      expect(result).toEqual({
+        dx: [
+          { test: `testThumbnailThumbnailSize < ${MIN_THUMBNAIL_SIZE}`, value: 0 },
+          { test: isNegativeBarExpr, signal: 'testThumbnailThumbnailSize' },
+          { signal: '-testThumbnailThumbnailSize' },
+        ],
+      });
+    });
+
+    test('should flip the label offset per row when diverging is active for a horizontal axis', () => {
+      const isNegativeBarExpr = "datum['value'] < 0";
+      const result = getAxisThumbnailLabelOffset('testThumbnail', 'bottom', isNegativeBarExpr);
+
+      expect(result).toEqual({
+        dy: [
+          { test: `testThumbnailThumbnailSize < ${MIN_THUMBNAIL_SIZE}`, value: 0 },
+          { test: isNegativeBarExpr, signal: '-testThumbnailThumbnailSize' },
           { signal: 'testThumbnailThumbnailSize' },
         ],
       });

--- a/packages/vega-spec-builder-s2/src/axis/axisThumbnailUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisThumbnailUtils.ts
@@ -15,6 +15,7 @@ import { FILTERED_TABLE, MAX_THUMBNAIL_SIZE, MIN_THUMBNAIL_SIZE, THUMBNAIL_OFFSE
 
 import { getGenericUpdateSignal } from '../signal/signalSpecBuilder';
 import { AxisSpecOptions, AxisThumbnailOptions, AxisThumbnailSpecOptions, Position } from '../types';
+import { DivergingBarContext } from './axisUtils';
 
 /**
  * Extracts and processes axis thumbnail options from the main axis options.
@@ -86,11 +87,24 @@ export const addAxisThumbnailSignals = (signals: Signal[], axisThumbnailName: st
  * @returns An array of Vega image marks configured for axis thumbnails
  */
 export const getAxisThumbnailMarks = (
-  axisOptions: AxisSpecOptions,
+  axisOptions: AxisSpecOptions & {
+    opposingScaleType?: string;
+    opposingScaleName?: string;
+    divergingContext?: DivergingBarContext;
+  },
   scaleName: string,
   scaleField: string
 ): ImageMark[] => {
-  const { position } = axisOptions;
+  const { position, opposingScaleType, opposingScaleName, divergingContext } = axisOptions;
+
+  // thumbnails are top-level sibling marks (not in the axis group), so the diverging flip is applied here manually
+  const diverging =
+    divergingContext && opposingScaleType === 'linear' && opposingScaleName
+      ? {
+          zeroLine: `scale('${opposingScaleName}', 0)`,
+          isNegativeBarExpr: `datum['${divergingContext.metric}'] < 0`,
+        }
+      : undefined;
 
   const thumbnails: ImageMark[] = [];
   const axisThumbnails = getAxisThumbnails(axisOptions);
@@ -104,7 +118,7 @@ export const getAxisThumbnailMarks = (
           url: { field: urlKey },
         },
         update: {
-          ...getAxisThumbnailPosition(scaleName, scaleField, position, name),
+          ...getAxisThumbnailPosition(scaleName, scaleField, position, name, diverging),
           width: { signal: `${name}ThumbnailSize` },
           height: { signal: `${name}ThumbnailSize` },
           opacity: [
@@ -130,36 +144,66 @@ export const getAxisThumbnailMarks = (
  * @param scaleField - The data field used for scale domain mapping
  * @param position - The position of the axis (left, right, top, bottom)
  * @param axisThumbnailName - The name of the thumbnail for signal references
+ * @param diverging - When diverging is active: the opposing scale's zero-line position and the expression true for a negative-bar row. Omitted otherwise (thumbnail pinned to the chart edge).
  * @returns An object with x/y coordinate encodings for thumbnail positioning
  */
 export const getAxisThumbnailPosition = (
   scaleName: string,
   scaleField: string,
   position: Position,
-  axisThumbnailName: string
+  axisThumbnailName: string,
+  diverging?: { zeroLine: string; isNegativeBarExpr: string }
 ) => {
   const centerEncoding = { signal: `scale('${scaleName}', datum.${scaleField}) + bandwidth('${scaleName}') / 2` };
+  const thumbnailSize = `${axisThumbnailName}ThumbnailSize`;
+  const zeroLine = diverging?.zeroLine;
+
+  // diverging: a row's thumbnail sits across the zero line from its own bar (mirrors the label align flip); else pinned to the edge
+  const getPositionRule = (edgeExpr: string, farSide: string, nearSide: string) => {
+    if (!diverging) return { signal: edgeExpr };
+    return [
+      { test: diverging.isNegativeBarExpr, signal: nearSide },
+      { signal: farSide },
+    ];
+  };
+
   switch (position) {
     case 'left':
       return {
-        x: { signal: `-${THUMBNAIL_OFFSET} - ${axisThumbnailName}ThumbnailSize` },
+        x: getPositionRule(
+          `-${THUMBNAIL_OFFSET} - ${thumbnailSize}`,
+          `${zeroLine} - ${THUMBNAIL_OFFSET} - ${thumbnailSize}`,
+          `${zeroLine} + ${THUMBNAIL_OFFSET}`
+        ),
         yc: centerEncoding,
       };
     case 'right':
       return {
-        x: { signal: `width + ${THUMBNAIL_OFFSET}` },
+        x: getPositionRule(
+          `width + ${THUMBNAIL_OFFSET}`,
+          `${zeroLine} + ${THUMBNAIL_OFFSET}`,
+          `${zeroLine} - ${THUMBNAIL_OFFSET} - ${thumbnailSize}`
+        ),
         yc: centerEncoding,
       };
     case 'top':
       return {
         xc: centerEncoding,
-        y: { signal: `-${THUMBNAIL_OFFSET} - ${axisThumbnailName}ThumbnailSize` },
+        y: getPositionRule(
+          `-${THUMBNAIL_OFFSET} - ${thumbnailSize}`,
+          `${zeroLine} - ${THUMBNAIL_OFFSET} - ${thumbnailSize}`,
+          `${zeroLine} + ${THUMBNAIL_OFFSET}`
+        ),
       };
     case 'bottom':
     default:
       return {
         xc: centerEncoding,
-        y: { signal: `height + ${THUMBNAIL_OFFSET}` },
+        y: getPositionRule(
+          `height + ${THUMBNAIL_OFFSET}`,
+          `${zeroLine} + ${THUMBNAIL_OFFSET}`,
+          `${zeroLine} - ${THUMBNAIL_OFFSET} - ${thumbnailSize}`
+        ),
       };
   }
 };
@@ -171,29 +215,32 @@ export const getAxisThumbnailPosition = (
  *
  * @param axisThumbnailName - The name of the thumbnail for signal reference
  * @param position - The position of the axis (left, right, top, bottom)
+ * @param isNegativeBarExpr - Expression true when a tick's own bar is negative; flips the label offset per row to match the thumbnail's flip.
  * @returns Text encoding entries for label offset adjustments
  */
-export const getAxisThumbnailLabelOffset = (axisThumbnailName: string, position: Position): TextEncodeEntry => {
+export const getAxisThumbnailLabelOffset = (
+  axisThumbnailName: string,
+  position: Position,
+  isNegativeBarExpr?: string
+): TextEncodeEntry => {
   // if the thumbnail is too small, it will be hidden and we don't want padding
   const hideThumbnailCondition = { test: `${axisThumbnailName}ThumbnailSize < ${MIN_THUMBNAIL_SIZE}`, value: 0 };
+  const thumbnailSize = `${axisThumbnailName}ThumbnailSize`;
+
+  const getOffsetRule = (outward: string, flipped: string) =>
+    isNegativeBarExpr
+      ? [hideThumbnailCondition, { test: isNegativeBarExpr, signal: flipped }, { signal: outward }]
+      : [hideThumbnailCondition, { signal: outward }];
 
   switch (position) {
     case 'left':
-      return {
-        dx: [hideThumbnailCondition, { signal: `-${axisThumbnailName}ThumbnailSize` }],
-      };
+      return { dx: getOffsetRule(`-${thumbnailSize}`, thumbnailSize) };
     case 'right':
-      return {
-        dx: [hideThumbnailCondition, { signal: `${axisThumbnailName}ThumbnailSize` }],
-      };
+      return { dx: getOffsetRule(thumbnailSize, `-${thumbnailSize}`) };
     case 'top':
-      return {
-        dy: [hideThumbnailCondition, { signal: `-${axisThumbnailName}ThumbnailSize` }],
-      };
+      return { dy: getOffsetRule(`-${thumbnailSize}`, thumbnailSize) };
     case 'bottom':
     default:
-      return {
-        dy: [hideThumbnailCondition, { signal: `${axisThumbnailName}ThumbnailSize` }],
-      };
+      return { dy: getOffsetRule(thumbnailSize, `-${thumbnailSize}`) };
   }
 };

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
@@ -751,16 +751,6 @@ describe('Chart spec builder', () => {
       expect(axes[0].grid).toBe(true);
     });
 
-    test('pins autosize off only when a diverging axis also has thumbnails', () => {
-      const spec = buildSpec({
-        ...defaultSpecOptions,
-        data: divergingData,
-        marks: [{ markType: 'bar', orientation: 'vertical', dimension: 'channel', metric: 'changeRate', diverging: true }],
-        axes: [{ position: 'bottom', baseline: true, axisThumbnails: [{ urlKey: 'thumbnail' }] }],
-      });
-      expect(spec.autosize).toEqual({ type: 'none' });
-    });
-
     test('leaves autosize unset for a diverging axis without thumbnails', () => {
       const spec = buildSpec({
         ...defaultSpecOptions,

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.test.ts
@@ -750,5 +750,35 @@ describe('Chart spec builder', () => {
       expect(axes[0]).not.toHaveProperty('offset'); // grid axis painted first (behind)
       expect(axes[0].grid).toBe(true);
     });
+
+    test('pins autosize off only when a diverging axis also has thumbnails', () => {
+      const spec = buildSpec({
+        ...defaultSpecOptions,
+        data: divergingData,
+        marks: [{ markType: 'bar', orientation: 'vertical', dimension: 'channel', metric: 'changeRate', diverging: true }],
+        axes: [{ position: 'bottom', baseline: true, axisThumbnails: [{ urlKey: 'thumbnail' }] }],
+      });
+      expect(spec.autosize).toEqual({ type: 'none' });
+    });
+
+    test('leaves autosize unset for a diverging axis without thumbnails', () => {
+      const spec = buildSpec({
+        ...defaultSpecOptions,
+        data: divergingData,
+        marks: [{ markType: 'bar', orientation: 'vertical', dimension: 'channel', metric: 'changeRate', diverging: true }],
+        axes: [{ position: 'bottom', baseline: true }],
+      });
+      expect(spec.autosize).toBeUndefined();
+    });
+
+    test('leaves autosize unset for a thumbnail axis when the bar is not diverging', () => {
+      const spec = buildSpec({
+        ...defaultSpecOptions,
+        data: divergingData,
+        marks: [{ markType: 'bar', orientation: 'vertical', dimension: 'channel', metric: 'changeRate' }],
+        axes: [{ position: 'bottom', baseline: true, axisThumbnails: [{ urlKey: 'thumbnail' }] }],
+      });
+      expect(spec.autosize).toBeUndefined();
+    });
   });
 });

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -230,8 +230,8 @@ export function buildSpec({
     spec.axes = [...spec.axes].sort((a, b) => Number(isDivergingAxis(a)) - Number(isDivergingAxis(b)));
   }
 
-  // diverging thumbnails are bandwidth-sized (width) and placed off the zero line (height), so Vega's default `pad`
-  // autosize feeds them back into width/height and collapses the plot; RSC sizes the view itself, so pin autosize off
+  // diverging thumbnails anchor to the opposing scale's zero line, so their overflow is coupled to the fitted plot
+  // size and `fit` has no stable fixpoint — it re-fits per pulse and collapses on hover; RSC sizes the view, so opt out
   if (spec.usermeta?.divergingBarMarks?.length && axes.some((axis) => axis.axisThumbnails?.length)) {
     spec.autosize = { type: 'none' };
   }

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -230,6 +230,12 @@ export function buildSpec({
     spec.axes = [...spec.axes].sort((a, b) => Number(isDivergingAxis(a)) - Number(isDivergingAxis(b)));
   }
 
+  // diverging thumbnails are bandwidth-sized (width) and placed off the zero line (height), so Vega's default `pad`
+  // autosize feeds them back into width/height and collapses the plot; RSC sizes the view itself, so pin autosize off
+  if (spec.usermeta?.divergingBarMarks?.length && axes.some((axis) => axis.axisThumbnails?.length)) {
+    spec.autosize = { type: 'none' };
+  }
+
   // add signals and update marks for controlled highlighting if there isn't a legend with highlight enabled
   if (highlightedSeries) {
     setHoverOpacityForMarks('', spec.marks ?? [], undefined, true);

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -230,12 +230,6 @@ export function buildSpec({
     spec.axes = [...spec.axes].sort((a, b) => Number(isDivergingAxis(a)) - Number(isDivergingAxis(b)));
   }
 
-  // diverging thumbnails anchor to the opposing scale's zero line, so their overflow is coupled to the fitted plot
-  // size and `fit` has no stable fixpoint — it re-fits per pulse and collapses on hover; RSC sizes the view, so opt out
-  if (spec.usermeta?.divergingBarMarks?.length && axes.some((axis) => axis.axisThumbnails?.length)) {
-    spec.autosize = { type: 'none' };
-  }
-
   // add signals and update marks for controlled highlighting if there isn't a legend with highlight enabled
   if (highlightedSeries) {
     setHoverOpacityForMarks('', spec.marks ?? [], undefined, true);


### PR DESCRIPTION
feat(s2): AxisThumbnail follows the diverging axis to the zero line
Jira: [AN-462759](https://jira.corp.adobe.com/browse/AN-462759)

## Description

With `<Bar diverging>`, the dimension axis and its labels move to the opposing scale's zero line, but axis thumbnails stayed pinned at the chart edge. Thumbnails are rendered as top-level sibling image marks (not nested in the axis group), so they never picked up the axis's diverging offset — leaving them visually detached from the labels they belong to.

Thumbnail image marks (and the label's thumbnail-clearance offset) now flip per row to the opposite side of the zero line from each row's own bar, mirroring the diverging label align flip

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

react-spectrum-charts-s2/.../Bar/Diverging.story.tsx — HorizontalWithThumbnail + VerticalWithThumbnail stories

## Screenshots (if appropriate):
<img width="763" height="420" alt="Screenshot 2026-08-04 at 4 29 03 PM" src="https://github.com/user-attachments/assets/068b07f8-1851-4584-8789-e3dcda21fd63" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
