### PR TITLE
AI component catalog and zod schema package - init impl

### DIFF
--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -70,6 +70,7 @@ jobs:
           yarn workspace @spectrum-charts/constants publish-package
           yarn workspace @spectrum-charts/locales publish-package
           yarn workspace @spectrum-charts/mcp publish-package
+          yarn workspace @spectrum-charts/schemas publish-package
           yarn workspace @spectrum-charts/themes publish-package
           yarn workspace @spectrum-charts/utils publish-package
           yarn workspace @spectrum-charts/vega-spec-builder publish-package

--- a/packages/react-spectrum-charts-s2/package.json
+++ b/packages/react-spectrum-charts-s2/package.json
@@ -7,28 +7,34 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/@types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js",
-      "types": "./dist/@types/index.d.ts",
       "default": "./dist/index.js"
     },
     "./alpha": {
+      "types": "./dist/@types/alpha/index.d.ts",
       "import": "./dist/alpha.js",
       "require": "./dist/alpha.js",
-      "types": "./dist/@types/alpha/index.d.ts",
       "default": "./dist/alpha.js"
     },
     "./beta": {
+      "types": "./dist/@types/beta/index.d.ts",
       "import": "./dist/beta.js",
       "require": "./dist/beta.js",
-      "types": "./dist/@types/beta/index.d.ts",
       "default": "./dist/beta.js"
     },
     "./rc": {
+      "types": "./dist/@types/rc/index.d.ts",
       "import": "./dist/rc.js",
       "require": "./dist/rc.js",
-      "types": "./dist/@types/rc/index.d.ts",
       "default": "./dist/rc.js"
+    },
+    "./ai-catalog": {
+      "types": "./dist/@types/src/ai-catalog/index.d.ts",
+      "import": "./dist/ai-catalog.js",
+      "require": "./dist/ai-catalog.js",
+      "default": "./dist/ai-catalog.js"
     }
   },
   "typesVersions": {
@@ -44,6 +50,9 @@
       ],
       "rc": [
         "./dist/@types/rc/index.d.ts"
+      ],
+      "ai-catalog": [
+        "./dist/@types/src/ai-catalog/index.d.ts"
       ]
     }
   },
@@ -78,6 +87,7 @@
   "dependencies": {
     "@spectrum-charts/constants": "1.49.0",
     "@spectrum-charts/locales": "1.49.0",
+    "@spectrum-charts/schemas": "1.49.0",
     "@spectrum-charts/themes": "1.49.0",
     "@spectrum-charts/utils": "1.49.0",
     "@spectrum-charts/vega-spec-builder-s2": "0.4.0",

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import React from 'react';
+
+import { findChart, getAllMarksByGroupName, render } from '../../../test-utils';
+import '../../../test-utils/__mocks__/matchMedia.mock.js';
+import { CatalogChart } from './CatalogChart';
+
+const barData = {
+  values: [
+    { browser: 'Chrome', downloads: 27000 },
+    { browser: 'Firefox', downloads: 8000 },
+    { browser: 'Safari', downloads: 7750 },
+  ],
+};
+
+const lineData = {
+  values: [
+    { month: 'Jan', browser: 'Chrome', downloads: 4200 },
+    { month: 'Feb', browser: 'Chrome', downloads: 5100 },
+    { month: 'Jan', browser: 'Firefox', downloads: 2100 },
+    { month: 'Feb', browser: 'Firefox', downloads: 2300 },
+  ],
+};
+
+describe('CatalogChart', () => {
+  test('renders a Bar mark from a valid request', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: barData,
+          axes: [
+            { component: 'Axis', position: 'bottom' },
+            { component: 'Axis', position: 'left' },
+          ],
+          children: [{ component: 'Bar', dimension: 'browser', metric: 'downloads' }],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+    expect(getAllMarksByGroupName(chart, 'bar0')).toHaveLength(barData.values.length);
+  });
+
+  test('renders Bar decorations without breaking the mark', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: barData,
+          children: [
+            {
+              component: 'Bar',
+              dimension: 'browser',
+              metric: 'downloads',
+              decorations: [
+                { component: 'BarDirectLabel', position: 'end-outside' },
+                { component: 'ChartInspect', highlightBy: 'item' },
+              ],
+            },
+          ],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    expect(getAllMarksByGroupName(chart, 'bar0')).toHaveLength(barData.values.length);
+    // BarDirectLabel adds a text mark per bar; confirms the decoration wasn't silently dropped by
+    // childrenAdapter.ts's displayName check (the exact failure mode renderBarDecoration guards against).
+    expect(chart.querySelectorAll('text').length).toBeGreaterThan(0);
+  });
+
+  test('renders a Line mark with multiple color-faceted series', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: lineData,
+          children: [
+            { component: 'Line', dimension: 'month', metric: 'downloads', color: 'browser', scaleType: 'point' },
+          ],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+    expect(getAllMarksByGroupName(chart, 'line0')).toHaveLength(2);
+  });
+
+  test('renders a LineDirectLabel decoration without breaking the mark', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: lineData,
+          children: [
+            {
+              component: 'Line',
+              dimension: 'month',
+              metric: 'downloads',
+              color: 'browser',
+              scaleType: 'point',
+              decorations: [{ component: 'LineDirectLabel', value: 'series', position: 'end' }],
+            },
+          ],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    expect(getAllMarksByGroupName(chart, 'line0')).toHaveLength(2);
+    expect(chart.querySelectorAll('text').length).toBeGreaterThan(0);
+  });
+
+  test('throws for a request with an invalid mark discriminator', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <CatalogChart
+          request={{
+            component: 'Chart',
+            data: barData,
+            children: [{ component: 'Donut', dimension: 'browser', metric: 'downloads' }],
+          }}
+        />
+      )
+    ).toThrow();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.test.tsx
@@ -11,7 +11,7 @@
  */
 import React from 'react';
 
-import { findChart, getAllMarksByGroupName, render } from '../../../test-utils';
+import { findChart, getAllMarksByGroupName, hoverNthElement, render, screen, within } from '../../../test-utils';
 import '../../../test-utils/__mocks__/matchMedia.mock.js';
 import { CatalogChart } from './CatalogChart';
 
@@ -81,6 +81,32 @@ describe('CatalogChart', () => {
     expect(chart.querySelectorAll('text').length).toBeGreaterThan(0);
   });
 
+  test('ChartInspect decoration shows the default "dimension: metric" tooltip body on hover', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: barData,
+          children: [
+            {
+              component: 'Bar',
+              dimension: 'browser',
+              metric: 'downloads',
+              decorations: [{ component: 'ChartInspect', highlightBy: 'item' }],
+            },
+          ],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    const bars = getAllMarksByGroupName(chart, 'bar0');
+
+    await hoverNthElement(bars, 0);
+    const tooltip = await screen.findByTestId('rsc-tooltip');
+    expect(within(tooltip).getByText('Chrome: 27000')).toBeInTheDocument();
+  });
+
   test('renders a Line mark with multiple color-faceted series', async () => {
     render(
       <CatalogChart
@@ -122,6 +148,68 @@ describe('CatalogChart', () => {
     const chart = await findChart();
     expect(getAllMarksByGroupName(chart, 'line0')).toHaveLength(2);
     expect(chart.querySelectorAll('text').length).toBeGreaterThan(0);
+  });
+
+  test('forwards colorScheme to the underlying Chart', async () => {
+    // "gray-100" is a named Spectrum token that resolves to a different hex value per color
+    // scheme, unlike the default categorical accent color (which happens to be scheme-invariant) —
+    // using it as backgroundColor makes colorScheme's effect on getColorValue observable.
+    const requestFor = (colorScheme: 'light' | 'dark') => ({
+      component: 'Chart' as const,
+      colorScheme,
+      backgroundColor: 'gray-100',
+      data: barData,
+      children: [{ component: 'Bar' as const, dimension: 'browser', metric: 'downloads' }],
+    });
+
+    const { container: lightContainer, unmount } = render(<CatalogChart request={requestFor('light')} />);
+    await findChart();
+    const lightBackground = lightContainer.querySelector('.rsc-container > div')?.getAttribute('style');
+    unmount();
+
+    const { container: darkContainer } = render(<CatalogChart request={requestFor('dark')} />);
+    await findChart();
+    const darkBackground = darkContainer.querySelector('.rsc-container > div')?.getAttribute('style');
+
+    // Regression test for the bug where CatalogChart always spread `colorScheme: parsed.colorScheme`
+    // onto <Chart> — an explicit `undefined` there silently overrode Chart's own default instead of
+    // falling back to it. This confirms an actually-provided colorScheme reaches the rendered chart.
+    expect(darkBackground).not.toEqual(lightBackground);
+  });
+
+  test('forwards backgroundColor to the underlying Chart', async () => {
+    const { container } = render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          backgroundColor: 'gray-100',
+          data: barData,
+          children: [{ component: 'Bar', dimension: 'browser', metric: 'downloads' }],
+        }}
+      />
+    );
+
+    await findChart();
+    const styledDiv = container.querySelector('.rsc-container > div');
+    // DEFAULT_BACKGROUND_COLOR is 'transparent' — an explicitly-provided backgroundColor should
+    // resolve to a real color instead of falling through to (or being overridden to) the default.
+    expect(styledDiv).not.toHaveStyle({ backgroundColor: 'transparent' });
+  });
+
+  test('renders without axes when the request omits them', async () => {
+    render(
+      <CatalogChart
+        request={{
+          component: 'Chart',
+          data: barData,
+          children: [{ component: 'Bar', dimension: 'browser', metric: 'downloads' }],
+        }}
+      />
+    );
+
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+    expect(getAllMarksByGroupName(chart, 'bar0')).toHaveLength(barData.values.length);
   });
 
   test('throws for a request with an invalid mark discriminator', () => {

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+'use client';
+import { FC, ReactElement } from 'react';
+
+import { AxisInput, MarkInput, parseChartRequest } from '@spectrum-charts/schemas';
+
+import { Chart } from '../../../Chart';
+import { Axis } from '../../../components';
+import { renderCatalogBar, renderCatalogLine } from './marks';
+
+export interface CatalogChartProps {
+  /** Raw agent-supplied payload, validated against @spectrum-charts/schemas' ChartSchema. */
+  request: unknown;
+}
+
+function renderAxis(axis: AxisInput, key: number): ReactElement {
+  const { component: _component, ...axisProps } = axis;
+  return <Axis key={key} {...axisProps} />;
+}
+
+function renderMark(mark: MarkInput, key: number): ReactElement {
+  switch (mark.component) {
+    case 'Bar':
+      return renderCatalogBar(mark, key);
+    case 'Line':
+      return renderCatalogLine(mark, key);
+  }
+}
+
+const CatalogChart: FC<CatalogChartProps> = ({ request }) => {
+  const parsed = parseChartRequest(request);
+  return (
+    <Chart data={parsed.data.values} colorScheme={parsed.colorScheme} backgroundColor={parsed.backgroundColor}>
+      {parsed.axes?.map(renderAxis)}
+      {parsed.children.map(renderMark)}
+    </Chart>
+  );
+};
+
+CatalogChart.displayName = 'CatalogChart';
+
+export { CatalogChart };

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
@@ -40,7 +40,11 @@ function renderMark(mark: MarkInput, key: number): ReactElement {
 const CatalogChart: FC<CatalogChartProps> = ({ request }) => {
   const parsed = parseChartRequest(request);
   return (
-    <Chart data={parsed.data.values} colorScheme={parsed.colorScheme} backgroundColor={parsed.backgroundColor}>
+    <Chart
+      data={parsed.data.values}
+      {...(parsed.colorScheme !== undefined && { colorScheme: parsed.colorScheme })}
+      {...(parsed.backgroundColor !== undefined && { backgroundColor: parsed.backgroundColor })}
+    >
       {parsed.axes?.map(renderAxis)}
       {parsed.children.map(renderMark)}
     </Chart>

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/CatalogChart.tsx
@@ -45,8 +45,8 @@ const CatalogChart: FC<CatalogChartProps> = ({ request }) => {
       {...(parsed.colorScheme !== undefined && { colorScheme: parsed.colorScheme })}
       {...(parsed.backgroundColor !== undefined && { backgroundColor: parsed.backgroundColor })}
     >
-      {parsed.axes?.map(renderAxis)}
-      {parsed.children.map(renderMark)}
+      {parsed.axes?.map((axis, key) => renderAxis(axis, key))}
+      {parsed.children.map((mark, key) => renderMark(mark, key))}
     </Chart>
   );
 };

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/index.ts
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './CatalogChart';

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogBar.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogBar.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { BarDecorationInput, BarInput } from '@spectrum-charts/schemas';
+
+import { Bar, BarDirectLabel, ChartInspect } from '../../../../components';
+
+function renderBarDecoration(
+  decoration: BarDecorationInput,
+  key: number,
+  dimension?: string,
+  metric?: string
+): ReactElement {
+  switch (decoration.component) {
+    case 'BarDirectLabel': {
+      const { component: _component, ...props } = decoration;
+      return <BarDirectLabel key={key} {...props} />;
+    }
+    case 'ChartInspect': {
+      const { component: _component, ...props } = decoration;
+      // ChartInspectProps.children is a (datum) => ReactNode render prop, which isn't representable
+      // in the JSON request — default to a plain "dimension: metric" tooltip body.
+      return (
+        <ChartInspect key={key} {...props}>
+          {(datum) => (
+            <>
+              {dimension ? String(datum[dimension]) : ''}: {metric ? String(datum[metric]) : ''}
+            </>
+          )}
+        </ChartInspect>
+      );
+    }
+  }
+}
+
+// A plain function, not a JSX-invoked component: childrenAdapter.ts identifies marks by
+// child.type.displayName on Chart's *direct* children, so the returned element's type must be
+// Bar itself. Wrapping this in a component rendered via `<CatalogBar />` would make the direct
+// child's type CatalogBar instead, which childrenAdapter doesn't recognize — it gets silently
+// dropped (logged as "Invalid component type") rather than rendered.
+export function renderCatalogBar(mark: BarInput, key: number): ReactElement {
+  const { component: _component, decorations, ...barProps } = mark;
+  return (
+    <Bar key={key} {...barProps}>
+      {decorations?.map((decoration, i) =>
+        renderBarDecoration(decoration, i, barProps.dimension, barProps.metric)
+      )}
+    </Bar>
+  );
+}

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogLine.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogLine.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { LineDecorationInput, LineInput } from '@spectrum-charts/schemas';
+
+import { Line, LineDirectLabel } from '../../../../components';
+
+function renderLineDecoration(decoration: LineDecorationInput, key: number): ReactElement {
+  switch (decoration.component) {
+    case 'LineDirectLabel': {
+      const { component: _component, ...props } = decoration;
+      return <LineDirectLabel key={key} {...props} />;
+    }
+  }
+}
+
+export function renderCatalogLine(mark: LineInput, key: number): ReactElement {
+  const { component: _component, decorations, ...lineProps } = mark;
+  return (
+    <Line key={key} {...lineProps}>
+      {decorations?.map((decoration, i) => renderLineDecoration(decoration, i))}
+    </Line>
+  );
+}

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogLine.tsx
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/CatalogLine.tsx
@@ -15,13 +15,12 @@ import { LineDecorationInput, LineInput } from '@spectrum-charts/schemas';
 
 import { Line, LineDirectLabel } from '../../../../components';
 
-function renderLineDecoration(decoration: LineDecorationInput, key: number): ReactElement {
-  switch (decoration.component) {
-    case 'LineDirectLabel': {
-      const { component: _component, ...props } = decoration;
-      return <LineDirectLabel key={key} {...props} />;
-    }
+function renderLineDecoration(decoration: LineDecorationInput, key: number): ReactElement | null {
+  if (decoration.component === 'LineDirectLabel') {
+    const { component: _component, ...props } = decoration;
+    return <LineDirectLabel key={key} {...props} />;
   }
+  return null;
 }
 
 export function renderCatalogLine(mark: LineInput, key: number): ReactElement {

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/index.ts
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/CatalogChart/marks/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './CatalogBar';
+export * from './CatalogLine';

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/components/index.ts
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/components/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './CatalogChart';

--- a/packages/react-spectrum-charts-s2/src/ai-catalog/index.ts
+++ b/packages/react-spectrum-charts-s2/src/ai-catalog/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './components';
+export * from '@spectrum-charts/schemas';

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './src';

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@spectrum-charts/schemas",
+  "version": "1.49.0",
+  "description": "Custom A2UI catalog defining chart component contracts for agent-driven chart generation with React Spectrum Charts",
+  "browser": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/@types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "author": "Adobe",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/react-spectrum-charts.git"
+  },
+  "scripts": {
+    "build": "webpack --config ./webpack.config.js",
+    "clean": "rm -rf dist",
+    "pack-test": "yarn clean && yarn build && cross-env NODE_ENV=development npm pack",
+    "pack": "cross-env NODE_ENV=production npm pack",
+    "publish-package": "npm publish --access public"
+  },
+  "devDependencies": {
+    "ts-loader": "^9.4.2",
+    "typescript": "^5.4.5",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  }
+}

--- a/packages/schemas/src/axis.schema.ts
+++ b/packages/schemas/src/axis.schema.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+// Mirrors the plain-value subset of AxisProps (react-spectrum-charts-s2/src/types/axis/axis.types.ts),
+// Advanced/rare fields (labels, subLabels, range, currencyLocale/Code, tick limits) are left out for now
+export const AxisSchema = z
+  .object({
+    component: z.literal('Axis'),
+    position: z.enum(['left', 'right', 'top', 'bottom']).describe('Where the axis is placed on the chart.'),
+    title: z.union([z.string(), z.array(z.string())]).optional().describe('Axis title.'),
+    grid: z.boolean().optional().describe('Displays gridlines at each tick location.'),
+    baseline: z.boolean().optional().describe('Adds a baseline rule for this axis.'),
+    ticks: z.boolean().optional().describe('Displays ticks at each label location.'),
+    labelFormat: z.enum(['duration', 'linear', 'percentage', 'time']).optional().describe('Format of axis labels.'),
+    numberFormat: z
+      .string()
+      .optional()
+      .describe('d3 number format specifier. Only valid if labelFormat is linear or undefined.'),
+    granularity: z
+      .enum(['second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'])
+      .optional()
+      .describe('Granularity of primary axis labels for a time axis. Ignored for non-time axes.'),
+  })
+  .describe('An axis for the chart. Omit axes entirely for chart types that have none (e.g. Donut).');
+
+export type AxisInput = z.infer<typeof AxisSchema>;

--- a/packages/schemas/src/chart.schema.test.ts
+++ b/packages/schemas/src/chart.schema.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { parseChartRequest } from '.';
+import { ChartSchema } from './chart.schema';
+
+const validBarRequest = {
+  component: 'Chart',
+  data: { values: [{ browser: 'Chrome', downloads: 27000 }] },
+  axes: [{ component: 'Axis', position: 'bottom' }],
+  children: [{ component: 'Bar', dimension: 'browser', metric: 'downloads' }],
+};
+
+describe('ChartSchema', () => {
+  test('parses a valid Bar request', () => {
+    const parsed = ChartSchema.parse(validBarRequest);
+    expect(parsed.children).toHaveLength(1);
+    expect(parsed.children[0]).toMatchObject({ component: 'Bar', dimension: 'browser' });
+  });
+
+  test('parses a valid Line request', () => {
+    const parsed = ChartSchema.parse({
+      ...validBarRequest,
+      children: [{ component: 'Line', dimension: 'month', metric: 'downloads', scaleType: 'point' }],
+    });
+    expect(parsed.children[0]).toMatchObject({ component: 'Line', scaleType: 'point' });
+  });
+
+  test('axes are optional', () => {
+    const { axes: _axes, ...withoutAxes } = validBarRequest;
+    expect(() => ChartSchema.parse(withoutAxes)).not.toThrow();
+  });
+
+  test('rejects an empty children array', () => {
+    const result = ChartSchema.safeParse({ ...validBarRequest, children: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a mark with an unrecognized component discriminator', () => {
+    const result = ChartSchema.safeParse({
+      ...validBarRequest,
+      children: [{ component: 'Donut', dimension: 'browser', metric: 'downloads' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a request missing the required data field', () => {
+    const { data: _data, ...withoutData } = validBarRequest;
+    const result = ChartSchema.safeParse(withoutData);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('parseChartRequest', () => {
+  test('returns the parsed request for a valid payload', () => {
+    expect(parseChartRequest(validBarRequest).component).toBe('Chart');
+  });
+
+  test('throws for an invalid payload', () => {
+    expect(() => parseChartRequest({ component: 'Chart' })).toThrow();
+  });
+});

--- a/packages/schemas/src/chart.schema.ts
+++ b/packages/schemas/src/chart.schema.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+import { AxisSchema } from './axis.schema';
+import { BarSchema } from './marks/bar.schema';
+import { LineSchema } from './marks/line.schema';
+
+// Add each new mark schema to this union as it's built out.
+export const MarkSchema = z.discriminatedUnion('component', [BarSchema, LineSchema]);
+
+export const ChartSchema = z.object({
+  component: z.literal('Chart'),
+  data: z.object({ values: z.array(z.record(z.string(), z.unknown())) }),
+  colorScheme: z.enum(['light', 'dark']).optional(),
+  backgroundColor: z.string().optional(),
+  // Optional and unbounded: some chart types (e.g. Donut) have no axes at all, so this must not
+  // default to any particular count or be assumed present by the renderer.
+  axes: z.array(AxisSchema).optional().describe('Axes for the chart. Omit for chart types that use none.'),
+  children: z.array(MarkSchema).min(1).describe('The mark(s) to render inside this chart.'),
+});
+
+export type MarkInput = z.infer<typeof MarkSchema>;
+export type ChartInput = z.infer<typeof ChartSchema>;

--- a/packages/schemas/src/dialogs/chartInspect.schema.ts
+++ b/packages/schemas/src/dialogs/chartInspect.schema.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+// Mirrors ChartInspectOptions (vega-spec-builder-s2/src/types/dialogs/chartInspectSpec.types.ts).
+// ChartInspectProps' `children` (a (datum) => ReactNode render prop) isn't representable in JSON,
+// so it isn't modeled here — the renderer supplies a default dimension/metric tooltip body instead.
+export const ChartInspectSchema = z
+  .object({
+    component: z.literal('ChartInspect'),
+    excludeDataKeys: z
+      .array(z.string())
+      .optional()
+      .describe('Data keys that disable the tooltip for a row when truthy.'),
+    highlightBy: z
+      .union([z.enum(['series', 'dimension', 'item']), z.array(z.string())])
+      .optional()
+      .describe('Which marks are highlighted while the tooltip is visible.'),
+    targets: z
+      .array(z.enum(['dimensionArea', 'item']))
+      .optional()
+      .describe('Which mark regions trigger the tooltip on hover.'),
+  })
+  .describe('A hover tooltip showing the dimension and metric for the hovered bar.');
+
+export type ChartInspectInput = z.infer<typeof ChartInspectSchema>;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ChartSchema } from './chart.schema';
+
+export * from './axis.schema';
+export * from './chart.schema';
+export * from './dialogs/chartInspect.schema';
+export * from './marks/bar.schema';
+export * from './marks/line.schema';
+export * from './marks/supplemental/barDirectLabel.schema';
+export * from './marks/supplemental/lineDirectLabel.schema';
+
+/** Validates and types an agent-supplied chart request against the catalog contract. */
+export function parseChartRequest(payload: unknown) {
+  return ChartSchema.parse(payload);
+}

--- a/packages/schemas/src/marks/bar.schema.test.ts
+++ b/packages/schemas/src/marks/bar.schema.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { BarSchema } from './bar.schema';
+
+describe('BarSchema', () => {
+  test('parses a minimal Bar', () => {
+    const parsed = BarSchema.parse({ component: 'Bar', dimension: 'browser', metric: 'downloads' });
+    expect(parsed).toMatchObject({ component: 'Bar', dimension: 'browser', metric: 'downloads' });
+  });
+
+  test('parses color as a data field name', () => {
+    const parsed = BarSchema.parse({
+      component: 'Bar',
+      dimension: 'browser',
+      metric: 'downloads',
+      color: 'operatingSystem',
+    });
+    expect(parsed.color).toBe('operatingSystem');
+  });
+
+  test('parses color as a dual facet tuple', () => {
+    const parsed = BarSchema.parse({
+      component: 'Bar',
+      dimension: 'browser',
+      metric: 'downloads',
+      color: ['operatingSystem', 'segment'],
+    });
+    expect(parsed.color).toEqual(['operatingSystem', 'segment']);
+  });
+
+  test('parses BarDirectLabel and ChartInspect decorations', () => {
+    const parsed = BarSchema.parse({
+      component: 'Bar',
+      dimension: 'browser',
+      metric: 'downloads',
+      decorations: [
+        { component: 'BarDirectLabel', position: 'end-outside' },
+        { component: 'ChartInspect', highlightBy: 'item' },
+      ],
+    });
+    expect(parsed.decorations).toHaveLength(2);
+    expect(parsed.decorations?.[0]).toMatchObject({ component: 'BarDirectLabel', position: 'end-outside' });
+    expect(parsed.decorations?.[1]).toMatchObject({ component: 'ChartInspect', highlightBy: 'item' });
+  });
+
+  test('rejects an unrecognized decoration discriminator', () => {
+    const result = BarSchema.safeParse({
+      component: 'Bar',
+      dimension: 'browser',
+      metric: 'downloads',
+      decorations: [{ component: 'LineDirectLabel', value: 'series' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing dimension', () => {
+    const result = BarSchema.safeParse({ component: 'Bar', metric: 'downloads' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a wrong component discriminator', () => {
+    const result = BarSchema.safeParse({ component: 'Line', dimension: 'browser', metric: 'downloads' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/marks/bar.schema.ts
+++ b/packages/schemas/src/marks/bar.schema.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+import { ChartInspectSchema } from '../dialogs/chartInspect.schema';
+import { BarDirectLabelSchema } from './supplemental/barDirectLabel.schema';
+
+// FacetRef<T> = string (data field name) | { value: T }, see specUtil.types.ts in vega-spec-builder.
+const facetRef = <T extends z.ZodTypeAny>(value: T) => z.union([z.string(), z.object({ value })]);
+// Two field names split a facet into a secondary/dual facet, see DualFacet in barSpec.types.ts.
+const dualFacet = z.tuple([z.string(), z.string()]);
+
+const orientation = z.enum(['vertical', 'horizontal']);
+
+// Bar's own supported decorations. barAnnotations/chartPopovers/trendlines are still deferred —
+// add them when a real request needs them, same as the rest of BarSchema's omissions below.
+export const BarDecorationSchema = z.discriminatedUnion('component', [BarDirectLabelSchema, ChartInspectSchema]);
+
+// Mirrors the plain-value subset of BarProps (react-spectrum-charts/src/types/marks/bar.types.ts),
+export const BarSchema = z
+  .object({
+    component: z.literal('Bar'),
+    dimension: z.string().describe('Data field for the bar categories (x-axis for a vertical bar).'),
+    metric: z.string().describe('Data field used as the bar value.'),
+    color: z
+      .union([facetRef(z.string()), dualFacet])
+      .optional()
+      .describe('Color, or a data field to color by. Two field names split into a secondary facet.'),
+    orientation: orientation.optional().default('vertical'),
+    type: z.enum(['dodged', 'stacked']).optional().describe('"dodged" (grouped) or "stacked".'),
+    trellis: z.string().optional().describe('Data field to split into small multiples.'),
+    trellisOrientation: orientation.optional(),
+    hasSquareCorners: z.boolean().optional().describe('Square instead of the default rounded top corners.'),
+    metricAxis: z.string().optional().describe('Name of the axis the metric is trended against.'),
+    decorations: z
+      .array(BarDecorationSchema)
+      .optional()
+      .describe('Direct labels and/or a hover tooltip attached to the bars.'),
+  })
+  .describe('Categorical bars for a metric. Supports grouping, stacking, and trellising into small multiples.');
+
+export type BarInput = z.infer<typeof BarSchema>;
+export type BarDecorationInput = z.infer<typeof BarDecorationSchema>;

--- a/packages/schemas/src/marks/line.schema.test.ts
+++ b/packages/schemas/src/marks/line.schema.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { LineSchema } from './line.schema';
+
+describe('LineSchema', () => {
+  test('parses a minimal Line', () => {
+    const parsed = LineSchema.parse({ component: 'Line', dimension: 'month', metric: 'downloads' });
+    expect(parsed).toMatchObject({ component: 'Line', dimension: 'month', metric: 'downloads' });
+  });
+
+  test('parses color as a data field name', () => {
+    const parsed = LineSchema.parse({
+      component: 'Line',
+      dimension: 'month',
+      metric: 'downloads',
+      color: 'browser',
+    });
+    expect(parsed.color).toBe('browser');
+  });
+
+  test('parses a valid scaleType', () => {
+    const parsed = LineSchema.parse({
+      component: 'Line',
+      dimension: 'datetime',
+      metric: 'users',
+      scaleType: 'time',
+    });
+    expect(parsed.scaleType).toBe('time');
+  });
+
+  test('rejects an invalid scaleType', () => {
+    const result = LineSchema.safeParse({
+      component: 'Line',
+      dimension: 'datetime',
+      metric: 'users',
+      scaleType: 'ordinal',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('parses a LineDirectLabel decoration', () => {
+    const parsed = LineSchema.parse({
+      component: 'Line',
+      dimension: 'datetime',
+      metric: 'users',
+      decorations: [{ component: 'LineDirectLabel', value: 'series', position: 'end' }],
+    });
+    expect(parsed.decorations).toHaveLength(1);
+    expect(parsed.decorations?.[0]).toMatchObject({ component: 'LineDirectLabel', value: 'series' });
+  });
+
+  test('rejects an unrecognized decoration discriminator', () => {
+    const result = LineSchema.safeParse({
+      component: 'Line',
+      dimension: 'datetime',
+      metric: 'users',
+      decorations: [{ component: 'BarDirectLabel', position: 'end-outside' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing metric', () => {
+    const result = LineSchema.safeParse({ component: 'Line', dimension: 'datetime' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/marks/line.schema.ts
+++ b/packages/schemas/src/marks/line.schema.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+import { LineDirectLabelSchema } from './supplemental/lineDirectLabel.schema';
+
+// FacetRef<T> = string (data field name) | { value: T }, see specUtil.types.ts in vega-spec-builder.
+const facetRef = <T extends z.ZodTypeAny>(value: T) => z.union([z.string(), z.object({ value })]);
+
+// Line's own supported decorations. chartPopovers/chartInspects/forecasts/linePointAnnotations/
+// metricRanges/trendlines are still deferred — add them when a real request needs them.
+export const LineDecorationSchema = z.discriminatedUnion('component', [LineDirectLabelSchema]);
+
+// Mirrors the plain-value subset of LineProps (react-spectrum-charts-s2/src/types/marks/line.types.ts),
+// Kept intentionally minimal for now
+export const LineSchema = z
+  .object({
+    component: z.literal('Line'),
+    dimension: z.string().describe('Data field the line is trended against (x-axis).'),
+    metric: z.string().describe('Data field used as the line value (y-axis).'),
+    color: facetRef(z.string()).optional().describe('Line color, or a data field to color by.'),
+    scaleType: z.enum(['linear', 'point', 'time', 'band']).optional().describe('Type of scale used for the dimension axis.'),
+    decorations: z
+      .array(LineDecorationSchema)
+      .optional()
+      .describe('Direct labels attached to the lines.'),
+  })
+  .describe('A trended line for a metric over a continuous or ordinal dimension.');
+
+export type LineInput = z.infer<typeof LineSchema>;
+export type LineDecorationInput = z.infer<typeof LineDecorationSchema>;

--- a/packages/schemas/src/marks/supplemental/barDirectLabel.schema.test.ts
+++ b/packages/schemas/src/marks/supplemental/barDirectLabel.schema.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { BarDirectLabelSchema } from './barDirectLabel.schema';
+
+describe('BarDirectLabelSchema', () => {
+  test('parses with no optional fields', () => {
+    const parsed = BarDirectLabelSchema.parse({ component: 'BarDirectLabel' });
+    expect(parsed.component).toBe('BarDirectLabel');
+  });
+
+  test('parses with position and format', () => {
+    const parsed = BarDirectLabelSchema.parse({
+      component: 'BarDirectLabel',
+      position: 'end-outside',
+      format: 'currency',
+    });
+    expect(parsed).toMatchObject({ position: 'end-outside', format: 'currency' });
+  });
+
+  test('rejects an invalid position', () => {
+    const result = BarDirectLabelSchema.safeParse({ component: 'BarDirectLabel', position: 'top' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a wrong component discriminator', () => {
+    const result = BarDirectLabelSchema.safeParse({ component: 'LineDirectLabel' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/marks/supplemental/barDirectLabel.schema.ts
+++ b/packages/schemas/src/marks/supplemental/barDirectLabel.schema.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+// Mirrors BarDirectLabelProps (react-spectrum-charts-s2/src/types/marks/supplemental/barDirectLabel.types.ts).
+export const BarDirectLabelSchema = z
+  .object({
+    component: z.literal('BarDirectLabel'),
+    position: z
+      .enum(['start', 'middle', 'end', 'end-outside'])
+      .optional()
+      .describe('Where to place the label relative to the bar. Defaults to "end-outside".'),
+    format: z
+      .string()
+      .optional()
+      .describe(
+        'Number format for the label value: "currency", "shortCurrency", "shortNumber", "standardNumber", ' +
+          '"percentage", or a custom d3-format specifier. Defaults to ",.2~f".'
+      ),
+  })
+  .describe('A value label rendered directly on each bar.');
+
+export type BarDirectLabelInput = z.infer<typeof BarDirectLabelSchema>;

--- a/packages/schemas/src/marks/supplemental/lineDirectLabel.schema.test.ts
+++ b/packages/schemas/src/marks/supplemental/lineDirectLabel.schema.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { LineDirectLabelSchema } from './lineDirectLabel.schema';
+
+describe('LineDirectLabelSchema', () => {
+  test('parses with no optional fields', () => {
+    const parsed = LineDirectLabelSchema.parse({ component: 'LineDirectLabel' });
+    expect(parsed.component).toBe('LineDirectLabel');
+  });
+
+  test('parses all optional fields', () => {
+    const parsed = LineDirectLabelSchema.parse({
+      component: 'LineDirectLabel',
+      value: 'series',
+      position: 'end',
+      format: 'shortNumber',
+      prefix: '$',
+      excludeSeries: ['Series B'],
+      fontSize: 12,
+    });
+    expect(parsed).toMatchObject({
+      value: 'series',
+      position: 'end',
+      format: 'shortNumber',
+      prefix: '$',
+      excludeSeries: ['Series B'],
+      fontSize: 12,
+    });
+  });
+
+  test('rejects an invalid value', () => {
+    const result = LineDirectLabelSchema.safeParse({ component: 'LineDirectLabel', value: 'max' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid position', () => {
+    const result = LineDirectLabelSchema.safeParse({ component: 'LineDirectLabel', position: 'middle' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a wrong component discriminator', () => {
+    const result = LineDirectLabelSchema.safeParse({ component: 'BarDirectLabel' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/marks/supplemental/lineDirectLabel.schema.ts
+++ b/packages/schemas/src/marks/supplemental/lineDirectLabel.schema.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { z } from 'zod';
+
+// Mirrors LineDirectLabelProps (react-spectrum-charts-s2/src/types/marks/supplemental/lineDirectLabel.types.ts).
+export const LineDirectLabelSchema = z
+  .object({
+    component: z.literal('LineDirectLabel'),
+    value: z
+      .enum(['last', 'average', 'series'])
+      .optional()
+      .describe(
+        '"last": value at the last data point, "average": average of all values, "series": series key/name. Defaults to "last".'
+      ),
+    position: z
+      .enum(['start', 'end'])
+      .optional()
+      .describe('Where to place the label along the line: "start" or "end". Defaults to "end".'),
+    format: z.string().optional().describe('Number format string (matches axis formatting).'),
+    prefix: z.string().optional().describe('Text prepended to the value.'),
+    excludeSeries: z.array(z.string()).optional().describe('Series values to exclude from labeling.'),
+    fontSize: z.number().optional().describe('Override font size in pixels.'),
+  })
+  .describe('A value label rendered at the start or end of each line.');
+
+export type LineDirectLabelInput = z.infer<typeof LineDirectLabelSchema>;

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "outDir": "./dist",
+    "declarationDir": "./dist/@types/",
+    "composite": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/schemas/webpack.config.js
+++ b/packages/schemas/webpack.config.js
@@ -14,20 +14,19 @@
 const path = require('path');
 const webpack = require('webpack');
 const nodeExternals = require('webpack-node-externals');
+
 const { name, version } = require('./package.json');
+
 const banner = `${name}@v${version}`;
 
 module.exports = {
-  entry: {
-    index: './index.ts',
-    'ai-catalog': './src/ai-catalog/index.ts',
-  },
+  entry: './src/index.ts',
   mode: 'production',
 
   output: {
-    filename: '[name].js',
+    filename: 'index.js',
     path: path.resolve(__dirname, 'dist'),
-    library: 'spectrumChartsReactSpectrumChartsS2',
+    library: 'spectrumChartsCustomCatalog',
     libraryTarget: 'umd',
     globalObject: 'this',
     clean: true,
@@ -40,34 +39,10 @@ module.exports = {
         exclude: /node_modules/,
         use: 'ts-loader',
       },
-      {
-        test: /\.(sa|sc|c)ss$/,
-        use: ['style-loader', 'css-loader'],
-        sideEffects: true,
-      },
     ],
   },
 
-  externals: [
-    nodeExternals(),
-    {
-      '@spectrum-charts/constants': '@spectrum-charts/constants',
-      '@spectrum-charts/utils': '@spectrum-charts/utils',
-      '@spectrum-charts/themes': '@spectrum-charts/themes',
-      '@spectrum-charts/locales': '@spectrum-charts/locales',
-      '@spectrum-charts/vega-spec-builder': '@spectrum-charts/vega-spec-builder',
-      '@spectrum-charts/vega-spec-builder-s2': '@spectrum-charts/vega-spec-builder-s2',
-      '@spectrum-charts/schemas': '@spectrum-charts/schemas',
-      '@adobe/react-spectrum': '@adobe/react-spectrum',
-      'react': 'react',
-      'react-dom': 'react-dom',
-      'react-dom/client': 'react-dom/client',
-      'react/jsx-runtime': 'react/jsx-runtime',
-      'react/jsx-dev-runtime': 'react/jsx-dev-runtime',
-      'vega': 'vega',
-      'vega-lite': 'vega-lite',
-    },
-  ],
+  externals: [nodeExternals()],
 
   optimization: {
     minimize: process.env.NODE_ENV === 'development' ? false : true,
@@ -76,7 +51,7 @@ module.exports = {
   plugins: [new webpack.BannerPlugin(banner)],
 
   resolve: {
-    extensions: ['.tsx', '.ts', '.js', '.jsx', '.css', '.json'],
+    extensions: ['.tsx', '.ts', '.js', '.jsx', '.json'],
   },
 
   devtool: 'source-map',

--- a/yarn.lock
+++ b/yarn.lock
@@ -20092,6 +20092,11 @@ zod-to-json-schema@^3.25.0:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.13.tgz#93699a8afe937ba96badbb0ce8be6033c0a4b6b1"
   integrity sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==
 
+zod@^3.25.76:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
## Description

Adds `@spectrum-charts/schemas` — a new Zod-based package defining validated JSON contracts for AI/agent-driven chart generation and wires it into a new ai-catalog module in react-spectrum-charts-s2 that renders those requests using RSC's real components.                                                                                                                                                            
                                                                                                                                                                                                                 
  - `@spectrum-charts/schemas (new package)`: ChartSchema, AxisSchema, BarSchema, LineSchema, and their decoration schemas (BarDirectLabel, LineDirectLabel, ChartInspect), plus parseChartRequest() for validating an arbitrary payload. Each schema is grounded directly in the corresponding real prop types (BarProps, LineProps, AxisProps, etc.) rather than an independently-designed shape, so the contract stays honest to what RSC actually supports.
                                                                                                                                                                          
  - `ai-catalog module (new, in react-spectrum-charts-s2, exposed via a new /ai-catalog subpath export)`: CatalogChart takes an unknown/untyped request, validates it with parseChartRequest, and renders it with the real <Chart>/<Axis>/<Bar>/<Line> components. Per-mark rendering (CatalogBar, CatalogLine) is implemented as plain functions rather than JSX components, since childrenAdapter.ts identifies marks by displayName on <Chart>'s direct children, wrapping them in another component would cause them to be silently dropped.

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
