### PR TITLE
bug: fix overflow flickering of metric range points that are out of view 

### DIFF
--- a/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.test.ts
@@ -18,6 +18,7 @@ import {
   DIMENSION_HOVER_AREA,
   FADE_FACTOR,
   HOVERED_ITEM,
+  LAST_RSC_SERIES_ID,
   SELECTED_SERIES,
   SERIES_ID,
 } from '@spectrum-charts/constants';
@@ -25,7 +26,7 @@ import {
 import type { Mark } from 'vega';
 
 import { getHoverContext } from '../marks/hoverContext';
-import { getLineHoverMarks, getLineMark, getLineOpacity, getLineYEncoding, getVoronoiYEncoding } from './lineMarkUtils';
+import { getClampedYEncoding, getLineHoverMarks, getLineMark, getLineOpacity, getLineYEncoding, getVoronoiYEncoding } from './lineMarkUtils';
 import { defaultLineMarkOptions, defaultLineOptions } from './lineTestUtils';
 
 describe('getLineMark()', () => {
@@ -224,6 +225,29 @@ describe('getVoronoiYEncoding()', () => {
       'value'
     );
     expect(encoding).toEqual([{ scale: 'yLinear', field: 'value' }]);
+  });
+});
+
+describe('getClampedYEncoding()', () => {
+  test('returns a signal that clamps the scaled metric to [0, height]', () => {
+    const encoding = getClampedYEncoding(defaultLineMarkOptions, 'metric');
+    expect(encoding).toEqual([{ signal: `clamp(scale('yLinear', datum['metric']), 0, height)` }]);
+  });
+
+  test('uses the metricAxis scale name when provided', () => {
+    const encoding = getClampedYEncoding({ ...defaultLineMarkOptions, metricAxis: 'yLinear2' }, 'metric');
+    expect(encoding).toEqual([{ signal: `clamp(scale('yLinear2', datum['metric']), 0, height)` }]);
+  });
+
+  test('clamps both branches when dualMetricAxis is true', () => {
+    const encoding = getClampedYEncoding({ ...defaultLineMarkOptions, dualMetricAxis: true }, 'metric');
+    expect(encoding).toEqual([
+      {
+        test: `datum.${SERIES_ID} === ${LAST_RSC_SERIES_ID}`,
+        signal: `clamp(scale('yLinearSecondary', datum['metric']), 0, height)`,
+      },
+      { signal: `clamp(scale('yLinearPrimary', datum['metric']), 0, height)` },
+    ]);
   });
 });
 

--- a/packages/vega-spec-builder/src/line/lineMarkUtils.ts
+++ b/packages/vega-spec-builder/src/line/lineMarkUtils.ts
@@ -80,6 +80,34 @@ export const getLineYEncoding = (lineMarkOptions: LineMarkOptions, metric: strin
   return [{ scale: metricAxis || 'yLinear', field: metric }];
 };
 
+const getClampedScaleSignal = (yScale: string, metric: string): string =>
+  `clamp(scale('${yScale}', datum['${metric}']), 0, height)`;
+
+/**
+ * Gets a Y encoding clamped to [0, height], for hover marks whose metric may fall outside the y domain.
+ * @param lineMarkOptions - Line mark options including metricAxis and dualMetricAxis
+ * @param metric - The metric field name
+ * @returns Clamped Y encoding with conditional scale selection for dual metric axis
+ */
+export const getClampedYEncoding = (lineMarkOptions: LineMarkOptions, metric: string): ProductionRule<NumericValueRef> => {
+  const { metricAxis } = lineMarkOptions;
+
+  if (isDualMetricAxis(lineMarkOptions)) {
+    const baseScaleName = metricAxis || 'yLinear';
+    const scaleNames = getDualAxisScaleNames(baseScaleName);
+
+    return [
+      {
+        test: `datum.${SERIES_ID} === ${LAST_RSC_SERIES_ID}`,
+        signal: getClampedScaleSignal(scaleNames.secondaryScale, metric),
+      },
+      { signal: getClampedScaleSignal(scaleNames.primaryScale, metric) },
+    ];
+  }
+
+  return [{ signal: getClampedScaleSignal(metricAxis || 'yLinear', metric) }];
+};
+
 /**
  * generates a line mark
  * @param lineOptions
@@ -324,7 +352,7 @@ export const getVoronoiYEncoding = (lineOptions: LineMarkOptions, metric: string
     // voronoi cell that dominates the visible chart area and causes hover flicker.
     ...hoverPointMetrics.map(mrMetric => ({
       test: `isValid(datum["${mrMetric}"])`,
-      signal: `clamp(scale('${yScale}', datum['${mrMetric}']), 0, height)`,
+      signal: getClampedScaleSignal(yScale, mrMetric),
     })),
     { scale: yScale, field: metric },
   ];

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.test.ts
@@ -416,6 +416,13 @@ describe('getMetricRangeHoverPoints', () => {
     expect(bg.encode?.update?.opacity).toEqual(expectedOpacity);
     expect(highlight.encode?.update?.opacity).toEqual(expectedOpacity);
   });
+
+  test('both marks clamp the y position to [0, height] so out-of-domain metrics do not overflow the plot', () => {
+    const [bg, highlight] = getMetricRangeHoverPoints(interactiveLineOptions, defaultMetricRangeSpecOptions);
+    const expectedSignal = `clamp(scale('yLinear', datum['${defaultMetricRangeSpecOptions.metric}']), 0, height)`;
+    expect(bg.encode?.enter?.y).toEqual([{ signal: expectedSignal }]);
+    expect(highlight.encode?.enter?.y).toEqual([{ signal: expectedSignal }]);
+  });
 });
 
 describe('getMetricRangeData', () => {

--- a/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
+++ b/packages/vega-spec-builder/src/metricRange/metricRangeUtils.ts
@@ -21,7 +21,7 @@ import {
 
 import { AreaMarkOptions, getAreaMark } from '../area/areaUtils';
 import { getFilteredIsValidData } from '../line/lineDataUtils';
-import { getLineMark, getLineYEncoding } from '../line/lineMarkUtils';
+import { getClampedYEncoding, getLineMark } from '../line/lineMarkUtils';
 import { LineMarkOptions } from '../line/lineUtils';
 import { getColorProductionRule, getOpacityProductionRule, getXProductionRule } from '../marks/markUtils';
 import { getHoverContext, getSeriesHoverPredicate } from '../marks/hoverContext';
@@ -140,7 +140,7 @@ export const getMetricRangeHoverPoints = (
       enter: {
         fill: { signal: BACKGROUND_COLOR },
         stroke: { signal: BACKGROUND_COLOR },
-        y: getLineYEncoding(lineMarkOptions, metric),
+        y: getClampedYEncoding(lineMarkOptions, metric),
       },
       update: {
         size: { value: DEFAULT_SYMBOL_SIZE },
@@ -159,7 +159,7 @@ export const getMetricRangeHoverPoints = (
     interactive: false,
     encode: {
       enter: {
-        y: getLineYEncoding(lineMarkOptions, metric),
+        y: getClampedYEncoding(lineMarkOptions, metric),
         stroke: getColorProductionRule(color, colorScheme, undefined, s2),
       },
       update: {


### PR DESCRIPTION
## Description

clamp getMetricRangeHoverPoints to [0, height] to prevent overflow flickering when metric range points are out of view. Same log that was implemented in PR #787 , just needed to apply to getMetricRangeHoverPoints as well. Centralized some of the clamping logic to be used in both places. 

## Related Issue

## Motivation and Context

Resolve chart flickering due to out-of-view MetricRange points being hoverable. 

## How Has This Been Tested?

Visually in storybook.
Unit test 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
