### PR TITLE
feat: line draw animation line implementation

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -164,7 +164,7 @@ export const SELECTED_SERIES = 'selectedSeries'; // series
 export const SELECTED_GROUP = 'selectedGroup'; // data point
 export const FIRST_RSC_SERIES_ID = 'firstRscSeriesId'; // first series for dual y-axis
 export const LAST_RSC_SERIES_ID = 'lastRscSeriesId'; // last series for dual y-axis
-export const HOVER_TIMER = 'hoverTimer'; // hover animation timer signal
+export const ANIMATION_TIMER = 'animationTimer'; // main animation timer signal
 export const HOVER_TARGETS = 'hoverTargets'; // hover animation target values
 export const HOVER_ANIMATING = 'hoverAnimating'; // hover animation state signal
 export const HOVER_ACTIVE_TIMER = 'hoverActiveTimer'; // animation timer to run only when hoverAnimating is true
@@ -199,6 +199,12 @@ export const DISCRETE_PADDING = 0.5;
 export const PADDING_RATIO = 0.4;
 export const LINEAR_PADDING = 0;
 export const TRELLIS_PADDING = 0.2;
+
+// animation constants
+/** Individual animation systems that can be toggled on via the `animationTypes` chart prop. */
+export type AnimationType = 'hover' | 'drawIn';
+/** Default `animationTypes` value: hover animations on, draw-in animations off. */
+export const DEFAULT_ANIMATION_TYPES: AnimationType[] = ['hover'];
 
 // hover animation constants
 /** Timer signal update interval in ms. Caps timer signal update at ~30fps. */

--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -38,6 +38,7 @@ interface ChartDialogProps {
 export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHandle> }) => {
   const {
     animations,
+    animationTypes,
     backgroundColor,
     data,
     chartWidth,
@@ -71,6 +72,7 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
   // THE MAGIC, builds our spec
   const spec = useSpec({
     animations,
+    animationTypes,
     backgroundColor,
     children: sanitizedChildren,
     colors,

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -21,6 +21,7 @@ import { SanitizedSpecProps } from '../types';
 
 export default function useSpec({
   animations,
+  animationTypes,
   backgroundColor,
   children,
   colors,
@@ -53,6 +54,7 @@ export default function useSpec({
 
     const chartOptions = rscPropsToSpecBuilderOptions({
       animations,
+      animationTypes,
       backgroundColor,
       children,
       colors,
@@ -75,6 +77,7 @@ export default function useSpec({
   }, [
     UNSAFE_vegaSpec,
     animations,
+    animationTypes,
     backgroundColor,
     children,
     colors,

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
@@ -175,19 +175,6 @@ const CategoricalPointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, 
   );
 };
 
-/** Using cardinal interpolation. */
-const CardinalInterpStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
-  return (
-    <Chart {...chartProps}>
-      <Axis position="left" grid title="Users" />
-      <Axis position="bottom" labelFormat="time" baseline ticks />
-      <Line {...args} />
-      <Legend />
-    </Chart>
-  );
-};
-
 const DualMetrixAxisStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
   const chartProps = useChartProps({ ...defaultChartProps, data: lineDualAxisData, animations, animationTypes });
   return (
@@ -271,7 +258,7 @@ FunkyDataShape.args = { ...defaultArgs };
 export const CategoricalPointScale = bindWithProps(CategoricalPointScaleStory);
 CategoricalPointScale.args = { ...defaultArgs, dimension: 'quarter', metric: 'value', scaleType: 'point' };
 
-export const CardinalInterpolation = bindWithProps(CardinalInterpStory);
+export const CardinalInterpolation = bindWithProps(TimeScaleStory);
 CardinalInterpolation.args = { ...defaultArgs, interpolate: 'cardinal' };
 
 export const DualMetrixAxisDrawIn = bindWithProps(DualMetrixAxisStory);

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
@@ -16,11 +16,13 @@ import { ComponentProps, ReactElement } from 'react';
 import { StoryFn } from '@storybook/react';
 
 import { Chart } from '../../../../Chart';
-import { Axis, Legend, Line } from '../../../../components';
+import { Axis, ChartInspect, Legend, Line, LineDirectLabel } from '../../../../components';
 import useChartProps from '../../../../hooks/useChartProps';
-import { workspaceTrendsData } from '../../../../stories/data/data';
+import { workspaceTrendsData, workspaceTrendsDataWithVisiblePoints } from '../../../../stories/data/data';
 import { bindWithProps } from '../../../../test-utils';
 import { ChartProps } from '../../../../types';
+import { formatTimestamp } from '../../../storyUtils';
+import { Datum } from 'vega';
 
 
 /**
@@ -51,6 +53,14 @@ const defaultArgs = {
   name: 'line0',
 };
 
+const dialogContent = (datum: Datum): ReactElement => (
+  <div>
+    <div>{formatTimestamp(datum.datetime as number)}</div>
+    <div>Event: {datum.series}</div>
+    <div>Users: {Number(datum.value).toLocaleString()}</div>
+  </div>
+);
+
 /**
  * Rows are interleaved out of chronological/series order (not the tidy per-series ascending blocks
  * `workspaceTrendsData` provides), and 'Add Bar viz' has a gap in the middle so its series is shorter
@@ -60,6 +70,7 @@ const funkyLineData = [...workspaceTrendsData]
   .filter((d) => !(d.series === 'Add Bar viz' && (d.datetime === 1668063600000 || d.datetime === 1668236400000)))
   .reverse();
 
+  
 /**
  * A genuinely categorical dimension (`quarter`, a string) on a point scale — unlike `PointScale`
  * below, which reuses `workspaceTrendsData`'s numeric `datetime` field and only *looks* like a
@@ -74,6 +85,23 @@ const categoricalPointData = ['Add Fallout', 'Add Freeform table', 'Add Line viz
       series,
     }))
 );
+
+const lineDualAxisData = [
+  { datetime: 1667890800000, value: 4500, series: 'Downloads', order: 0 },
+  { datetime: 1667977200000, value: 5200, series: 'Downloads', order: 0 },
+  { datetime: 1668063600000, value: 4800, series: 'Downloads', order: 0 },
+  { datetime: 1668150000000, value: 6100, series: 'Downloads', order: 0 },
+  { datetime: 1668236400000, value: 5800, series: 'Downloads', order: 0 },
+  { datetime: 1668322800000, value: 6500, series: 'Downloads', order: 0 },
+  { datetime: 1668409200000, value: 7200, series: 'Downloads', order: 0 },
+  { datetime: 1667890800000, value: 2.3, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1667977200000, value: 2.8, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1668063600000, value: 2.5, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1668150000000, value: 3.2, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1668236400000, value: 3, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1668322800000, value: 3.5, series: 'Conversion Rate (%)', order: 1 },
+  { datetime: 1668409200000, value: 3.8, series: 'Conversion Rate (%)', order: 1 },
+];
 
 /** Baseline — a time-scale line, the only scale type draw-in currently animates. */
 const TimeScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
@@ -147,6 +175,87 @@ const CategoricalPointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, 
   );
 };
 
+/** Using cardinal interpolation. */
+const CardinalInterpStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line {...args} />
+      <Legend />
+    </Chart>
+  );
+};
+
+const DualMetrixAxisStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: lineDualAxisData, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline ticks title="Date" />
+      <Axis position="left" grid ticks title="Downloads" />
+      <Axis position="right" ticks title="Conversion Rate (%)" />
+      <Line {...args}>
+      </Line>
+      <Legend title="Metrics" highlight />
+    </Chart>
+  );
+};
+
+/**
+ * Static point hover — hovering a data point (`ChartInspect`) fades the always-visible static point
+ * markers for deemphasized series along with the line itself, demonstrating `getLineStaticPoint`'s
+ * wiring into the same animated fraction as `getLineOpacity`.
+ */
+const StaticPointStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+/**
+ * Direct label hover — hovering a data point (`ChartInspect`) fades the end-of-line direct labels
+ * for deemphasized series along with the line itself. The label's background halo stays fully
+ * opaque throughout — only the foreground text fades.
+ */
+const DirectLabelStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line {...args}>
+        <LineDirectLabel value="series" />
+        <ChartInspect>{dialogContent}</ChartInspect>
+      </Line>
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+/** Hidden Series - combines Legend `defaultHiddenSeries`/`isToggleable` with the hover-animation */
+const HiddenSeriesStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Users" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+      </Line>
+      <Legend highlight isToggleable defaultHiddenSeries={['Add Bar viz']} />
+    </Chart>
+  );
+};
+
 export const TimeScale = bindWithProps(TimeScaleStory);
 TimeScale.args = { ...defaultArgs };
 
@@ -161,3 +270,18 @@ FunkyDataShape.args = { ...defaultArgs };
 
 export const CategoricalPointScale = bindWithProps(CategoricalPointScaleStory);
 CategoricalPointScale.args = { ...defaultArgs, dimension: 'quarter', metric: 'value', scaleType: 'point' };
+
+export const CardinalInterpolation = bindWithProps(CardinalInterpStory);
+CardinalInterpolation.args = { ...defaultArgs, interpolate: 'cardinal' };
+
+export const DualMetrixAxisDrawIn = bindWithProps(DualMetrixAxisStory);
+DualMetrixAxisDrawIn.args = { ...defaultArgs, dualMetricAxis: true };
+
+export const StaticPointDrawIn= bindWithProps(StaticPointStory);
+StaticPointDrawIn.args = { ...defaultArgs, staticPoint: 'staticPoint' };
+
+export const DirectLabelDrawIn = bindWithProps(DirectLabelStory);
+DirectLabelDrawIn.args = { ...defaultArgs };
+
+export const HiddenSeriesDrawIn = bindWithProps(HiddenSeriesStory);
+HiddenSeriesDrawIn.args = { ...defaultArgs };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx
@@ -15,6 +15,8 @@ import { ComponentProps, ReactElement } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
+import { AnimationType } from '@spectrum-charts/constants';
+
 import { Chart } from '../../../../Chart';
 import { Axis, ChartInspect, Legend, Line, LineDirectLabel } from '../../../../components';
 import useChartProps from '../../../../hooks/useChartProps';
@@ -35,13 +37,18 @@ export default {
   argTypes: {
     animations: {
       control: 'boolean',
-      description: 'Chart-level toggle for the animated draw-in/hover system.',
+      description: 'Chart-level master kill switch for all animations.',
+    },
+    animationTypes: {
+      control: { type: 'check' },
+      options: ['hover', 'drawIn'],
+      description: 'Which animation types are enabled.',
     },
   },
-  args: { animations: true },
+  args: { animations: true, animationTypes: ['hover', 'drawIn'] },
 };
 
-type DrawInAnimationArgs = ComponentProps<typeof Line> & { animations?: boolean };
+type DrawInAnimationArgs = ComponentProps<typeof Line> & { animations?: boolean; animationTypes?: AnimationType[] };
 
 const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400 };
 
@@ -103,9 +110,9 @@ const lineDualAxisData = [
   { datetime: 1668409200000, value: 3.8, series: 'Conversion Rate (%)', order: 1 },
 ];
 
-/** Baseline — a time-scale line, the only scale type draw-in currently animates. */
-const TimeScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+/** Baseline — a time-scale line, one of the three scale types draw-in supports (time/linear/point). */
+const TimeScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -116,12 +123,9 @@ const TimeScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): 
   );
 };
 
-/**
- * Point scale — not yet supported by draw-in (`isLineDrawInSupported` gates it off), so the line
- * should render at its normal, static position regardless of the `animations` toggle.
- */
-const PointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+/** Point scale — a point-scale line */
+const PointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -132,9 +136,9 @@ const PointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }):
   );
 };
 
-/** Linear scale — the other continuous scale type draw-in supports, using the numeric `point` field. */
-const LinearScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+/** Linear scale — a linear-scale line, using the numeric `point` field. */
+const LinearScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -146,8 +150,8 @@ const LinearScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args })
 };
 
 /** Funky data shape — unsorted, uneven-length series data, still on a time scale. */
-const FunkyDataShapeStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: funkyLineData, animations });
+const FunkyDataShapeStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: funkyLineData, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -158,13 +162,9 @@ const FunkyDataShapeStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args
   );
 };
 
-/**
- * Categorical point scale — a real string dimension (`quarter`), the shape the scale-type gate
- * actually protects against (unlike `PointScale`, whose numeric `datetime` field works whether or
- * not the gate is applied). Should render at normal static positions, no draw-in, no crash.
- */
-const CategoricalPointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: categoricalPointData, animations });
+/** Categorical point scale — a real string dimension (`quarter`), unlike `PointScale`'s numeric field. */
+const CategoricalPointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: categoricalPointData, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Value" />
@@ -176,8 +176,8 @@ const CategoricalPointScaleStory: StoryFn<DrawInAnimationArgs> = ({ animations, 
 };
 
 /** Using cardinal interpolation. */
-const CardinalInterpStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const CardinalInterpStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -188,8 +188,8 @@ const CardinalInterpStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args
   );
 };
 
-const DualMetrixAxisStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: lineDualAxisData, animations });
+const DualMetrixAxisStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: lineDualAxisData, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="bottom" labelFormat="time" baseline ticks title="Date" />
@@ -207,8 +207,8 @@ const DualMetrixAxisStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args
  * markers for deemphasized series along with the line itself, demonstrating `getLineStaticPoint`'s
  * wiring into the same animated fraction as `getLineOpacity`.
  */
-const StaticPointStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints, animations });
+const StaticPointStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -226,8 +226,8 @@ const StaticPointStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args })
  * for deemphasized series along with the line itself. The label's background halo stays fully
  * opaque throughout — only the foreground text fades.
  */
-const DirectLabelStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const DirectLabelStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -242,8 +242,8 @@ const DirectLabelStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args })
 };
 
 /** Hidden Series - combines Legend `defaultHiddenSeries`/`isToggleable` with the hover-animation */
-const HiddenSeriesStory: StoryFn<DrawInAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const HiddenSeriesStory: StoryFn<DrawInAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
@@ -15,7 +15,7 @@ import { ComponentProps, ReactElement, useMemo, useState } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
-import { DRAW_IN_ANIMATION_DURATION_MS } from '@spectrum-charts/constants';
+import { AnimationType, DRAW_IN_ANIMATION_DURATION_MS } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../../../Chart';
@@ -32,7 +32,12 @@ export default {
   argTypes: {
     animations: {
       control: 'boolean',
-      description: 'Chart-level toggle for the animated hover/highlight system.',
+      description: 'Chart-level master kill switch for all animations.',
+    },
+    animationTypes: {
+      control: { type: 'check' },
+      options: ['hover', 'drawIn'],
+      description: 'Which animation types are enabled.',
     },
     chartCount: {
       control: { type: 'number', min: 1, max: 40, step: 1 },
@@ -47,11 +52,12 @@ export default {
       description: 'Number of data points generated per series.',
     },
   },
-  args: { animations: true, chartCount: 20, seriesPerChart: 30, pointsPerSeries: 10 },
+  args: { animations: true, animationTypes: ['hover', 'drawIn'], chartCount: 20, seriesPerChart: 30, pointsPerSeries: 10 },
 };
 
 type DashboardArgs = {
   animations?: boolean;
+  animationTypes?: AnimationType[];
   chartCount: number;
   seriesPerChart: number;
   pointsPerSeries: number;
@@ -79,6 +85,7 @@ const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400
 type DashboardChartProps = {
   data: GeneratedTimeSeriesDatum[];
   animations?: boolean;
+  animationTypes?: AnimationType[];
 };
 
 /**
@@ -86,8 +93,8 @@ type DashboardChartProps = {
  * makes the Line interactive (wires up the voronoi hover overlay + hoveredItem signal), which is
  * what the hover-animation system needs to trigger at all.
  */
-const DashboardChart = ({ data, animations }: DashboardChartProps): ReactElement => {
-  const chartProps: ChartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
+const DashboardChart = ({ data, animations, animationTypes }: DashboardChartProps): ReactElement => {
+  const chartProps: ChartProps = useChartProps({ data, animations, animationTypes, width: 'auto', height: '100%' });
   return (
     <div style={{ height: CHART_HEIGHT, overflow: 'hidden', border: '1px solid var(--spectrum-gray-300)' }}>
       <Chart {...chartProps}>
@@ -104,11 +111,12 @@ const DashboardChart = ({ data, animations }: DashboardChartProps): ReactElement
 /**
  * Performance stress test — a resizable dashboard of `chartCount` independently-hovering line
  * charts, each seeded with its own deterministic dataset (`generateLargeData`). Resize the
- * container to see how the hover-animation system holds up under realistic dashboard layout
- * changes, not just data volume within a single chart.
+ * container to see how the hover- and draw-in-animation systems hold up under realistic dashboard
+ * layout changes at various chart/series/point counts, not just data volume within a single chart.
  */
 const DashboardStory: StoryFn<DashboardArgs> = ({
   animations,
+  animationTypes,
   chartCount,
   seriesPerChart,
   pointsPerSeries,
@@ -141,22 +149,38 @@ const DashboardStory: StoryFn<DashboardArgs> = ({
       }}
     >
       {chartData.map(({ id, data }) => (
-        <DashboardChart key={id} data={data} animations={animations} />
+        <DashboardChart key={id} data={data} animations={animations} animationTypes={animationTypes} />
       ))}
     </div>
   );
 };
 
-type LargeDatasetArgs = ComponentProps<typeof Line> & { seriesPerChart: number; pointsPerSeries: number; animations?: boolean };
+type LargeDatasetArgs = ComponentProps<typeof Line> & {
+  seriesPerChart: number;
+  pointsPerSeries: number;
+  animations?: boolean;
+  animationTypes?: AnimationType[];
+};
 
 /**
- * Performance stress test — a single chart with a large generated dataset. Hover a legend entry
- * or a data point to watch the hover-animation system fade/emphasize at scale (toggle
- * `animations` to compare).
+ * Performance stress test — a single chart with a large generated dataset. On mount, watch the
+ * draw-in animation sweep in at scale; hover a legend entry or a data point afterward to watch the
+ * hover-animation system fade/emphasize at scale (toggle `animationTypes` independently to compare).
  */
-const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({ seriesPerChart, pointsPerSeries, animations, ...args }): ReactElement => {
+const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({
+  seriesPerChart,
+  pointsPerSeries,
+  animations,
+  animationTypes,
+  ...args
+}): ReactElement => {
   const data = useMemo(() => generateLargeData(seriesPerChart, pointsPerSeries), [seriesPerChart, pointsPerSeries]);
-  const chartProps = useChartProps({ ...defaultChartProps, data, animations });
+  const chartProps = useChartProps({
+    ...defaultChartProps,
+    data,
+    animations,
+    animationTypes,
+  });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Value" />
@@ -172,6 +196,7 @@ type ResizeDuringAnimationArgs = ComponentProps<typeof Line> & {
   seriesPerChart: number;
   pointsPerSeries: number;
   animations?: boolean;
+  animationTypes?: AnimationType[];
 };
 
 /**
@@ -184,11 +209,18 @@ const ResizeDuringAnimationStory: StoryFn<ResizeDuringAnimationArgs> = ({
   seriesPerChart,
   pointsPerSeries,
   animations,
+  animationTypes,
   ...args
 }): ReactElement => {
   const [replayKey, setReplayKey] = useState(0);
   const data = useMemo(() => generateLargeData(seriesPerChart, pointsPerSeries), [seriesPerChart, pointsPerSeries]);
-  const chartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
+  const chartProps = useChartProps({
+    data,
+    animations,
+    animationTypes,
+    width: 'auto',
+    height: '100%',
+  });
 
   return (
     <div>
@@ -222,7 +254,13 @@ const ResizeDuringAnimationStory: StoryFn<ResizeDuringAnimationArgs> = ({
 };
 
 export const Dashboard = bindWithProps(DashboardStory);
-Dashboard.args = { animations: true, chartCount: 20, seriesPerChart: 10, pointsPerSeries: 10 };
+Dashboard.args = {
+  animations: true,
+  animationTypes: ['hover', 'drawIn'],
+  chartCount: 20,
+  seriesPerChart: 10,
+  pointsPerSeries: 10,
+};
 
 export const ManySeriesFewPointsDataset = bindWithProps(LargeDatasetStory);
 ManySeriesFewPointsDataset.args = { ...defaultArgs, seriesPerChart: 100, pointsPerSeries: 10 };
@@ -237,7 +275,13 @@ FewSeriesManyPointsDataset.args = { ...defaultArgs, seriesPerChart: 3, pointsPer
 };
 
 export const ResizeDuringAnimation = bindWithProps(ResizeDuringAnimationStory);
-ResizeDuringAnimation.args = { ...defaultArgs, seriesPerChart: 8, pointsPerSeries: 200, animations: true };
+ResizeDuringAnimation.args = {
+  ...defaultArgs,
+  seriesPerChart: 8,
+  pointsPerSeries: 200,
+  animations: true,
+  animationTypes: ['hover', 'drawIn'],
+};
 (ResizeDuringAnimation as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
   chartCount: { table: { disable: true } },
 };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
@@ -11,10 +11,11 @@
  */
 
 /* eslint-disable react/prop-types -- story args are typed via StoryFn generics, not React propTypes */
-import { ComponentProps, ReactElement, useMemo } from 'react';
+import { ComponentProps, ReactElement, useMemo, useState } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
+import { DRAW_IN_ANIMATION_DURATION_MS } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../../../Chart';
@@ -167,11 +168,79 @@ const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({ seriesPerChart, pointsPe
   );
 };
 
+type ResizeDuringAnimationArgs = ComponentProps<typeof Line> & {
+  seriesPerChart: number;
+  pointsPerSeries: number;
+  animations?: boolean;
+};
+
+/**
+ * Performance stress test — a single resizable chart with draw-in animation enabled. Click "Replay"
+ * then immediately drag the container's resize handle to resize while the line is still drawing in
+ * (draw-in only runs for DRAW_IN_ANIMATION_DURATION_MS after mount), checking that the animated x/y
+ * encoding stays in sync with the container's new dimensions instead of desyncing or jumping.
+ */
+const ResizeDuringAnimationStory: StoryFn<ResizeDuringAnimationArgs> = ({
+  seriesPerChart,
+  pointsPerSeries,
+  animations,
+  ...args
+}): ReactElement => {
+  const [replayKey, setReplayKey] = useState(0);
+  const data = useMemo(
+    () => generateLargeData(seriesPerChart, pointsPerSeries),
+    [seriesPerChart, pointsPerSeries, replayKey]
+  );
+  const chartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
+
+  return (
+    <div>
+      <button type="button" onClick={() => setReplayKey((key) => key + 1)} style={{ marginBottom: 8 }}>
+        Replay ({DRAW_IN_ANIMATION_DURATION_MS}ms window — start dragging the resize handle right after clicking)
+      </button>
+      <div
+        style={{
+          resize: 'both',
+          overflow: 'auto',
+          width: 700,
+          height: 400,
+          minWidth: 200,
+          minHeight: 200,
+          maxWidth: 1600,
+          maxHeight: 1200,
+          border: '2px solid var(--spectrum-gray-400)',
+          padding: 16,
+        }}
+      >
+        <Chart {...chartProps} key={replayKey}>
+          <Axis position="left" grid title="Value" />
+          <Axis position="bottom" labelFormat="time" baseline ticks />
+          <Line {...args}>
+            <ChartInspect>{dialogContent}</ChartInspect>
+          </Line>
+        </Chart>
+      </div>
+    </div>
+  );
+};
+
 export const Dashboard = bindWithProps(DashboardStory);
 Dashboard.args = { animations: true, chartCount: 20, seriesPerChart: 10, pointsPerSeries: 10 };
 
-export const LargeDataset = bindWithProps(LargeDatasetStory);
-LargeDataset.args = { ...defaultArgs, seriesPerChart: 100, pointsPerSeries: 10 };
-(LargeDataset as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
+export const ManySeriesFewPointsDataset = bindWithProps(LargeDatasetStory);
+ManySeriesFewPointsDataset.args = { ...defaultArgs, seriesPerChart: 100, pointsPerSeries: 10 };
+(ManySeriesFewPointsDataset as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
+  chartCount: { table: { disable: true } },
+};
+
+export const FewSeriesManyPointsDataset = bindWithProps(LargeDatasetStory);
+FewSeriesManyPointsDataset.args = { ...defaultArgs, seriesPerChart: 3, pointsPerSeries: 300 };
+(FewSeriesManyPointsDataset as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
+  chartCount: { table: { disable: true } },
+};
+
+export const ResizeDuringAnimation = bindWithProps(ResizeDuringAnimationStory);
+ResizeDuringAnimation.args = { ...defaultArgs, seriesPerChart: 8, pointsPerSeries: 200, animations: true };
+(ResizeDuringAnimation as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
   chartCount: { table: { disable: true } },
 };

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable react/prop-types -- story args are typed via StoryFn generics, not React propTypes */
+import { ComponentProps, ReactElement, useMemo } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Chart } from '../../../../../Chart';
+import { Axis, ChartInspect, Line } from '../../../../../components';
+import useChartProps from '../../../../../hooks/useChartProps';
+import { workspaceTrendsData } from '../../../../data/data';
+import { GeneratedTimeSeriesDatum, formatTimestamp, generateLargeData } from '../../../../storyUtils';
+import { bindWithProps } from '../../../../../test-utils';
+import { ChartProps } from '../../../../../types';
+
+export default {
+  title: 'React Spectrum Charts 2/Line/Features/DrawInAnimation/Performance',
+  component: Line,
+  argTypes: {
+    animations: {
+      control: 'boolean',
+      description: 'Chart-level toggle for the animated hover/highlight system.',
+    },
+    chartCount: {
+      control: { type: 'number', min: 1, max: 40, step: 1 },
+      description: 'Number of independent line charts to render in the dashboard grid.',
+    },
+    seriesPerChart: {
+      control: { type: 'number', min: 1, max: 50, step: 1 },
+      description: 'Number of series generated per chart.',
+    },
+    pointsPerSeries: {
+      control: { type: 'number', min: 10, max: 5_000, step: 10 },
+      description: 'Number of data points generated per series.',
+    },
+  },
+  args: { animations: true, chartCount: 20, seriesPerChart: 30, pointsPerSeries: 10 },
+};
+
+type DashboardArgs = {
+  animations?: boolean;
+  chartCount: number;
+  seriesPerChart: number;
+  pointsPerSeries: number;
+};
+
+const CHART_HEIGHT = 260;
+
+const defaultArgs = {
+  color: 'series',
+  dimension: 'datetime',
+  metric: 'value',
+  scaleType: 'time' as const,
+};
+
+const dialogContent = (datum: Datum): ReactElement => (
+  <div>
+    <div>{formatTimestamp(datum.datetime as number)}</div>
+    <div>Series: {datum.series}</div>
+    <div>Value: {Number(datum.value).toLocaleString()}</div>
+  </div>
+);
+
+const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400 };
+
+type DashboardChartProps = {
+  data: GeneratedTimeSeriesDatum[];
+  animations?: boolean;
+};
+
+/**
+ * A single dashboard tile — its own Chart, sized to fill its grid cell. `ChartInspect` is what
+ * makes the Line interactive (wires up the voronoi hover overlay + hoveredItem signal), which is
+ * what the hover-animation system needs to trigger at all.
+ */
+const DashboardChart = ({ data, animations }: DashboardChartProps): ReactElement => {
+  const chartProps: ChartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
+  return (
+    <div style={{ height: CHART_HEIGHT, overflow: 'hidden', border: '1px solid var(--spectrum-gray-300)' }}>
+      <Chart {...chartProps}>
+        <Axis position="left" grid />
+        <Axis position="bottom" labelFormat="time" baseline />
+        <Line {...defaultArgs}>
+          <ChartInspect>{dialogContent}</ChartInspect>
+        </Line>
+      </Chart>
+    </div>
+  );
+};
+
+/**
+ * Performance stress test — a resizable dashboard of `chartCount` independently-hovering line
+ * charts, each seeded with its own deterministic dataset (`generateLargeData`). Resize the
+ * container to see how the hover-animation system holds up under realistic dashboard layout
+ * changes, not just data volume within a single chart.
+ */
+const DashboardStory: StoryFn<DashboardArgs> = ({
+  animations,
+  chartCount,
+  seriesPerChart,
+  pointsPerSeries,
+}): ReactElement => {
+  const chartData = useMemo(
+    () =>
+      Array.from({ length: chartCount }, (_, i) => ({
+        id: `chart-${i}`,
+        data: generateLargeData(seriesPerChart, pointsPerSeries, i),
+      })),
+    [chartCount, seriesPerChart, pointsPerSeries]
+  );
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+        gap: 16,
+        width: 1400,
+        minWidth: 600,
+        maxWidth: 2800,
+        height: 900,
+        minHeight: 300,
+        maxHeight: 2400,
+        overflow: 'auto',
+        resize: 'both',
+        border: '2px solid var(--spectrum-gray-400)',
+        padding: 16,
+      }}
+    >
+      {chartData.map(({ id, data }) => (
+        <DashboardChart key={id} data={data} animations={animations} />
+      ))}
+    </div>
+  );
+};
+
+type LargeDatasetArgs = ComponentProps<typeof Line> & { seriesPerChart: number; pointsPerSeries: number; animations?: boolean };
+
+/**
+ * Performance stress test — a single chart with a large generated dataset. Hover a legend entry
+ * or a data point to watch the hover-animation system fade/emphasize at scale (toggle
+ * `animations` to compare).
+ */
+const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({ seriesPerChart, pointsPerSeries, animations, ...args }): ReactElement => {
+  const data = useMemo(() => generateLargeData(seriesPerChart, pointsPerSeries), [seriesPerChart, pointsPerSeries]);
+  const chartProps = useChartProps({ ...defaultChartProps, data, animations });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" grid title="Value" />
+      <Axis position="bottom" labelFormat="time" baseline ticks />
+      <Line {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+      </Line>
+    </Chart>
+  );
+};
+
+export const Dashboard = bindWithProps(DashboardStory);
+Dashboard.args = { animations: true, chartCount: 20, seriesPerChart: 10, pointsPerSeries: 10 };
+
+export const LargeDataset = bindWithProps(LargeDatasetStory);
+LargeDataset.args = { ...defaultArgs, seriesPerChart: 100, pointsPerSeries: 10 };
+(LargeDataset as unknown as { argTypes: Record<string, { table: { disable: true } }> }).argTypes = {
+  chartCount: { table: { disable: true } },
+};

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/Performance/LineDrawInAnimationPerformanceTesting.story.tsx
@@ -187,10 +187,7 @@ const ResizeDuringAnimationStory: StoryFn<ResizeDuringAnimationArgs> = ({
   ...args
 }): ReactElement => {
   const [replayKey, setReplayKey] = useState(0);
-  const data = useMemo(
-    () => generateLargeData(seriesPerChart, pointsPerSeries),
-    [seriesPerChart, pointsPerSeries, replayKey]
-  );
+  const data = useMemo(() => generateLargeData(seriesPerChart, pointsPerSeries), [seriesPerChart, pointsPerSeries]);
   const chartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
 
   return (

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/HoverAnimation/LineHoverAnimation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/HoverAnimation/LineHoverAnimation.story.tsx
@@ -16,6 +16,7 @@ import { ComponentProps, ReactElement } from 'react';
 import { action } from '@storybook/addon-actions';
 import { StoryFn } from '@storybook/react';
 
+import { AnimationType } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../../Chart';
@@ -61,13 +62,18 @@ export default {
   argTypes: {
     animations: {
       control: 'boolean',
-      description: 'Chart-level toggle for the animated hover/highlight system.',
+      description: 'Chart-level master kill switch for all animations.',
+    },
+    animationTypes: {
+      control: { type: 'check' },
+      options: ['hover'],
+      description: "Which animation types are enabled (only 'hover' is relevant to this story group).",
     },
   },
-  args: { animations: true },
+  args: { animations: true, animationTypes: ['hover'] },
 };
 
-type HoverAnimationArgs = ComponentProps<typeof Line> & { animations?: boolean };
+type HoverAnimationArgs = ComponentProps<typeof Line> & { animations?: boolean; animationTypes?: AnimationType[] };
 
 const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400, maxWidth: 800, height: 400 };
 
@@ -103,8 +109,8 @@ const groupedData = workspaceTrendsData.map((d) => ({ ...d, category: seriesCate
  * Point hover — hovering a data point emphasizes that point's series (the `hoveredMatch` rule).
  * ChartInspect makes the line interactive, which is what creates the hover-animation data.
  */
-const PointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const PointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -118,8 +124,8 @@ const PointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): 
 };
 
 /** Legend hover — hovering a legend entry emphasizes that series (the injected `legendHoverMatch` rule). */
-const LegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const LegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -131,8 +137,8 @@ const LegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }):
 };
 
 /** Grouped legend hover — hovering a grouped legend entry emphasizes every series in that group. */
-const GroupedLegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: groupedData, animations });
+const GroupedLegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: groupedData, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -144,8 +150,8 @@ const GroupedLegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...a
 };
 
 /** Popover selection — clicking a point selects its series (the `popoverMatch` rule) and keeps it emphasized. */
-const PopoverSelectionStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const PopoverSelectionStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -159,8 +165,8 @@ const PopoverSelectionStory: StoryFn<HoverAnimationArgs> = ({ animations, ...arg
 };
 
 /** Controlled highlight — an external `highlightedSeries` chart prop emphasizes a series (the `controlledSeriesMatch` rule). */
-const ControlledHighlightStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, highlightedSeries: 'Add Freeform table', animations });
+const ControlledHighlightStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, highlightedSeries: 'Add Freeform table', animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -172,8 +178,8 @@ const ControlledHighlightStory: StoryFn<HoverAnimationArgs> = ({ animations, ...
 };
 
 /** Controlled highlight — an external `highlightedItem` chart prop emphasizes the row's series (the `controlledTableMatch` rule). */
-const ControlledHighlightItemStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, highlightedItem: 0, animations });
+const ControlledHighlightItemStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, highlightedItem: 0, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -185,8 +191,8 @@ const ControlledHighlightItemStory: StoryFn<HoverAnimationArgs> = ({ animations,
 };
 
 /** onClick — an onClick handler makes the line interactive, so hovering points animates the emphasis. */
-const OnClickStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const OnClickStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -202,8 +208,8 @@ const OnClickStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): Rea
  * markers for deemphasized series along with the line itself, demonstrating `getLineStaticPoint`'s
  * wiring into the same animated fraction as `getLineOpacity`.
  */
-const StaticPointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints, animations });
+const StaticPointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsDataWithVisiblePoints, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -221,8 +227,8 @@ const StaticPointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...arg
  * for deemphasized series along with the line itself. The label's background halo stays fully
  * opaque throughout — only the foreground text fades.
  */
-const DirectLabelHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const DirectLabelHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />
@@ -237,8 +243,8 @@ const DirectLabelHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, ...arg
 };
 
 /** Hidden Series - combines Legend `defaultHiddenSeries`/`isToggleable` with the hover-animation */
-const HiddenSeriesStory: StoryFn<HoverAnimationArgs> = ({ animations, ...args }): ReactElement => {
-  const chartProps = useChartProps({ ...defaultChartProps, animations });
+const HiddenSeriesStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Users" />

--- a/packages/react-spectrum-charts-s2/src/stories/Line/Features/HoverAnimation/Performance/LineHoverAnimationPerformanceTesting.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Line/Features/HoverAnimation/Performance/LineHoverAnimationPerformanceTesting.story.tsx
@@ -15,6 +15,7 @@ import { ComponentProps, ReactElement, useMemo } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
+import { AnimationType } from '@spectrum-charts/constants';
 import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../../../Chart';
@@ -31,7 +32,12 @@ export default {
   argTypes: {
     animations: {
       control: 'boolean',
-      description: 'Chart-level toggle for the animated hover/highlight system.',
+      description: 'Chart-level master kill switch for all animations.',
+    },
+    animationTypes: {
+      control: { type: 'check' },
+      options: ['hover'],
+      description: "Which animation types are enabled (only 'hover' is relevant to this story group).",
     },
     chartCount: {
       control: { type: 'number', min: 1, max: 40, step: 1 },
@@ -46,11 +52,12 @@ export default {
       description: 'Number of data points generated per series.',
     },
   },
-  args: { animations: true, chartCount: 20, seriesPerChart: 30, pointsPerSeries: 10 },
+  args: { animations: true, animationTypes: ['hover'], chartCount: 20, seriesPerChart: 30, pointsPerSeries: 10 },
 };
 
 type DashboardArgs = {
   animations?: boolean;
+  animationTypes?: AnimationType[];
   chartCount: number;
   seriesPerChart: number;
   pointsPerSeries: number;
@@ -78,6 +85,7 @@ const defaultChartProps: ChartProps = { data: workspaceTrendsData, minWidth: 400
 type DashboardChartProps = {
   data: GeneratedTimeSeriesDatum[];
   animations?: boolean;
+  animationTypes?: AnimationType[];
 };
 
 /**
@@ -85,8 +93,8 @@ type DashboardChartProps = {
  * makes the Line interactive (wires up the voronoi hover overlay + hoveredItem signal), which is
  * what the hover-animation system needs to trigger at all.
  */
-const DashboardChart = ({ data, animations }: DashboardChartProps): ReactElement => {
-  const chartProps: ChartProps = useChartProps({ data, animations, width: 'auto', height: '100%' });
+const DashboardChart = ({ data, animations, animationTypes }: DashboardChartProps): ReactElement => {
+  const chartProps: ChartProps = useChartProps({ data, animations, animationTypes, width: 'auto', height: '100%' });
   return (
     <div style={{ height: CHART_HEIGHT, overflow: 'hidden', border: '1px solid var(--spectrum-gray-300)' }}>
       <Chart {...chartProps}>
@@ -108,6 +116,7 @@ const DashboardChart = ({ data, animations }: DashboardChartProps): ReactElement
  */
 const DashboardStory: StoryFn<DashboardArgs> = ({
   animations,
+  animationTypes,
   chartCount,
   seriesPerChart,
   pointsPerSeries,
@@ -140,22 +149,33 @@ const DashboardStory: StoryFn<DashboardArgs> = ({
       }}
     >
       {chartData.map(({ id, data }) => (
-        <DashboardChart key={id} data={data} animations={animations} />
+        <DashboardChart key={id} data={data} animations={animations} animationTypes={animationTypes} />
       ))}
     </div>
   );
 };
 
-type LargeDatasetArgs = ComponentProps<typeof Line> & { seriesPerChart: number; pointsPerSeries: number; animations?: boolean };
+type LargeDatasetArgs = ComponentProps<typeof Line> & {
+  seriesPerChart: number;
+  pointsPerSeries: number;
+  animations?: boolean;
+  animationTypes?: AnimationType[];
+};
 
 /**
  * Performance stress test — a single chart with a large generated dataset. Hover a legend entry
  * or a data point to watch the hover-animation system fade/emphasize at scale (toggle
  * `animations` to compare).
  */
-const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({ seriesPerChart, pointsPerSeries, animations, ...args }): ReactElement => {
+const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({
+  seriesPerChart,
+  pointsPerSeries,
+  animations,
+  animationTypes,
+  ...args
+}): ReactElement => {
   const data = useMemo(() => generateLargeData(seriesPerChart, pointsPerSeries), [seriesPerChart, pointsPerSeries]);
-  const chartProps = useChartProps({ ...defaultChartProps, data, animations });
+  const chartProps = useChartProps({ ...defaultChartProps, data, animations, animationTypes });
   return (
     <Chart {...chartProps}>
       <Axis position="left" grid title="Value" />
@@ -168,7 +188,7 @@ const LargeDatasetStory: StoryFn<LargeDatasetArgs> = ({ seriesPerChart, pointsPe
 };
 
 export const Dashboard = bindWithProps(DashboardStory);
-Dashboard.args = { animations: true, chartCount: 20, seriesPerChart: 10, pointsPerSeries: 10 };
+Dashboard.args = { animations: true, animationTypes: ['hover'], chartCount: 20, seriesPerChart: 10, pointsPerSeries: 10 };
 
 export const LargeDataset = bindWithProps(LargeDatasetStory);
 LargeDataset.args = { ...defaultArgs, seriesPerChart: 100, pointsPerSeries: 10 };

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -101,6 +101,7 @@ const isDivergingAxis = (axis: Axis): boolean => {
 
 export function buildSpec({
   animations,
+  animationTypes,
   axes = [],
   backgroundColor = DEFAULT_BACKGROUND_COLOR,
   chartHeight,
@@ -155,6 +156,7 @@ export function buildSpec({
   const legendHighlightSignals = getLegendHighlightSignals(legends);
   const specOptions = {
     animations,
+    animationTypes,
     backgroundColor,
     colorScheme,
     idKey,

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
@@ -613,4 +613,18 @@ describe('getLineHighlightOverlayGroup()', () => {
     const marks = (group as { marks: { encode: { update: { opacity: unknown } } }[] }).marks;
     expect(Array.isArray(marks[0].encode.update.opacity)).toBe(true);
   });
+
+  test('overlay line does not use draw-in x/y encoding, even when the parent line is draw-in animated', () => {
+    // the overlay mark is renamed to `${name}_highlightOverlayLine`, but the draw-in cutoff signal is
+    // only ever registered under the original line's name — using draw-in encoding here would reference
+    // a signal that doesn't exist (e.g. "line0_highlightOverlayLine_drawInAnimCutoff")
+    const group = getLineHighlightOverlayGroup(
+      { ...defaultLineMarkOptions, isDrawInAnimate: true },
+      'filteredTable',
+      [SERIES_ID]
+    );
+    const marks = (group as { marks: { encode: { update: { x: { signal?: string } } } }[] }).marks;
+    expect(marks[0].encode.update.x).not.toHaveProperty('signal');
+    expect(marks[0].encode.update).not.toHaveProperty('y');
+  });
 });

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
@@ -26,6 +26,7 @@ import {
   SERIES_ID,
 } from '@spectrum-charts/constants';
 
+import { getLineDrawInXEncoding, getLineDrawInYEncoding } from '../marks/drawInAnimationUtils';
 import { getDeemphasisRamp, getHoverFractionSignal } from '../marks/hoverAnimationUtils';
 import {
   getAlternateSegmentStrokeDash,
@@ -132,6 +133,22 @@ describe('getLineMark()', () => {
       signal: expect.stringContaining("data('line0_hoverFractionData')"),
     });
     expect(Array.isArray(notAnimated.encode?.update?.opacity)).toBe(true);
+  });
+
+  describe('isDrawInAnimate', () => {
+    test('omits the enter y encoding and uses the draw-in x/y encodings in update when true', () => {
+      const lineMark = getLineMark({ ...defaultLineMarkOptions, isDrawInAnimate: true }, 'line0_facet');
+      expect(lineMark.encode?.enter).not.toHaveProperty('y');
+      expect(lineMark.encode?.update?.x).toStrictEqual(getLineDrawInXEncoding({ ...defaultLineMarkOptions, isDrawInAnimate: true }));
+      expect(lineMark.encode?.update?.y).toStrictEqual(getLineDrawInYEncoding({ ...defaultLineMarkOptions, isDrawInAnimate: true }));
+    });
+
+    test('keeps the static enter y encoding and the scale-based update x, with no update y, when false', () => {
+      const lineMark = getLineMark({ ...defaultLineMarkOptions, isDrawInAnimate: false }, 'line0_facet');
+      expect(lineMark.encode?.enter).toHaveProperty('y');
+      expect(lineMark.encode?.update).not.toHaveProperty('y');
+      expect(lineMark.encode?.update?.x).toStrictEqual({ field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' });
+    });
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.test.ts
@@ -116,17 +116,17 @@ describe('getLineMark()', () => {
     expect(stroke[1]).toEqual({ field: 'series', scale: COLOR_SCALE });
   });
 
-  test('isAnimate: false forces the static instant-rule opacity even for an otherwise-interactive line', () => {
+  test('isHoverAnimate: false forces the static instant-rule opacity even for an otherwise-interactive line', () => {
     // this is the override every renamed-mark reuse of getLineMark relies on (highlight overlay,
     // trendlines, metric-range boundary line) — they all spread an interactive parent's options under
-    // a different mark name, so isAnimate must be forced false or the opacity would reference a
+    // a different mark name, so isHoverAnimate must be forced false or the opacity would reference a
     // `_hoverFractionData` that only exists for the base line's name
     const animated = getLineMark(
-      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isAnimate: true },
+      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isHoverAnimate: true },
       'line0_facet'
     );
     const notAnimated = getLineMark(
-      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isAnimate: false },
+      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isHoverAnimate: false },
       'line0_facet'
     );
     expect(animated.encode?.update?.opacity).toStrictEqual({
@@ -273,12 +273,12 @@ describe('getLineOpacity()', () => {
     expect(comboRule?.test).toBe(`isValid(bar0_${HOVERED_ITEM}) || isValid(bar1_${HOVERED_ITEM})`);
   });
 
-  describe('when isAnimate is true', () => {
+  describe('when isHoverAnimate is true', () => {
     test('returns the animated deemphasis-ramp signal instead of the instant production rules', () => {
       const opacityRule = getLineOpacity({
         ...defaultLineMarkOptions,
         interactiveMarkName: 'line0',
-        isAnimate: true,
+        isHoverAnimate: true,
       });
       const ramp = getDeemphasisRamp(getHoverFractionSignal('line0'));
       expect(opacityRule).toStrictEqual({ signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}` });
@@ -288,7 +288,7 @@ describe('getLineOpacity()', () => {
       const opacityRule = getLineOpacity({
         ...defaultLineMarkOptions,
         interactiveMarkName: 'line0',
-        isAnimate: true,
+        isHoverAnimate: true,
         displayOnHover: true,
       });
       expect(opacityRule).toEqual([DEFAULT_OPACITY_RULE]);
@@ -602,11 +602,11 @@ describe('getLineHighlightOverlayGroup()', () => {
   });
 
   test('overlay opacity always comes from getHighlightedSeriesOpacityRules, even when the parent line is animated', () => {
-    // opacity is always overwritten by opacityRules (below), regardless of isAnimate — the isAnimate:
+    // opacity is always overwritten by opacityRules (below), regardless of isHoverAnimate — the isHoverAnimate:
     // false passed into the underlying getLineMark call only matters for encodings that AREN'T
     // subsequently overwritten here (see the getLineMark() tests for where that override is observable)
     const group = getLineHighlightOverlayGroup(
-      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isAnimate: true },
+      { ...defaultLineMarkOptions, interactiveMarkName: 'line0', isHoverAnimate: true },
       'filteredTable',
       [SERIES_ID]
     );

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
@@ -43,6 +43,7 @@ import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getPopovers } from '../chartPopover/chartPopoverUtils';
 import { getDeemphasisRamp, getHoverFractionSignal } from '../marks/hoverAnimationUtils';
+import { getLineDrawInXEncoding, getLineDrawInYEncoding } from '../marks/drawInAnimationUtils'
 import {
   getColorProductionRule,
   getColorProductionRuleSignalString,
@@ -234,6 +235,7 @@ export const getLineMark = (lineMarkOptions: LineMarkOptions, dataSource: string
     scaleType,
     primarySeries,
     interpolate,
+    isDrawInAnimate,
   } = lineMarkOptions;
   const popovers = getPopovers(chartPopovers ?? [], name);
   const popoverWithDimensionHighlightExists = popovers.some(
@@ -248,7 +250,7 @@ export const getLineMark = (lineMarkOptions: LineMarkOptions, dataSource: string
     interactive: false,
     encode: {
       enter: {
-        y: getLineYEncoding(lineMarkOptions, metric),
+        ...(isDrawInAnimate ? {} : { y: getLineYEncoding(lineMarkOptions, metric) }),
         stroke: getStrokeEncoding(primarySeries, otherSeriesColor, color, colorScheme),
         strokeCap: { value: lineCap },
         strokeDash: alternateSegmentKey
@@ -258,7 +260,8 @@ export const getLineMark = (lineMarkOptions: LineMarkOptions, dataSource: string
       },
       update: {
         // x and strokeWidth must be in update: x changes on resize, strokeWidth changes on hover
-        x: getXProductionRule(scaleType, dimension),
+        x: isDrawInAnimate ? getLineDrawInXEncoding(lineMarkOptions) : getXProductionRule(scaleType, dimension),
+        ...(isDrawInAnimate ? { y: getLineDrawInYEncoding(lineMarkOptions) } : {}),
         ...(popoverWithDimensionHighlightExists ? {} : { opacity: getLineOpacity(lineMarkOptions) }),
         ...(interpolate ? { interpolate: { value: interpolate } } : {}),
         strokeWidth: getLineStrokeWidth(lineMarkOptions),

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
@@ -619,7 +619,7 @@ export const getLineHighlightOverlayGroup = (
   const opacityRules = getHighlightedSeriesOpacityRules(markOptions);
 
   const baseLineMark = getLineMark(
-    { ...markOptions, name: `${name}_highlightOverlayLine`, isAnimate: false },
+    { ...markOptions, name: `${name}_highlightOverlayLine`, isAnimate: false, isDrawInAnimate: false },
     `${name}_highlightOverlay_facet`
   );
 

--- a/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineMarkUtils.ts
@@ -278,11 +278,11 @@ export const getLineDeemphasisOpacitySignal = (name: string): ProductionRule<Num
 };
 
 export const getLineOpacity = (lineMarkOptions: LineMarkOptions): ProductionRule<NumericValueRef> => {
-  const { displayOnHover, isAnimate, name } = lineMarkOptions;
+  const { displayOnHover, isHoverAnimate, name } = lineMarkOptions;
   // displayOnHover overlay marks manage their own visibility via getHighlightedSeriesOpacityRules
   if (displayOnHover) return [DEFAULT_OPACITY_RULE];
 
-  if (isAnimate) {
+  if (isHoverAnimate) {
     // Fade deemphasized series; neutral and emphasized both stay fully opaque
     return getLineDeemphasisOpacitySignal(name);
   }
@@ -619,7 +619,7 @@ export const getLineHighlightOverlayGroup = (
   const opacityRules = getHighlightedSeriesOpacityRules(markOptions);
 
   const baseLineMark = getLineMark(
-    { ...markOptions, name: `${name}_highlightOverlayLine`, isAnimate: false, isDrawInAnimate: false },
+    { ...markOptions, name: `${name}_highlightOverlayLine`, isHoverAnimate: false, isDrawInAnimate: false },
     `${name}_highlightOverlay_facet`
   );
 

--- a/packages/vega-spec-builder-s2/src/line/linePointUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointUtils.test.ts
@@ -237,9 +237,9 @@ describe('getLineStaticPoint()', () => {
     ]);
   });
 
-  describe('when isAnimate is true', () => {
+  describe('when isHoverAnimate is true', () => {
     test('returns the animated deemphasis-ramp signal instead of the instant production rules', () => {
-      const mark = getLineStaticPoint({ ...defaultLineOptions, interactiveMarkName: 'line0', isAnimate: true });
+      const mark = getLineStaticPoint({ ...defaultLineOptions, interactiveMarkName: 'line0', isHoverAnimate: true });
       const ramp = getDeemphasisRamp(getHoverFractionSignal('line0'));
       expect(mark.encode?.update?.opacity).toStrictEqual({
         signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}`,
@@ -251,7 +251,7 @@ describe('getLineStaticPoint()', () => {
         ...defaultLineOptions,
         interactiveMarkName: 'line0',
         isHighlightedByGroup: true,
-        isAnimate: true,
+        isHoverAnimate: true,
       });
       const ramp = getDeemphasisRamp(getHoverFractionSignal('line0'));
       expect(mark.encode?.update?.opacity).toStrictEqual({

--- a/packages/vega-spec-builder-s2/src/line/linePointUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/linePointUtils.ts
@@ -72,12 +72,12 @@ const getOpacity = (lineOptions: LineSpecOptions): ProductionRule<NumericValueRe
   const {
     name,
     interactiveMarkName,
-    isAnimate,
+    isHoverAnimate,
     isHighlightedByGroup,
   } = lineOptions;
-  
-  // Animated 
-  if (isAnimate) return getLineDeemphasisOpacitySignal(name);
+
+  // Animated
+  if (isHoverAnimate) return getLineDeemphasisOpacitySignal(name);
   
   // Non-animated
   const opacityRules: ProductionRule<NumericValueRef> = [];

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -419,6 +419,48 @@ describe('lineSpecBuilder', () => {
         expect(rules).toEqual(expect.arrayContaining(['controlledTableMatch', 'controlledSeriesMatch']));
       });
     });
+
+    describe('isDrawInAnimate gate', () => {
+      test.each(['time', 'linear', 'point'] as const)(
+        'animations: true creates draw-in data sources for a %s scale',
+        (scaleType) => {
+          const spec = addLine(startingSpec, {
+            idKey: MARK_ID,
+            color: DEFAULT_COLOR,
+            markType: 'line',
+            animations: true,
+            scaleType,
+          });
+          expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(true);
+        }
+      );
+
+      test('animations: true does not create draw-in data sources for an unsupported (band) scale', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          animations: true,
+          scaleType: 'band',
+        });
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
+      });
+
+      test('animations: false does not create draw-in data sources', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          animations: false,
+        });
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
+      });
+
+      test('omitting the animations prop does not create draw-in data sources', () => {
+        const spec = addLine(startingSpec, { idKey: MARK_ID, color: DEFAULT_COLOR, markType: 'line' });
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
+      });
+    });
   });
 
   describe('addData()', () => {
@@ -635,6 +677,56 @@ describe('lineSpecBuilder', () => {
         });
         expect(resultData.find((d) => d.name === 'line0_hoverTargetData')).toBeUndefined();
         expect(resultData.find((d) => d.name === HOVER_ANIM_LAST_CHANGE_DATA)).toBeUndefined();
+      });
+    });
+
+    describe('draw-in animation', () => {
+      test('for a time scale, adds the ms-formula transform, the lead transform on filteredTable, and the prev/tip/lerp sources', () => {
+        const resultData = addData(baseData, { ...defaultLineOptions, isDrawInAnimate: true, scaleType: 'time' });
+        const tableData = resultData.find((d) => d.name === TABLE);
+        expect(tableData?.transform).toContainEqual({
+          type: 'formula',
+          expr: `toNumber(datum.${DEFAULT_TIME_DIMENSION})`,
+          as: 'rscDrawInTimeMs',
+        });
+        const filteredTableData = resultData.find((d) => d.name === FILTERED_TABLE);
+        expect(filteredTableData?.transform?.some((t) => t.type === 'window')).toBe(true);
+        expect(resultData.find((d) => d.name === 'line0_drawInPrev')).toBeDefined();
+        expect(resultData.find((d) => d.name === 'line0_drawInTip')).toBeDefined();
+        expect(resultData.find((d) => d.name === 'line0_drawInLerp')).toBeDefined();
+      });
+
+      test('for a linear scale, adds the lead transform on filteredTable without the ms-formula transform', () => {
+        const resultData = addData(baseData, { ...defaultLineOptions, isDrawInAnimate: true, scaleType: 'linear' });
+        const tableData = resultData.find((d) => d.name === TABLE);
+        expect(tableData?.transform?.some((t) => 'as' in t && t.as === 'rscDrawInTimeMs')).toBe(false);
+        const filteredTableData = resultData.find((d) => d.name === FILTERED_TABLE);
+        expect(filteredTableData?.transform?.some((t) => t.type === 'window')).toBe(true);
+        expect(resultData.find((d) => d.name === 'line0_drawInLerp')).toBeDefined();
+      });
+
+      test('for a point scale, adds a name-scoped indexed source with the lead transform instead of transforming filteredTable', () => {
+        const resultData = addData(baseData, {
+          ...defaultLineOptions,
+          isDrawInAnimate: true,
+          scaleType: 'point',
+          dimension: 'category',
+        });
+        const indexedData = resultData.find((d) => d.name === 'line0_drawInIndexed');
+        expect(indexedData).toBeDefined();
+        expect(indexedData?.transform?.some((t) => t.type === 'window')).toBe(true);
+        const filteredTableData = resultData.find((d) => d.name === FILTERED_TABLE);
+        expect(filteredTableData?.transform?.some((t) => t.type === 'window') ?? false).toBe(false);
+        expect(resultData.find((d) => d.name === 'line0_drawInPrev')).toHaveProperty('source', 'line0_drawInIndexed');
+        expect(resultData.find((d) => d.name === 'line0_drawInLerp')).toBeDefined();
+      });
+
+      test('does not add any draw-in data sources when isDrawInAnimate is false', () => {
+        const resultData = addData(baseData, { ...defaultLineOptions, isDrawInAnimate: false });
+        expect(resultData.find((d) => d.name === 'line0_drawInPrev')).toBeUndefined();
+        expect(resultData.find((d) => d.name === 'line0_drawInTip')).toBeUndefined();
+        expect(resultData.find((d) => d.name === 'line0_drawInLerp')).toBeUndefined();
+        expect(resultData.find((d) => d.name === 'line0_drawInIndexed')).toBeUndefined();
       });
     });
   });
@@ -1004,6 +1096,17 @@ describe('lineSpecBuilder', () => {
       expect(groupMark.from.facet.data).toBe(FILTERED_TABLE);
     });
 
+    test('with isDrawInAnimate uses the draw-in lerp source as facet data, overriding alternateSegmentKey/primarySeries', () => {
+      const marks = addLineMarks([], {
+        ...defaultLineOptions,
+        isDrawInAnimate: true,
+        alternateSegmentKey: 'isEstimated',
+        primarySeries: 3,
+      });
+      const groupMark = marks[0] as { from: { facet: { data: string } } };
+      expect(groupMark.from.facet.data).toBe('line0_drawInLerp');
+    });
+
     test('with alternateSegmentKey, line mark strokeDash uses a signal', () => {
       const marks = addLineMarks([], {
         ...defaultLineOptions,
@@ -1153,6 +1256,28 @@ describe('lineSpecBuilder', () => {
       test('does not add the hover-animation engine signals when isAnimate is false', () => {
         const signals = addSignals([], { ...defaultLineOptions, isAnimate: false });
         expect(signals.some((s) => s.name === HOVER_TIMER)).toBe(false);
+      });
+    });
+
+    describe('draw-in animation', () => {
+      test('adds the shared clock chain plus the per-mark domain/cutoff signals when isDrawInAnimate is true', () => {
+        const signals = addSignals([], { ...defaultLineOptions, isDrawInAnimate: true });
+        expect(signals.map((s) => s.name)).toEqual(
+          expect.arrayContaining([
+            'drawInStart',
+            'drawInAnimT',
+            'drawInAnimTEased',
+            'line0_drawInDomainMin',
+            'line0_drawInDomainMax',
+            'line0_drawInAnimCutoff',
+          ])
+        );
+      });
+
+      test('does not add the draw-in animation signals when isDrawInAnimate is false', () => {
+        const signals = addSignals([], { ...defaultLineOptions, isDrawInAnimate: false });
+        expect(signals.some((s) => s.name === 'drawInStart')).toBe(false);
+        expect(signals.some((s) => s.name === 'line0_drawInAnimCutoff')).toBe(false);
       });
     });
   });

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -26,7 +26,7 @@ import {
   HOVERED_ITEM,
   HOVER_ANIM_LAST_CHANGE_DATA,
   HOVER_TARGETS,
-  HOVER_TIMER,
+  ANIMATION_TIMER,
   LINEAR_PADDING,
   MARK_ID,
   SERIES_ID,
@@ -333,8 +333,8 @@ describe('lineSpecBuilder', () => {
       );
     });
 
-    describe('isAnimate gate', () => {
-      test('an interactive line resolves isAnimate true, registers usermeta.animatedMarks, and creates hover-animation data', () => {
+    describe('isHoverAnimate gate', () => {
+      test('an interactive line resolves isHoverAnimate true, registers usermeta.animatedMarks, and creates hover-animation data', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
@@ -351,7 +351,19 @@ describe('lineSpecBuilder', () => {
         expect(spec.data?.some((d) => d.name === 'line0_hoverTargetData')).toBe(false);
       });
 
-      test('the chart-level animations: false prop disables animation even for an interactive line', () => {
+      test('an animationTypes list without "hover" disables animation even for an interactive line', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          chartInspects: [{}],
+          animationTypes: [],
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'line0_hoverTargetData')).toBe(false);
+      });
+
+      test('the chart-level animations: false master switch disables animation even for an interactive line', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
@@ -379,7 +391,7 @@ describe('lineSpecBuilder', () => {
         expect(spec.usermeta?.animatedMarks).toStrictEqual(['line0']);
       });
 
-      test('interactionMode "item" resolves isAnimate the same as the default (nearest) mode', () => {
+      test('interactionMode "item" resolves isHoverAnimate the same as the default (nearest) mode', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
@@ -401,7 +413,7 @@ describe('lineSpecBuilder', () => {
         expect(hoveredMatchRule?.expr).toContain(`line0_${HOVERED_ITEM}`);
       });
 
-      test('a chart-level highlightedItem alone (no other line interactivity) resolves isAnimate true', () => {
+      test('a chart-level highlightedItem alone (no other line interactivity) resolves isHoverAnimate true', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
@@ -422,42 +434,95 @@ describe('lineSpecBuilder', () => {
 
     describe('isDrawInAnimate gate', () => {
       test.each(['time', 'linear', 'point'] as const)(
-        'animations: true creates draw-in data sources for a %s scale',
+        'animationTypes: ["drawIn"] creates draw-in data sources for a %s scale',
         (scaleType) => {
           const spec = addLine(startingSpec, {
             idKey: MARK_ID,
             color: DEFAULT_COLOR,
             markType: 'line',
-            animations: true,
+            animationTypes: ['drawIn'],
             scaleType,
           });
           expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(true);
         }
       );
 
-      test('animations: true does not create draw-in data sources for an unsupported (band) scale', () => {
+      test('animationTypes: ["drawIn"] does not create draw-in data sources for an unsupported (band) scale', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
           markType: 'line',
-          animations: true,
+          animationTypes: ['drawIn'],
           scaleType: 'band',
         });
         expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
       });
 
-      test('animations: false does not create draw-in data sources', () => {
+      test('an animationTypes list without "drawIn" does not create draw-in data sources', () => {
         const spec = addLine(startingSpec, {
           idKey: MARK_ID,
           color: DEFAULT_COLOR,
           markType: 'line',
-          animations: false,
+          animationTypes: ['hover'],
         });
         expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
       });
 
-      test('omitting the animations prop does not create draw-in data sources', () => {
+      test('omitting the animationTypes prop does not create draw-in data sources', () => {
         const spec = addLine(startingSpec, { idKey: MARK_ID, color: DEFAULT_COLOR, markType: 'line' });
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
+      });
+    });
+
+    describe('animations master switch', () => {
+      test('animations: false disables hover animation even for an interactive line', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          chartInspects: [{}],
+          animations: false,
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+      });
+
+      test('animations: false disables draw-in animation even when animationTypes includes "drawIn"', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          scaleType: 'time',
+          animations: false,
+          animationTypes: ['drawIn'],
+        });
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
+      });
+    });
+
+    describe('hover/drawIn animationTypes independence', () => {
+      test('animationTypes: ["drawIn"] (without "hover") enables draw-in but not hover animation', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          chartInspects: [{}],
+          scaleType: 'time',
+          animationTypes: ['drawIn'],
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(true);
+      });
+
+      test('animationTypes: ["hover"] (without "drawIn") enables hover animation but not draw-in', () => {
+        const spec = addLine(startingSpec, {
+          idKey: MARK_ID,
+          color: DEFAULT_COLOR,
+          markType: 'line',
+          chartInspects: [{}],
+          scaleType: 'time',
+          animationTypes: ['hover'],
+        });
+        expect(spec.usermeta?.animatedMarks).toStrictEqual(['line0']);
         expect(spec.data?.some((d) => d.name === 'line0_drawInLerp')).toBe(false);
       });
     });
@@ -656,11 +721,11 @@ describe('lineSpecBuilder', () => {
     });
 
     describe('hover animation', () => {
-      test('adds the hover-animation data sources when isAnimate is true', () => {
+      test('adds the hover-animation data sources when isHoverAnimate is true', () => {
         const resultData = addData(baseData, {
           ...defaultLineOptions,
           interactiveMarkName: 'line0',
-          isAnimate: true,
+          isHoverAnimate: true,
           seriesIds: ['a', 'b'],
         });
         expect(resultData.find((d) => d.name === 'line0_hoverTargetData')).toBeDefined();
@@ -669,11 +734,11 @@ describe('lineSpecBuilder', () => {
         expect(resultData.find((d) => d.name === HOVER_ANIM_LAST_CHANGE_DATA)).toBeDefined();
       });
 
-      test('does not add the hover-animation data sources when isAnimate is false', () => {
+      test('does not add the hover-animation data sources when isHoverAnimate is false', () => {
         const resultData = addData(baseData, {
           ...defaultLineOptions,
           interactiveMarkName: 'line0',
-          isAnimate: false,
+          isHoverAnimate: false,
         });
         expect(resultData.find((d) => d.name === 'line0_hoverTargetData')).toBeUndefined();
         expect(resultData.find((d) => d.name === HOVER_ANIM_LAST_CHANGE_DATA)).toBeUndefined();
@@ -1247,15 +1312,15 @@ describe('lineSpecBuilder', () => {
     });
 
     describe('hover animation', () => {
-      test('adds the hover-animation engine signals (shared timer + per-mark targets) when isAnimate is true', () => {
-        const signals = addSignals([], { ...defaultLineOptions, isAnimate: true });
-        expect(signals.some((s) => s.name === HOVER_TIMER)).toBe(true);
+      test('adds the hover-animation engine signals (shared timer + per-mark targets) when isHoverAnimate is true', () => {
+        const signals = addSignals([], { ...defaultLineOptions, isHoverAnimate: true });
+        expect(signals.some((s) => s.name === ANIMATION_TIMER)).toBe(true);
         expect(signals.some((s) => s.name === `line0_${HOVER_TARGETS}`)).toBe(true);
       });
 
-      test('does not add the hover-animation engine signals when isAnimate is false', () => {
-        const signals = addSignals([], { ...defaultLineOptions, isAnimate: false });
-        expect(signals.some((s) => s.name === HOVER_TIMER)).toBe(false);
+      test('does not add the hover-animation engine signals when isHoverAnimate is false', () => {
+        const signals = addSignals([], { ...defaultLineOptions, isHoverAnimate: false });
+        expect(signals.some((s) => s.name === ANIMATION_TIMER)).toBe(false);
       });
     });
 

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -59,7 +59,16 @@ import { getDualAxisScaleNames } from '../scale/scaleUtils';
 import { addHoveredItemSignal, getFirstRscSeriesIdSignal, getLastRscSeriesIdSignal } from '../signal/signalSpecBuilder';
 import { addUserMetaAnimatedMark, addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
 import { addTrendlineData, getTrendlineMarks, getTrendlineScales, setTrendlineSignals } from '../trendline';
-import { ChartData, ColorScheme, HighlightedItem, LineOptions, LineSpecOptions, ScSpec } from '../types';
+import {
+  ChartData,
+  ColorScheme,
+  HighlightedItem,
+  LineDirectLabelSpecOptions,
+  LineForecastOptions,
+  LineOptions,
+  LineSpecOptions,
+  ScSpec,
+} from '../types';
 import {
   getHoverLabelData,
   getLineHighlightedData,
@@ -443,20 +452,41 @@ export const setScales = produce<Scale[], [LineSpecOptions]>((scales, options) =
 
 // The order that marks are added is important since it determines the draw order.
 export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) => {
-  const {
-    alternateSegmentKey,
-    color,
-    gradient,
-    highlightedItem,
-    isSparkline,
-    legendHighlightSignals,
-    linePointAnnotations,
-    lineType,
-    name,
-    opacity,
-    primarySeries,
-    staticPoint,
-  } = options;
+  const { highlightedItem, legendHighlightSignals, name } = options;
+  const forecasts = options.forecasts ?? [];
+  const { facetData, facetGroupby, markOptions } = getLineFacetContext(options);
+
+  const hasInteractiveHighlight = isInteractive(options) || highlightedItem !== undefined;
+  const hasHighlightState = hasInteractiveHighlight || (legendHighlightSignals?.length ?? 0) > 0;
+
+  // boundary rules are drawn behind everything
+  addLineForecastBoundaryMarks(marks, forecasts, options);
+  addLineGroupMark(marks, name, markOptions, facetData, facetGroupby);
+  addLineStaticPointMarks(marks, options);
+  marks.push(...getMetricRangeGroupMarks(options), ...getTrendlineMarks(options));
+
+  const labelSpecOpts = getLineDirectLabelSpecOptionsList(options);
+  addLineDirectLabelMarks(marks, options, labelSpecOpts);
+  if (hasHighlightState) {
+    addLineHighlightOverlayMarks(marks, options, markOptions, facetData, facetGroupby, labelSpecOpts);
+  }
+  // hover marks are last so hollow points and interaction marks always render above everything
+  if (hasInteractiveHighlight) {
+    marks.push(...getLineHoverMarks(markOptions, `${FILTERED_TABLE}ForInspect`));
+  }
+  // forecast labels are drawn last so they appear on top of other marks
+  addLineForecastLabelMarks(marks, forecasts, options);
+});
+
+/**
+ * Computes the facet source/groupby that the line's main group mark and highlight overlay both
+ * facet from, plus the mark options those marks render with (metric/alternateSegmentKey are
+ * overridden when a forecast is present, to trigger getAlternateSegmentStrokeDash in getLineMark).
+ */
+const getLineFacetContext = (
+  options: LineSpecOptions
+): { facetData: string; facetGroupby: string[]; markOptions: LineSpecOptions } => {
+  const { alternateSegmentKey, color, lineType, name, opacity, primarySeries } = options;
   const forecasts = options.forecasts ?? [];
   const hasForecast = !alternateSegmentKey && forecasts.length > 0;
 
@@ -472,24 +502,30 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
   const facetData = options.isDrawInAnimate ? `${name}_drawInLerp` : alternateSegmentsFacetData;
   const facetGroupby = usesAlternateSegments ? [...facets, `${name}_segmentId`] : facets;
 
-  // when forecasts are present, override metric to effectiveValue and set alternateSegmentKey
-  // to trigger getAlternateSegmentStrokeDash in getLineMark
   const markOptions = hasForecast
-    ? {
-        ...options,
-        metric: `${name}_effectiveValue`,
-        alternateSegmentKey: `${name}_alternateFlag`,
-      }
+    ? { ...options, metric: `${name}_effectiveValue`, alternateSegmentKey: `${name}_alternateFlag` }
     : options;
 
-  const hasInteractiveHighlight = isInteractive(options) || highlightedItem !== undefined;
-  const hasHighlightState = hasInteractiveHighlight || (legendHighlightSignals?.length ?? 0) > 0;
+  return { facetData, facetGroupby, markOptions };
+};
 
-  // boundary rules are drawn behind everything
+const addLineForecastBoundaryMarks = (
+  marks: Mark[],
+  forecasts: LineForecastOptions[],
+  options: LineSpecOptions
+): void => {
   for (const [i, forecast] of forecasts.entries()) {
     marks.push(getLineForecastBoundaryMark(getLineForecastSpecOptions(forecast, i, options)));
   }
+};
 
+const addLineGroupMark = (
+  marks: Mark[],
+  name: string,
+  markOptions: LineSpecOptions,
+  facetData: string,
+  facetGroupby: string[]
+): void => {
   marks.push({
     name: `${name}_group`,
     type: 'group',
@@ -501,54 +537,75 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
       },
     },
     marks: [
-      ...(gradient ? [getLineGradientMark(markOptions, `${name}_facet`)] : []),
+      ...(markOptions.gradient ? [getLineGradientMark(markOptions, `${name}_facet`)] : []),
       getLineMark(markOptions, `${name}_facet`),
     ],
   });
+};
 
-  if (staticPoint || isSparkline) {
-    marks.push(getLineStaticPointBackground(options), getLineStaticPoint(options));
-    if (linePointAnnotations.length > 0) {
-      marks.push(...getLinePointAnnotationMarks(options));
-    }
+const addLineStaticPointMarks = (marks: Mark[], options: LineSpecOptions): void => {
+  const { isSparkline, linePointAnnotations, staticPoint } = options;
+  if (!staticPoint && !isSparkline) return;
+  marks.push(getLineStaticPointBackground(options), getLineStaticPoint(options));
+  if (linePointAnnotations.length > 0) {
+    marks.push(...getLinePointAnnotationMarks(options));
   }
-  marks.push(...getMetricRangeGroupMarks(options), ...getTrendlineMarks(options));
-  // direct labels
-  const labelSpecOpts = (options.lineDirectLabels ?? []).map((label, i) =>
-    getLineDirectLabelSpecOptions(label, i, options)
-  );
+};
+
+const getLineDirectLabelSpecOptionsList = (options: LineSpecOptions): LineDirectLabelSpecOptions[] =>
+  (options.lineDirectLabels ?? []).map((label, i) => getLineDirectLabelSpecOptions(label, i, options));
+
+const addLineDirectLabelMarks = (
+  marks: Mark[],
+  options: LineSpecOptions,
+  labelSpecOpts: LineDirectLabelSpecOptions[]
+): void => {
   for (const specOpts of labelSpecOpts) {
     marks.push(
       ...getLineDirectLabelMarks(options.name, specOpts, options, options.backgroundColor, options.colorScheme)
     );
   }
-  // overlay renders the highlighted series on top of labels so the line stays in the foreground on hover
-  // fg labels are pushed in the same call (after the overlay group) so they always render above all overlay lines
-  if (hasHighlightState && labelSpecOpts.length) {
-    const opacityRules = getHighlightedSeriesOpacityRules(markOptions);
-    marks.push(
-      getLineHighlightOverlayGroup(markOptions, facetData, facetGroupby),
-      ...labelSpecOpts.flatMap((specOpts) =>
-        getLineDirectLabelMarks(
-          options.name,
-          specOpts,
-          options,
-          options.backgroundColor,
-          options.colorScheme,
-          opacityRules
-        )
+};
+
+/**
+ * Renders the highlighted series on top of labels so the line stays in the foreground on hover.
+ * Foreground labels are pushed in the same call (after the overlay group) so they always render
+ * above all overlay lines.
+ */
+const addLineHighlightOverlayMarks = (
+  marks: Mark[],
+  options: LineSpecOptions,
+  markOptions: LineSpecOptions,
+  facetData: string,
+  facetGroupby: string[],
+  labelSpecOpts: LineDirectLabelSpecOptions[]
+): void => {
+  if (!labelSpecOpts.length) return;
+  const opacityRules = getHighlightedSeriesOpacityRules(markOptions);
+  marks.push(
+    getLineHighlightOverlayGroup(markOptions, facetData, facetGroupby),
+    ...labelSpecOpts.flatMap((specOpts) =>
+      getLineDirectLabelMarks(
+        options.name,
+        specOpts,
+        options,
+        options.backgroundColor,
+        options.colorScheme,
+        opacityRules
       )
-    );
-  }
-  // hover marks are last so hollow points and interaction marks always render above everything
-  if (hasInteractiveHighlight) {
-    marks.push(...getLineHoverMarks(markOptions, `${FILTERED_TABLE}ForInspect`));
-  }
-  // forecast labels are drawn last so they appear on top of other marks
+    )
+  );
+};
+
+const addLineForecastLabelMarks = (
+  marks: Mark[],
+  forecasts: LineForecastOptions[],
+  options: LineSpecOptions
+): void => {
   for (const [i, forecast] of forecasts.entries()) {
     marks.push(...getLineForecastLabelMarks(getLineForecastSpecOptions(forecast, i, options)));
   }
-});
+};
 
 const getMetricKeys = (lineOptions: LineSpecOptions) => {
   const hasForecast = (lineOptions.forecasts ?? []).length > 0 && !lineOptions.alternateSegmentKey;

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -33,7 +33,7 @@ import {
   isHighlightedByGroup,
 } from '../chartInspect/chartInspectUtils';
 import { addPopoverData } from '../chartPopover/chartPopoverUtils';
-import { addTimeTransform, getFilteredInspectData, getTableData } from '../data/dataUtils';
+import { addTimeTransform, getFilteredInspectData, getFilteredTableData, getTableData } from '../data/dataUtils';
 import { getLineDirectLabelData, getLineDirectLabelMarks, getLineDirectLabelSpecOptions } from '../lineDirectLabel';
 import {
   getForecastAlternateFlagTransform,
@@ -75,6 +75,7 @@ import {
 import { getLinePointAnnotationMarks } from './linePointAnnotation';
 import { getLineStaticPoint, getLineStaticPointBackground } from './linePointUtils';
 import { getPopoverMarkName, isDualMetricAxis } from './lineUtils';
+import { addLineDrawInAnimationSignals, addLineDrawInLeadTransform, addLineDrawInTimeMsTransform, getLineDrawInData, getLineDrawInPointIndexData } from '../marks/drawInAnimationUtils';
 
 export const addLine = produce<
   ScSpec,
@@ -185,6 +186,7 @@ export const addLine = produce<
     };
     lineOptions.isHighlightedByGroup = isHighlightedByGroup(lineOptions) || dimensionHover;
     lineOptions.isAnimate = usesHoverAnimation(animations, lineOptions);
+    lineOptions.isDrawInAnimate = isLineDrawInSupported(animations, lineOptions);
     spec.usermeta = addUserMetaInteractiveMark(spec.usermeta, lineOptions.interactiveMarkName);
     if (lineOptions.isAnimate) spec.usermeta = addUserMetaAnimatedMark(spec.usermeta, lineName);
     spec.data = addData(spec.data ?? [], lineOptions);
@@ -213,6 +215,13 @@ const usesHoverAnimation = (animations: boolean | undefined, options: LineSpecOp
     (options.legendHighlightSignals?.length ?? 0) > 0);
 
 /**
+ * Whether the line participates in the draw-in animation system.
+ */
+const isLineDrawInSupported = (animations: boolean | undefined, options: LineSpecOptions): boolean =>
+  animations === true &&
+  (options.scaleType === 'time' || options.scaleType === 'linear' || options.scaleType === 'point');
+
+/**
  * Gets the unique series ids for the line
  * @param data - the data for the line
  * @param facets - the facets for the line
@@ -228,10 +237,24 @@ export const addData = produce<Data[], [LineSpecOptions]>((data, options) => {
   const tableData = getTableData(data);
   if (scaleType === 'time') {
     tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
+    if (options.isDrawInAnimate) {
+      tableData.transform = addLineDrawInTimeMsTransform(tableData.transform ?? [], dimension);
+    }
   }
   addDimensionHoverGroupTransform(tableData, chartInspects, dimensionHover, dimension, name);
   addSegmentData(data, tableData, options);
   addLineHoverData(data, options);
+
+  if (options.isDrawInAnimate) {
+    if (scaleType === 'point') {
+      const pointIndexData = getLineDrawInPointIndexData(options);
+      addLineDrawInLeadTransform(pointIndexData, options);
+      data.push(pointIndexData, ...getLineDrawInData(options));
+    } else {
+      addLineDrawInLeadTransform(getFilteredTableData(data), options);
+      data.push(...getLineDrawInData(options));
+    }
+  }
 
   if (staticPoint || isSparkline) {
     data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE, isSparkline, isMethodLast));
@@ -349,6 +372,10 @@ export const addSignals = produce<Signal[], [LineSpecOptions]>((signals, options
     addHoverAnimationSignals(signals, name);
   }
 
+  if (options.isDrawInAnimate) {
+    addLineDrawInAnimationSignals(signals, options);
+  }
+
   if (!isInteractive(options)) return;
   const { primarySeries } = options;
   // datum.datum because the voronoi mark uses datumOrder=2
@@ -417,7 +444,10 @@ export const addLineMarks = produce<Mark[], [LineSpecOptions]>((marks, options) 
   const usesAlternateSegments = !!alternateSegmentKey || hasForecast;
   // when primarySeries is set, use a pre-sorted source so "other" series facets are drawn first (behind primary)
   const defaultFacetData = primarySeries ? `${name}_primarySeriesFacetData` : FILTERED_TABLE;
-  const facetData = usesAlternateSegments ? `${name}_with_bridges` : defaultFacetData;
+  const alternateSegmentsFacetData = usesAlternateSegments ? `${name}_with_bridges` : defaultFacetData;
+  // when animated, facet from the draw-in lerp source (prev + tip) so the line renders clipped to
+  // the animated cutoff instead of the full series
+  const facetData = options.isDrawInAnimate ? `${name}_drawInLerp` : alternateSegmentsFacetData;
   const facetGroupby = usesAlternateSegments ? [...facets, `${name}_segmentId`] : facets;
 
   // when forecasts are present, override metric to effectiveValue and set alternateSegmentKey

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -13,7 +13,9 @@ import { produce } from 'immer';
 import { Data, Mark, Scale, Signal } from 'vega';
 
 import {
+  AnimationType,
   COLOR_SCALE,
+  DEFAULT_ANIMATION_TYPES,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_METRIC,
   DEFAULT_TIME_DIMENSION,
@@ -83,6 +85,7 @@ export const addLine = produce<
   [
     LineOptions & {
       animations?: boolean;
+      animationTypes?: AnimationType[];
       colorScheme?: ColorScheme;
       highlightedItem?: HighlightedItem;
       highlightedSeries?: string | number;
@@ -97,6 +100,7 @@ export const addLine = produce<
     spec,
     {
       animations,
+      animationTypes,
       chartPopovers = [],
       chartInspects = [],
       color = { value: 'categorical-100' },
@@ -186,10 +190,10 @@ export const addLine = produce<
       ...options,
     };
     lineOptions.isHighlightedByGroup = isHighlightedByGroup(lineOptions) || dimensionHover;
-    lineOptions.isAnimate = usesHoverAnimation(animations, lineOptions);
-    lineOptions.isDrawInAnimate = isLineDrawInSupported(animations, lineOptions);
+    lineOptions.isHoverAnimate = usesHoverAnimation(animations, animationTypes, lineOptions);
+    lineOptions.isDrawInAnimate = isLineDrawInSupported(animations, animationTypes, lineOptions);
     spec.usermeta = addUserMetaInteractiveMark(spec.usermeta, lineOptions.interactiveMarkName);
-    if (lineOptions.isAnimate) spec.usermeta = addUserMetaAnimatedMark(spec.usermeta, lineName);
+    if (lineOptions.isHoverAnimate) spec.usermeta = addUserMetaAnimatedMark(spec.usermeta, lineName);
     spec.data = addData(spec.data ?? [], lineOptions);
     spec.signals = addSignals(spec.signals ?? [], lineOptions);
     spec.scales = setScales(spec.scales ?? [], lineOptions);
@@ -201,15 +205,21 @@ export const addLine = produce<
 
 /**
  * Whether the line participates in the hover-animation system.
- * Computed once in `addLine` and stored on `options.isAnimate`; every downstream gate reads that
+ * Computed once in `addLine` and stored on `options.isHoverAnimate`; every downstream gate reads that
  * resolved boolean. A highlight legend counts (via legendHighlightSignals) so both the legend and the line animate.
  * `highlightedItem`/`highlightedSeries` are the chart-level controlled-highlight props; either one alone
  * is enough to animate, since `getLineHoverRules` always wires both `controlledTableMatch` and
  * `controlledSeriesMatch` regardless of which is set.
- * `animations === false` opts out unconditionally, regardless of the other conditions.
+ * `animations === false` is the master kill switch and opts out unconditionally; otherwise hover is
+ * gated on `animationTypes` including `'hover'` (defaults to `DEFAULT_ANIMATION_TYPES`, which does).
  */
-const usesHoverAnimation = (animations: boolean | undefined, options: LineSpecOptions): boolean =>
+const usesHoverAnimation = (
+  animations: boolean | undefined,
+  animationTypes: AnimationType[] | undefined,
+  options: LineSpecOptions
+): boolean =>
   animations !== false &&
+  (animationTypes ?? DEFAULT_ANIMATION_TYPES).includes('hover') &&
   (isInteractive(options) ||
     options.highlightedItem !== undefined ||
     options.highlightedSeries !== undefined ||
@@ -217,9 +227,16 @@ const usesHoverAnimation = (animations: boolean | undefined, options: LineSpecOp
 
 /**
  * Whether the line participates in the draw-in animation system.
+ * Unlike hover animation, this is opt-in — `animationTypes` must explicitly include `'drawIn'` — since
+ * draw-in is still gated to a subset of scale types. `animations === false` still overrides unconditionally.
  */
-const isLineDrawInSupported = (animations: boolean | undefined, options: LineSpecOptions): boolean =>
-  animations === true &&
+const isLineDrawInSupported = (
+  animations: boolean | undefined,
+  animationTypes: AnimationType[] | undefined,
+  options: LineSpecOptions
+): boolean =>
+  animations !== false &&
+  (animationTypes ?? DEFAULT_ANIMATION_TYPES).includes('drawIn') &&
   (options.scaleType === 'time' || options.scaleType === 'linear' || options.scaleType === 'point');
 
 /**
@@ -321,14 +338,14 @@ const addSegmentData = (data: Data[], tableData: Data, options: LineSpecOptions)
  * hover-animation engine's data sources when the line is animated.
  */
 const addLineHoverData = (data: Data[], options: LineSpecOptions): void => {
-  const { chartInspects, highlightedItem, isAnimate, name, seriesIds, showHoverLabel } = options;
+  const { chartInspects, highlightedItem, isHoverAnimate, name, seriesIds, showHoverLabel } = options;
   if (isInteractive(options) || highlightedItem !== undefined) {
     data.push(getLineHighlightedData(options), getFilteredInspectData(chartInspects));
     if (showHoverLabel) {
       data.push(getHoverLabelData(options));
     }
   }
-  if (isAnimate) {
+  if (isHoverAnimate) {
     data.push(
       getHoverTargetData({ name, groupby: [SERIES_ID], rules: getLineHoverRules(options) }),
       getHoverAnimStateData({ name, keys: seriesIds ?? [] }),
@@ -373,7 +390,7 @@ export const addSignals = produce<Signal[], [LineSpecOptions]>((signals, options
     signals.push(getFirstRscSeriesIdSignal(), getLastRscSeriesIdSignal());
   }
 
-  if (options.isAnimate) {
+  if (options.isHoverAnimate) {
     addHoverAnimationSignals(signals, name);
   }
 

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_COLOR_SCHEME,
   DEFAULT_METRIC,
   DEFAULT_TIME_DIMENSION,
+  DRAW_IN_PREV_DATA,
   FILTERED_TABLE,
   INTERACTION_MODE,
   LAST_RSC_SERIES_ID,
@@ -257,7 +258,11 @@ export const addData = produce<Data[], [LineSpecOptions]>((data, options) => {
   }
 
   if (staticPoint || isSparkline) {
-    data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE, isSparkline, isMethodLast));
+    if (options.isDrawInAnimate){
+      data.push(getLineStaticPointData(name, staticPoint, `${name}_${DRAW_IN_PREV_DATA}`, isSparkline, isMethodLast));
+    } else {
+      data.push(getLineStaticPointData(name, staticPoint, FILTERED_TABLE, isSparkline, isMethodLast));
+    }
   }
 
   addDualMetricAxisData(data, options);

--- a/packages/vega-spec-builder-s2/src/line/lineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineUtils.ts
@@ -90,6 +90,6 @@ export interface LineMarkOptions {
   alternateSegmentLabel?: string;
   primarySeries?: number | string[];
   otherSeriesColor?: string;
-  isAnimate?: boolean;
+  isHoverAnimate?: boolean;
   isDrawInAnimate?: boolean;
 }

--- a/packages/vega-spec-builder-s2/src/line/lineUtils.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineUtils.ts
@@ -91,4 +91,5 @@ export interface LineMarkOptions {
   primarySeries?: number | string[];
   otherSeriesColor?: string;
   isAnimate?: boolean;
+  isDrawInAnimate?: boolean;
 }

--- a/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.test.ts
@@ -467,8 +467,8 @@ describe('getLineDirectLabelMarks', () => {
 		expect(marks[1].encode?.update).toHaveProperty('opacity');
 	});
 
-	test('foreground mark uses the animated deemphasis-ramp signal when isAnimate is true, background stays opaque', () => {
-		const lineOpts = { ...defaultLineOptions, interactiveMarkName: 'line0', isAnimate: true };
+	test('foreground mark uses the animated deemphasis-ramp signal when isHoverAnimate is true, background stays opaque', () => {
+		const lineOpts = { ...defaultLineOptions, interactiveMarkName: 'line0', isHoverAnimate: true };
 		const marks = getLineDirectLabelMarks('line0', defaultLabelSpecOptions, lineOpts, 'gray-50', 'light');
 		const ramp = getDeemphasisRamp(getHoverFractionSignal('line0'));
 		expect(marks[1].encode?.update).toHaveProperty('opacity', {

--- a/packages/vega-spec-builder-s2/src/marks/drawInAnimationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/marks/drawInAnimationUtils.test.ts
@@ -13,6 +13,7 @@ import { Data, Signal, SourceData, Transforms } from 'vega';
 
 import {
   ANIMATION_THROTTLE,
+  ANIMATION_TIMER,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
   DRAW_IN_ANIMATION_DURATION_MS,
   FILTERED_TABLE,
@@ -201,16 +202,16 @@ describe('addDrawInClockSignals()', () => {
     const signals: Signal[] = [];
     addDrawInClockSignals(signals);
     expect(signals).toStrictEqual([
+      {
+        name: ANIMATION_TIMER,
+        value: 0,
+        on: [{ events: { type: 'timer', throttle: ANIMATION_THROTTLE }, update: 'now()' }],
+      },
       { name: 'drawInStart', init: 'now()' },
       {
         name: 'drawInAnimT',
-        init: '0',
-        on: [
-          {
-            events: { type: 'timer', throttle: ANIMATION_THROTTLE },
-            update: `clamp((now() - drawInStart) / ${DRAW_IN_ANIMATION_DURATION_MS}, 0, 1)`,
-          },
-        ],
+        value: 0,
+        update: `clamp((${ANIMATION_TIMER} - drawInStart) / ${DRAW_IN_ANIMATION_DURATION_MS}, 0, 1)`,
       },
       {
         name: 'drawInAnimTEased',
@@ -223,7 +224,7 @@ describe('addDrawInClockSignals()', () => {
     const signals: Signal[] = [];
     addDrawInClockSignals(signals);
     addDrawInClockSignals(signals);
-    expect(signals).toHaveLength(3);
+    expect(signals).toHaveLength(4);
   });
 
   test('eases 0 -> 0, 1 -> 1, and the midpoint -> 0.5', () => {
@@ -246,6 +247,7 @@ describe('addLineDrawInAnimationSignals()', () => {
     const options: LineSpecOptions = { ...defaultLineOptions, name: 'line0', scaleType: 'time' };
     addLineDrawInAnimationSignals(signals, options);
     expect(signals.map((s) => s.name)).toEqual([
+      ANIMATION_TIMER,
       'drawInStart',
       'drawInAnimT',
       'drawInAnimTEased',
@@ -285,6 +287,7 @@ describe('addLineDrawInAnimationSignals()', () => {
     const signals: Signal[] = [];
     addLineDrawInAnimationSignals(signals, { ...defaultLineOptions, name: 'line0', scaleType: 'time' });
     addLineDrawInAnimationSignals(signals, { ...defaultLineOptions, name: 'line1', scaleType: 'time' });
+    expect(signals.filter((s) => s.name === ANIMATION_TIMER)).toHaveLength(1);
     expect(signals.filter((s) => s.name === 'drawInStart')).toHaveLength(1);
     expect(signals.filter((s) => s.name === 'drawInAnimT')).toHaveLength(1);
     expect(signals.filter((s) => s.name === 'drawInAnimTEased')).toHaveLength(1);

--- a/packages/vega-spec-builder-s2/src/marks/drawInAnimationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/drawInAnimationUtils.ts
@@ -14,6 +14,7 @@ import { Data, NumericValueRef, ProductionRule, Signal, SourceData, Transforms }
 
 import {
   ANIMATION_THROTTLE,
+  ANIMATION_TIMER,
   DEFAULT_TRANSFORMED_TIME_DIMENSION,
   DRAW_IN_ANIM_CUTOFF,
   DRAW_IN_ANIM_T,
@@ -184,19 +185,21 @@ export const getLineDrawInData = (options: LineSpecOptions): Data[] => {
  * `drawInAnimTEased` - the animation progress with easing applied. Current easing formula is in-out quadratic
  */
 export const addDrawInClockSignals = (signals: Signal[]): void => {
+  if (!hasSignalByName(signals, ANIMATION_TIMER)) {
+    signals.push({
+      name: ANIMATION_TIMER,
+      value: 0,
+      on: [{ events: { type: 'timer', throttle: ANIMATION_THROTTLE }, update: 'now()' }],
+    });
+  }
   if (!hasSignalByName(signals, DRAW_IN_START)) {
     signals.push({ name: DRAW_IN_START, init: 'now()' });
   }
   if (!hasSignalByName(signals, DRAW_IN_ANIM_T)) {
     signals.push({
       name: DRAW_IN_ANIM_T,
-      init: '0',
-      on: [
-        {
-          events: { type: 'timer', throttle: ANIMATION_THROTTLE },
-          update: `clamp((now() - ${DRAW_IN_START}) / ${DRAW_IN_ANIMATION_DURATION_MS}, 0, 1)`,
-        },
-      ],
+      value: 0,
+      update: `clamp((${ANIMATION_TIMER} - ${DRAW_IN_START}) / ${DRAW_IN_ANIMATION_DURATION_MS}, 0, 1)`
     });
   }
   if (!hasSignalByName(signals, DRAW_IN_ANIM_T_EASED)) {

--- a/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.test.ts
@@ -20,7 +20,7 @@ import {
   HOVER_IDLE_TICKS,
   HOVER_NEUTRAL_TARGET,
   HOVER_TARGETS,
-  HOVER_TIMER,
+  ANIMATION_TIMER,
   MARK_ID,
   SERIES_ID,
   TABLE,
@@ -195,26 +195,26 @@ describe('addHoverAnimationSignals()', () => {
     addHoverAnimationSignals(signals, 'line0');
     expect(signals).toStrictEqual([
       {
-        name: HOVER_TIMER,
+        name: ANIMATION_TIMER,
         value: 0,
         on: [{ events: { type: 'timer', throttle: ANIMATION_THROTTLE }, update: 'now()' }],
       },
       {
         name: HOVER_ANIMATING,
         value: false,
-        update: `(${HOVER_TIMER} - data('${HOVER_ANIM_LAST_CHANGE_DATA}')[0].lastChange) < ${
+        update: `(${ANIMATION_TIMER} - data('${HOVER_ANIM_LAST_CHANGE_DATA}')[0].lastChange) < ${
           ANIMATION_HOVER_SPEED + ANIMATION_THROTTLE
         }`,
       },
       {
         name: HOVER_IDLE_TICKS,
         value: 0,
-        update: `${HOVER_ANIMATING} ? 0 : min(${HOVER_TIMER} - ${HOVER_TIMER} + ${HOVER_IDLE_TICKS} + 1, 2)`,
+        update: `${HOVER_ANIMATING} ? 0 : min(${ANIMATION_TIMER} - ${ANIMATION_TIMER} + ${HOVER_IDLE_TICKS} + 1, 2)`,
       },
       {
         name: HOVER_ACTIVE_TIMER,
         value: 0,
-        update: `${HOVER_ANIMATING} || ${HOVER_IDLE_TICKS} <= 1 ? ${HOVER_TIMER} : ${HOVER_ACTIVE_TIMER}`,
+        update: `${HOVER_ANIMATING} || ${HOVER_IDLE_TICKS} <= 1 ? ${ANIMATION_TIMER} : ${HOVER_ACTIVE_TIMER}`,
       },
       {
         name: `line0_${HOVER_TARGETS}`,
@@ -228,12 +228,12 @@ describe('addHoverAnimationSignals()', () => {
     addHoverAnimationSignals(signals, 'line0');
     addHoverAnimationSignals(signals, 'line1');
     // one shared timer, one shared gate pair, one targets signal per mark
-    expect(signals.filter((s) => s.name === HOVER_TIMER)).toHaveLength(1);
+    expect(signals.filter((s) => s.name === ANIMATION_TIMER)).toHaveLength(1);
     expect(signals.filter((s) => s.name === HOVER_ANIMATING)).toHaveLength(1);
     expect(signals.filter((s) => s.name === HOVER_IDLE_TICKS)).toHaveLength(1);
     expect(signals.filter((s) => s.name === HOVER_ACTIVE_TIMER)).toHaveLength(1);
     expect(signals.map((s) => s.name)).toEqual([
-      HOVER_TIMER,
+      ANIMATION_TIMER,
       HOVER_ANIMATING,
       HOVER_IDLE_TICKS,
       HOVER_ACTIVE_TIMER,
@@ -249,7 +249,7 @@ describe('addHoverAnimationSignals()', () => {
     const evalUpdate = (elapsed: number): boolean => {
       const dataFn = () => [{ lastChange: 0 }];
       // eslint-disable-next-line no-new-func
-      return new Function(HOVER_TIMER, 'data', `return ${animating?.update};`)(elapsed, dataFn);
+      return new Function(ANIMATION_TIMER, 'data', `return ${animating?.update};`)(elapsed, dataFn);
     };
     expect(evalUpdate(0)).toBe(true);
     expect(evalUpdate(ANIMATION_HOVER_SPEED + ANIMATION_THROTTLE - 1)).toBe(true);
@@ -262,7 +262,7 @@ describe('addHoverAnimationSignals()', () => {
     const idleTicks = signals.find((s) => s.name === HOVER_IDLE_TICKS) as { update: string } | undefined;
     const evalUpdate = (animating: boolean, previous: number, timer = 0): number => {
       // eslint-disable-next-line no-new-func
-      return new Function(HOVER_ANIMATING, HOVER_IDLE_TICKS, HOVER_TIMER, 'min', `return ${idleTicks?.update};`)(
+      return new Function(HOVER_ANIMATING, HOVER_IDLE_TICKS, ANIMATION_TIMER, 'min', `return ${idleTicks?.update};`)(
         animating,
         previous,
         timer,
@@ -283,7 +283,7 @@ describe('addHoverAnimationSignals()', () => {
     const signals: Signal[] = [];
     addHoverAnimationSignals(signals, 'line0');
     const idleTicks = signals.find((s) => s.name === HOVER_IDLE_TICKS) as { update: string } | undefined;
-    expect(idleTicks?.update).toContain(HOVER_TIMER);
+    expect(idleTicks?.update).toContain(ANIMATION_TIMER);
   });
 
   test('hoverActiveTimer tracks hoverTimer while animating, for one tick past that, and freezes otherwise', () => {
@@ -295,7 +295,7 @@ describe('addHoverAnimationSignals()', () => {
       return new Function(
         HOVER_ANIMATING,
         HOVER_IDLE_TICKS,
-        HOVER_TIMER,
+        ANIMATION_TIMER,
         HOVER_ACTIVE_TIMER,
         `return ${activeTimer?.update};`
       )(animating, idleTicks, timer, previous);

--- a/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.ts
@@ -23,7 +23,7 @@ import {
   HOVER_NEUTRAL_TARGET,
   HOVER_TARGET_DATA,
   HOVER_TARGETS,
-  HOVER_TIMER,
+  ANIMATION_TIMER,
   SERIES_ID,
   TABLE,
 } from '@spectrum-charts/constants';
@@ -204,9 +204,9 @@ export const getEmphasisRamp = (fractionExpr: string): string =>
  * @param name - the name of the mark
  */
 export const addHoverAnimationSignals = (signals: Signal[], name: string): void => {
-  if (!hasSignalByName(signals, HOVER_TIMER)) {
+  if (!hasSignalByName(signals, ANIMATION_TIMER)) {
     signals.push({
-      name: HOVER_TIMER,
+      name: ANIMATION_TIMER,
       value: 0,
       on: [{ events: { type: 'timer', throttle: ANIMATION_THROTTLE }, update: 'now()' }],
     });
@@ -217,7 +217,7 @@ export const addHoverAnimationSignals = (signals: Signal[], name: string): void 
       // + ANIMATION_THROTTLE gives the timer one extra tick of headroom past the nominal
       // duration so a transition is guaranteed to reach its exact resting value before pausing.
       value: false,
-      update: `(${HOVER_TIMER} - data('${HOVER_ANIM_LAST_CHANGE_DATA}')[0].lastChange) < ${
+      update: `(${ANIMATION_TIMER} - data('${HOVER_ANIM_LAST_CHANGE_DATA}')[0].lastChange) < ${
         ANIMATION_HOVER_SPEED + ANIMATION_THROTTLE
       }`,
     });
@@ -229,7 +229,7 @@ export const addHoverAnimationSignals = (signals: Signal[], name: string): void 
       // idle tick (still grace), 2+ once fully idle. Capped at 2 since nothing checks higher values.
       // Grace period prevents bug with slow machines skipping the final tick of the animation.
       value: 0,
-      update: `${HOVER_ANIMATING} ? 0 : min(${HOVER_TIMER} - ${HOVER_TIMER} + ${HOVER_IDLE_TICKS} + 1, 2)`,
+      update: `${HOVER_ANIMATING} ? 0 : min(${ANIMATION_TIMER} - ${ANIMATION_TIMER} + ${HOVER_IDLE_TICKS} + 1, 2)`,
     });
   }
   if (!hasSignalByName(signals, HOVER_ACTIVE_TIMER)) {
@@ -239,7 +239,7 @@ export const addHoverAnimationSignals = (signals: Signal[], name: string): void 
       // tracks hoverTimer while animating, and for one tick past that (hoverIdleTicks <= 1) so the
       // tick that captures the fraction's clamped resting value can't be skipped by a delayed frame
       // on a slow machine; holds its previous value (self-reference) from the second idle tick on
-      update: `${HOVER_ANIMATING} || ${HOVER_IDLE_TICKS} <= 1 ? ${HOVER_TIMER} : ${HOVER_ACTIVE_TIMER}`,
+      update: `${HOVER_ANIMATING} || ${HOVER_IDLE_TICKS} <= 1 ? ${ANIMATION_TIMER} : ${HOVER_ACTIVE_TIMER}`,
     });
   }
 

--- a/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
@@ -182,10 +182,10 @@ describe('getMetricRangeMark', () => {
 
   test('boundary line opacity stays the static instant-rule array even when the parent line is animated', () => {
     // the boundary line renders under `${metricRangeName}_line`, which has no `_hoverFractionData` of
-    // its own — getMetricRangeMark forces isAnimate: false for exactly this reason, otherwise this
+    // its own — getMetricRangeMark forces isHoverAnimate: false for exactly this reason, otherwise this
     // would reference a data source that was only ever created for the parent line's name
     const [lineMark] = getMetricRangeMark(
-      { ...defaultLineOptions, interactiveMarkName: 'line0', isAnimate: true },
+      { ...defaultLineOptions, interactiveMarkName: 'line0', isHoverAnimate: true },
       defaultMetricRangeSpecOptions
     );
     expect(Array.isArray((lineMark as { encode: { update: { opacity: unknown } } }).encode.update.opacity)).toBe(

--- a/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.ts
@@ -123,7 +123,7 @@ export const getMetricRangeMark = (
     lineType: { value: metricRangeOptions.lineType },
     lineWidth: { value: metricRangeOptions.lineWidth },
     displayOnHover: metricRangeOptions.displayOnHover,
-    isAnimate: false,
+    isHoverAnimate: false,
   };
 
   const dataSource = `${metricRangeOptions.name}_facet`;

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.test.ts
@@ -108,10 +108,10 @@ describe('getTrendlineRuleMark()', () => {
 
   test('opacity stays the static instant-rule array even when the parent line is animated', () => {
     // the trendline renders under its own mark name (`${parentName}Trendline${index}`), which has no
-    // `_hoverFractionData` of its own — getLineMarkOptions forces isAnimate: false for exactly this
+    // `_hoverFractionData` of its own — getLineMarkOptions forces isHoverAnimate: false for exactly this
     // reason, otherwise this would reference a data source that was only created for the parent's name
     const mark = getTrendlineRuleMark(
-      { ...defaultLineOptions, interactiveMarkName: 'line0', isAnimate: true },
+      { ...defaultLineOptions, interactiveMarkName: 'line0', isHoverAnimate: true },
       { ...defaultTrendlineOptions, method: 'median' }
     );
     expect(Array.isArray(mark.encode?.update?.opacity)).toBe(true);
@@ -209,7 +209,7 @@ describe('getTrendlineLineMark()', () => {
 
   test('opacity stays the static instant-rule array even when the parent line is animated', () => {
     const mark = getTrendlineLineMark(
-      { ...defaultLineOptions, interactiveMarkName: 'line0', isAnimate: true },
+      { ...defaultLineOptions, interactiveMarkName: 'line0', isHoverAnimate: true },
       defaultTrendlineOptions
     );
     expect(Array.isArray(mark.encode?.update?.opacity)).toBe(true);

--- a/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts
+++ b/packages/vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts
@@ -344,7 +344,7 @@ const getLineMarkOptions = (
     popoverMarkName,
     scaleType: dimensionScaleType,
     staticPoint,
-    isAnimate: false,
+    isHoverAnimate: false,
     ...override,
   };
 };

--- a/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
@@ -11,6 +11,8 @@
  */
 import { Data, Spec } from 'vega';
 
+import { AnimationType } from '@spectrum-charts/constants';
+
 import { AxisOptions } from './axis';
 import { LegendOptions } from './legendSpec.types';
 import {
@@ -66,8 +68,11 @@ export type MarkOptions =
 // Notice that things like data and width/height are not included here
 // This is intentional as we don't want to have to rebuild the entire spec anytime data updates or the width/height change
 export interface ChartOptions {
-  /** Whether interactive marks use the animated hover system */
+  /** Master kill switch for all chart animations. Defaults to `true`; set to `false` to disable every
+   * animation type regardless of `animationTypes` (e.g. to honor `prefers-reduced-motion`). */
   animations?: boolean;
+  /** Which animation types are enabled. Defaults to `['hover']`. */
+  animationTypes?: AnimationType[];
   /** Background color of the chart. */
   backgroundColor?: string;
   /** Color scale. Defaults to the `categorical16' color scale. */

--- a/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
@@ -159,7 +159,7 @@ type LineOptionsWithDefaults =
 export interface LineSpecOptions extends PartiallyRequired<LineOptions, LineOptionsWithDefaults> {
   data?: ChartData[];
   seriesIds?: string[];
-  isAnimate?: boolean;
+  isHoverAnimate?: boolean;
   isDrawInAnimate?: boolean;
   backgroundColor?: string;
   colorScheme: ColorScheme;

--- a/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/lineSpec.types.ts
@@ -160,6 +160,7 @@ export interface LineSpecOptions extends PartiallyRequired<LineOptions, LineOpti
   data?: ChartData[];
   seriesIds?: string[];
   isAnimate?: boolean;
+  isDrawInAnimate?: boolean;
   backgroundColor?: string;
   colorScheme: ColorScheme;
   comboSiblingNames?: string[];

--- a/planning/research/draw-in-animation/draw-in-animation.md
+++ b/planning/research/draw-in-animation/draw-in-animation.md
@@ -1,9 +1,11 @@
 # Line Draw-In Animation — Design & Architecture
 
-A reference for the line mount-animation system: on mount, an animated line "draws in" left to right
-instead of appearing fully formed. Companion to [`hover-animation-system.md`](../hover-animation-system/hover-animation-system.md),
-which documents the animated hover/highlight engine this feature shares an opt-in gate with (`isAnimate`)
-but is otherwise fully independent from.
+A reference for the mount-animation system, currently wired into line only: on mount, an animated line
+"draws in" left to right instead of appearing fully formed. `drawInAnimationUtils.ts` is written
+mark-agnostic (see §7) so other marks can adopt it later. Companion to
+`[hover-animation-system.md](../hover-animation-system/hover-animation-system.md)`, which documents the
+animated hover/highlight engine this feature shares an opt-in gate with (`isHoverAnimate`) but is
+otherwise fully independent from.
 
 ---
 
@@ -15,14 +17,18 @@ The point currently being crossed (the "tip") is smoothly interpolated between i
 next point's position, so the leading edge moves continuously rather than jumping point-to-point.
 
 Draw-in activates when both are true, resolved once as `LineSpecOptions.isDrawInAnimate`:
-- `animations === true` — explicit chart-level opt-in (not `!== false` — draw-in has no other gate like
-  hover-animation's interactivity check, so it must default off)
+
+- `animations !== false` (chart-level master kill switch, default on) **and** `animationTypes` includes
+`'drawIn'` — unlike hover, draw-in is opt-in: `animationTypes` defaults to `['hover']`, so `'drawIn'`
+must be added explicitly
 - the line's `scaleType` is `'time'`, `'linear'`, or `'point'` (§2)
 
 Everything downstream — data sources, signals, the facet-source swap, and the mark's x/y encoding —
 gates on `isDrawInAnimate`.
 
 ---
+
+
 
 ## 2. Scale-type support
 
@@ -40,7 +46,7 @@ value doubles as both the sort key (for cutoff/tween math) and the scale-lookup 
 picks the right one — the raw dimension for `'linear'`, or a numeric-ms proxy for `'time'` (§3a, since
 Vega's time scale domain is Date-typed but the math needs raw numbers).
 
-**`'point'` (ordinal/categorical) needs two separate fields, not one.** A numeric dimension on a point
+`'point'` **(ordinal/categorical) needs two separate fields, not one.** A numeric dimension on a point
 scale happens to work using the same single-field approach as linear (the sort/cutoff math never
 touches the scale's *positions*, only the raw field value) — but a *genuinely categorical* dimension
 (e.g. a `quarter` string field) can't be compared to a numeric cutoff directly. So for `'point'`,
@@ -50,6 +56,8 @@ the rest of the pipeline alongside the *real* category value (still needed, unch
 `scale('xPoint', ...)` position lookups).
 
 ---
+
+
 
 ## 3. The Vega data-flow pipeline
 
@@ -67,11 +75,13 @@ already numeric.
 
 `addDrawInLeadTransform` adds a `window` transform to its source (`filteredTable` for time/linear, the
 point-index source for point scale — §3i):
+
 ```
 { type: 'window', sort: { field: <sortField>, order: 'ascending' }, groupby: [rscSeriesId],
   ops: ['lead', ...], fields: [<sortField>, metric, ...],
   as: ['${name}_drawInNextDimValue', '${name}_drawInNextMetricValue', ...] }
 ```
+
 For `'point'` scale, a third field/lead is added — the next row's real category value
 (`DRAW_IN_NEXT_CATEGORY_FIELD`) — since `<sortField>` (the ordinal index) isn't a valid scale-lookup
 value there (§3i). Vega's `window` transform sorts internally by `sort` regardless of the incoming
@@ -81,11 +91,15 @@ against duplicate insertion.
 
 ### 3c. Derived sources — `getLineDrawInData`
 
-| Source | Built from | Purpose |
-|---|---|---|
-| `${name}_drawInPrev` | `getDrawInDataSourceName`'s source (`filteredTable`, or `${name}_drawInIndexed` for point scale — §3i) filtered to `<sortField> <= cutoff` | the already-drawn portion of the line |
-| `${name}_drawInTip` | same source, filtered per-row (§3e) | each series' currently-active bracketing point, flagged `isDrawInTip: true` |
-| `${name}_drawInLerp` | `source: ['${name}_drawInPrev', '${name}_drawInTip']` | the merged source the line mark actually facets/renders from |
+
+| Source               | Built from                                                                                                                                 | Purpose                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `${name}_drawInPrev` | `getDrawInDataSourceName`'s source (`filteredTable`, or `${name}_drawInIndexed` for point scale — §3i) filtered to `<sortField> <= cutoff` | the already-drawn portion of the line                                       |
+| `${name}_drawInTip`  | same source, filtered per-row (§3e)                                                                                                        | each series' currently-active bracketing point, flagged `isDrawInTip: true` |
+| `${name}_drawInLerp` | `source: ['${name}_drawInPrev', '${name}_drawInTip']`                                                                                      | the merged source the line mark actually facets/renders from                |
+
+
+
 
 ### 3d. Signals — `addLineDrawInAnimationSignals`
 
@@ -96,6 +110,7 @@ drawInAnimTEased          = <shared, quadratic ease-in-out of drawInAnimT>
 ${name}_drawInDomainMin/Max  = extent(domain(<xScaleName>))[0]/[1]     // this mark's own x-domain range
 ${name}_drawInAnimCutoff  = drawInAnimTEased * (max - min) + min       // the sweeping cutoff, in domain units
 ```
+
 `<xScaleName>` is `getScaleName('x', scaleType)` (`xTime`/`xLinear`/`xPoint`), so this generalizes across
 supported scale types. For `'point'` scale, `domain(<xScaleName>)` holds category values, not numbers,
 so domain min/max are instead the ordinal index range `[0, domain length - 1]` — matching the sort field
@@ -115,9 +130,11 @@ computed in §3b — no cross-row or cross-series lookup anywhere.
 ### 3e. Tip identification (in `getLineDrawInData`)
 
 A row is the active tip for its series if:
+
 ```
 datum.<sortField> <= cutoff && isValid(datum.<nextDimField>) && datum.<nextDimField> > cutoff
 ```
+
 i.e. the cutoff has passed this row but not yet its own next row. A series' last point (no next point)
 never qualifies — once past it, that row just stays a normal fully-drawn point via `drawInPrev` alone,
 with nothing left to interpolate toward.
@@ -127,6 +144,7 @@ with nothing left to interpolate toward.
 ```ts
 const tween = `clamp((cutoff - datum.<sortField>) / (datum.<nextDimField> - datum.<sortField>), 0, 1)`;
 ```
+
 Computed inline per-datum in the mark's x/y encoding (not a signal) — purely local to each row, using
 only that row's own sortField and its own lead-computed next value.
 
@@ -136,9 +154,10 @@ only that row's own sortField and its own lead-computed next value.
 x: isValid(datum.isDrawInTip) ? lerp([scale(xScale, datum[dimField]), scale(xScale, datum.<nextLookupField>)], tween) : scale(xScale, datum[dimField])
 y: isValid(datum.isDrawInTip) ? lerp([scale(yScale, datum[metric]), scale(yScale, datum.<nextMetricField>)], tween) : scale(yScale, datum[metric])
 ```
+
 Non-tip rows render at their normal scaled position (same as the static path). `<nextLookupField>` is
 `<nextDimField>` for time/linear, but `DRAW_IN_NEXT_CATEGORY_FIELD` for `'point'` scale — see §3i for why
-those diverge there. `getLineMark` branches on `isDrawInAnimate` (not `isAnimate`): static lines keep `y`
+those diverge there. `getLineMark` branches on `isDrawInAnimate` (not `isHoverAnimate`): static lines keep `y`
 in `encode.enter` (evaluated once); draw-in animated lines move both `x` and `y` into `encode.update`
 (re-evaluated every animation tick). Dual-metric-axis lines branch onto the primary/secondary y-scale via
 the shared `getDualAxisDrawInRule`, matching `getLineYEncoding`'s static equivalent — the metric axis is
@@ -156,7 +175,7 @@ aware (§7) — its leading edge jumps point-to-point rather than tweening smoot
 (`${name}_with_bridges`, used for forecasts/`alternateSegmentKey`) — combining draw-in with either isn't
 handled and hasn't been tested.
 
-The highlight overlay (`getLineHighlightOverlayGroup`) forces `isAnimate: false` **and**
+The highlight overlay (`getLineHighlightOverlayGroup`) forces `isHoverAnimate: false` **and**
 `isDrawInAnimate: false` on its duplicate line mark so it always renders with the static encoding, even
 though it still facets from the same (possibly `${name}_drawInLerp`) source as the base line.
 
@@ -175,7 +194,7 @@ the x scale's domain**.
 }
 ```
 
-This has to live on a data source **downstream of both `filteredTable` and the x scale** — never on
+This has to live on a data source **downstream of both** `filteredTable` **and the x scale** — never on
 `filteredTable` itself. The x scale's domain is derived *from* `filteredTable`, so a formula added to
 `filteredTable` that reads `domain('xPoint')` would create a circular dependency (the scale needs
 `filteredTable` to finish; the formula needs the scale to finish first). `${name}_drawInIndexed` is a
@@ -194,33 +213,44 @@ as the time/linear path does) — `getDrawInDataSourceName` tells `getLineDrawIn
 
 ---
 
+
+
 ## 4. Constants
 
-| Section | Constants |
-|---|---|
-| animation timing | `DRAW_IN_ANIMATION_DURATION_MS` (1000) |
-| vega data source names | `DRAW_IN_PREV_DATA`, `DRAW_IN_TIP_DATA`, `DRAW_IN_LERP_DATA`, `DRAW_IN_POINT_INDEX_DATA` (point scale only, §3i) |
-| vega data field names | `DRAW_IN_TIME_MS_FIELD`, `DRAW_IN_NEXT_DIM_FIELD`, `DRAW_IN_NEXT_METRIC_FIELD`, `DRAW_IN_TIP_FLAG`, `DRAW_IN_POINT_INDEX_FIELD` (point scale only, §3i), `DRAW_IN_NEXT_CATEGORY_FIELD` (point scale only, §3i) |
-| signal names | `DRAW_IN_START`, `DRAW_IN_ANIM_T`, `DRAW_IN_ANIM_T_EASED` (shared), `DRAW_IN_DOMAIN_MIN`, `DRAW_IN_DOMAIN_MAX`, `DRAW_IN_ANIM_CUTOFF` (per-mark) |
+
+| Section                | Constants                                                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| animation timing       | `DRAW_IN_ANIMATION_DURATION_MS` (1000)                                                                                                                                                                         |
+| vega data source names | `DRAW_IN_PREV_DATA`, `DRAW_IN_TIP_DATA`, `DRAW_IN_LERP_DATA`, `DRAW_IN_POINT_INDEX_DATA` (point scale only, §3i)                                                                                               |
+| vega data field names  | `DRAW_IN_TIME_MS_FIELD`, `DRAW_IN_NEXT_DIM_FIELD`, `DRAW_IN_NEXT_METRIC_FIELD`, `DRAW_IN_TIP_FLAG`, `DRAW_IN_POINT_INDEX_FIELD` (point scale only, §3i), `DRAW_IN_NEXT_CATEGORY_FIELD` (point scale only, §3i) |
+| signal names           | `DRAW_IN_START`, `DRAW_IN_ANIM_T`, `DRAW_IN_ANIM_T_EASED` (shared), `DRAW_IN_DOMAIN_MIN`, `DRAW_IN_DOMAIN_MAX`, `DRAW_IN_ANIM_CUTOFF` (per-mark)                                                               |
+
 
 ---
+
+
 
 ## 5. Key files
 
-| File | Role |
-|---|---|
-| `packages/constants/constants.ts` | draw-in constants (§4) |
-| `vega-spec-builder-s2/src/marks/drawInAnimationUtils.ts` | everything: `getDrawInSortField`, `getDrawInDataSourceName`, `getLineDrawInPointIndexData` (§3i), `addDrawInTimeMsTransform`, `addDrawInLeadTransform`, `getLineDrawInData`, `addLineDrawInAnimationSignals`, `getDrawInTweenExpr`, `getLineDrawInXEncoding`/`getLineDrawInYEncoding`, `getDualAxisDrawInRule` |
-| `vega-spec-builder-s2/src/line/lineSpecBuilder.ts` | `isLineDrawInSupported` gate, computes `isDrawInAnimate`; wires `addData`/`addSignals`/`addLineMarks` to call into `drawInAnimationUtils.ts` when true |
-| `vega-spec-builder-s2/src/line/lineMarkUtils.ts` | `getLineMark`'s `isDrawInAnimate` branch; highlight-overlay override |
-| `vega-spec-builder-s2/src/types/marks/lineSpec.types.ts`, `vega-spec-builder-s2/src/line/lineUtils.ts` | `isDrawInAnimate` field on `LineSpecOptions`/`LineMarkOptions` |
+
+| File                                                                                                   | Role                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/constants/constants.ts`                                                                      | draw-in constants (§4)                                                                                                                                                                                                                                                                                         |
+| `vega-spec-builder-s2/src/marks/drawInAnimationUtils.ts`                                               | everything: `getDrawInSortField`, `getDrawInDataSourceName`, `getLineDrawInPointIndexData` (§3i), `addDrawInTimeMsTransform`, `addDrawInLeadTransform`, `getLineDrawInData`, `addLineDrawInAnimationSignals`, `getDrawInTweenExpr`, `getLineDrawInXEncoding`/`getLineDrawInYEncoding`, `getDualAxisDrawInRule` |
+| `vega-spec-builder-s2/src/line/lineSpecBuilder.ts`                                                     | `isLineDrawInSupported` gate, computes `isDrawInAnimate`; wires `addData`/`addSignals`/`addLineMarks` to call into `drawInAnimationUtils.ts` when true                                                                                                                                                         |
+| `vega-spec-builder-s2/src/line/lineMarkUtils.ts`                                                       | `getLineMark`'s `isDrawInAnimate` branch; highlight-overlay override                                                                                                                                                                                                                                           |
+| `vega-spec-builder-s2/src/types/marks/lineSpec.types.ts`, `vega-spec-builder-s2/src/line/lineUtils.ts` | `isDrawInAnimate` field on `LineSpecOptions`/`LineMarkOptions`                                                                                                                                                                                                                                                 |
+
 
 ---
+
+
 
 ## 6. Storybook coverage
 
 `packages/react-spectrum-charts-s2/src/stories/Line/Features/DrawInAnimation/LineDrawInAnimation.story.tsx`
-exposes the same `animations` toggle pattern as the hover-animation stories, with stories for: baseline
+exposes `animations` (master switch) and `animationTypes` (a check-control for `'hover'`/`'drawIn'`) as
+direct Storybook controls, with stories for: baseline
 time scale, linear scale, point scale (numeric dimension — uses the same single-field path as linear,
 §2), categorical point scale (a genuine string dimension — the two-field ordinal-index case, §3i; draws
 in correctly), and a "funky data shape" case (unsorted/interleaved rows with a mid-series gap, to
@@ -228,15 +258,40 @@ demonstrate order-independence).
 
 ---
 
+
+
 ## 7. Known gaps / not yet done
 
 - **Gradient mark doesn't tween its tip.** `getLineGradientMark` always uses the static x/y encoding, so
-  during draw-in its leading edge jumps between data points instead of smoothly tracking the line's
-  interpolated tip.
+during draw-in its leading edge jumps between data points instead of smoothly tracking the line's
+interpolated tip.
 - **Alternate segments / forecasts untested with draw-in.** The facet-source swap (§3h) unconditionally
-  overrides `${name}_with_bridges`; combining the two hasn't been exercised.
-- **No unit tests yet** for `drawInAnimationUtils.ts` (mirroring `hoverAnimationUtils.test.ts`'s
-  coverage) or for the `isDrawInAnimate` gate in `lineSpecBuilder.test.ts`.
+overrides `${name}_with_bridges`; combining the two hasn't been exercised.
+- **Fixed:** `drawInAnimT` **signal was invalid Vega** — it declared both `init` and `update`, which Vega
+rejects at parse time ("Signals can not include both init and update expressions"), so the whole spec
+failed to build and the chart rendered blank whenever `'drawIn'` was in `animationTypes`. Fixed by using
+`value: 0` instead of `init: '0'` (`value` is a plain starting number and can coexist with `update`;
+`init` is a one-time expression and cannot). Caught by parsing/running the built spec through real Vega
+(`vega.parse` + `View.runAsync`) rather than only asserting on individual data/signal array shapes —
+worth doing for any future signal-chain change here.
 - **Only line uses this system.** `drawInAnimationUtils.ts` was written to generalize (parameterized by
-  `name`/`dimension`/`metric`/`scaleType`, not line-specific internals) but hasn't been ported to
-  another mark yet.
+`name`/`dimension`/`metric`/`scaleType`, not line-specific internals) but hasn't been ported to
+another mark yet. Currently, most of the functions in `drawInAnimationUtils.ts` are line specific since 
+line's animation is more complicated than just animating one property. The main timer signals are built 
+to be used for other marks.
+- **Wiring to other marks.** In theory, a draw-in animation for most other marks will just mean animating 
+some property from one value to another. For these cases, the signal `DRAW_IN_ANIM_T_EASED` or `DRAW_IN_ANIM_T` 
+can be directly used with scaling and offset math to animate any desired property. For other charts like donut 
+or scatter where we might want marks to draw one-after-another, extra math and/or helper function may be needed.
+- **One-after-another animations.** One idea for allowing this type of animation would be to use the 
+`DRAW_IN_ANIM_T` in the encoding for a desired property to animate (opacity, y positon, etc) and offset its 
+start and end based on the x value. 
+i.e. Say we have a bar chart with 3 bars (bar1, bar2, bar3) and we want the bars to animate their y from 
+0 to their value one-after-another. The meaning of `DRAW_IN_ANIM_T_EASED` stays the same where the 0-1 
+fraction still represents the entire animation's progress. Plugging this directly into y2 (with scaling + 
+offset) would animate nicely, but wouldn't have the one-after-another effect we want. For this we can use 
+the following formula: `t_local(delay, duration) = clamp((t - delay) / duration, 0, 1)` where t is 
+`DRAW_IN_ANIM_T_EASED` and delay + duration <= 1. If we can find a way to compute this delay and duration 
+for each bar, this function would should allow each bar to adjust it's start/end time and create a staggered 
+one-after-another draw-in animation.
+

--- a/planning/research/hover-animation-system/hover-animation-system.md
+++ b/planning/research/hover-animation-system/hover-animation-system.md
@@ -1,9 +1,9 @@
 # Hover Animation System — Design & Architecture
 
-A reference for rebuilding the line/mark hover-animation system (smooth opacity / stroke-width
-transitions on hover) from scratch. Written against the `vega-spec-builder-s2` implementation but the
-design is engine-agnostic: it's a Vega-signal/data-flow pattern that can be reproduced anywhere charts
-are compiled to Vega specs.
+A reference for rebuilding the hover-animation system (smooth opacity / stroke-width transitions on
+hover) from scratch. Written against the `vega-spec-builder-s2` implementation but the design is
+mark-agnostic and currently wired into line only (see §11) — it's a Vega-signal/data-flow pattern that
+can be reproduced for any mark compiled to a Vega spec.
 
 ---
 
@@ -126,7 +126,7 @@ that freezes this recompute while nothing is transitioning.
 ### 3f. Idle gating — freezing the clock while nothing animates
 
 `hoverTimer` (§3a) ticks at 30fps for as long as *any* animated mark exists on the chart (gated at the
-chart level by `isAnimate`, §6 — that gate decides *whether the timer exists at all*). But most of a
+chart level by `isHoverAnimate`, §6 — that gate decides *whether the timer exists at all*). But most of a
 chart's life is spent with nothing hovered and no transition in flight: once a fade/grow finishes, there's
 no reason to keep recomputing `hoverFractionData`'s `lerp(...)` for every row of every animated mark on
 every tick forever. Idle gating adds a second, narrower gate: **pause the *clock that drives the fraction
@@ -325,7 +325,7 @@ nothing active at all → falls through to the neutral fallback (`0.5`).
 
 ---
 
-## 6. The gate — resolve once, thread down (`isAnimate`)
+## 6. The gate — resolve once, thread down (`isHoverAnimate`)
 
 Creating the timer + data sources on a static, non-interactive chart means a 30fps re-render forever, so
 whether a line animates is gated. The gate is **computed exactly once**, in `addLine`, where the full
@@ -333,39 +333,43 @@ whether a line animates is gated. The gate is **computed exactly once**, in `add
 
 ```ts
 // in addLine, LineSpecOptions in scope (has legendHighlightSignals + everything isInteractive needs)
-// `animations` is a chart-level prop (default on) that can force the whole line onto the old system.
-lineOptions.isAnimate = animations !== false && usesHoverAnimation(lineOptions);
+// `animations` (master kill switch, default on) and `animationTypes` (default ['hover']) are both
+// chart-level props that can force the whole line onto the old system.
+lineOptions.isHoverAnimate = usesHoverAnimation(animations, animationTypes, lineOptions);
 
-const usesHoverAnimation = (options) =>
-  isInteractive(options) || options.highlightedItem !== undefined
-  || (options.legendHighlightSignals?.length ?? 0) > 0;
+const usesHoverAnimation = (animations, animationTypes, options) =>
+  animations !== false && (animationTypes ?? DEFAULT_ANIMATION_TYPES).includes('hover') &&
+  (isInteractive(options) || options.highlightedItem !== undefined
+  || (options.legendHighlightSignals?.length ?? 0) > 0);
 ```
 
-`isAnimate` is stored on the options object (added to both `LineSpecOptions` and the narrower
+`isHoverAnimate` is stored on the options object (added to both `LineSpecOptions` and the narrower
 `LineMarkOptions`) so every downstream reader gets the *same resolved answer* rather than recomputing:
 
-- data sources (`hoverTargetData` / `hoverAnimStateData` / `hoverFractionData`) — `if (options.isAnimate)`
-- the `hoverTimer` + `hoverTargets` signals — `if (options.isAnimate)`
-- `animatedMarks` registration (see §7) — `if (isAnimate)`
-- the property encodings — `getLineOpacity` branches: `isAnimate` → animated signal, else → the original
+- data sources (`hoverTargetData` / `hoverAnimStateData` / `hoverFractionData`) — `if (options.isHoverAnimate)`
+- the `hoverTimer` + `hoverTargets` signals — `if (options.isHoverAnimate)`
+- `animatedMarks` registration (see §7) — `if (isHoverAnimate)`
+- the property encodings — `getLineOpacity` branches: `isHoverAnimate` → animated signal, else → the original
   instant production-rule fade (`getLineOpacityRules`). This is currently the *only* wired consumer for
-  line — see §1. `getLineStrokeWidth` does not read `isAnimate` at all yet and always returns the original
+  line — see §1. `getLineStrokeWidth` does not read `isHoverAnimate` at all yet and always returns the original
   instant production rules; wiring it up means splitting it the same way (`getLineStrokeWidth` wrapper +
   a `getLineStrokeWidthRules` fallback), which hasn't been done.
 - any mark options that reuse `getLineMark`/`getLineOpacity` under a **different mark name** than the one
-  the data sources were built for **must** override `isAnimate: false` — otherwise the encoding references
+  the data sources were built for **must** override `isHoverAnimate: false` — otherwise the encoding references
   a `_hoverFractionData` that doesn't exist for that name and Vega throws "Unrecognized data set" at
   runtime. Three call sites do this today: the highlight overlay, trendlines, and the metric-range boundary
   line (see the Overlay exception note below).
 
-### The `animations` toggle (chart-level prop)
+### The `animations`/`animationTypes` toggles (chart-level props)
 
-`<Chart animations={false}>` opts the whole chart out of the animated system back to the original instant
-production-rule highlight. It's a `ChartOptions` field (default `true` = animated), threaded through
-`chartSpecBuilder`'s `specOptions` into every mark — so `animations !== false` simply becomes one more
-factor in `isAnimate`. When off: no hover data/timer is created, `animatedMarks` stays empty (so the
+`<Chart animations={false}>` is a master kill switch: it opts the whole chart out of every animation type
+(hover and draw-in) back to the original instant production-rule highlight, regardless of `animationTypes`.
+`animationTypes` (default `['hover']`) is the per-type opt-in list — omit `'hover'` to disable just the
+hover system while leaving `animations` (and e.g. draw-in) untouched. Both are `ChartOptions` fields
+threaded through `chartSpecBuilder`'s `specOptions` into every mark. When off: no hover data/timer is
+created, `animatedMarks` stays empty (so the
 legend falls back to `getOpacityEncoding`), and `getLineOpacity` returns the production-rule array
-(`getLineStrokeWidth` returns that array unconditionally either way, since it isn't gated on `isAnimate`
+(`getLineStrokeWidth` returns that array unconditionally either way, since it isn't gated on `isHoverAnimate`
 yet — see above). The `!Array.isArray` guards in `setHoverOpacityForMarks` / `setHoverStrokeWidthForMarks`
 then re-engage (array ⇒ old legend-hover path applies), so the entire old system is restored coherently by
 flipping one prop.
@@ -390,18 +394,18 @@ This unified the previously-split gate and **closed the legend-only-highlight ga
 interactivity is a highlight legend now animates both its legend entry *and* its strokes/opacity.
 
 > Overlay exception: the highlight overlay (§10) reuses `getLineMark` under a *different* mark name that
-> has no `_hoverFractionData`. It's built with `isAnimate: false` so its animated encodings resolve to the
+> has no `_hoverFractionData`. It's built with `isHoverAnimate: false` so its animated encodings resolve to the
 > static default instead of referencing a data source that only exists for the base line's name.
 >
 > The same fix is required anywhere else `getLineMark`/`getLineOpacity` is reused under a renamed mark by
-> spreading the parent line's options — spreading also carries along the parent's `isAnimate: true`, which
+> spreading the parent line's options — spreading also carries along the parent's `isHoverAnimate: true`, which
 > is wrong for the renamed mark. Trendlines (`getLineMarkOptions` in `trendlineMarkUtils.ts`) and the
 > metric-range boundary line (`getMetricRangeMark` in `metricRangeUtils.ts`) both hit this and now both
-> explicitly set `isAnimate: false` for the same reason as the overlay.
+> explicitly set `isHoverAnimate: false` for the same reason as the overlay.
 
 > Static points and direct labels are the opposite of the overlay: they're **not** renamed marks, so they
-> correctly keep the parent's `isAnimate` and read the *same* line's `_hoverFractionData` rather than getting
-> their own. `getLineStaticPoint` branches on `isAnimate` via the shared `getLineDeemphasisOpacitySignal`;
+> correctly keep the parent's `isHoverAnimate` and read the *same* line's `_hoverFractionData` rather than getting
+> their own. `getLineStaticPoint` branches on `isHoverAnimate` via the shared `getLineDeemphasisOpacitySignal`;
 > `getLineDirectLabelMarks` just calls `getLineOpacity` directly. In both, only the **foreground** is
 > opacity-driven — the background halo mark has no `opacity` key at all, so it stays permanently opaque.
 
@@ -481,8 +485,8 @@ one shared row for the whole chart (§3f).
 | `vega-spec-builder-s2/src/line/linePointUtils.ts` | `getLineStaticPoint` (wired via `getLineDeemphasisOpacitySignal`) |
 | `vega-spec-builder-s2/src/lineDirectLabel/lineDirectLabelUtils.ts` | `getLineDirectLabelMarks` — foreground wired via `getLineOpacity`; background has no `opacity` key, stays opaque |
 | `vega-spec-builder-s2/src/line/lineSpecBuilder.ts` | `usesHoverAnimation` gate; wires data/signals/registration in `addData`/`addSignals`/`addLine` |
-| `vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts` | `getLineMarkOptions` — sets `isAnimate: false` for trendline marks (§6 overlay exception) |
-| `vega-spec-builder-s2/src/metricRange/metricRangeUtils.ts` | `getMetricRangeMark` — sets `isAnimate: false` for the boundary line (§6 overlay exception) |
+| `vega-spec-builder-s2/src/trendline/trendlineMarkUtils.ts` | `getLineMarkOptions` — sets `isHoverAnimate: false` for trendline marks (§6 overlay exception) |
+| `vega-spec-builder-s2/src/metricRange/metricRangeUtils.ts` | `getMetricRangeMark` — sets `isHoverAnimate: false` for the boundary line (§6 overlay exception) |
 | `vega-spec-builder-s2/src/legend/legendHighlightUtils.ts` | `injectLegendHoverIntoData`, `getLegendHighlightSignals`; `setHoverOpacityForMarks` + `isAnimatedOpacity` (§7) |
 | `vega-spec-builder-s2/src/legend/legendUtils.ts` | `getLegendOpacity` (legend consumer, reads `animatedMarks`) |
 | `vega-spec-builder-s2/src/specUtils.ts` + `types/specUtil.types.ts` | `addUserMetaAnimatedMark`, `animatedMarks` on `UserMeta` — **line names only**, see §7 |
@@ -504,13 +508,13 @@ mark could pass `rscMarkId` (bar) etc. — see §11.
   production rules with fallback `0` (hidden at rest), the *opposite* resting state from the main line
   (visible at rest). Do not try to feed it the fraction — at rest the fraction is neutral (→ visible),
   which would make the overlay cover the labels. The main line carries the animation; the overlay just
-  reorders. Also build the overlay with **`isAnimate: false`**: it reuses `getLineMark` under a different
+  reorders. Also build the overlay with **`isHoverAnimate: false`**: it reuses `getLineMark` under a different
   mark name that has no `_hoverFractionData`, so an animated encoding on it would reference a data source
   that was only emitted for the base line's name (Vega "unrecognized data set"). Trendlines and the
   metric-range boundary line hit this same trap (both reuse `getLineMark`/`getLineOpacity` under a renamed
-  mark by spreading the parent line's options, which also spreads `isAnimate: true`) and both now set
-  `isAnimate: false` explicitly for the same reason — see §6.
-- **Gate the data and the encoding with the *same resolved value*.** Compute `isAnimate` once (§6) and
+  mark by spreading the parent line's options, which also spreads `isHoverAnimate: true`) and both now set
+  `isHoverAnimate: false` explicitly for the same reason — see §6.
+- **Gate the data and the encoding with the *same resolved value*.** Compute `isHoverAnimate` once (§6) and
   thread it to both the data-creation gate and the encoding functions. If the two are computed
   independently they can drift, and an animated encoding will reference a `_hoverFractionData` that was
   never created. Resolving once and threading also lets the encoding functions honor conditions their
@@ -573,28 +577,29 @@ and legend-hover injection silently stops matching (no error, nothing highlights
 ## 12. Status / not-yet-done
 
 - **Opacity is wired for line, static points, and direct labels (done); stroke width is intentionally
-  deferred.** `getLineOpacity` branches on `isAnimate` (animated signal vs. `getLineOpacityRules` fallback)
+  deferred.** `getLineOpacity` branches on `isHoverAnimate` (animated signal vs. `getLineOpacityRules` fallback)
   and was the original reference example; `getLineStaticPoint` and `getLineDirectLabelMarks` now follow the
   same pattern (§1, §6). `getLineStrokeWidth` was deliberately left untouched — still the original
   unconditional instant production rules — so it remains a clean next-consumer exercise. The engine itself
   is not limited to these properties; any property whose visual treatment maps onto the emphasize/deemphasize
   ramp (§2, §4) is a valid consumer.
-- **Gate resolved via `isAnimate`** (§6): computed once in `addLine`, threaded to data/signals/encodings.
+- **Gate resolved via `isHoverAnimate`** (§6): computed once in `addLine`, threaded to data/signals/encodings.
   This closed the earlier legend-only-highlight gap — legend-only lines now animate their strokes/opacity
   too, not just the legend.
-- **`animations` toggle (done)** (§6): chart-level prop (default on) that swaps the whole chart between
-  the animated system and the restored original production-rule highlight (`getLineOpacityRules`; there is
-  no `getLineStrokeWidthRules` — `getLineStrokeWidth` only has the one, unconditional, implementation).
+- **`animations`/`animationTypes` toggles (done)** (§6): `animations` is a chart-level master kill switch
+  (default on); `animationTypes` (default `['hover']`) is the per-type opt-in list. Either can swap a line
+  between the animated system and the restored original production-rule highlight (`getLineOpacityRules`;
+  there is no `getLineStrokeWidthRules` — `getLineStrokeWidth` only has the one, unconditional, implementation).
 - **`hoverAnimationUtils` unit tests (done)**: engine + ramps covered in `hoverAnimationUtils.test.ts`.
 - **Idle gating (§3f) — done, wired into `addLine`/`addData`/`addSignals`.** `addHoverAnimLastChangeData(data, name)`
-  is called alongside `addHoverAnimationSignals(signals, name)`, both gated by `if (options.isAnimate)` in
+  is called alongside `addHoverAnimationSignals(signals, name)`, both gated by `if (options.isHoverAnimate)` in
   `addData`/`addSignals` respectively, so the pairing required by the §10 gotcha holds for every animated line.
 - **`comboSiblingMatch`** semantics predate the 3-state target — review before relying on it.
 - **Metric-range line and trendlines under an animated parent (fixed).** Like the overlay, both the
   metric-range boundary line (`getMetricRangeMark`) and trendline marks (`getLineMarkOptions` in
   `trendlineMarkUtils.ts`) reuse `getLineMark`/`getLineOpacity` under a renamed mark with no
-  `_hoverFractionData` of its own. Both now explicitly set `isAnimate: false` — see §6/§10. (The
-  `isAnimate` field is new in this branch; spreading the parent line's options into a renamed mark
+  `_hoverFractionData` of its own. Both now explicitly set `isHoverAnimate: false` — see §6/§10. (The
+  `isHoverAnimate` field is new in this branch; spreading the parent line's options into a renamed mark
   silently carries it along unless overridden, which is why these two needed the same fix already applied
   to the overlay.)
 - **Legend integration (done)** (§7): `injectLegendHoverIntoData` wired into `addData` (`legendSpecBuilder.ts`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Wiring to implement line charts into the new draw-in animation system. Lines animate on load by "drawing in" from left to right. Controls have also been updated so now the `animations` control acts as a kill switch for disabling/enabling all animations and individual animation types (hover and/or draw-in) can be toggled on/off by adding to an animationType array.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been added/updated to cover new changes. New storybooks have also been added for testing the draw-in animation on different types of line charts.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
