### PR TITLE
feat: Migrate Area (S1) to S2 as a pre-alpha component

### DIFF
--- a/packages/docs/docs/spectrum2/area.md
+++ b/packages/docs/docs/spectrum2/area.md
@@ -1,0 +1,144 @@
+---
+sidebar_position: 8
+---
+
+# Area (S2)
+
+:::note Pre-alpha component
+`Area` is a [pre-alpha component](./pre-alpha) — it has no finalized Spectrum 2 design yet
+and is imported from the `pre-alpha` subpath.
+:::
+
+The `Area` component displays area charts. Areas are most useful for showing how a metric
+changes over a continuous dimension, such as time, and stack by default when multiple series
+share the same dimension value.
+
+```jsx
+import { Chart, Axis, Legend } from '@spectrum-charts/react-spectrum-charts-s2';
+import { Area } from '@spectrum-charts/react-spectrum-charts-s2/pre-alpha';
+```
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" labelFormat="time" baseline />
+  <Axis position="left" grid />
+  <Area dimension="datetime" metric="value" color="series" />
+  <Legend />
+</Chart>
+```
+
+---
+
+## Tooltips and popovers
+
+`Area` supports `ChartInspect` and `ChartPopover` like other S2 chart mark components.
+Unlike the base package, S2 does not have a `ChartTooltip` component — use `ChartInspect`
+instead.
+
+```jsx
+<Area dimension="datetime" metric="value" color="series">
+  <ChartInspect>
+    {(datum) => (
+      <div>
+        <div>Series: {datum.series}</div>
+        <div>Value: {datum.value}</div>
+      </div>
+    )}
+  </ChartInspect>
+</Area>
+```
+
+---
+
+## Floating areas
+
+Pass `metricStart` and `metricEnd` instead of `metric` to draw a "floating" area between two
+data fields (for example, a min/max range) rather than a stacked area from zero. Both must be
+provided together — if only one is set, `Area` logs an error and falls back to `metric`.
+
+```jsx
+<Area dimension="datetime" metricStart="minTemperature" metricEnd="maxTemperature" />
+```
+
+---
+
+## Area props (S2)
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>children</td>
+            <td>ChartInspect | ChartPopover</td>
+            <td>–</td>
+            <td>Optional child components for inspect panels and popovers.</td>
+        </tr>
+        <tr>
+            <td>color</td>
+            <td>string</td>
+            <td>'series'</td>
+            <td>Key in the data used as the color facet.</td>
+        </tr>
+        <tr>
+            <td>dimension</td>
+            <td>string</td>
+            <td>'datetime'</td>
+            <td>Key in the data that the metric is trended against (x-axis).</td>
+        </tr>
+        <tr>
+            <td>metric</td>
+            <td>string</td>
+            <td>'value'</td>
+            <td>Key in the data used as the metric (y-axis). Ignored if <code>metricStart</code>/<code>metricEnd</code> are provided.</td>
+        </tr>
+        <tr>
+            <td>metricEnd</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Key in the data for the end of a floating area. Must be paired with <code>metricStart</code>.</td>
+        </tr>
+        <tr>
+            <td>metricStart</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Key in the data for the start of a floating area. Must be paired with <code>metricEnd</code>.</td>
+        </tr>
+        <tr>
+            <td>name</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Name of the area component. Useful when referencing the area marks programmatically.</td>
+        </tr>
+        <tr>
+            <td>opacity</td>
+            <td>number</td>
+            <td>0.8</td>
+            <td>The fill opacity of the area.</td>
+        </tr>
+        <tr>
+            <td>order</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Key in the data used to set the stack order of the area (higher order stacks on top).</td>
+        </tr>
+        <tr>
+            <td>padding</td>
+            <td>number</td>
+            <td>–</td>
+            <td>Horizontal padding — a ratio from 0 to 1 for categorical (point) scales, or a pixel value for continuous (time, linear) scales.</td>
+        </tr>
+        <tr>
+            <td>scaleType</td>
+            <td>'time' | 'linear' | 'point'</td>
+            <td>'time'</td>
+            <td>The type of scale used for the dimension.</td>
+        </tr>
+    </tbody>
+</table>

--- a/packages/docs/docs/spectrum2/pre-alpha.md
+++ b/packages/docs/docs/spectrum2/pre-alpha.md
@@ -18,6 +18,7 @@ Pre-alpha components:
 
 ## Current pre-alpha components
 
+- `Area` — area charts
 - `Scatter` — scatter plots, with `ScatterPath`, `ScatterAnnotation`, and `Trendline`
   (+ `TrendlineAnnotation`) child components
 - `Donut`, `DonutSummary`, `SegmentLabel` — donut charts

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -79,7 +79,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Pre-Alpha Components',
           collapsed: true,
-          items: ['spectrum2/pre-alpha', 'spectrum2/scatter'],
+          items: ['spectrum2/pre-alpha', 'spectrum2/area', 'spectrum2/scatter'],
         },
       ],
     },

--- a/packages/react-spectrum-charts-s2/src/pre-alpha/components/Area/Area.tsx
+++ b/packages/react-spectrum-charts-s2/src/pre-alpha/components/Area/Area.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { DEFAULT_COLOR, DEFAULT_METRIC, DEFAULT_TIME_DIMENSION } from '@spectrum-charts/constants';
+
+import { AreaProps } from '../../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const Area: FC<AreaProps> = ({
+  children,
+  name,
+  opacity = 0.8,
+  order,
+  scaleType = 'time',
+  color = DEFAULT_COLOR,
+  dimension = DEFAULT_TIME_DIMENSION,
+  metric = DEFAULT_METRIC,
+  metricEnd,
+  metricStart,
+  padding,
+}) => {
+  return null;
+};
+
+// displayName is used to validate the component type in the spec builder
+Area.displayName = 'Area';
+
+export { Area };

--- a/packages/react-spectrum-charts-s2/src/pre-alpha/components/Area/index.ts
+++ b/packages/react-spectrum-charts-s2/src/pre-alpha/components/Area/index.ts
@@ -11,11 +11,3 @@
  */
 
 export * from './Area';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/areaAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/areaAdapter.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { createElement } from 'react';
+
+import { DEFAULT_COLOR } from '@spectrum-charts/constants';
+
+import { ChartInspect } from '../components/ChartInspect';
+import { ChartPopover } from '../components/ChartPopover';
+import { getAreaOptions } from './areaAdapter';
+
+describe('getAreaOptions()', () => {
+  it('should return all basic options', () => {
+    const options = getAreaOptions({});
+    expect(options.markType).toBe('area');
+    expect(options.chartInspects).toHaveLength(0);
+    expect(options.chartPopovers).toHaveLength(0);
+  });
+
+  it('should convert popover children to chartPopovers array', () => {
+    const options = getAreaOptions({ children: [createElement(ChartPopover)] });
+    expect(options.chartPopovers).toHaveLength(1);
+  });
+
+  it('should convert ChartInspect children to chartInspects array', () => {
+    const options = getAreaOptions({ children: [createElement(ChartInspect)] });
+    expect(options.chartInspects).toHaveLength(1);
+  });
+
+  it('should pass through included props', () => {
+    const options = getAreaOptions({ color: DEFAULT_COLOR });
+    expect(options).toHaveProperty('color', DEFAULT_COLOR);
+  });
+
+  it('should not add props that are not provided', () => {
+    const options = getAreaOptions({});
+    expect(options).not.toHaveProperty('color');
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/areaAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/areaAdapter.ts
@@ -9,13 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { AreaOptions } from '@spectrum-charts/vega-spec-builder-s2';
 
-export * from './Area';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
+import { AreaProps } from '../types';
+import { childrenToOptions } from './childrenAdapter';
+
+export const getAreaOptions = ({ children, ...areaProps }: AreaProps): AreaOptions => {
+  const { chartInspects, chartPopovers } = childrenToOptions(children);
+  return {
+    ...areaProps,
+    chartInspects,
+    chartPopovers,
+    markType: 'area',
+  };
+};

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
@@ -46,6 +46,7 @@ import { LinePointAnnotation } from '../components/LinePointAnnotation';
 import { ReferenceLine } from '../components/ReferenceLine';
 import { Title } from '../components/Title';
 import {
+  Area,
   Donut,
   DonutSummary,
   Scatter,
@@ -56,6 +57,7 @@ import {
   TrendlineAnnotation,
 } from '../pre-alpha';
 import {
+  AreaProps,
   AxisProps,
   AxisThumbnailProps,
   BarDirectLabelProps,
@@ -79,6 +81,7 @@ import {
   TrendlineProps,
 } from '../types';
 import { sanitizeChildren } from '../utils';
+import { getAreaOptions } from './areaAdapter';
 import { getAxisOptions } from './axisAdapter';
 import { getBarOptions } from './barAdapter';
 import { getChartPopoverOptions } from './chartPopoverAdapter';
@@ -140,6 +143,10 @@ export const childrenToOptions = (
       continue;
     }
     switch (child.type.displayName) {
+      case Area.displayName:
+        marks.push(getAreaOptions(child.props as AreaProps));
+        break;
+
       case Axis.displayName:
         axes.push(getAxisOptions(child.props as AxisProps));
         break;

--- a/packages/react-spectrum-charts-s2/src/stories/Area/Area.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Area/Area.test.tsx
@@ -9,13 +9,19 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Area } from '../../pre-alpha/components/Area';
+import { findChart, render } from '../../test-utils';
+import { Basic } from './Features/AreaBasic.story';
 
-export * from './Area';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
+describe('Area', () => {
+  // Area is not a real React component. This test just provides test coverage for sonarqube
+  test('Area pseudo element', () => {
+    render(<Area />);
+  });
+
+  test('Basic renders properly', async () => {
+    render(<Basic {...Basic.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/stories/Area/Features/AreaBasic.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Area/Features/AreaBasic.story.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../Chart';
+import { Axis, Legend } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { Area } from '../../../pre-alpha';
+import { bindWithProps } from '../../../test-utils';
+import { AreaProps, ChartProps } from '../../../types';
+import { workspaceTrendsData } from '../../data/data';
+
+export default {
+  title: 'React Spectrum Charts 2/Area/Features',
+  component: Area,
+};
+
+// weather data is single-series, used by the basic and floating examples
+const weatherData = [
+  { datetime: 1667890800000, maxTemperature: 73, minTemperature: 47, series: 'Add Fallout' },
+  { datetime: 1667977200000, maxTemperature: 70, minTemperature: 48, series: 'Add Fallout' },
+  { datetime: 1668063600000, maxTemperature: 73, minTemperature: 48, series: 'Add Fallout' },
+  { datetime: 1668150000000, maxTemperature: 56, minTemperature: 31, series: 'Add Fallout' },
+  { datetime: 1668236400000, maxTemperature: 41, minTemperature: 18, series: 'Add Fallout' },
+  { datetime: 1668322800000, maxTemperature: 60, minTemperature: 45, series: 'Add Fallout' },
+  { datetime: 1668409200000, maxTemperature: 64, minTemperature: 43, series: 'Add Fallout' },
+];
+
+const weatherDataWithGaps = [
+  { datetime: 1667890800000, maxTemperature: 73, minTemperature: 47, series: 'Add Fallout' },
+  { datetime: 1667977200000, maxTemperature: 70, minTemperature: 48, series: 'Add Fallout' },
+  { datetime: 1668063600000, maxTemperature: undefined, minTemperature: undefined, series: 'Add Fallout' },
+  { datetime: 1668150000000, maxTemperature: 56, minTemperature: 31, series: 'Add Fallout' },
+  { datetime: 1668236400000, maxTemperature: 41, minTemperature: 18, series: 'Add Fallout' },
+  { datetime: 1668322800000, maxTemperature: 60, minTemperature: 45, series: 'Add Fallout' },
+  { datetime: 1668409200000, maxTemperature: 64, minTemperature: 43, series: 'Add Fallout' },
+];
+
+// browser/OS data is categorical, used to demonstrate stacking on a point scale rather than time
+const browserData = [
+  { browser: 'Chrome', value: 5, operatingSystem: 'Windows' },
+  { browser: 'Chrome', value: 3, operatingSystem: 'Mac' },
+  { browser: 'Chrome', value: 2, operatingSystem: 'Other' },
+  { browser: 'Firefox', value: 3, operatingSystem: 'Windows' },
+  { browser: 'Firefox', value: 3, operatingSystem: 'Mac' },
+  { browser: 'Firefox', value: 1, operatingSystem: 'Other' },
+  { browser: 'Safari', value: 3, operatingSystem: 'Windows' },
+  { browser: 'Safari', value: 0, operatingSystem: 'Mac' },
+  { browser: 'Safari', value: 1, operatingSystem: 'Other' },
+];
+
+const defaultChartProps: ChartProps = { data: weatherData, minWidth: 400, maxWidth: 800, height: 400 };
+
+const AreaStory: StoryFn<AreaProps> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline />
+      <Axis position="left" title="Temperature (F)" grid />
+      <Area {...args} />
+    </Chart>
+  );
+};
+
+const StackedStory: StoryFn<AreaProps> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: workspaceTrendsData });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline />
+      <Axis position="left" grid />
+      <Area {...args} />
+      <Legend lineWidth={{ value: 0 }} />
+    </Chart>
+  );
+};
+
+const CategoricalStory: StoryFn<AreaProps> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: browserData });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline />
+      <Axis position="left" grid />
+      <Area {...args} />
+      <Legend />
+    </Chart>
+  );
+};
+
+// the stack transform back-fills a 0 baseline even when the metric is undefined, masking the gap — floating (start/end) area is used here instead so the gap renders
+const WithGapsInDataStory: StoryFn<AreaProps> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, data: weatherDataWithGaps });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" labelFormat="time" baseline />
+      <Axis position="left" title="Temperature (F)" grid />
+      <Area {...args} />
+    </Chart>
+  );
+};
+
+const Basic = bindWithProps(AreaStory);
+Basic.args = { metric: 'maxTemperature' };
+
+// relies on Area's own defaults (dimension: 'datetime', metric: 'value', color: 'series', scaleType: 'time')
+const Stacked = bindWithProps(StackedStory);
+Stacked.args = {};
+
+const Categorical = bindWithProps(CategoricalStory);
+Categorical.args = { dimension: 'browser', color: 'operatingSystem', scaleType: 'point' };
+
+const Floating = bindWithProps(AreaStory);
+Floating.args = { metricStart: 'minTemperature', metricEnd: 'maxTemperature' };
+
+const WithGapsInData = bindWithProps(WithGapsInDataStory);
+WithGapsInData.args = { metricStart: 'minTemperature', metricEnd: 'maxTemperature', opacity: 0.6 };
+
+export { Basic, Stacked, Categorical, Floating, WithGapsInData };

--- a/packages/react-spectrum-charts-s2/src/stories/Area/Features/Inspect/AreaInspect.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Area/Features/Inspect/AreaInspect.story.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Chart } from '../../../../Chart';
+import { Axis, ChartInspect, ChartPopover, Legend } from '../../../../components';
+import useChartProps from '../../../../hooks/useChartProps';
+import { Area } from '../../../../pre-alpha';
+import { bindWithProps } from '../../../../test-utils';
+import { AreaProps, ChartProps } from '../../../../types';
+
+export default {
+  title: 'React Spectrum Charts 2/Area/Features/Inspect',
+  component: Area,
+};
+
+const data = [
+  { browser: 'Chrome', value: 5, operatingSystem: 'Windows' },
+  { browser: 'Chrome', value: 3, operatingSystem: 'Mac' },
+  { browser: 'Chrome', value: 2, operatingSystem: 'Other' },
+  { browser: 'Firefox', value: 3, operatingSystem: 'Windows' },
+  { browser: 'Firefox', value: 3, operatingSystem: 'Mac' },
+  { browser: 'Firefox', value: 1, operatingSystem: 'Other' },
+  { browser: 'Safari', value: 3, operatingSystem: 'Windows' },
+  { browser: 'Safari', value: 0, operatingSystem: 'Mac' },
+  { browser: 'Safari', value: 1, operatingSystem: 'Other' },
+];
+const defaultChartProps: ChartProps = { data, minWidth: 400, maxWidth: 800, height: 400 };
+const defaultArgs: Partial<AreaProps> = { dimension: 'browser', color: 'operatingSystem', scaleType: 'point' };
+
+const AreaStory: StoryFn<AreaProps> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline />
+      <Axis position="left" grid />
+      <Area {...args} />
+      <Legend highlight />
+    </Chart>
+  );
+};
+
+const dialogContent = (datum: Datum) => (
+  <div>
+    <div>Browser: {datum.browser as string}</div>
+    <div>OS: {datum.operatingSystem as string}</div>
+    <div>Downloads: {datum.value as number}</div>
+  </div>
+);
+
+const Inspect = bindWithProps(AreaStory);
+Inspect.args = {
+  ...defaultArgs,
+  children: <ChartInspect>{dialogContent}</ChartInspect>,
+};
+
+const Popover = bindWithProps(AreaStory);
+Popover.args = {
+  ...defaultArgs,
+  children: (
+    <ChartPopover width="auto" key={0}>
+      {dialogContent}
+    </ChartPopover>
+  ),
+};
+
+export { Inspect, Popover };

--- a/packages/react-spectrum-charts-s2/src/types/chart.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/chart.types.ts
@@ -27,12 +27,13 @@ import {
 import { AxisElement } from './axis';
 import { ChartInspectElement, ChartPopoverElement } from './dialogs';
 import { LegendElement } from './legend.types';
-import { BarAnnotationElement, BarElement, DonutElement, DonutSummaryElement, LineElement } from './marks';
+import { AreaElement, BarAnnotationElement, BarElement, DonutElement, DonutSummaryElement, LineElement } from './marks';
 import { ScatterElement } from './marks/scatter.types';
 import { TitleElement } from './title.types';
 import { Children } from './util.types';
 
 export type ChartChildElement =
+  | AreaElement
   | AxisElement
   | BarElement
   | DonutElement

--- a/packages/react-spectrum-charts-s2/src/types/marks/area.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/area.types.ts
@@ -9,13 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { JSXElementConstructor, ReactElement } from 'react';
 
-export * from './Area';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
+import { AreaOptions } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { ChartInspectElement, ChartPopoverElement } from '../dialogs';
+import { Children } from '../util.types';
+
+type AreaChildElement = ChartInspectElement | ChartPopoverElement;
+
+export interface AreaProps extends Omit<AreaOptions, 'chartInspects' | 'chartPopovers' | 'markType'> {
+  children?: Children<AreaChildElement>;
+}
+
+export type AreaElement = ReactElement<AreaProps, JSXElementConstructor<AreaProps>>;

--- a/packages/react-spectrum-charts-s2/src/types/marks/index.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/index.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+export * from './area.types';
 export * from './bar.types';
 export * from './donut.types';
 export * from './line.types';

--- a/packages/react-spectrum-charts-s2/src/utils/utils.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.test.tsx
@@ -13,7 +13,7 @@ import { Fragment, createElement } from 'react';
 
 import { Chart } from '../Chart';
 import { Bar, ChartInspect, Line } from '../components';
-import { Donut, Scatter, Trendline } from '../pre-alpha';
+import { Area, Donut, Scatter, Trendline } from '../pre-alpha';
 import {
   debugLog,
   getAllElements,
@@ -57,12 +57,15 @@ describe('utils', () => {
               <ChartInspect />
             </Trendline>
           </Scatter>
+          <Area>
+            <ChartInspect />
+          </Area>
         </Chart>
       );
 
       const matches = getAllElements(element, ChartInspect);
 
-      expect(matches).toHaveLength(6);
+      expect(matches).toHaveLength(7);
       expect(matches[0].name).toBe('bar0');
       expect(matches[1].name).toBe('myLine');
       expect(matches[2].name).toBe('line1');
@@ -72,6 +75,7 @@ describe('utils', () => {
       // parent), so it must combine with its parent as `scatter1Trendline`, matching the
       // `${name}Trendline_hoverGroup` mark name in vega-spec-builder-s2.
       expect(matches[5].name).toBe('scatter1Trendline');
+      expect(matches[6].name).toBe('area0');
     });
   });
 

--- a/packages/react-spectrum-charts-s2/src/utils/utils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.ts
@@ -41,6 +41,7 @@ import {
   Title,
 } from '../components';
 import {
+  Area,
   Donut,
   DonutSummary,
   Scatter,
@@ -51,6 +52,7 @@ import {
   TrendlineAnnotation,
 } from '../pre-alpha';
 import {
+  AreaElement,
   AxisChildElement,
   AxisElement,
   BarAnnotationElement,
@@ -89,6 +91,7 @@ type MarkChildElement =
   | TrendlineElement;
 type RscElement =
   | MarkChildElement
+  | AreaElement
   | AxisElement
   | BarElement
   | DonutElement
@@ -99,6 +102,7 @@ type RscElement =
 
 type MappedElement = { name: string; element: ChartElement | RscElement; parent?: string };
 type ElementCounts = {
+  area: number;
   axis: number;
   axisAnnotation: number;
   bar: number;
@@ -130,6 +134,7 @@ export const getElementDisplayName = (element: unknown): string => {
 
 export const sanitizeChildren = (children: unknown): (ChartChildElement | MarkChildElement)[] => {
   const validDisplayNames = new Set([
+    Area.displayName,
     Axis.displayName,
     AxisThumbnail.displayName,
     Bar.displayName,
@@ -162,6 +167,7 @@ export const sanitizeChildren = (children: unknown): (ChartChildElement | MarkCh
 // removes all non-chart specific elements
 export const sanitizeRscChartChildren = (children: unknown): ChartChildElement[] => {
   const chartChildDisplyNames = new Set([
+    Area.displayName,
     Axis.displayName,
     Bar.displayName,
     Donut.displayName,
@@ -347,6 +353,9 @@ const getElementName = (element: unknown, elementCounts: ElementCounts) => {
     return '';
   // use displayName since it is the olny way to check alpha and beta components
   switch (element.type.displayName) {
+    case Area.displayName:
+      elementCounts.area++;
+      return getComponentName(element as AreaElement, `area${elementCounts.area}`);
     case Axis.displayName:
       elementCounts.axis++;
       return getComponentName(element as AxisElement, `axis${elementCounts.axis}`);
@@ -380,6 +389,7 @@ export const getComponentName = (element: ChildElement<RscElement>, defaultName:
 };
 
 const initElementCounts = (): ElementCounts => ({
+  area: -1,
   axis: -1,
   axisAnnotation: -1,
   bar: -1,

--- a/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/area/areaSpecBuilder.test.ts
@@ -107,6 +107,7 @@ const defaultSpec = initializeSpec({
               strokeWidth: { value: 1.5 },
               strokeJoin: { value: 'round' },
               tooltip: undefined,
+              defined: { signal: 'isValid(datum["value0"]) || isValid(datum["value1"])' },
             },
             update: {
               x: { field: DEFAULT_TRANSFORMED_TIME_DIMENSION, scale: 'xTime' },

--- a/packages/vega-spec-builder-s2/src/area/areaUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/area/areaUtils.test.ts
@@ -58,6 +58,9 @@ describe('getAreaMark', () => {
             scale: COLOR_SCALE,
             field: DEFAULT_COLOR,
           },
+          defined: {
+            signal: 'isValid(datum["metricStart"]) || isValid(datum["metricEnd"])',
+          },
         },
         update: {
           cursor: undefined,
@@ -109,6 +112,9 @@ describe('getAreaMark', () => {
           fill: {
             scale: COLOR_SCALE,
             field: DEFAULT_COLOR,
+          },
+          defined: {
+            signal: 'isValid(datum["metricStart"]) || isValid(datum["metricEnd"])',
           },
           stroke: {
             signal: BACKGROUND_COLOR,
@@ -172,6 +178,9 @@ describe('getAreaMark', () => {
             scale: COLOR_SCALE,
             field: DEFAULT_COLOR,
           },
+          defined: {
+            signal: 'isValid(datum["metricStart"]) || isValid(datum["metricEnd"])',
+          },
         },
         update: {
           cursor: undefined,
@@ -223,6 +232,9 @@ describe('getAreaMark', () => {
           fill: {
             scale: COLOR_SCALE,
             field: DEFAULT_COLOR,
+          },
+          defined: {
+            signal: 'isValid(datum["metricStart"]) || isValid(datum["metricEnd"])',
           },
         },
         update: {

--- a/packages/vega-spec-builder-s2/src/area/areaUtils.ts
+++ b/packages/vega-spec-builder-s2/src/area/areaUtils.ts
@@ -88,6 +88,7 @@ export const getAreaMark = (
         y2: { scale: 'yLinear', field: metricEnd },
         fill: getColorProductionRule(color, colorScheme),
         tooltip: getInspectEncoding(chartInspects ?? [], name),
+        defined: { signal: `isValid(datum["${metricStart}"]) || isValid(datum["${metricEnd}"])` },
         ...getBorderStrokeEncodings(isStacked, true),
       },
       update: {

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.test.ts
@@ -246,6 +246,7 @@ const metricRangeGroupMark = {
             field: 'series',
           },
           tooltip: undefined,
+          defined: { signal: 'isValid(datum["start"]) || isValid(datum["end"])' },
         },
         update: {
           cursor: undefined,

--- a/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/metricRange/metricRangeUtils.test.ts
@@ -121,6 +121,7 @@ const basicMetricRangeMarks = [
         y: { scale: 'yLinear', field: 'metricStart' },
         y2: { scale: 'yLinear', field: 'metricEnd' },
         fill: { scale: COLOR_SCALE, field: 'series' },
+        defined: { signal: 'isValid(datum["metricStart"]) || isValid(datum["metricEnd"])' },
       },
       update: {
         cursor: undefined,


### PR DESCRIPTION
Migrate Area (S1) to S2 as a pre-alpha component
## Description

Adds Area to react-spectrum-charts-s2, following the same precedent already established for Scatter

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Stories: stories/Area/Features/ — Basic (single-series), Stacked (multi-series, time), Categorical (point scale), Floating (start/end range), WithGapsInData, plus Features/Inspect/ covering ChartInspect/ChartPopover. Together these give full parity with S1's Area.story.tsx + StackedArea.story.tsx.

## Screenshots (if appropriate):
<img width="1154" height="370" alt="Screenshot 2026-08-12 at 3 18 26 PM" src="https://github.com/user-attachments/assets/500ed468-ad1b-4f28-8acd-9a3af5f47f5c" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
