### PR TITLE
Fix: S2 line forecast point label position

### DIFF
--- a/packages/vega-spec-builder-s2/src/line/lineDataUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineDataUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FilterTransform } from 'vega';
+import { FilterTransform, FormulaTransform } from 'vega';
 
 import {
   CONTROLLED_HIGHLIGHTED_SERIES,
@@ -21,7 +21,7 @@ import {
   SERIES_ID,
 } from '@spectrum-charts/constants';
 
-import { getLineHighlightedData, getLineHoverRules, getPrimarySeriesOtherExpr } from './lineDataUtils';
+import { getHoverLabelData, getLineHighlightedData, getLineHoverRules, getPrimarySeriesOtherExpr } from './lineDataUtils';
 import { defaultLineOptions } from './lineTestUtils';
 
 describe('getLineHighlightedData()', () => {
@@ -45,6 +45,21 @@ describe('getLineHighlightedData()', () => {
       }).transform?.[0] as FilterTransform
     ).expr;
     expect(expr.includes(GROUP_ID)).toBeTruthy();
+  });
+});
+
+describe('getHoverLabelData()', () => {
+  test('uses the raw metric field when there is no forecast', () => {
+    const scaledYFormula = getHoverLabelData(defaultLineOptions).transform?.[2] as FormulaTransform;
+    expect(scaledYFormula.expr).toBe(`scale('yLinear', datum["${defaultLineOptions.metric}"])`);
+  });
+
+  test('uses the forecast-aware effectiveValue field when a forecast is active', () => {
+    const scaledYFormula = getHoverLabelData({
+      ...defaultLineOptions,
+      forecasts: [{ metric: 'forecastValue', start: 5 }],
+    }).transform?.[2] as FormulaTransform;
+    expect(scaledYFormula.expr).toBe(`scale('yLinear', datum["${defaultLineOptions.name}_effectiveValue"])`);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/line/lineDataUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineDataUtils.ts
@@ -13,6 +13,7 @@ import { SourceData } from 'vega';
 
 import { CONTROLLED_HIGHLIGHTED_ITEM, CONTROLLED_HIGHLIGHTED_SERIES, CONTROLLED_HIGHLIGHTED_TABLE, FILTERED_TABLE, GROUP_ID, HOVERED_ITEM, SELECTED_ITEM, SELECTED_SERIES, SERIES_ID } from '@spectrum-charts/constants';
 
+import { getEffectiveMetricField } from '../lineForecast';
 import { HoverMatchRule } from '../marks/hoverAnimationUtils';
 import { hasPopover, isInteractive } from '../marks/markUtils';
 import { LineSpecOptions } from '../types';
@@ -89,13 +90,13 @@ export const getPrimarySeriesFacetData = (name: string, primarySeries: number | 
  * at the same hovered dimension are spread apart rather than overlapping.
  */
 export const getHoverLabelData = (options: LineSpecOptions): SourceData => {
-  const { metric, name, metricAxis } = options;
+  const { name, metricAxis } = options;
   const yScaleName = metricAxis || 'yLinear';
 
   return {
     name: `${name}_hoverLabelData`,
     source: `${name}_highlightedData`,
-    transform: getCascadeTransforms(yScaleName, metric, 'hover'),
+    transform: getCascadeTransforms(yScaleName, getEffectiveMetricField(options), 'hover'),
   };
 };
 

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -36,6 +36,7 @@ import { addPopoverData } from '../chartPopover/chartPopoverUtils';
 import { addTimeTransform, getFilteredInspectData, getTableData } from '../data/dataUtils';
 import { getLineDirectLabelData, getLineDirectLabelMarks, getLineDirectLabelSpecOptions } from '../lineDirectLabel';
 import {
+  getEffectiveMetricField,
   getForecastAlternateFlagTransform,
   getForecastEffectiveValueTransform,
   getLineForecastBoundaryMark,
@@ -425,7 +426,7 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
   const markOptions = hasForecast
     ? {
         ...options,
-        metric: `${name}_effectiveValue`,
+        metric: getEffectiveMetricField(options),
         alternateSegmentKey: `${name}_alternateFlag`,
       }
     : options;
@@ -499,10 +500,7 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
 });
 
 const getMetricKeys = (lineOptions: LineSpecOptions) => {
-  const hasForecast = (lineOptions.forecasts ?? []).length > 0 && !lineOptions.alternateSegmentKey;
-  // when forecasts are present, use effectiveValue for the y-scale domain since it covers both
-  // the historical metric and forecast metric(s) in a single unified field
-  const metricKeys = hasForecast ? [`${lineOptions.name}_effectiveValue`] : [lineOptions.metric];
+  const metricKeys = [getEffectiveMetricField(lineOptions)];
 
   // metric range fields should be added if metric-axis will be scaled to fit
   const metricRanges = getMetricRanges(lineOptions);

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts
@@ -18,6 +18,7 @@ import { getCascadeTransforms, MIN_LABEL_GAP } from '../line/directLabelUtils';
 
 import { getPrimarySeriesOtherExpr } from '../line/lineDataUtils';
 import { getLineOpacity } from '../line/lineMarkUtils';
+import { getEffectiveMetricField } from '../lineForecast';
 import { getColorProductionRule, getDirectLabelFontSizeProductionRule } from '../marks/markUtils';
 import { getScaleName } from '../scale/scaleSpecBuilder';
 import { escapeD3FormatSpecifier, getDimensionField, getFacetsFromOptions } from '../specUtils';
@@ -230,7 +231,7 @@ export const getLineDirectLabelSpecOptions = (
 	format: labelOptions.format ?? '',
 	index,
 	lineName: lineOptions.name,
-	metric: lineOptions.metric,
+	metric: getEffectiveMetricField(lineOptions),
 	position: labelOptions.position ?? 'end',
 	prefix: labelOptions.prefix ?? '',
 	scaleType: lineOptions.scaleType,

--- a/packages/vega-spec-builder-s2/src/lineForecast/index.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/index.ts
@@ -10,4 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export { getForecastAlternateFlagTransform, getForecastEffectiveValueTransform, getLineForecastBoundaryMark, getLineForecastLabelMarks, getLineForecastSpecOptions } from './lineForecastUtils';
+export { getEffectiveMetricField, getForecastAlternateFlagTransform, getForecastEffectiveValueTransform, getLineForecastBoundaryMark, getLineForecastLabelMarks, getLineForecastSpecOptions } from './lineForecastUtils';

--- a/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.test.ts
@@ -10,12 +10,39 @@
  * governing permissions and limitations under the License.
  */
 
-import { getForecastEffectiveValueTransform } from './lineForecastUtils';
+import { getEffectiveMetricField, getForecastEffectiveValueTransform } from './lineForecastUtils';
 
 describe('getForecastEffectiveValueTransform', () => {
   test('builds a formula that uses the historical metric when valid, falling back to forecast', () => {
     const transform = getForecastEffectiveValueTransform('line0', 'value', 'forecastValue');
     expect(transform.as).toBe('line0_effectiveValue');
     expect(transform.expr).toBe("isValid(datum['value']) ? datum['value'] : datum['forecastValue']");
+  });
+});
+
+describe('getEffectiveMetricField', () => {
+  test('returns the raw metric when there are no forecasts', () => {
+    const field = getEffectiveMetricField({ alternateSegmentKey: undefined, forecasts: [], metric: 'value', name: 'line0' });
+    expect(field).toBe('value');
+  });
+
+  test('returns the raw metric when alternateSegmentKey is set, even with forecasts present', () => {
+    const field = getEffectiveMetricField({
+      alternateSegmentKey: 'isAlternate',
+      forecasts: [{ metric: 'forecastValue', start: 5 }],
+      metric: 'value',
+      name: 'line0',
+    });
+    expect(field).toBe('value');
+  });
+
+  test('returns the effective value field when forecasts are present and alternateSegmentKey is unset', () => {
+    const field = getEffectiveMetricField({
+      alternateSegmentKey: undefined,
+      forecasts: [{ metric: 'forecastValue', start: 5 }],
+      metric: 'value',
+      name: 'line0',
+    });
+    expect(field).toBe('line0_effectiveValue');
   });
 });

--- a/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
+++ b/packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts
@@ -28,6 +28,19 @@ export const getForecastEffectiveValueTransform = (name: string, metric: string,
   expr: `isValid(datum['${metric}']) ? datum['${metric}'] : datum['${forecastMetric}']`,
 });
 
+/**
+ * Resolves the metric field to plot, using the forecast-aware effective value when a forecast is active.
+ * @param options
+ * @returns string
+ */
+export const getEffectiveMetricField = ({
+  alternateSegmentKey,
+  forecasts,
+  metric,
+  name,
+}: Pick<LineSpecOptions, 'alternateSegmentKey' | 'forecasts' | 'metric' | 'name'>): string =>
+  !alternateSegmentKey && forecasts.length > 0 ? `${name}_effectiveValue` : metric;
+
 export const getLineForecastSpecOptions = (
   forecast: LineForecastOptions,
   index: number,

--- a/planning/specs/README.md
+++ b/planning/specs/README.md
@@ -116,21 +116,48 @@ in the code and why, with file:line references. It is not an investigation log. 
 
 ## Complexity rubric
 
-Scored 1-2 / 3 / 5, like story points, in the `complexity.score` field:
+Scored 1 / 2 / 3 / 5, like story points, in the `complexity.score` field. **Remaining
+research burden is the primary axis, implementation size is secondary** — the score reflects
+what's left to figure out and build *as of the current state of this spec*, not how hard the
+original investigation was historically:
 
-- **1-2 (Simple):** plain value prop, passes through `*Options` unchanged, no new
-  encode/scale/signal logic. Touches the type file + one encode site + story.
-- **3 (Moderate):** new field needs logic in *one* of `addData` / `addSignals` /
-  `setScales` / `addMarks` for an existing mark (new signal, conditional encode, new
-  transform).
-- **5 (Complex):** new mark type, new child component, or a change spanning multiple of
-  data/signals/scales/marks — includes new interaction behavior (hover/selection) or S1/S2
-  parity work across packages.
+- **1 (No research, basic implementation):** the approach is fully known and the change
+  itself is trivial — a literal constant/value tweak, a single encode line, a plain
+  passthrough prop. Nothing left to investigate, nothing nontrivial to coordinate.
+- **2 (No research, more than basic implementation):** the approach is fully known — no
+  open questions, no unconfirmed root cause — but the change touches a few coordinated
+  call sites or files, possibly including both s1 and s2, or a verification story that
+  follows an existing story as a template. Still mechanical and low-risk, just more than a
+  one-liner. **This is where most "spans multiple files" or "s1 + s2" fixes belong**, as
+  long as every site is the *same already-precedented edit* applied again — e.g. copying a
+  sibling mark's existing opacity-encode call to a new mark, or making the identical change
+  in each package.
+- **3 (Minimal research, real implementation complexity):** some investigation or
+  verification is still genuinely left to do (a small unresolved question whose answer
+  could change the shape of the fix, not just confirm a strong existing hypothesis) *and*
+  at least one site requires actual new logic or a design decision — not just repeating a
+  pattern that already exists elsewhere in the same file.
+- **5 (Significant research *and* implementation complexity):** both axes are heavy at
+  once — substantial unknowns still to resolve (unconfirmed root cause, an open design
+  question that could change the shape of the fix) combined with an implementation where
+  multiple sites each require *different*, non-precedented reasoning (new mark type, new
+  child component, genuinely new interaction behavior) — not the same known fix copied to
+  more places.
 
-The same rubric applies to bugs: score by how much of the codebase the *fix* is expected to
-touch, not how hard the bug was to find. A one-line missing-encode fix is a 1-2 even if the
-investigation took a while; an unconfirmed root cause spanning layout/autosize or multiple
-packages is a 5.
+**Breadth is not depth.** The number of files, call sites, or packages a fix touches does
+not by itself raise the score. Ask, per site: does this edit require a new design decision,
+or is it the same already-working pattern (already visible elsewhere in the codebase) copied
+to one more place? A fix that touches four files across s1 and s2 but does the identical,
+already-precedented thing at each one is a 2, not a 5 — "S1/S2 parity work across packages"
+only earns a 5 when the packages' implementations genuinely diverge and each needs separate
+reasoning, not when it's one pattern applied twice.
+
+**Score at spec-lock-in time, not at first-report time.** A bug that took a long
+investigation to root-cause is not automatically a 5 — once that investigation is captured
+in `rootCause` and the fix approach is fully decided, remaining research is zero and the
+score should reflect only what's left: usually a 1 or 2. Re-score whenever a spec's design
+changes (e.g. after choosing a simpler implementation approach during review) rather than
+leaving the original estimate in place.
 
 ## Edge case checklist
 

--- a/planning/specs/chart/issues/s2-dotted-line-gap-too-tight.json
+++ b/planning/specs/chart/issues/s2-dotted-line-gap-too-tight.json
@@ -1,0 +1,47 @@
+{
+  "id": "s2-dotted-line-gap-too-tight",
+  "title": "S2 Dotted Line Segments Have a Too-Tight Gap Between Dots",
+  "chartType": "chart",
+  "kind": "bug",
+  "variant": "s2",
+  "status": "approved",
+  "lastUpdated": "2026-08-05",
+  "complexity": {
+    "score": 1,
+    "rationale": "No research remaining - root cause and exact target value are fully confirmed by the round-cap math above. Implementation is a single literal value change in one shared lookup function plus a matching test update - no new logic, encode site, or mark."
+  },
+  "summary": "S2 dotted line segments (Line lineType='dotted', MetricRange dotted styling, Line forecast's default alternateSegmentLineType='dotted', etc.) render with a visually tight ~2px gap between dots at the default line width, instead of the intended 3px gap.",
+  "symptom": "At the default line width, S2 dotted strokes show roughly a 2px visible gap between dots, which reads as too tight. A 3px visible gap is the intended spacing.",
+  "rootCause": "getStrokeDashFromLineType in packages/vega-spec-builder-s2/src/specUtils.ts (~line 121) returns `[0, 4]` for `'dotted'`. With the default `lineCap: 'round'` (packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts:229) and default `lineWidth: 'M'` resolving to a 2px stroke width (`getLineWidthPixelsFromLineWidth`, specUtils.ts:141-159, `case 'M': return 2`), a zero-length dash renders as a round dot with radius = strokeWidth/2 = 1px, and dot centers are spaced `gap` (4px) apart along the path. The visible edge-to-edge gap between dots is therefore `gap - strokeWidth` = `4 - 2` = 2px, not the array's literal `4` - this is a general property of round-capped dash patterns (declared gap minus stroke width equals visible gap), not specific to this one entry.",
+  "comparison": [
+    {
+      "aspect": "Visible edge-to-edge gap for s2 'dotted' at the default line width",
+      "expected": "3px visible gap between dots at the default (M, 2px) line width.",
+      "actual": "getStrokeDashFromLineType('dotted') returns [0, 4]; with round line caps and the 2px default stroke width, the visible gap is 4 - 2 = 2px."
+    }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": false,
+    "touchesLegendInteraction": false,
+    "touchesTooltipOrPopover": false,
+    "requiresNewSignalOrScale": false,
+    "requiresS1S2Parity": false,
+    "notes": "requiresS1S2Parity is false per explicit instruction - s1 is out of scope for this fix even though vega-spec-builder's 'dotted' value ([2, 3]) is already different from s2's and would need its own separate consideration if ever addressed."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder-s2/src/specUtils.ts",
+      "change": "In getStrokeDashFromLineType, change the 'dotted' case's array from [0, 4] to [0, 5], so the visible edge-to-edge gap at the default 2px line width becomes 5 - 2 = 3px. This affects every s2 consumer that reaches 'dotted' via the shared getStrokeDashFromLineType/getStrokeDashProductionRule pipeline: Line, Trendline, Scatter, Bar, ReferenceLine, MetricRange, legend swatches, and Line forecast's default alternateSegmentLineType.",
+      "lines": "~121"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/specUtils.test.ts",
+      "change": "Update the existing getStrokeDashFromLineType test assertion for 'dotted' to expect [0, 5] instead of [0, 4].",
+      "lines": "~131-136"
+    }
+  ],
+  "openQuestions": [
+    "The 3px target is only exact at the default lineWidth ('M', 2px). Because round-capped dash gaps are (declared gap - strokeWidth), a series using a different lineWidth (XS/S/L/XL, or a numeric override) will see a different visible gap with this fixed array - e.g. 5 - 3 (L) = 2px, 5 - 4 (XL) = 1px. This spec scopes the fix to the reported default-width case only; a lineWidth-adaptive dash gap (computing gap = target + strokeWidth per instance) is a larger change not included here."
+  ]
+}

--- a/planning/specs/line/issues/implemented/line-forecast-hover-label-top-of-chart.json
+++ b/planning/specs/line/issues/implemented/line-forecast-hover-label-top-of-chart.json
@@ -1,0 +1,64 @@
+{
+  "id": "line-forecast-hover-label-top-of-chart",
+  "title": "S2 Line Forecast Point Hover Labels Render at Top of Chart",
+  "chartType": "line",
+  "kind": "bug",
+  "variant": "s2",
+  "status": "implemented",
+  "lastUpdated": "2026-08-05",
+  "complexity": {
+    "score": 1,
+    "rationale": "No research remaining - root cause and the exact fix design (getEffectiveMetricField shared utility, three call sites, line numbers) are fully locked in. Every edit is a small, mechanical, low-risk substitution of already-correct logic for a function call - basic implementation complexity."
+  },
+  "summary": "For an S2 Line with a forecast segment, hovering a data point within the forecast portion renders its hover label at the top of the chart (y=0) instead of at the point's actual location, unlike hovering a non-forecast point on the same line.",
+  "symptom": "On an S2 Line chart configured with `forecasts`, hovering a point that falls within the forecast (forward-projected) portion of the line shows its hover label pinned to the top of the chart. Hovering a point in the non-forecast (historical) portion of the same line correctly shows the label at the point's own (x,y) location.",
+  "rootCause": "The forecast feature (`forecasts?: LineForecastOptions[]` on `LineSpecOptions`) exists only in vega-spec-builder-s2 - there is no forecast-related code in vega-spec-builder (s1) or in either package's trendline directory. packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts:425-431 builds a local `markOptions` for the marks pipeline that overrides `metric` to `${name}_effectiveValue` whenever `hasForecast` is true, and this correctly-overridden `markOptions` is passed into `getLineHoverMarks` (lineSpecBuilder.ts:493), so the hover-label mark's own y encode (lineMarkUtils.ts:464) resolves the right field. However, the hover-label *data source* is built separately in the data pipeline: `addLineHoverData(data, options)` is called at lineSpecBuilder.ts:234 with the original, unmodified `options` (not `markOptions`), so `getHoverLabelData` (lineDataUtils.ts:91-100, called from lineSpecBuilder.ts:300) destructures the raw historical `metric` field (e.g. `value`) instead of the forecast-aware `effectiveValue` field. For a forecast-portion row, the raw historical metric field is null, so `getCascadeTransforms(yScaleName, metric, 'hover')` (lineDataUtils.ts:98, transforms in directLabelUtils.ts:37-67) computes `_hover_scaledY = scale(yScaleName, datum.value)` as NaN (directLabelUtils.ts:56), which propagates through `_hover_adjustedY` and the windowed `_hover_cumMaxAdjusted` (lines 57-65). That NaN flows into the label mark's `cascadeOffset` (lineMarkUtils.ts:455) and then the final y encode (lineMarkUtils.ts:464, `scale(yScaleName, effectiveValue) + NaN`), which Vega/SVG renders as y=0 - the top of the chart. Normal and forecast points share the same `${name}_hoverLabel`/`${name}_hoverLabelBg` marks and the same `${name}_hoverLabelData` source; the gap is only that the data source's cascade calculation was never updated to use the same forecast-aware `effectiveValue` field the marks pipeline already uses. CORRECTION during implementation: the originally-cited 'third call site' was misattributed - lineSpecBuilder.ts:502-505 is actually the local `getMetricKeys` helper (used for the y-scale domain), which already re-derived the same `hasForecast ? \\`${name}_effectiveValue\\` : metric` logic correctly, confirming addLineHoverData was the one duplicate-pattern site that never got it. Separately, `getLineDirectLabelSpecOptions` (packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts:221-239) was found to have NO forecast-awareness at all - it passed through the raw `lineOptions.metric` unconditionally - a related but previously-undetected gap in the same bug class (line direct labels combined with forecasts), fixed as part of this same centralization since it's a one-line, zero-risk substitution using the same new helper.",
+  "comparison": [
+    {
+      "aspect": "Metric field used to compute hover-label cascade position",
+      "expected": "Should resolve to the forecast-aware `${name}_effectiveValue` field when `hasForecast` is true, matching what the marks pipeline already does via its local markOptions override (lineSpecBuilder.ts:425-431).",
+      "actual": "addLineHoverData/getHoverLabelData (lineSpecBuilder.ts:234, 295-302) receives the original unmodified `options`, so getHoverLabelData (lineDataUtils.ts:91-100) reads the raw historical `metric` field, which is null for forecast-portion rows, producing NaN cascade values that render the label at y=0."
+    }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": false,
+    "touchesLegendInteraction": false,
+    "touchesTooltipOrPopover": true,
+    "requiresNewSignalOrScale": false,
+    "requiresS1S2Parity": false,
+    "notes": "touchesTooltipOrPopover is true because this is the hover-label mark/data system (getLineHoverMarks, ${name}_hoverLabelData), which is part of the interactive-mark hover pipeline. requiresS1S2Parity is false because the forecast feature (LineForecastOptions) doesn't exist in vega-spec-builder (s1) at all - confirmed via grep, no forecast-related code exists there - so there is no s1 equivalent to check or port."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.ts",
+      "change": "Add a new exported `getEffectiveMetricField({ alternateSegmentKey, forecasts, metric, name })` helper that returns `${name}_effectiveValue` when `!alternateSegmentKey && forecasts.length > 0`, else the raw `metric` - centralizing the hasForecast/field-name derivation next to `getForecastEffectiveValueTransform`, which writes the field this reads. Export it from this module's `index.ts` alongside the existing forecast exports.",
+      "lines": "new function, after line 29 (getForecastEffectiveValueTransform)"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts",
+      "change": "In addLineMarks's local `markOptions` (~425-431), replaced the inline hasForecast check and metric templating with `metric: getEffectiveMetricField(options)`; left the separate `alternateSegmentKey` override untouched. In `getMetricKeys` (~501-505, the actual location previously mislabeled as getLineDirectLabelSpecOptions), replaced its independent hasForecast/metricKeys derivation with the same call. Neither call site's behavior changes - this is a pure de-duplication of already-correct logic.",
+      "lines": "425-431, 501-505"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/line/lineDataUtils.ts",
+      "change": "This is the actual fix: getHoverLabelData (91-100) calls getEffectiveMetricField(options) instead of destructuring the raw `metric` field, so forecast-portion rows resolve to `${name}_effectiveValue` and the cascade transform no longer computes NaN.",
+      "lines": "91-100"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts",
+      "change": "Additional fix found during implementation (not in the original plan): getLineDirectLabelSpecOptions (221-239) had no forecast-awareness at all - `metric: lineOptions.metric` was an unconditional pass-through. Replaced with `metric: getEffectiveMetricField(lineOptions)` so line direct labels combined with forecasts also resolve to the effective-value field instead of the raw (possibly-null) historical metric.",
+      "lines": "233"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/lineForecast/lineForecastUtils.test.ts",
+      "change": "Add unit tests for getEffectiveMetricField: returns the raw metric when forecasts is empty or alternateSegmentKey is set, returns `${name}_effectiveValue` when hasForecast.",
+      "lines": "n/a - new test cases"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/line/lineDataUtils.test.ts",
+      "change": "Add a regression test with a forecast option asserting getHoverLabelData's cascade transform references `${name}_effectiveValue`, not the raw metric, when hasForecast is true - this is the test that would have caught the original bug.",
+      "lines": "n/a - new test case"
+    }
+  ]
+}

--- a/planning/specs/line/issues/line-point-annotation-hover-opacity-gap.json
+++ b/planning/specs/line/issues/line-point-annotation-hover-opacity-gap.json
@@ -1,0 +1,63 @@
+{
+  "id": "line-point-annotation-hover-opacity-gap",
+  "title": "LinePointAnnotation Ignores Legend/Line Hover Opacity",
+  "chartType": "line",
+  "kind": "bug",
+  "variant": "both",
+  "status": "approved",
+  "lastUpdated": "2026-08-05",
+  "complexity": {
+    "score": 2,
+    "rationale": "No further research needed to start - wire LinePointAnnotation into the same getLineOpacity-style helper the line/points already use (which bundles item-hover, legend-hover, and controlled-highlight together), extend markIsSeriesAware to recognize it, and add the verification story. Implementation touches multiple coordinated files (4 source files across s1/s2) but every edit follows an existing, well-understood pattern - no unknowns, just more than a one-file change."
+  },
+  "summary": "LinePointAnnotation marks do not dim when a legend item is hovered, unlike the line itself and other line-mark children (static points, metric range), which correctly fade to the non-hovered opacity. Whether the same gap exists when hovering the line directly (not via the legend) is unverified, since no existing story pairs LinePointAnnotation with a line that has its own hover-interactive elements.",
+  "symptom": "Hovering a legend item correctly dims the line path and other series-aware marks for non-hovered series, but any LinePointAnnotation marks on the chart stay at full opacity regardless of legend hover state. It is unverified whether hovering the line mark itself (rather than the legend) produces the same gap, since no story currently demonstrates that combination.",
+  "rootCause": "LinePointAnnotation's mark-building code has no opacity encode tied to hover/legend state in either package. In s1, `getLinePointAnnotationMarks` (packages/vega-spec-builder/src/line/linePointAnnotation/linePointAnnotationUtils.ts:43-62) builds a single TextMark whose `encode.enter` only sets `text` and optionally `fill` - there is no `opacity`/`fillOpacity`/`strokeOpacity` key and no `update` block at all. In s2, `getLinePointAnnotationMarks` (packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts:40-59) delegates to `getLabelTransformTextMarks` (packages/vega-spec-builder-s2/src/line/directLabelUtils.ts:132-173), whose `update.opacity` (line 168) is `{ field: 'opacity' }` - the label-collision-transform's own computed opacity, unrelated to hover/legend state. By contrast, comparable line marks (the line itself in lineMarkUtils.ts:118,126; static points in linePointUtils.ts:100,106) set `strokeOpacity`/`fillOpacity` via `getOpacityProductionRule(opacity)` on enter and `opacity: getLineOpacity(lineMarkOptions)` on update. Legend-hover dimming itself is applied as a separate post-processing pass, `setHoverOpacityForMarks` (packages/vega-spec-builder/src/legend/legendHighlightUtils.ts, mirrored in vega-spec-builder-s2/src/legend/legendHighlightUtils.ts:148-183,260-298), which flattens all marks, filters to `markIsSeriesAware` (~lines 129-130: mark's fill/stroke/strokeDash/opacity references the color scale, OR its name matches `/(Trendline\\d+|MetricRange\\d+_line)$/`), and splices an `isValid(legend0_hoveredSeries)` fade-opacity rule into each matching mark's existing `update.opacity` array. `applyLegendOpacityToMark` bails immediately if `update.opacity === undefined` (line 40). LinePointAnnotation fails both gates: it has no `update.opacity` for the pass to touch, and even if it did, its `fill` is a literal `datum.fill` field reference (not scale-based) and its mark names (`${lineName}Annotation${index}`, or the `_bg`/foreground names from getLabelTransformTextMarks) don't match the Trendline/MetricRange regex special-case, so `markIsSeriesAware` would return false regardless.",
+  "comparison": [
+    {
+      "aspect": "Opacity encode + series-awareness for legend-hover dimming",
+      "expected": "Line mark / static points set update.opacity via getLineOpacity(...)/getOpacityProductionRule(...), and setHoverOpacityForMarks's markIsSeriesAware() recognizes them (fill/stroke reference the color scale, or the mark name matches the Trendline/MetricRange regex special-case), so legendHighlightUtils splices in the isValid(legend0_hoveredSeries) fade rule.",
+      "actual": "LinePointAnnotation's TextMark(s) have no update.opacity tied to hover/legend state at all (s1), or only the label-collision-transform's own computed opacity (s2). applyLegendOpacityToMark bails early with no update.opacity to touch, and markIsSeriesAware wouldn't match anyway since the mark's fill is a literal datum.fill field reference and its name doesn't match the regex special-case."
+    }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": true,
+    "touchesLegendInteraction": true,
+    "touchesTooltipOrPopover": true,
+    "requiresNewSignalOrScale": false,
+    "requiresS1S2Parity": true,
+    "notes": "touchesLegendInteraction is the core symptom (legend0_hoveredSeries-driven fade never reaches this mark). touchesControlledHighlight is true because the natural fix is to give LinePointAnnotation the same update.opacity wiring as the line/points (getLineOpacity or equivalent), and that helper's opacity-rule pipeline bundles legend hover, item hover, and externally-controlled highlight rules together rather than legend hover alone - so fixing this is expected to restore controlled-highlight behavior for this mark too, not just legend hover. touchesTooltipOrPopover is true because part of this spec's scope is adding a story that pairs LinePointAnnotation with a Line that has its own hover-interactive elements (ChartTooltip/ChartPopover) to verify whether direct line-hover has the same gap - unresolved without that story. requiresS1S2Parity is true (variant is 'both' - confirmed independently in each package via linePointAnnotationUtils.ts and legendHighlightUtils.ts, which are structurally duplicated with the same gap in each) rather than being a port from one to the other."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder/src/line/linePointAnnotation/linePointAnnotationUtils.ts",
+      "change": "Add an opacity encode to getLinePointAnnotationMarks's TextMark - enter fillOpacity via getOpacityProductionRule(opacity), update opacity via the same getLineOpacity-style helper used by lineMarkUtils.ts/linePointUtils.ts - so the mark participates in hover/controlled-highlight opacity rules.",
+      "lines": "43-62"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/line/linePointAnnotation/linePointAnnotationUtils.ts",
+      "change": "Same fix for s2, via getLabelTransformTextMarks (directLabelUtils.ts:132-173) - must combine the existing label-collision-transform opacity (field: 'opacity') with a hover/legend/controlled-highlight opacity rule rather than replacing it outright, since both need to apply simultaneously.",
+      "lines": "40-59"
+    },
+    {
+      "file": "packages/vega-spec-builder/src/legend/legendHighlightUtils.ts",
+      "change": "Extend markIsSeriesAware (or the Trendline/MetricRange regex special-case) to recognize LinePointAnnotation mark names, since its fill is a literal datum.fill field reference rather than a color-scale reference and would otherwise still be excluded even after adding update.opacity.",
+      "lines": "~129-130"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts",
+      "change": "Same markIsSeriesAware extension for s2.",
+      "lines": "~148-183, 260-298"
+    },
+    {
+      "file": "packages/react-spectrum-charts-s2/src/stories/Line/Features/Interactions/LinePointAnnotationHover.story.tsx (new)",
+      "change": "Add a story pairing LinePointAnnotation with a Line that has its own hover-interactive elements (ChartTooltip/ChartPopover), modeled on LineInteractions.story.tsx (uses ChartPopover/ChartInspect with Line + Legend highlight, lines 18,58,70,121), to verify whether hovering the line itself (not just the legend) correctly dims the annotation. This determines whether the fix also needs to wire direct line-hover opacity, or whether legend-hover coverage alone resolves the full symptom.",
+      "lines": "n/a - new file"
+    }
+  ],
+  "openQuestions": [
+    "Whether hovering the line itself (not the legend) has the same annotation-opacity gap is unverified - no story currently pairs LinePointAnnotation with line-level hover interactivity. This spec includes adding that story as part of the fix so the question can be answered directly before implementation is considered complete.",
+    "Confirm the correct way to combine the s2 label-collision-transform's computed field: 'opacity' with a hover/legend/controlled-highlight opacity rule (e.g. multiply the two, or build a production-rule test/value list) without breaking existing collision-avoidance opacity behavior."
+  ]
+}

--- a/planning/specs/schema.json
+++ b/planning/specs/schema.json
@@ -71,7 +71,7 @@
         "score": {
           "type": "integer",
           "enum": [1, 2, 3, 5],
-          "description": "1-2 simple (plain passthrough prop), 3 moderate (new logic in one spec-builder function), 5 complex (new mark/child component or cross-cutting change). See README.md rubric."
+          "description": "Research burden is the primary axis, implementation size secondary, scored as of the spec's current state (not first-report time): 1 no research + basic implementation, 2 no research + multi-file/s1+s2 implementation where every site repeats the same precedented edit, 3 minimal remaining research + at least one site needing new (non-precedented) logic, 5 significant remaining research + multiple sites each needing different, non-precedented reasoning. Breadth (file/package count) alone never raises the score. See README.md rubric."
         },
         "rationale": {
           "type": "string",


### PR DESCRIPTION
 Fixes an S2 Line bug where hovering a data point in the forecast (forward-projected) portion of a line rendered its hover label pinned to the top of the chart (y=0) instead of at the point's actual location. Non-forecast points on the same line were unaffected.

Root cause: the hover-label data source (`getHoverLabelData`) computed its position cascade using the raw historical `metric` field, which is `null` for forecast rows, producing `NaN` that Vega renders as `y=0`. 

Centralized the forecast-aware metric resolution into a single `getEffectiveMetricField()` helper and applied it consistently across the hover-label data source, the line mark options, and the y-scale domain calculation.

  ## Related Issue

  N/A

  ## Motivation and Context

  Forecast hover labels rendering at the top of the chart made the forecast hover interaction broken/unusable for any chart combining `forecasts` with
  hover labels.

  ## How Has This Been Tested?

  - Added a regression test on `getHoverLabelData` asserting the cascade transform uses the effective-value field when a forecast is present; confirmed
  it fails without the fix and passes with it.
  - Added unit tests for the new `getEffectiveMetricField` helper.
  - `yarn tsc --noEmit` and `yarn eslint` clean.
  - Full affected test suite passing (256 tests).

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
