### PR TITLE
feat: bar opacity animations

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -123,6 +123,8 @@ export const HOVER_ANIM_LAST_CHANGE_DATA = 'hoverAnimLastChangeData';
 export const HOVER_TARGET_DATA = 'hoverTargetData';
 export const HOVER_ANIM_STATE_DATA = 'hoverAnimStateData';
 export const HOVER_FRACTION_DATA = 'hoverFractionData';
+/** Series-level (max) aggregate of a per-item-animated mark's hoverFractionData, for ungrouped legends that need one fraction per series */
+export const HOVER_SERIES_FRACTION_DATA = 'hoverSeriesFractionData';
 /** Draw-in animation: the already-drawn portion, the single lerping tip point, and their merge (source the line mark renders from) */
 export const DRAW_IN_PREV_DATA = 'drawInPrev'; // suffix: ${name}_drawInPrev
 export const DRAW_IN_TIP_DATA = 'drawInTip'; // suffix: ${name}_drawInTip
@@ -136,6 +138,8 @@ export const GROUP_DATA = 'rscGroupData';
 export const MARK_ID = 'rscMarkId';
 export const GROUP_ID = 'rscGroupId';
 export const SERIES_ID = 'rscSeriesId';
+/** Composite per-bar hover-animation identity: dimension + series (+ trellis) values joined, since MARK_ID is runtime-assigned and not JS-computable ahead of time */
+export const BAR_ANIM_ID = 'rscBarAnimId';
 export const STACK_ID = 'rscStackId';
 export const COMPONENT_NAME = 'rscComponentName';
 export const TRENDLINE_VALUE = 'rscTrendlineValue';

--- a/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
@@ -403,9 +403,12 @@ describe('Chart', () => {
       expect(chart).toBeInTheDocument();
       const bars = getAllMarksByGroupName(chart, 'bar0');
 
-      expect(bars[14]).toHaveAttribute('opacity', '1');
-      expect(bars[13]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-      expect(bars[15]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      // opacity is now animated, so it settles asynchronously -- hence waitFor
+      await waitFor(() => {
+        expect(bars[14]).toHaveAttribute('opacity', '1');
+        expect(bars[13]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+        expect(bars[15]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      });
     });
   });
 

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/Bar.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/Bar.test.tsx
@@ -21,6 +21,7 @@ import {
   rightClickNthElement,
   screen,
   unhoverNthElement,
+  waitForMarksByGroupName,
   within,
 } from '../../../test-utils';
 import '../../../test-utils/__mocks__/matchMedia.mock.js';
@@ -234,15 +235,20 @@ describe('Bar', () => {
       let inspect = await screen.findByTestId('rsc-tooltip');
       expect(inspect).toBeInTheDocument();
       expect(within(inspect).getByText('Chrome: 27000')).toBeInTheDocument();
-      expect(bars[0]).toHaveAttribute('opacity', `1`);
-      expect(bars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      // opacity is now animated, so it settles asynchronously -- hence waitForMarksByGroupName
+      await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+        expect(updatedBars[0]).toHaveAttribute('opacity', `1`);
+        expect(updatedBars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      });
 
       await unhoverNthElement(dimensionAreas, 0);
 
       // hovering bar should do normal stuff
       await hoverNthElement(bars, 4);
-      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-      expect(bars[4]).toHaveAttribute('opacity', `1`);
+      await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+        expect(updatedBars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+        expect(updatedBars[4]).toHaveAttribute('opacity', `1`);
+      });
       inspect = await screen.findByTestId('rsc-tooltip');
       expect(inspect).toBeInTheDocument();
       expect(within(inspect).getByText('Explorer: 500')).toBeInTheDocument();
@@ -258,8 +264,11 @@ describe('Bar', () => {
 
       // hovering bar should do normal stuff
       await hoverNthElement(bars, 4);
-      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-      expect(bars[4]).toHaveAttribute('opacity', `1`);
+      // opacity is now animated, so it settles asynchronously -- hence waitForMarksByGroupName
+      await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+        expect(updatedBars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+        expect(updatedBars[4]).toHaveAttribute('opacity', `1`);
+      });
       const inspect = await screen.findByTestId('rsc-tooltip');
       expect(inspect).toBeInTheDocument();
       expect(within(inspect).getByText('Explorer: 500')).toBeInTheDocument();

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarHoverAnimation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarHoverAnimation.story.tsx
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable react/prop-types -- story args are typed via StoryFn generics, not React propTypes */
+import { ComponentProps, ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { AnimationType, GROUP_DATA, MARK_ID } from '@spectrum-charts/constants';
+import { ChartData, Datum, SpectrumColor } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Chart } from '../../../Chart';
+import { Axis, Bar, ChartInspect, ChartPopover, Legend } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { bindWithProps } from '../../../test-utils';
+import { BarProps } from '../../../types';
+import { barSeriesData, barSubSeriesData, generateMockDataForTrellis } from './data';
+
+// ┌───────────────────────────┬──────────────────────────────────────────────────┬────────────────────────────────────────────────┐
+// │           Story           │                      Trigger                      │                   Match rule                    │
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │      StackedPointHover     │       <ChartInspect> — hover a single segment     │ hoveredMatch (per-bar, not per-series/stack)    │
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │    StackedDimensionHover   │ <ChartInspect> — hover the dimension-hover-area   │ dimensionHoverMatch (drives axis-label hover too)│
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │      StackedLegendHover    │  <Legend highlight /> — hover a legend entry      │      injected legendHoverMatch (per series)     │
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │  StackedControlledHighlight│         highlightedSeries chart prop              │           controlledSeriesMatch (per series)    │
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │  StackedPopoverSelection   │     <ChartPopover> — click a bar to select        │             popoverMatch (per-bar)              │
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │ DodgedStackedPointHover    │ <ChartInspect> — hover one dual-facet segment      │ hoveredMatch (composite id includes both facets)│
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │ DodgedStackedLegendHover   │  <Legend highlight /> — hover a legend entry      │ legendHoverMatch (series aggregate across facets)│
+// ├───────────────────────────┼──────────────────────────────────────────────────┼────────────────────────────────────────────────┤
+// │      TrellisPointHover     │       <ChartInspect> — hover a single bar         │  hoveredMatch (per-bar, unique across trellis)  │
+// └───────────────────────────┴──────────────────────────────────────────────────┴────────────────────────────────────────────────┘
+
+/** Showcases the bar hover-animation system across every interaction that can emphasize a series. */
+export default {
+  title: 'React Spectrum Charts 2/Bar/Features/Hover Animation',
+  component: Bar,
+  argTypes: {
+    animations: {
+      control: 'boolean',
+      description: 'Chart-level master kill switch for all animations.',
+    },
+    animationTypes: {
+      control: { type: 'check' },
+      options: ['hover'],
+      description: "Which animation types are enabled (only 'hover' is relevant to this story group).",
+    },
+  },
+  args: { animations: true, animationTypes: ['hover'] },
+};
+
+type HoverAnimationArgs = ComponentProps<typeof Bar> & { animations?: boolean; animationTypes?: AnimationType[] };
+
+const colors: SpectrumColor[] = ['categorical-100', 'categorical-200', 'categorical-300', 'categorical-400'];
+
+// Mirrors DodgedBar.story.tsx's `DodgedStacked` -- each primary facet (operatingSystem) gets its own
+// pair of shades, one per secondary facet (version), rather than one flat palette across both facets.
+const dualFacetColors: SpectrumColor[][] = [
+  ['categorical-700', 'categorical-1000'],
+  ['categorical-400', 'categorical-500'],
+  ['categorical-300', 'categorical-1100'],
+];
+
+const defaultArgs: BarProps = {
+  dimension: 'browser',
+  order: 'order',
+  color: 'operatingSystem',
+};
+
+const dialogContent = (datum: Datum): ReactElement => (
+  <div>
+    <div>Operating system: {datum.operatingSystem}</div>
+    <div>Browser: {datum.browser}</div>
+    <div>Downloads: {datum.value}</div>
+  </div>
+);
+
+/** Per-segment breakdown for the dimension-area tooltip, mirroring `SharedBarStories.tsx`'s `DimensionAreaStory`. */
+const dimensionAreaDialogContent = (datum: Datum): ReactElement => (
+  <>
+    <div style={{ fontWeight: 'bold' }}>{datum.browser} Downloads</div>
+    {datum[GROUP_DATA]?.map((d) => (
+      <div key={d[MARK_ID]}>
+        {d.operatingSystem}: {d.value}
+      </div>
+    ))}
+  </>
+);
+
+/** Point hover — hovering one segment/bar fades every other segment/bar independently, not the whole stack/group it's in. */
+const createPointHoverStory = (data: ChartData[], storyColors: SpectrumColor[] | SpectrumColor[][]): StoryFn<HoverAnimationArgs> => {
+  const PointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+    const chartProps = useChartProps({
+      data,
+      colors: storyColors,
+      width: 800,
+      height: 600,
+      animations,
+      animationTypes,
+    });
+    return (
+      <Chart {...chartProps}>
+        <Axis position="bottom" baseline title="Browser" />
+        <Axis position="left" grid title="Downloads" />
+        <Bar {...args}>
+          <ChartInspect>{dialogContent}</ChartInspect>
+        </Bar>
+        <Legend title="Operating system" />
+      </Chart>
+    );
+  };
+  return PointHoverStory;
+};
+
+const PointHoverStory = createPointHoverStory(barSeriesData, colors);
+const DualFacetPointHoverStory = createPointHoverStory(barSubSeriesData, dualFacetColors);
+
+/** Dimension-area hover — hovering the padding around a stack (or an axis label) fades every OTHER dimension value, independent of the per-bar hoveredMatch rule. The dimensionArea inspect is its own `<ChartInspect>` rendering the per-segment breakdown via `GROUP_DATA`, matching `SharedBarStories.tsx`'s `DimensionAreaStory` rather than reusing the item-level dialog. */
+const StackedDimensionHoverStory: StoryFn<HoverAnimationArgs> = ({
+  animations,
+  animationTypes,
+  ...args
+}): ReactElement => {
+  const chartProps = useChartProps({ data: barSeriesData, colors, width: 800, height: 600, animations, animationTypes });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline title="Browser" />
+      <Axis position="left" grid title="Downloads" />
+      <Bar {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+        <ChartInspect targets={['dimensionArea']}>{dimensionAreaDialogContent}</ChartInspect>
+      </Bar>
+      <Legend title="Operating system" highlight />
+    </Chart>
+  );
+};
+
+/** Legend hover — hovering a legend entry emphasizes every bar of that series, across every stack/group. Shared by the single-facet and dual-facet variants (`data`/`color`/`colors` differ). */
+const createLegendHoverStory = (
+  data: ChartData[],
+  storyColors: SpectrumColor[] | SpectrumColor[][]
+): StoryFn<HoverAnimationArgs> => {
+  const LegendHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+    const chartProps = useChartProps({
+      data,
+      colors: storyColors,
+      width: 800,
+      height: 600,
+      animations,
+      animationTypes,
+    });
+    return (
+      <Chart {...chartProps}>
+        <Axis position="bottom" baseline title="Browser" />
+        <Axis position="left" grid title="Downloads" />
+        <Bar {...args} />
+        <Legend title="Operating system" highlight />
+      </Chart>
+    );
+  };
+  return LegendHoverStory;
+};
+
+const LegendHoverStory = createLegendHoverStory(barSeriesData, colors);
+const DualFacetLegendHoverStory = createLegendHoverStory(barSubSeriesData, dualFacetColors);
+
+/** Controlled highlight — an external `highlightedSeries` chart prop emphasizes a series (the `controlledSeriesMatch` rule). */
+const StackedControlledHighlightStory: StoryFn<HoverAnimationArgs> = ({
+  animations,
+  animationTypes,
+  ...args
+}): ReactElement => {
+  const chartProps = useChartProps({
+    data: barSeriesData,
+    colors,
+    width: 800,
+    height: 600,
+    highlightedSeries: 'Windows',
+    animations,
+    animationTypes,
+  });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline title="Browser" />
+      <Axis position="left" grid title="Downloads" />
+      <Bar {...args} />
+      <Legend title="Operating system" />
+    </Chart>
+  );
+};
+
+/** Popover selection — clicking a bar selects it (the `popoverMatch` rule) and keeps it emphasized per-bar, not per-series. */
+const StackedPopoverSelectionStory: StoryFn<HoverAnimationArgs> = ({
+  animations,
+  animationTypes,
+  ...args
+}): ReactElement => {
+  const chartProps = useChartProps({ data: barSeriesData, colors, width: 800, height: 600, animations, animationTypes });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="bottom" baseline title="Browser" />
+      <Axis position="left" grid title="Downloads" />
+      <Bar {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+        <ChartPopover width={200}>{dialogContent}</ChartPopover>
+      </Bar>
+      <Legend title="Operating system" />
+    </Chart>
+  );
+};
+
+/** Trellis variant — the same browser+operatingSystem bar can repeat across trellis panels, so the composite identity must include the trellis facet or animation would collide across panels. */
+const TrellisPointHoverStory: StoryFn<HoverAnimationArgs> = ({ animations, animationTypes, ...args }): ReactElement => {
+  const chartProps = useChartProps({
+    data: generateMockDataForTrellis({
+      property1: ['All users', 'Roku', 'Chromecast'],
+      property2: ['A. Sign up', 'B. Watch a video'],
+      property3: ['1-5 times', '6-10 times', '11-15 times'],
+      propertyNames: ['segment', 'event', 'bucket'],
+      randomizeSteps: false,
+      orderBy: 'bucket',
+    }),
+    width: 800,
+    height: 800,
+    animations,
+    animationTypes,
+  });
+  return (
+    <Chart {...chartProps}>
+      <Axis position="left" title="Users, Count" grid />
+      <Axis position="bottom" title="Platform" baseline />
+      <Bar {...args}>
+        <ChartInspect>{dialogContent}</ChartInspect>
+      </Bar>
+      <Legend />
+    </Chart>
+  );
+};
+
+export const StackedPointHover = bindWithProps(PointHoverStory);
+StackedPointHover.args = { ...defaultArgs };
+
+export const StackedDimensionHover = bindWithProps(StackedDimensionHoverStory);
+StackedDimensionHover.args = { ...defaultArgs };
+
+export const StackedLegendHover = bindWithProps(LegendHoverStory);
+StackedLegendHover.args = { ...defaultArgs };
+
+export const StackedControlledHighlight = bindWithProps(StackedControlledHighlightStory);
+StackedControlledHighlight.args = { ...defaultArgs };
+
+export const StackedPopoverSelection = bindWithProps(StackedPopoverSelectionStory);
+StackedPopoverSelection.args = { ...defaultArgs };
+
+const dodgedStackedArgs: BarProps = {
+  type: 'dodged',
+  dimension: 'browser',
+  color: ['operatingSystem', 'version'],
+};
+
+export const DodgedStackedPointHover = bindWithProps(DualFacetPointHoverStory);
+DodgedStackedPointHover.args = { ...dodgedStackedArgs };
+
+export const DodgedStackedLegendHover = bindWithProps(DualFacetLegendHoverStory);
+DodgedStackedLegendHover.args = { ...dodgedStackedArgs };
+
+export const TrellisPointHover = bindWithProps(TrellisPointHoverStory);
+TrellisPointHover.args = {
+  type: 'stacked',
+  dimension: 'segment',
+  color: 'bucket',
+  order: 'order',
+  trellis: 'event',
+  trellisOrientation: 'horizontal',
+};

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarHoverAnimation.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/BarHoverAnimation.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { DIMENSION_HOVER_AREA, FADE_FACTOR } from '@spectrum-charts/constants';
+
+import {
+  allElementsHaveAttributeValue,
+  clickNthElement,
+  findAllMarksByGroupName,
+  findChart,
+  getAllLegendEntries,
+  getAllLegendSymbols,
+  hoverNthElement,
+  render,
+  screen,
+} from '../../../test-utils';
+import '../../../test-utils/__mocks__/matchMedia.mock.js';
+import {
+  DodgedStackedLegendHover,
+  DodgedStackedPointHover,
+  StackedControlledHighlight,
+  StackedDimensionHover,
+  StackedLegendHover,
+  StackedPointHover,
+  StackedPopoverSelection,
+  TrellisPointHover,
+} from './BarHoverAnimation.story';
+
+// `animations={false}` restores the original instant, synchronous highlighting for every trigger.
+describe('animations={false}', () => {
+  test('direct item hover fades every other bar instantly', async () => {
+    render(<StackedPointHover {...StackedPointHover.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    await hoverNthElement(bars, 4);
+    expect(bars[4]).toHaveAttribute('opacity', '1');
+    expect(allElementsHaveAttributeValue(bars.filter((_, i) => i !== 4), 'opacity', FADE_FACTOR)).toBeTruthy();
+  });
+
+  test('dimension-hover-area hover fades every other dimension value instantly', async () => {
+    render(<StackedDimensionHover {...StackedDimensionHover.args} animations={false} />);
+    const chart = await findChart();
+    const dimensionAreas = await findAllMarksByGroupName(chart, `bar0_${DIMENSION_HOVER_AREA}`);
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    await hoverNthElement(dimensionAreas, 0);
+    const inspect = await screen.findByTestId('rsc-tooltip');
+    expect(inspect).toBeInTheDocument();
+    // every bar at the hovered dimension value stays opaque; every other bar fades
+    const opacities = bars.map((bar) => bar.getAttribute('opacity'));
+    expect(opacities).toContain('1');
+    expect(opacities).toContain(`${FADE_FACTOR}`);
+  });
+
+  test('legend hover fades every bar of the non-hovered series instantly', async () => {
+    render(<StackedLegendHover {...StackedLegendHover.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    const legendSymbols = getAllLegendSymbols(chart);
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    const legendEntries = getAllLegendEntries(chart);
+    await hoverNthElement(legendEntries, 0);
+
+    expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
+    expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+  });
+
+  test('a controlled highlightedSeries fades every bar of every other series instantly', async () => {
+    render(<StackedControlledHighlight {...StackedControlledHighlight.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+
+    const opacities = bars.map((bar) => bar.getAttribute('opacity'));
+    expect(opacities).toContain('1');
+    expect(opacities).toContain(`${FADE_FACTOR}`);
+  });
+
+  test('popover selection fades every other bar instantly', async () => {
+    render(<StackedPopoverSelection {...StackedPopoverSelection.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    await clickNthElement(bars, 4);
+    expect(await screen.findByTestId('rsc-popover')).toBeInTheDocument();
+    expect(bars[4]).toHaveAttribute('opacity', '1');
+    expect(allElementsHaveAttributeValue(bars.filter((_, i) => i !== 4), 'opacity', FADE_FACTOR)).toBeTruthy();
+  });
+
+  test('dodged-and-stacked (dual-facet) point hover keeps two segments sharing a dimension + primary facet independent', async () => {
+    render(<DodgedStackedPointHover {...DodgedStackedPointHover.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    await hoverNthElement(bars, 0);
+    expect(bars[0]).toHaveAttribute('opacity', '1');
+    expect(allElementsHaveAttributeValue(bars.filter((_, i) => i !== 0), 'opacity', FADE_FACTOR)).toBeTruthy();
+  });
+
+  test('dodged-and-stacked (dual-facet) legend hover aggregates correctly across the secondary facet', async () => {
+    render(<DodgedStackedLegendHover {...DodgedStackedLegendHover.args} animations={false} />);
+    const chart = await findChart();
+    const legendEntries = getAllLegendEntries(chart);
+    const legendSymbols = getAllLegendSymbols(chart);
+    expect(allElementsHaveAttributeValue(legendSymbols, 'opacity', 1)).toBeTruthy();
+
+    await hoverNthElement(legendEntries, 0);
+    expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
+    expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+  });
+
+  test('trellis point hover keeps identity unique across repeated trellis panels', async () => {
+    render(<TrellisPointHover {...TrellisPointHover.args} animations={false} />);
+    const chart = await findChart();
+    const bars = await findAllMarksByGroupName(chart, 'bar0');
+    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+
+    await hoverNthElement(bars, 0);
+    expect(bars[0]).toHaveAttribute('opacity', '1');
+    // at least one bar (in a different trellis panel or dimension value) fades independently
+    expect(bars.some((bar) => bar.getAttribute('opacity') === `${FADE_FACTOR}`)).toBe(true);
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/DodgedBar.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/DodgedBar.test.tsx
@@ -18,6 +18,8 @@ import {
   render,
   screen,
   unhoverNthElement,
+  waitFor,
+  waitForMarksByGroupName,
   within,
 } from '../../../test-utils';
 import { InspectOnDimensionArea } from './DodgedBar.story';
@@ -37,18 +39,25 @@ describe('InspectOnDimensionArea', () => {
     const inspect = await screen.findByTestId('rsc-tooltip');
     expect(inspect).toBeInTheDocument();
     expect(within(inspect).getByText('Chrome Downloads')).toBeInTheDocument();
-    expect(bars[0]).toHaveAttribute('opacity', `1`);
-    expect(bars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    // opacity is now animated, so it settles asynchronously -- hence waitForMarksByGroupName/waitFor
+    await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+      expect(updatedBars[0]).toHaveAttribute('opacity', `1`);
+      expect(updatedBars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
 
     await unhoverNthElement(dimensionAreas, 0);
 
     // hovering bar should do normal stuff
     await hoverNthElement(bars, 4);
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[4]).toHaveAttribute('opacity', `1`);
+    await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+      expect(updatedBars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(updatedBars[4]).toHaveAttribute('opacity', `1`);
+    });
 
-    expect(legendSymbols[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
-    expect(legendSymbols[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    await waitFor(() => {
+      expect(legendSymbols[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
+      expect(legendSymbols[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
   });
 });

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.test.tsx
@@ -18,6 +18,7 @@ import {
   render,
   screen,
   unhoverNthElement,
+  waitForMarksByGroupName,
   within,
 } from '../../../test-utils';
 import { InspectOnDimensionArea } from './StackedBar.story';
@@ -36,14 +37,19 @@ describe('InspectOnDimensionArea', () => {
     const inspect = await screen.findByTestId('rsc-tooltip');
     expect(inspect).toBeInTheDocument();
     expect(within(inspect).getByText('Chrome Downloads')).toBeInTheDocument();
-    expect(bars[0]).toHaveAttribute('opacity', `1`);
-    expect(bars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    // opacity is now animated, so it settles asynchronously -- hence waitForMarksByGroupName
+    await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+      expect(updatedBars[0]).toHaveAttribute('opacity', `1`);
+      expect(updatedBars[4]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
 
     await unhoverNthElement(dimensionAreas, 0);
 
     // hovering bar should do normal stuff
     await hoverNthElement(bars, 4);
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[4]).toHaveAttribute('opacity', `1`);
+    await waitForMarksByGroupName(chart, 'bar0', (updatedBars) => {
+      expect(updatedBars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(updatedBars[4]).toHaveAttribute('opacity', `1`);
+    });
   });
 });

--- a/packages/react-spectrum-charts-s2/src/stories/components/ChartInspect/ChartInspect.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/ChartInspect/ChartInspect.test.tsx
@@ -22,6 +22,7 @@ import {
   render,
   screen,
   unhoverNthElement,
+  waitFor,
   within,
 } from '../../../test-utils';
 import '../../../test-utils/__mocks__/matchMedia.mock.js';
@@ -44,10 +45,11 @@ describe('ChartInspect', () => {
     const inspect = await screen.findByTestId('rsc-tooltip');
     expect(inspect).toBeInTheDocument();
     expect(within(inspect).getByText('Operating system: Windows')).toBeInTheDocument();
-    expect(bars[1].getAttribute('opacity')).toEqual(`${FADE_FACTOR}`);
+    // opacity is now animated, so it settles asynchronously -- hence waitFor
+    await waitFor(() => expect(bars[1].getAttribute('opacity')).toEqual(`${FADE_FACTOR}`));
 
     await unhoverNthElement(bars, 0);
-    expect(bars[1].getAttribute('opacity')).toEqual('1');
+    await waitFor(() => expect(bars[1].getAttribute('opacity')).toEqual('1'));
   });
 
   test('Line renders properly and hover works as expected', async () => {
@@ -87,10 +89,13 @@ describe('ChartInspect', () => {
     expect(within(inspect).getByText('Browser: Firefox')).toBeInTheDocument();
     expect(within(inspect).getByText('Users: 3')).toBeInTheDocument();
 
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[4]).toHaveAttribute('opacity', '1');
+    // opacity is now animated, so it settles asynchronously -- hence waitFor
+    await waitFor(() => {
+      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[4]).toHaveAttribute('opacity', '1');
+    });
 
     await unhoverNthElement(bars, 4);
-    expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy();
+    await waitFor(() => expect(allElementsHaveAttributeValue(bars, 'opacity', 1)).toBeTruthy());
   });
 });

--- a/packages/react-spectrum-charts-s2/src/stories/components/ChartPopover/ChartPopover.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/ChartPopover/ChartPopover.test.tsx
@@ -114,8 +114,8 @@ describe('ChartPopover', () => {
     expect(bars[0]).toHaveAttribute('opacity', '1');
     expect(bars[0]).toHaveAttribute('stroke', spectrum2Colors.light['static-blue']);
     expect(bars[0]).toHaveAttribute('stroke-width', '2');
-    // all other bars should be faded
-    expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    // all other bars should be faded -- opacity is now animated, so it settles asynchronously
+    await waitFor(() => expect(allElementsHaveAttributeValue(bars.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy());
   });
 
   test('Popover should be corrrect size', async () => {
@@ -320,9 +320,11 @@ describe('ChartPopover', () => {
 
     bars = getAllMarksByGroupName(chart, 'bar0');
 
-    // validate the highlight visuals are present
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[4]).toHaveAttribute('opacity', '1');
+    // validate the highlight visuals are present -- opacity is now animated, so it settles asynchronously
+    await waitFor(() => {
+      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[4]).toHaveAttribute('opacity', '1');
+    });
     expect(bars[4]).toHaveAttribute('stroke', spectrum2Colors.light['static-blue']);
     expect(bars[4]).toHaveAttribute('stroke-width', '2');
   });
@@ -346,9 +348,11 @@ describe('ChartPopover', () => {
 
     bars = getAllMarksByGroupName(chart, 'bar0');
 
-    // validate the highlight visuals are present
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[4]).toHaveAttribute('opacity', '1');
+    // validate the highlight visuals are present -- opacity is now animated, so it settles asynchronously
+    await waitFor(() => {
+      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[4]).toHaveAttribute('opacity', '1');
+    });
 
     const selectionRingMarks = getAllMarksByGroupName(chart, 'bar0_selectionRing');
 

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendHideShow.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendHideShow.test.tsx
@@ -22,6 +22,7 @@ import {
   render,
   rightClickNthElement,
   screen,
+  waitFor,
 } from '../../../test-utils';
 import '../../../test-utils/__mocks__/matchMedia.mock';
 import { DefaultHiddenSeries, HiddenSeries, IsToggleable } from './LegendHideShow.story';
@@ -117,12 +118,13 @@ test('Hidden series should not highlight any marks', async () => {
   // hovering the second entry should lower the opacity of the first series
   await hoverNthElement(entries, 1);
   let bars = await findAllMarksByGroupName(chart, 'bar0');
-  expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+  // opacity is now animated, so it settles asynchronously -- hence waitFor
+  await waitFor(() => expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`));
 
   // hovering the third entry should not adjust the opcity of any of the bars since it is a hidden series
   await hoverNthElement(entries, 2);
   bars = await findAllMarksByGroupName(chart, 'bar0');
-  expect(bars[0]).toHaveAttribute('opacity', '1');
+  await waitFor(() => expect(bars[0]).toHaveAttribute('opacity', '1'));
 });
 
 test('Right clicking on a legend entry should not hide the series or trigger onClick', async () => {

--- a/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendHighlight.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Legend/LegendHighlight.test.tsx
@@ -19,9 +19,11 @@ import {
   hoverNthElement,
   render,
   screen,
+  waitFor,
 } from '../../../test-utils';
 import { Basic, Controlled } from './LegendHighlight.story';
 
+// opacity is now animated, so it settles asynchronously -- hence waitFor
 describe('Controlled', () => {
   test('non highlighted series bars should have opacity applied', async () => {
     render(<Controlled {...Controlled.args} />);
@@ -29,9 +31,11 @@ describe('Controlled', () => {
 
     const bars = await findAllMarksByGroupName(chart, 'bar0');
     expect(bars.length).toEqual(9);
-    expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[1]).toHaveAttribute('opacity', '1');
-    expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    await waitFor(() => {
+      expect(bars[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[1]).toHaveAttribute('opacity', '1');
+      expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
   });
 
   test('non highlighted series legend symbols should have opacity applied', async () => {
@@ -40,9 +44,11 @@ describe('Controlled', () => {
 
     const legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendSymbols.length).toEqual(3);
-    expect(legendSymbols[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
-    expect(legendSymbols[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    await waitFor(() => {
+      expect(legendSymbols[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(legendSymbols[1]).toHaveAttribute('opacity', '1');
+      expect(legendSymbols[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
   });
 
   test('non highlighted series legend labels should have opacity applied', async () => {
@@ -51,9 +57,11 @@ describe('Controlled', () => {
 
     const legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendLabels.length).toEqual(3);
-    expect(legendLabels[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(legendLabels[1]).toHaveAttribute('opacity', '1');
-    expect(legendLabels[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    await waitFor(() => {
+      expect(legendLabels[0]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(legendLabels[1]).toHaveAttribute('opacity', '1');
+      expect(legendLabels[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
   });
 });
 
@@ -76,9 +84,11 @@ describe('Uncontrolled', () => {
     await hoverNthElement(legendEntries, 0);
 
     bars = await findAllMarksByGroupName(chart, 'bar0');
-    expect(bars[0]).toHaveAttribute('opacity', '1');
-    expect(bars[1]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
-    expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    await waitFor(() => {
+      expect(bars[0]).toHaveAttribute('opacity', '1');
+      expect(bars[1]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+      expect(bars[2]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
   });
 
   test('hovering over legend items adds opacity to the non hovered legend symbols', async () => {
@@ -93,8 +103,10 @@ describe('Uncontrolled', () => {
     await hoverNthElement(legendEntries, 0);
 
     legendSymbols = await findAllMarksByGroupName(chart, 'role-legend-symbol');
-    expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    await waitFor(() => {
+      expect(legendSymbols[0]).toHaveAttribute('opacity', '1');
+      expect(allElementsHaveAttributeValue(legendSymbols.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    });
   });
 
   test('hovering over legend items adds opacity to the non hovered legend labels', async () => {
@@ -110,7 +122,9 @@ describe('Uncontrolled', () => {
 
     legendLabels = await findAllMarksByGroupName(chart, 'role-legend-symbol');
     expect(legendLabels.length).toEqual(3);
-    expect(legendLabels[0]).toHaveAttribute('opacity', '1');
-    expect(allElementsHaveAttributeValue(legendLabels.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    await waitFor(() => {
+      expect(legendLabels[0]).toHaveAttribute('opacity', '1');
+      expect(allElementsHaveAttributeValue(legendLabels.slice(1), 'opacity', FADE_FACTOR)).toBeTruthy();
+    });
   });
 });

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
@@ -72,6 +72,14 @@ const startingSpec = initializeSpec({
   scales: [{ name: COLOR_SCALE, type: 'ordinal' }],
 });
 
+// addInspectSignals() (chartInspectUtils.ts) looks up the chart-level HIGHLIGHTED_GROUP signal by
+// name and expects it to already exist -- normally added by chartSpecBuilder before any mark builder
+// runs, so group-highlighted-by tests need to seed it explicitly since they call addBar() in isolation.
+const startingSpecWithHighlightSignals = initializeSpec({
+  scales: [{ name: COLOR_SCALE, type: 'ordinal' }],
+  signals: defaultSignals,
+});
+
 const defaultMetricScaleDomain: ScaleData = { data: FILTERED_TABLE, fields: ['value1'] };
 const defaultMetricScale: Scale = {
   name: 'yLinear',
@@ -469,7 +477,7 @@ describe('barSpecBuilder', () => {
 
       describe('group-highlighted-by', () => {
         test('highlightBy: "dimension" adds a groupId transform keyed by the dimension and includes it in the hoverTargetData groupby', () => {
-          const spec = addBar(startingSpec, {
+          const spec = addBar(startingSpecWithHighlightSignals, {
             idKey: MARK_ID,
             markType: 'bar',
             chartInspects: [{ highlightBy: 'dimension' }],
@@ -491,7 +499,7 @@ describe('barSpecBuilder', () => {
         });
 
         test('highlightBy: "series" adds a groupId transform keyed by the series id', () => {
-          const spec = addBar(startingSpec, {
+          const spec = addBar(startingSpecWithHighlightSignals, {
             idKey: MARK_ID,
             markType: 'bar',
             chartInspects: [{ highlightBy: 'series' }],
@@ -506,7 +514,7 @@ describe('barSpecBuilder', () => {
         });
 
         test('highlightBy: [fields] adds a groupId transform joining the supplied fields', () => {
-          const spec = addBar(startingSpec, {
+          const spec = addBar(startingSpecWithHighlightSignals, {
             idKey: MARK_ID,
             markType: 'bar',
             chartInspects: [{ highlightBy: ['fieldA', 'fieldB'] }],

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
@@ -12,6 +12,7 @@
 import {
   AggregateTransform,
   Data,
+  FormulaTransform,
   GroupMark,
   Mark,
   RectMark,
@@ -32,6 +33,7 @@ import {
   DEFAULT_SECONDARY_COLOR,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
+  GROUP_ID,
   HOVERED_ITEM,
   LINE_TYPE_SCALE,
   MARK_ID,
@@ -463,6 +465,70 @@ describe('barSpecBuilder', () => {
         );
         expect(ids).toHaveLength(2);
         expect(new Set(ids)).toHaveProperty('size', 2);
+      });
+
+      describe('group-highlighted-by', () => {
+        test('highlightBy: "dimension" adds a groupId transform keyed by the dimension and includes it in the hoverTargetData groupby', () => {
+          const spec = addBar(startingSpec, {
+            idKey: MARK_ID,
+            markType: 'bar',
+            chartInspects: [{ highlightBy: 'dimension' }],
+            animations: true,
+          });
+          const tableData = spec.data?.find((d) => d.name === TABLE);
+          expect(tableData?.transform).toContainEqual({
+            type: 'formula',
+            as: `bar0_${GROUP_ID}`,
+            expr: `datum.${DEFAULT_CATEGORICAL_DIMENSION}`,
+          });
+          const hoverTargetData = spec.data?.find((d) => d.name === 'bar0_hoverTargetData') as
+            | SourceData
+            | undefined;
+          const aggregateTransform = hoverTargetData?.transform?.find(
+            (t): t is AggregateTransform => t.type === 'aggregate'
+          );
+          expect(aggregateTransform?.groupby).toContain(`bar0_${GROUP_ID}`);
+        });
+
+        test('highlightBy: "series" adds a groupId transform keyed by the series id', () => {
+          const spec = addBar(startingSpec, {
+            idKey: MARK_ID,
+            markType: 'bar',
+            chartInspects: [{ highlightBy: 'series' }],
+            animations: true,
+          });
+          const tableData = spec.data?.find((d) => d.name === TABLE);
+          expect(tableData?.transform).toContainEqual({
+            type: 'formula',
+            as: `bar0_${GROUP_ID}`,
+            expr: `datum.${SERIES_ID}`,
+          });
+        });
+
+        test('highlightBy: [fields] adds a groupId transform joining the supplied fields', () => {
+          const spec = addBar(startingSpec, {
+            idKey: MARK_ID,
+            markType: 'bar',
+            chartInspects: [{ highlightBy: ['fieldA', 'fieldB'] }],
+            animations: true,
+          });
+          const tableData = spec.data?.find((d) => d.name === TABLE);
+          const groupIdTransform = tableData?.transform?.find(
+            (t): t is FormulaTransform => 'as' in t && t.as === `bar0_${GROUP_ID}`
+          );
+          expect(groupIdTransform?.expr).toBe('datum.fieldA + " | " + datum.fieldB');
+        });
+
+        test('highlightBy: "item" does not add a groupId transform', () => {
+          const spec = addBar(startingSpec, {
+            idKey: MARK_ID,
+            markType: 'bar',
+            chartInspects: [{ highlightBy: 'item' }],
+            animations: true,
+          });
+          const tableData = spec.data?.find((d) => d.name === TABLE);
+          expect(tableData?.transform?.some((t) => 'as' in t && t.as === `bar0_${GROUP_ID}`)).toBe(false);
+        });
       });
     });
   });

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
@@ -36,6 +36,7 @@ import {
   LINE_TYPE_SCALE,
   MARK_ID,
   OPACITY_SCALE,
+  SERIES_ID,
   STACK_ID,
   TABLE,
 } from '@spectrum-charts/constants';
@@ -338,6 +339,130 @@ describe('barSpecBuilder', () => {
           opacity: 'tier',
         }).usermeta;
         expect(usermeta.divergingBarMarks).toBeUndefined();
+      });
+    });
+
+    describe('isHoverAnimate gate', () => {
+      test('an interactive bar does not animate by default -- animations must be explicitly opted into', () => {
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverTargetData')).toBe(false);
+      });
+
+      test('an interactive bar with animations explicitly true resolves isHoverAnimate true, registers usermeta.animatedMarks, and creates hover-animation data', () => {
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+          animations: true,
+        });
+        expect(spec.usermeta?.animatedMarks).toStrictEqual(['bar0']);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverTargetData')).toBe(true);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverAnimStateData')).toBe(true);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverFractionData')).toBe(true);
+        // series-level aggregate needed so an ungrouped legend can read one fraction per series
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverSeriesFractionData')).toBe(true);
+      });
+
+      test('a non-interactive bar does not animate', () => {
+        const spec = addBar(startingSpec, { idKey: MARK_ID, markType: 'bar' });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverTargetData')).toBe(false);
+      });
+
+      test('an animationTypes list without "hover" disables animation even for an interactive, animations:true bar', () => {
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+          animations: true,
+          animationTypes: [],
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverTargetData')).toBe(false);
+      });
+
+      test('the chart-level animations: false master switch disables animation even for an interactive bar', () => {
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+          animations: false,
+        });
+        expect(spec.usermeta?.animatedMarks ?? []).toStrictEqual([]);
+        expect(spec.data?.some((d) => d.name === 'bar0_hoverTargetData')).toBe(false);
+      });
+
+      test('a chart-level highlightedSeries alone (no other bar interactivity) resolves isHoverAnimate true when animations is opted into', () => {
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          highlightedSeries: 'seriesA',
+          animations: true,
+        });
+        expect(spec.usermeta?.animatedMarks).toStrictEqual(['bar0']);
+      });
+
+      test('computes the composite per-bar identity field from the real data and uses it as the hoverTargetData groupby / hoverAnimStateData keyField', () => {
+        const data = [
+          { [DEFAULT_CATEGORICAL_DIMENSION]: 'A', [DEFAULT_METRIC]: 1 },
+          { [DEFAULT_CATEGORICAL_DIMENSION]: 'B', [DEFAULT_METRIC]: 2 },
+        ];
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+          animations: true,
+          data,
+        });
+        const hoverTargetData = spec.data?.find((d) => d.name === 'bar0_hoverTargetData') as
+          | SourceData
+          | undefined;
+        const aggregateTransform = hoverTargetData?.transform?.find(
+          (t): t is AggregateTransform => t.type === 'aggregate'
+        );
+        expect(aggregateTransform?.groupby).toStrictEqual([
+          'bar0_rscBarAnimId',
+          MARK_ID,
+          SERIES_ID,
+          DEFAULT_CATEGORICAL_DIMENSION,
+        ]);
+
+        const hoverAnimStateData = spec.data?.find((d) => d.name === 'bar0_hoverAnimStateData') as
+          | ValuesData
+          | undefined;
+        expect(hoverAnimStateData?.values).toStrictEqual([
+          { bar0_rscBarAnimId: 'A', startTime: 0, startValue: 1, target: 1 },
+          { bar0_rscBarAnimId: 'B', startTime: 0, startValue: 1, target: 1 },
+        ]);
+      });
+
+      test('includes the secondary facet in the composite identity for dodged-and-stacked bars, so segments sharing a dimension + primary-facet value stay unique', () => {
+        // regression: the composite id previously omitted the secondary facet, colliding here
+        const data = [
+          { [DEFAULT_CATEGORICAL_DIMENSION]: 'A', primaryColor: 'X', secondaryColor: 'Y1', [DEFAULT_METRIC]: 1 },
+          { [DEFAULT_CATEGORICAL_DIMENSION]: 'A', primaryColor: 'X', secondaryColor: 'Y2', [DEFAULT_METRIC]: 2 },
+        ];
+        const spec = addBar(startingSpec, {
+          idKey: MARK_ID,
+          markType: 'bar',
+          chartInspects: [{}],
+          animations: true,
+          color: ['primaryColor', 'secondaryColor'],
+          data,
+        });
+        const hoverAnimStateData = spec.data?.find((d) => d.name === 'bar0_hoverAnimStateData') as
+          | ValuesData
+          | undefined;
+        const ids = (hoverAnimStateData?.values as { bar0_rscBarAnimId: string }[] | undefined)?.map(
+          (v) => v.bar0_rscBarAnimId
+        );
+        expect(ids).toHaveLength(2);
+        expect(new Set(ids)).toHaveProperty('size', 2);
       });
     });
   });

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
@@ -13,12 +13,15 @@ import { produce } from 'immer';
 import { BandScale, Data, FormulaTransform, Mark, OrdinalScale, Scale, Signal } from 'vega';
 
 import {
+  AnimationType,
   COLOR_SCALE,
+  DEFAULT_ANIMATION_TYPES,
   DEFAULT_CATEGORICAL_DIMENSION,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_METRIC,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
+  GROUP_ID,
   LAST_RSC_SERIES_ID,
   LINE_TYPE_SCALE,
   OPACITY_SCALE,
@@ -31,8 +34,22 @@ import {
 import { toCamelCase } from '@spectrum-charts/utils';
 
 import { addPopoverData, getPopovers } from '../chartPopover/chartPopoverUtils';
-import { addInspectData, addInspectSignals } from '../chartInspect/chartInspectUtils';
+import {
+  addInspectData,
+  addInspectSignals,
+  getGroupIdTransform,
+  getInspects,
+  isHighlightedByGroup,
+} from '../chartInspect/chartInspectUtils';
 import { addTimeTransform, getTableData, getTransformSort } from '../data/dataUtils';
+import {
+  addHoverAnimLastChangeData,
+  addHoverAnimationSignals,
+  getHoverAnimStateData,
+  getHoverFractionData,
+  getHoverSeriesFractionData,
+  getHoverTargetData,
+} from '../marks/hoverAnimationUtils';
 import { getInteractiveMarkName, isInteractive } from '../marks/markUtils';
 import {
   addDomainFields,
@@ -50,11 +67,13 @@ import {
   getGenericValueSignal,
   getLastRscSeriesIdSignal,
 } from '../signal/signalSpecBuilder';
-import { addUserMetaDivergingBarMark, addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
+import { addUserMetaAnimatedMark, addUserMetaDivergingBarMark, addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
 import { getBarDirectLabelMarks, getBarDirectLabelSpecOptions } from '../barDirectLabel/barDirectLabelUtils';
 import { addTrendlineData, getTrendlineMarks, setTrendlineSignals } from '../trendline';
-import { BarOptions, BarSpecOptions, ColorScheme, HighlightedItem, ScSpec } from '../types';
+import { BarOptions, BarSpecOptions, ChartData, ColorScheme, HighlightedItem, ScSpec } from '../types';
 import {
+  getBarAnimIdField,
+  getBarHoverRules,
   getBarPadding,
   getBaseScaleName,
   getDimensionSelectionRing,
@@ -71,23 +90,31 @@ export const addBar = produce<
   ScSpec,
   [
     BarOptions & {
+      animations?: boolean;
+      animationTypes?: AnimationType[];
       colorScheme?: ColorScheme;
+      data?: ChartData[];
       highlightedItem?: HighlightedItem;
+      highlightedSeries?: string | number;
       index?: number;
       idKey: string;
       comboSiblingNames?: string[];
+      legendHighlightSignals?: string[];
     }
   ]
 >(
   (
     spec,
     {
+      animations,
+      animationTypes,
       barAnnotations = [],
       barDirectLabels = [],
       chartPopovers = [],
       chartInspects = [],
       color = { value: 'categorical-100' },
       colorScheme = DEFAULT_COLOR_SCHEME,
+      data,
       dimension = DEFAULT_CATEGORICAL_DIMENSION,
       diverging = false,
       dualMetricAxis = false,
@@ -110,10 +137,14 @@ export const addBar = produce<
     }
   ) => {
     const barName = toCamelCase(name || `bar${index}`);
+    const { facets, secondaryFacets } = getFacetsFromOptions({ color, lineType, opacity });
+    // both facets matter for per-bar uniqueness (e.g. dodged-and-stacked bars), unlike getStackFields
+    const barIds = getUniqueBarIds(data, dimension, [...facets, ...secondaryFacets], options.trellis);
     // put options back together now that all defaults are set
     const barOptions: BarSpecOptions = {
       barAnnotations,
       barDirectLabels,
+      barIds,
       chartPopovers,
       chartInspects,
       dimensionScaleType: 'band',
@@ -137,12 +168,15 @@ export const addBar = produce<
       name: barName,
       opacity,
       paddingRatio,
+      popoverMarkName: chartPopovers.length ? barName : undefined,
       trellisOrientation,
       trellisPadding,
       trendlines,
       type,
       ...options,
     };
+    barOptions.isHighlightedByGroup = isHighlightedByGroup(barOptions);
+    barOptions.isHoverAnimate = usesBarHoverAnimation(animations, animationTypes, barOptions);
 
     spec.usermeta = {
       ...spec.usermeta,
@@ -155,9 +189,12 @@ export const addBar = produce<
       barOptions.interactiveMarkName,
       isInteractive(barOptions) ? barOptions.dimension : undefined
     );
+    if (barOptions.isHoverAnimate) {
+      spec.usermeta = addUserMetaAnimatedMark(spec.usermeta, barName);
+    }
 
     // diverging is single-series only: dodged and faceted (multi-row-per-category) bars have no well-defined sign
-    const hasSeriesFacet = getFacetsFromOptions({ color, lineType, opacity }).facets.length > 0;
+    const hasSeriesFacet = facets.length > 0;
     if (diverging && type !== 'dodged' && !hasSeriesFacet) {
       spec.usermeta = addUserMetaDivergingBarMark(
         spec.usermeta,
@@ -174,12 +211,42 @@ export const addBar = produce<
   }
 );
 
+/**
+ * Whether the bar participates in the hover-animation system. Unlike line's `usesHoverAnimation`
+ * (opt-out via `animations === false`), bar requires an explicit `animations={true}` -- bar's
+ * animated path is new and not yet the default experience, so it must be opted into per chart.
+ */
+const usesBarHoverAnimation = (
+  animations: boolean | undefined,
+  animationTypes: AnimationType[] | undefined,
+  options: BarSpecOptions
+): boolean =>
+  animations === true &&
+  (animationTypes ?? DEFAULT_ANIMATION_TYPES).includes('hover') &&
+  (isInteractive(options) ||
+    options.highlightedItem !== undefined ||
+    options.highlightedSeries !== undefined ||
+    (options.legendHighlightSignals?.length ?? 0) > 0);
+
+/** Unique composite hover-animation identity per rendered bar, computed from the real data (see `BarSpecOptions.barIds`). */
+const getUniqueBarIds = (
+  data: ChartData[] | undefined,
+  dimension: string,
+  facets: string[],
+  trellis?: string
+): string[] => {
+  if (!data?.length) return [];
+  const fields = [...(trellis ? [trellis] : []), dimension, ...facets];
+  return [...new Set(data.map((row) => fields.map((f) => (row as Record<string, unknown>)[f]).join(' | ')))];
+};
+
 export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options) => {
   const {
     barAnnotations,
     chartInspects,
     chartPopovers,
     hasOnClick,
+    isHoverAnimate,
     name,
     paddingRatio,
     paddingOuter: barPaddingOuter,
@@ -191,6 +258,10 @@ export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options)
 
   if (isDualMetricAxis(options)) {
     signals.push(getFirstRscSeriesIdSignal(), getLastRscSeriesIdSignal());
+  }
+
+  if (isHoverAnimate) {
+    addHoverAnimationSignals(signals, name);
   }
 
   if (!barAnnotations.length && !chartPopovers.length && !chartInspects.length && !trendlines.length && !hasOnClick) {
@@ -216,6 +287,8 @@ export const addData = produce<Data[], [BarSpecOptions]>((data, options) => {
     tableData.transform = addTimeTransform(tableData.transform ?? [], dimension);
   }
 
+  addBarHoverData(data, options);
+
   const index = data.findIndex((d) => d.name === FILTERED_TABLE);
   data[index].transform = data[index].transform ?? [];
   if (type === 'stacked' || isDodgedAndStacked(options)) {
@@ -240,6 +313,52 @@ export const addData = produce<Data[], [BarSpecOptions]>((data, options) => {
   addInspectData(data, options);
   addPopoverData(data, options);
 });
+
+/** Adds the hover-animation engine's data sources for a bar mark (see `marks/hoverAnimationUtils.ts`). */
+const addBarHoverData = (data: Data[], options: BarSpecOptions): void => {
+  const { color, dimension, isHighlightedByGroup: highlightedByGroup, isHoverAnimate, lineType, name, opacity, trellis } = options;
+  if (!isHoverAnimate) return;
+
+  const { facets, secondaryFacets } = getFacetsFromOptions({ color, lineType, opacity });
+  const barAnimIdField = getBarAnimIdField(name);
+  const tableData = getTableData(data);
+  tableData.transform = tableData.transform ?? [];
+  tableData.transform.push({
+    type: 'formula',
+    as: barAnimIdField,
+    expr: [...(trellis ? [trellis] : []), dimension, ...facets, ...secondaryFacets]
+      .map((f) => `datum.${f}`)
+      .join(' + " | " + '),
+  });
+
+  // dimension must be its own groupby field since dimensionHoverMatch compares datum.${dimension} directly
+  const groupby = [barAnimIdField, options.idKey, SERIES_ID, dimension];
+  if (highlightedByGroup) {
+    const groupFields = getGroupHighlightFields(options);
+    if (groupFields) {
+      tableData.transform.push(getGroupIdTransform(groupFields, name));
+      groupby.push(`${name}_${GROUP_ID}`);
+    }
+  }
+
+  data.push(
+    getHoverTargetData({ name, groupby, rules: getBarHoverRules(options) }),
+    getHoverAnimStateData({ name, keys: options.barIds ?? [], keyField: barAnimIdField }),
+    getHoverFractionData(name),
+    getHoverSeriesFractionData(name, barAnimIdField)
+  );
+  addHoverAnimLastChangeData(data, name);
+};
+
+/** Resolves the fields a `ChartInspect`'s `highlightBy` refers to. Mirrors `chartInspectUtils.addInspectData`. */
+const getGroupHighlightFields = (options: BarSpecOptions): string[] | undefined => {
+  const inspect = getInspects(options).find(({ highlightBy }) => highlightBy && highlightBy !== 'item');
+  if (!inspect) return undefined;
+  if (inspect.highlightBy === 'dimension') return [options.dimension];
+  if (inspect.highlightBy === 'series') return [SERIES_ID];
+  if (Array.isArray(inspect.highlightBy)) return inspect.highlightBy;
+  return undefined;
+};
 
 /**
  * data aggregate used to calculate the min and max of the stack

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.test.ts
@@ -14,10 +14,16 @@ import { RectEncodeEntry } from 'vega';
 import {
   BACKGROUND_COLOR,
   COLOR_SCALE,
+  CONTROLLED_HIGHLIGHTED_SERIES,
+  CONTROLLED_HIGHLIGHTED_TABLE,
   DEFAULT_CATEGORICAL_DIMENSION,
   DEFAULT_COLOR,
   DEFAULT_METRIC,
+  DIMENSION_HOVER_AREA,
+  FADE_FACTOR,
   FILTERED_TABLE,
+  GROUP_ID,
+  HOVERED_ITEM,
   LAST_RSC_SERIES_ID,
   MARK_ID,
   PADDING_RATIO,
@@ -38,11 +44,14 @@ import {
   defaultStackedYEncodings,
 } from './barTestUtils';
 import {
+  getBarAnimIdField,
   getBarDimensionAreaPositionEncodings,
   getBarDimensionHoverArea,
   getBarFillEncoding,
+  getBarHoverRules,
   getBarItemSelectionBackdrop,
   getBarItemSelectionRing,
+  getBarOpacity,
   getBarPadding,
   getBaseBarEnterEncodings,
   getBaseScaleName,
@@ -908,5 +917,108 @@ describe('getBarDimensionAreaPositionEncodings()', () => {
       orientation: 'horizontal',
     });
     expect(Object.keys(positionsEncodings)).toEqual(['x', 'x2', 'y', 'height']);
+  });
+});
+
+describe('getBarHoverRules()', () => {
+  test('without interactiveMarkName or popoverMarkName only includes the controlled rules', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, interactiveMarkName: undefined });
+    expect(rules).toStrictEqual([
+      {
+        as: 'controlledTableMatch',
+        expr: `length(data('${CONTROLLED_HIGHLIGHTED_TABLE}')) ? (indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'), '${MARK_ID}'), datum.${MARK_ID}) > -1 ? 1 : 0) : null`,
+      },
+      {
+        as: 'controlledSeriesMatch',
+        expr: `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) ? (${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID} ? 1 : 0) : null`,
+      },
+    ]);
+  });
+
+  test('with interactiveMarkName adds a hoveredMatch rule keyed off the hovered-item signal by idKey', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, interactiveMarkName: 'bar0' });
+    expect(rules[0]).toStrictEqual({
+      as: 'hoveredMatch',
+      expr: `isValid(bar0_${HOVERED_ITEM}) ? (bar0_${HOVERED_ITEM}.${MARK_ID} === datum.${MARK_ID} ? 1 : 0) : null`,
+    });
+  });
+
+  test('with interactiveMarkName and isHighlightedByGroup, hoveredMatch reads the shared highlightedData set instead of the direct hover signal', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, interactiveMarkName: 'bar0', isHighlightedByGroup: true });
+    expect(rules[0]).toStrictEqual({
+      as: 'hoveredMatch',
+      expr: `length(data('bar0_highlightedData')) ? (indexof(pluck(data('bar0_highlightedData'), 'bar0_${GROUP_ID}'), datum.bar0_${GROUP_ID}) !== -1 ? 1 : 0) : null`,
+    });
+  });
+
+  test('when isInteractive, adds a dimensionHoverMatch rule keyed off the dimension-hover-area signal (drives both dimension-area hover and axis-label hover)', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, interactiveMarkName: undefined, chartInspects: [{}] });
+    const dimensionHoverRule = rules.find((r) => r.as === 'dimensionHoverMatch');
+    expect(dimensionHoverRule).toStrictEqual({
+      as: 'dimensionHoverMatch',
+      expr: `isValid(bar0_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}) ? (bar0_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}.${DEFAULT_CATEGORICAL_DIMENSION} === datum.${DEFAULT_CATEGORICAL_DIMENSION} ? 1 : 0) : null`,
+    });
+  });
+
+  test('when not isInteractive, does not add a dimensionHoverMatch rule', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, interactiveMarkName: undefined });
+    expect(rules.find((r) => r.as === 'dimensionHoverMatch')).toBeUndefined();
+  });
+
+  test('with popoverMarkName adds a popoverMatch rule keyed off the selected item', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, popoverMarkName: 'bar0' });
+    const popoverRule = rules.find((r) => r.as === 'popoverMatch');
+    expect(popoverRule).toStrictEqual({
+      as: 'popoverMatch',
+      expr: `isValid(${SELECTED_ITEM}) ? (${SELECTED_ITEM} === datum.${MARK_ID} ? 1 : 0) : null`,
+    });
+  });
+
+  test('with comboSiblingNames adds a comboSiblingMatch rule checking every sibling hovered-item signal', () => {
+    const rules = getBarHoverRules({ ...defaultBarOptions, comboSiblingNames: ['line0'] });
+    const comboRule = rules.find((r) => r.as === 'comboSiblingMatch');
+    expect(comboRule).toStrictEqual({
+      as: 'comboSiblingMatch',
+      expr: `(isValid(line0_${HOVERED_ITEM})) ? 1 : 0`,
+    });
+  });
+
+  test('composes all rules together in order when every condition applies', () => {
+    const rules = getBarHoverRules({
+      ...defaultBarOptions,
+      interactiveMarkName: 'bar0',
+      chartInspects: [{}],
+      popoverMarkName: 'bar0',
+      comboSiblingNames: ['line0'],
+    });
+    expect(rules.map((r) => r.as)).toStrictEqual([
+      'hoveredMatch',
+      'dimensionHoverMatch',
+      'controlledTableMatch',
+      'controlledSeriesMatch',
+      'popoverMatch',
+      'comboSiblingMatch',
+    ]);
+  });
+});
+
+describe('getBarAnimIdField()', () => {
+  test('namespaces the composite hover-animation identity field by mark name', () => {
+    expect(getBarAnimIdField('bar0')).toBe('bar0_rscBarAnimId');
+  });
+});
+
+describe('getBarOpacity()', () => {
+  test('returns the animated deemphasis signal when isHoverAnimate', () => {
+    const opacity = getBarOpacity({ ...defaultBarOptions, isHoverAnimate: true });
+    expect(opacity).toStrictEqual({
+      signal: expect.stringContaining(`${FADE_FACTOR} + (1 - ${FADE_FACTOR}) *`),
+    });
+    expect((opacity as { signal: string }).signal).toContain('bar0_rscBarAnimId');
+  });
+
+  test('falls back to the instant getMarkOpacity rules when not isHoverAnimate', () => {
+    const opacity = getBarOpacity(defaultBarOptions);
+    expect(opacity).toStrictEqual([{ value: 1 }]);
   });
 });

--- a/packages/vega-spec-builder-s2/src/bar/barUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barUtils.ts
@@ -22,8 +22,14 @@ import {
 
 import {
   BACKGROUND_COLOR,
+  BAR_ANIM_ID,
+  CONTROLLED_HIGHLIGHTED_SERIES,
+  CONTROLLED_HIGHLIGHTED_TABLE,
   DIMENSION_HOVER_AREA,
+  FADE_FACTOR,
   FILTERED_TABLE,
+  GROUP_ID,
+  HOVERED_ITEM,
   LAST_RSC_SERIES_ID,
   SELECTED_GROUP,
   SELECTED_ITEM,
@@ -34,6 +40,7 @@ import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { hasInspectWithDimensionAreaTarget } from '../chartInspect/chartInspectUtils';
 import { getPopovers } from '../chartPopover/chartPopoverUtils';
+import { getDeemphasisRamp, getHoverFractionSignal, HoverMatchRule } from '../marks/hoverAnimationUtils';
 import {
   getColorProductionRule,
   getCursor,
@@ -42,11 +49,15 @@ import {
   getStrokeDashProductionRule,
   getInspectEncoding,
   hasPopover,
+  isInteractive,
 } from '../marks/markUtils';
 import { getBandPadding } from '../scale/scaleSpecBuilder';
 import { getLineWidthPixelsFromLineWidth } from '../specUtils';
 import { BarSpecOptions, Orientation } from '../types';
 import { getTrellisProperties, isTrellised } from './trellisedBarUtils';
+
+/** Per-mark-namespaced field name for the composite per-bar hover-animation identity (see `BarSpecOptions.barIds`). */
+export const getBarAnimIdField = (name: string): string => `${name}_${BAR_ANIM_ID}`;
 
 /**
  * checks to see if the bar is faceted in the stacked and dodged dimensions
@@ -298,11 +309,73 @@ export const getBarEnterEncodings = (options: BarSpecOptions): EncodeEntry => ({
 
 export const getBarUpdateEncodings = (options: BarSpecOptions): EncodeEntry => ({
   cursor: getCursor(options.chartPopovers, options.hasOnClick),
-  opacity: getMarkOpacity(options),
+  opacity: getBarOpacity(options),
   stroke: getStroke(options),
   strokeDash: getStrokeDash(options),
   strokeWidth: getStrokeWidth(options),
 });
+
+/** Builds the hover-animation engine's match rules for a bar mark (see `getLineHoverRules` for the line analog). */
+export const getBarHoverRules = (options: BarSpecOptions): HoverMatchRule[] => {
+  const { comboSiblingNames, dimension, idKey, interactiveMarkName, isHighlightedByGroup, name, popoverMarkName } =
+    options;
+  const rules: HoverMatchRule[] = [];
+
+  if (interactiveMarkName) {
+    // group-highlighted-by reads the shared highlightedData set (like line), not the direct hover signal
+    const hoveredGroupExpr = `length(data('${interactiveMarkName}_highlightedData')) ? (indexof(pluck(data('${interactiveMarkName}_highlightedData'), '${name}_${GROUP_ID}'), datum.${name}_${GROUP_ID}) !== -1 ? 1 : 0) : null`;
+    const hoveredItemExpr = `isValid(${interactiveMarkName}_${HOVERED_ITEM}) ? (${interactiveMarkName}_${HOVERED_ITEM}.${idKey} === datum.${idKey} ? 1 : 0) : null`;
+    rules.push({ as: 'hoveredMatch', expr: isHighlightedByGroup ? hoveredGroupExpr : hoveredItemExpr });
+  }
+  if (isInteractive(options)) {
+    // also drives axis-label hover (axisLabelHoverUtils.ts); independent of hoveredMatch
+    const dimensionHoveredItemSignal = `${name}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`;
+    rules.push({
+      as: 'dimensionHoverMatch',
+      expr: `isValid(${dimensionHoveredItemSignal}) ? (${dimensionHoveredItemSignal}.${dimension} === datum.${dimension} ? 1 : 0) : null`,
+    });
+  }
+  rules.push(
+    {
+      as: 'controlledTableMatch',
+      expr: `length(data('${CONTROLLED_HIGHLIGHTED_TABLE}')) ? (indexof(pluck(data('${CONTROLLED_HIGHLIGHTED_TABLE}'), '${idKey}'), datum.${idKey}) > -1 ? 1 : 0) : null`,
+    },
+    {
+      as: 'controlledSeriesMatch',
+      expr: `isValid(${CONTROLLED_HIGHLIGHTED_SERIES}) ? (${CONTROLLED_HIGHLIGHTED_SERIES} === datum.${SERIES_ID} ? 1 : 0) : null`,
+    }
+  );
+  if (popoverMarkName) {
+    // keyed by item, not series like line's popoverMatch
+    rules.push({
+      as: 'popoverMatch',
+      expr: `isValid(${SELECTED_ITEM}) ? (${SELECTED_ITEM} === datum.${idKey} ? 1 : 0) : null`,
+    });
+  }
+  if (comboSiblingNames?.length) {
+    const siblingTest = comboSiblingNames.map((s) => `isValid(${s}_${HOVERED_ITEM})`).join(' || ');
+    rules.push({ as: 'comboSiblingMatch', expr: `(${siblingTest}) ? 1 : 0` });
+  }
+  return rules;
+};
+
+/** Animated deemphasis-opacity signal for a per-item-keyed mark. Mirrors line's `getLineDeemphasisOpacitySignal`. */
+const getBarDeemphasisOpacitySignal = (name: string, keyField: string): ProductionRule<NumericValueRef> => {
+  const ramp = getDeemphasisRamp(getHoverFractionSignal(name, keyField));
+  return { signal: `${FADE_FACTOR} + (1 - ${FADE_FACTOR}) * ${ramp}` };
+};
+
+/**
+ * Bar's opacity encoding: the animated per-bar fraction when hover-animated, else `getMarkOpacity`.
+ * @param options - the bar spec options
+ * @returns ProductionRule<NumericValueRef>
+ */
+export const getBarOpacity = (options: BarSpecOptions): ProductionRule<NumericValueRef> => {
+  if (options.isHoverAnimate) {
+    return getBarDeemphasisOpacitySignal(options.name, getBarAnimIdField(options.name));
+  }
+  return getMarkOpacity(options);
+};
 
 export const getStroke = (options: BarSpecOptions): ProductionRule<ColorValueRef> => {
   const { name, chartPopovers, colorScheme, idKey } = options;

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
@@ -236,6 +236,18 @@ describe('dodgedBarUtils', () => {
         },
       ]);
     });
+    test('uses the animated per-bar opacity signal when isHoverAnimate, instead of the instant opacity rules', () => {
+      const options = { ...defaultDodgedOptions, chartInspects: [{}], isHoverAnimate: true };
+      const marks = getDodgedMarks(options) as Mark[];
+      const group = marks.find((m) => m.type === 'group') as GroupMark;
+      const bar = group.marks?.find((m) => m.name === 'bar0');
+      const opacity = bar?.encode?.update?.opacity as { signal?: string };
+      expect(opacity.signal).toContain('bar0_rscBarAnimId');
+      // background bar has no opacity key at all -- it stays permanently opaque
+      const background = group.marks?.find((m) => m.name === 'bar0_background');
+      expect(background?.encode?.update?.opacity).toBeUndefined();
+    });
+
     test('subseries, should include advanced fill, advanced corner radius, and border strokes,', () => {
       expect(getDodgedMarks({ ...defaultDodgedOptions, color: [DEFAULT_COLOR, DEFAULT_SECONDARY_COLOR] })).toEqual([
         {

--- a/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.test.ts
@@ -86,6 +86,16 @@ describe('stackedBarUtils', () => {
       expect(annotationGroup.marks?.[0].name).toEqual('bar0_annotationText');
       expect(annotationGroup.marks?.[1].name).toEqual('bar0_annotationBackground');
     });
+    test('uses the animated per-bar opacity signal when isHoverAnimate, instead of the instant opacity rules', () => {
+      const marks = getStackedBarMarks({ ...defaultBarOptions, isHoverAnimate: true });
+      const bar = marks.find((m) => m.name === 'bar0');
+      const opacity = bar?.encode?.update?.opacity as { signal?: string };
+      expect(opacity.signal).toContain('bar0_rscBarAnimId');
+      // background bar has no opacity key at all -- it stays permanently opaque
+      const background = marks.find((m) => m.name === 'bar0_background');
+      expect(background?.encode?.update?.opacity).toBeUndefined();
+    });
+
     test('should add dimension hover area marks if has inspect with dimension area target', () => {
       const marks = getStackedBarMarks({
         ...defaultBarOptions,

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -171,7 +171,7 @@ export function buildSpec({
         return addArea(acc, { ...mark, ...specOptions, index: areaCount });
       case 'bar':
         barCount++;
-        return addBar(acc, { ...mark, ...specOptions, index: barCount });
+        return addBar(acc, { ...mark, ...specOptions, index: barCount, data });
       case 'bullet':
         bulletCount++;
         return addBullet(acc, { ...mark, ...specOptions, index: bulletCount });

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.test.ts
@@ -386,6 +386,21 @@ describe('setHoverStrokeWidthForMarks()', () => {
     setHoverStrokeWidthForMarks('legend0', marks, ['category']);
     expect(marks[0].encode.update.strokeWidth[0]).toHaveProperty('test', `isValid(legend0_${HOVERED_SERIES})`);
   });
+
+  test.each(['rect', 'symbol', 'area'])('should not thicken a %s mark on hover -- only line marks do', (type) => {
+    const marks = JSON.parse(JSON.stringify([{ ...markWithStrokeWidth, type }]));
+    setHoverStrokeWidthForMarks('legend0', marks);
+    expect(marks[0].encode.update.strokeWidth).toStrictEqual([DEFAULT_STROKE_WIDTH_RULE]);
+  });
+
+  test.each(['line0Trendline0', 'line0MetricRange0_line', 'line0_highlightOverlayLine'])(
+    'should not thicken a renamed line mark on hover -- %s is not the chart\'s own line',
+    (name) => {
+      const marks = JSON.parse(JSON.stringify([{ ...markWithStrokeWidth, name }]));
+      setHoverStrokeWidthForMarks('legend0', marks);
+      expect(marks[0].encode.update.strokeWidth).toStrictEqual([DEFAULT_STROKE_WIDTH_RULE]);
+    }
+  );
 });
 
 describe('encodingUsesScale()', () => {

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -290,7 +290,7 @@ const isTrendlineOrMetricRangeLineMark = (mark: Mark): boolean =>
 
 /** Determines if a mark is a renamed reuse of `getLineMark` rather than the chart's own primary line mark. */
 const isRenamedLineMark = (mark: Mark): boolean =>
-  isTrendlineOrMetricRangeLineMark(mark) || (Boolean(mark.name) && /_highlightOverlayLine$/.test(mark.name as string));
+  isTrendlineOrMetricRangeLineMark(mark) || Boolean(mark.name?.endsWith('_highlightOverlayLine'));
 
 /**
  * Determines if a mark should receive a legend-hover opacity rule — either because its own

--- a/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendHighlightUtils.ts
@@ -182,13 +182,13 @@ export const setHoverOpacityForMarks = (legendName: string, marks: Mark[], keys?
   });
 };
 
-/**
- * Injects a strokeWidth rule into marks that use the color scale so legend hover thickens the hovered series.
- */
+/** Injects a strokeWidth rule so legend hover thickens the hovered series -- the chart's own line mark only. */
 export const setHoverStrokeWidthForMarks = (legendName: string, marks: Mark[], keys?: string[], controlled = false) => {
   if (!marks.length) return;
   const flatMarks = flattenMarks(marks);
-  const seriesMarks = flatMarks.filter(markUsesSeriesColorScale);
+  const seriesMarks = flatMarks.filter(
+    (mark) => mark.type === 'line' && !isRenamedLineMark(mark) && markUsesSeriesColorScale(mark)
+  );
   seriesMarks.forEach((mark) => {
     if (!mark.encode?.update) return;
     const { update } = mark.encode;
@@ -287,6 +287,10 @@ export const markUsesSeriesColorScale = (mark: Mark): boolean => {
  */
 const isTrendlineOrMetricRangeLineMark = (mark: Mark): boolean =>
   Boolean(mark.name) && /(Trendline\d+|MetricRange\d+_line)$/.test(mark.name as string);
+
+/** Determines if a mark is a renamed reuse of `getLineMark` rather than the chart's own primary line mark. */
+const isRenamedLineMark = (mark: Mark): boolean =>
+  isTrendlineOrMetricRangeLineMark(mark) || (Boolean(mark.name) && /_highlightOverlayLine$/.test(mark.name as string));
 
 /**
  * Determines if a mark should receive a legend-hover opacity rule — either because its own

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.test.ts
@@ -260,8 +260,9 @@ describe('getLegendOpacity()', () => {
     expect(getLegendOpacity(options, { animatedMarks: [] })).toStrictEqual(getOpacityEncoding(options, {}));
   });
 
-  test('builds a per-series animated rule for an ungrouped legend', () => {
-    const fractionData = `data('line0_hoverFractionData')`;
+  test('builds a per-series animated rule for an ungrouped legend, reading the series-aggregated fraction data', () => {
+    // line's fraction data is already one row per series, so this aggregate is a no-op
+    const fractionData = `data('line0_hoverSeriesFractionData')`;
     const fraction = `(${fractionData}[indexof(pluck(${fractionData}, '${SERIES_ID}'), datum.value)] || {fraction: ${FADE_FACTOR}}).fraction`;
     const ramp = getDeemphasisRamp(fraction);
 

--- a/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
+++ b/packages/vega-spec-builder-s2/src/legend/legendUtils.ts
@@ -184,7 +184,9 @@ export const getLegendOpacity = (options: LegendSpecOptions, userMeta: UserMeta)
 
   for (const markName of userMeta.animatedMarks || []) {
     const isGrouped = !!options.keys?.length;
-    const fractionData = isGrouped ? `data('${markName}_hoverGroupFractionData')` : `data('${markName}_hoverFractionData')`;
+    // ungrouped legends always read the series-level aggregate, not a mark's fraction data directly
+    const fractionDataName = isGrouped ? `${markName}_hoverGroupFractionData` : `${markName}_hoverSeriesFractionData`;
+    const fractionData = `data('${fractionDataName}')`;
     const lookupField = isGrouped ? `${options.name}_${GROUP_ID}` : SERIES_ID;
     const seriesLookup = `indexof(pluck(${fractionData}, '${lookupField}'), datum.value)`;
     // default to the neutral emphasis level when a legend entry has no animation row

--- a/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/line/lineSpecBuilder.ts
@@ -51,6 +51,7 @@ import {
   addHoverAnimationSignals,
   getHoverAnimStateData,
   getHoverFractionData,
+  getHoverSeriesFractionData,
   getHoverTargetData,
 } from '../marks/hoverAnimationUtils';
 import { getHoverMarkNames, getInteractiveMarkName, isInteractive } from '../marks/markUtils';
@@ -359,7 +360,8 @@ const addLineHoverData = (data: Data[], options: LineSpecOptions): void => {
     data.push(
       getHoverTargetData({ name, groupby: [SERIES_ID], rules: getLineHoverRules(options) }),
       getHoverAnimStateData({ name, keys: seriesIds ?? [] }),
-      getHoverFractionData(name)
+      getHoverFractionData(name),
+      getHoverSeriesFractionData(name) // no-op for line, already one row per series
     );
     addHoverAnimLastChangeData(data, name);
   }

--- a/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.test.ts
@@ -34,6 +34,7 @@ import {
   getHoverAnimStateData,
   getHoverFractionData,
   getHoverFractionSignal,
+  getHoverSeriesFractionData,
   getHoverTargetData,
 } from './hoverAnimationUtils';
 
@@ -138,6 +139,44 @@ describe('getHoverFractionData()', () => {
           as: 'fraction',
           expr: `lerp([datum.startValue, datum.target], datum.target === datum.startValue ? 1 : clamp((${HOVER_ACTIVE_TIMER} - datum.startTime) / (${ANIMATION_HOVER_SPEED} * abs(datum.target - datum.startValue)), 0, 1))`,
         },
+      ],
+    });
+  });
+});
+
+describe('getHoverSeriesFractionData()', () => {
+  test('defaults to SERIES_ID as the keyField (line: hoverFractionData is already keyed by series, so the lookup is a no-op)', () => {
+    expect(getHoverSeriesFractionData('line0')).toStrictEqual({
+      name: 'line0_hoverSeriesFractionData',
+      source: 'line0_hoverFractionData',
+      transform: [
+        {
+          type: 'lookup',
+          from: 'line0_hoverTargetData',
+          key: SERIES_ID,
+          fields: [SERIES_ID],
+          values: [SERIES_ID],
+          as: [SERIES_ID],
+        },
+        { type: 'aggregate', groupby: [SERIES_ID], fields: ['fraction'], ops: ['max'], as: ['fraction'] },
+      ],
+    });
+  });
+
+  test('looks up SERIES_ID via the mark-specific keyField before aggregating (bar: hoverFractionData is keyed by the composite barAnimId, which carries no SERIES_ID field of its own)', () => {
+    expect(getHoverSeriesFractionData('bar0', 'bar0_rscBarAnimId')).toStrictEqual({
+      name: 'bar0_hoverSeriesFractionData',
+      source: 'bar0_hoverFractionData',
+      transform: [
+        {
+          type: 'lookup',
+          from: 'bar0_hoverTargetData',
+          key: 'bar0_rscBarAnimId',
+          fields: ['bar0_rscBarAnimId'],
+          values: [SERIES_ID],
+          as: [SERIES_ID],
+        },
+        { type: 'aggregate', groupby: [SERIES_ID], fields: ['fraction'], ops: ['max'], as: ['fraction'] },
       ],
     });
   });

--- a/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/hoverAnimationUtils.ts
@@ -21,6 +21,7 @@ import {
   HOVER_FRACTION_DATA,
   HOVER_IDLE_TICKS,
   HOVER_NEUTRAL_TARGET,
+  HOVER_SERIES_FRACTION_DATA,
   HOVER_TARGET_DATA,
   HOVER_TARGETS,
   ANIMATION_TIMER,
@@ -135,6 +136,28 @@ export const getHoverFractionData = (name: string): SourceData => ({
       as: 'fraction',
       expr: `lerp([datum.startValue, datum.target], datum.target === datum.startValue ? 1 : clamp((${HOVER_ACTIVE_TIMER} - datum.startTime) / (${ANIMATION_HOVER_SPEED} * abs(datum.target - datum.startValue)), 0, 1))`,
     },
+  ],
+});
+
+/**
+ * Aggregates a mark's `hoverFractionData` up to one row per series (max fraction) for legend use.
+ * @param name - the name of the mark
+ * @param keyField - the identity field `hoverFractionData` is keyed by (defaults to SERIES_ID)
+ * @returns SourceData - the series-aggregated fraction data
+ */
+export const getHoverSeriesFractionData = (name: string, keyField: string = SERIES_ID): SourceData => ({
+  name: `${name}_${HOVER_SERIES_FRACTION_DATA}`,
+  source: `${name}_${HOVER_FRACTION_DATA}`,
+  transform: [
+    {
+      type: 'lookup',
+      from: `${name}_${HOVER_TARGET_DATA}`,
+      key: keyField,
+      fields: [keyField],
+      values: [SERIES_ID],
+      as: [SERIES_ID],
+    },
+    { type: 'aggregate', groupby: [SERIES_ID], fields: ['fraction'], ops: ['max'], as: ['fraction'] },
   ],
 });
 

--- a/packages/vega-spec-builder-s2/src/types/marks/barSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/barSpec.types.ts
@@ -105,11 +105,18 @@ type BarOptionsWithDefaults =
   | 'type';
 
 export interface BarSpecOptions extends PartiallyRequired<BarOptions, BarOptionsWithDefaults> {
+  /** Unique composite hover-animation identity per rendered bar, computed from the real data (not `rscMarkId`). */
+  barIds?: string[];
   colorScheme: ColorScheme;
   comboSiblingNames?: string[];
   dimensionScaleType: 'band';
   highlightedItem?: HighlightedItem;
+  highlightedSeries?: string | number;
   idKey: string;
   index: number;
   interactiveMarkName: string | undefined;
+  isHighlightedByGroup?: boolean;
+  isHoverAnimate?: boolean;
+  legendHighlightSignals?: string[];
+  popoverMarkName?: string;
 }

--- a/planning/research/hover-animation-system/hover-animation-system.md
+++ b/planning/research/hover-animation-system/hover-animation-system.md
@@ -1,9 +1,9 @@
 # Hover Animation System — Design & Architecture
 
 A reference for rebuilding the hover-animation system (smooth opacity / stroke-width transitions on
-hover) from scratch. Written against the `vega-spec-builder-s2` implementation but the design is
-mark-agnostic and currently wired into line only (see §11) — it's a Vega-signal/data-flow pattern that
-can be reproduced for any mark compiled to a Vega spec.
+hover) from scratch. Written against the `vega-spec-builder-s2` implementation. The design is
+mark-agnostic and is wired into line (per-series identity) and bar (per-item identity, §13) — it's a
+Vega-signal/data-flow pattern that can be reproduced for any mark compiled to a Vega spec.
 
 ---
 
@@ -561,13 +561,16 @@ mark could pass `rscMarkId` (bar) etc. — see §11.
 6. Legend: `animatedMarks` UserMeta registry, `injectLegendHoverIntoData`, `getLegendOpacity`.
 
 **Extending to other marks (e.g. bar):** the engine is reusable. Choose the identity `keyField` = the
-finest independently-animatable unit (series for line; `rscMarkId` for bar). Write mark-specific match
-rules and consumers. For bars, carry both `rscMarkId` (animation identity) and `rscSeriesId`/group in the
-target-data `groupby` so series/legend-level highlights can set the target for all bars of a series.
-Everything downstream of `target` is generic. This isn't optional: `injectLegendHoverIntoData`'s ungrouped
-match expression hard-codes `datum.${SERIES_ID}` (not the mark's own `keyField`) precisely so legend hover
-matches at the series level regardless of animation identity — skip `rscSeriesId` in a new mark's groupby
-and legend-hover injection silently stops matching (no error, nothing highlights).
+finest independently-animatable unit (series for line; a computed composite for bar — see §13, NOT
+`rscMarkId`). Write mark-specific match rules and consumers. Carry both the identity `keyField` and
+`rscSeriesId`/group in the target-data `groupby` so series/legend-level highlights can set the target for
+all items of a series. Everything downstream of `target` is generic. This isn't optional:
+`injectLegendHoverIntoData`'s ungrouped match expression hard-codes `datum.${SERIES_ID}` (not the mark's
+own `keyField`) precisely so legend hover matches at the series level regardless of animation identity —
+skip `rscSeriesId` in a new mark's groupby and legend-hover injection silently stops matching (no error,
+nothing highlights). If the identity is finer than series (bar: many rows per series), an ungrouped
+legend also needs `getHoverSeriesFractionData` (§13) — reading the mark's raw fraction data directly
+would pick one arbitrary row's fraction for the whole series.
 
 **Adding a new animated property:** just add a consumer that maps `getHoverFractionSignal` (via
 `getDeemphasisRamp`, `getEmphasisRamp`, or its own math). No engine change.
@@ -606,4 +609,84 @@ and legend-hover injection silently stops matching (no error, nothing highlights
   behind `if (highlight)`; `getLegendOpacity` wired into `getHoverEncodings` (`legendUtils.ts`), replacing
   `getOpacityEncoding` for labels/symbols. `setHoverOpacityForMarks` no longer clobbers already-animated
   marks' opacity, via the structural `isAnimatedOpacity()` check (§7) rather than a name list.
-- **Other marks** (bar, area, …) don't use the system yet.
+- **Bar (done)** — see §13 for the mark-specific design: composite `barAnimId` identity, the
+  `dimensionHoverMatch` consumer (axis-label/dimension-hover-area), and the `hoverSeriesFractionData`
+  lookup needed for legend integration.
+- **Other marks** (area, …) don't use the system yet.
+
+---
+
+## 13. Bar extension — mark-specific design
+
+Bar reuses the same engine (§3–§4) but everything about *identity* differs from line, because bar
+animates **per rendered bar**, not per series. Key files: `bar/barSpecBuilder.ts` (`addBarHoverData`,
+`usesBarHoverAnimation`, `getUniqueBarIds`), `bar/barUtils.ts` (`getBarHoverRules`, `getBarOpacity`,
+`getBarAnimIdField`), `marks/hoverAnimationUtils.ts` (`getHoverSeriesFractionData`).
+
+**Bar's animation is opt-in, not opt-out, unlike line.** `usesBarHoverAnimation` requires
+`animations === true` exactly. Line's `usesHoverAnimation` uses `animations !== false` (animates by
+default; `animations: false` is the escape hatch) because hover-fade is an established, already-shipped
+part of line's default experience. Bar's extension is newer, so every interactive/highlighted/
+legend-highlighted bar chart still gets the original instant highlight system by default — a consumer
+must explicitly pass `animations={true}` to opt into the animated path. In this codebase only
+`BarHoverAnimation.story.tsx` does this.
+
+**Identity: a computed composite, not `rscMarkId`.** `getHoverAnimStateData`'s `keys` must be a JS-side
+list, computable at spec-build time from the real `data` array (mirrors line's `seriesIds`, via
+`getUniqueSeriesIds`). `rscMarkId` is assigned by Vega's `identifier` transform *at runtime* after
+`view.insert(TABLE, data)` — not something JS can reliably predict ahead of time. Instead, bar computes
+`barAnimId` = `[trellis?, dimension, ...facets, ...secondaryFacets].join(' | ')`, both in JS
+(`getUniqueBarIds`, for `barIds`) and as a matching Vega `formula` transform on `TABLE`
+(`getBarAnimIdField`, in `addBarHoverData`) — the two must byte-match, same as any keyField (§10).
+
+**Both `facets` and `secondaryFacets` are required for uniqueness — this bit us.** `getFacetsFromOptions`
+returns `{facets, secondaryFacets}`; bar's own aggregation helpers (`getStackFields`, used for the
+`stack`/dodge transforms) deliberately only reference *one* of the two depending on `type`, since that
+serves a narrower grouping purpose. The composite identity is different: it must always include *both*,
+because a dodged-and-stacked (dual-facet, e.g. `color: [primary, secondary]`) bar has two independent
+axes of faceting, and two segments can share the same `dimension` + primary-facet value while differing
+only in the secondary facet. Omitting `secondaryFacets` collapses those two distinct bars onto one
+`barAnimId` — corrupting the shared animation-state row for both (wrong highlight targets, and two
+different bars visibly sharing one fade/emphasis state, as if only one of them existed).
+
+**`hoverTargetData`'s groupby carries extra fields purely for match-rule/lookup convenience.** Beyond
+`barAnimId`, it also includes `idKey` (`rscMarkId`) and `dimension` — none of these fan out extra rows
+(each is functionally determined by `barAnimId`, which is already unique), they just make
+`datum.<field>` available to match-rule expressions that need it directly rather than via `barAnimId`
+string-parsing. `dimensionHoverMatch` (below) is why `dimension` must be there explicitly.
+
+**`dimensionHoverMatch` — the axis-label/dimension-hover-area consumer.** Bar has a second, independent
+direct-interaction path beyond per-item hover: hovering the dimension-hover-area rect (the padding
+around a stack/dodge group) or an axis label (`axisLabelHoverUtils.ts`) both write into the same
+`${name}_dimensionHoverArea_hoveredItem` signal (wired in `addSignals`, gated by `isInteractive`).
+`getBarHoverRules` adds a `dimensionHoverMatch` rule reading that signal and comparing
+`datum.${dimension}` — this is *in addition to* the per-item `hoveredMatch` rule, and was missed in the
+first pass of the port (line has no equivalent path), which silently broke axis-label/dimension-area
+highlighting the moment a bar became hover-animated (the *old* instant `getMarkOpacity` path — via
+`addHoverdDimenstionAreaOpacityRules` in `chartInspectUtils.ts` — already had this rule; the animated
+path needs its own copy since it replaces `getMarkOpacity` entirely when `isHoverAnimate`).
+
+**Group-highlighted-by (ChartInspect `highlightBy`) also needs its own consumer path.** Mirrors line's
+`hoveredMatch` group branch exactly: when `isHighlightedByGroup`, the rule reads
+`${interactiveMarkName}_highlightedData`'s length (a data source already keyed by the shared
+`HIGHLIGHTED_GROUP` signal, which can be driven by more than just this mark's own hover) rather than the
+mark's direct per-item hover signal — reading the direct signal instead would miss group-highlight state
+set by anything other than this exact mark's own hover.
+
+**`getHoverSeriesFractionData` needs a lookup for any per-item-keyed mark.** `hoverFractionData`'s rows
+are keyed only by `keyField` — for bar that's `barAnimId`, which carries no `rscSeriesId` field of its
+own (unlike line, whose `keyField` *is* `rscSeriesId`, making the equivalent lookup a no-op). An
+ungrouped legend needs one fraction per series, so `getHoverSeriesFractionData(name, keyField)` first
+does a Vega `lookup` transform (`from: hoverTargetData, key: keyField, values: [SERIES_ID]`) to bring
+`rscSeriesId` onto each `hoverFractionData` row, *then* aggregates (max) by `rscSeriesId`. This lookup
+is only correct if `keyField` (`barAnimId`) is unique per row in `hoverTargetData` — i.e., depends
+directly on the facets/secondaryFacets uniqueness fix above. Get that wrong and the lookup silently
+associates the wrong series with colliding rows instead of just failing loudly.
+
+**Bar's stroke width does not thicken on hover, unlike line.** `setHoverStrokeWidthForMarks`
+(`legendHighlightUtils.ts`) filters to `mark.type === 'line'` — stroke growth is a line-specific visual
+language, so it's an allowlist rather than excluding each mark type that shouldn't grow. Within that
+allowlist, `isRenamedLineMark` further excludes marks that are `type: 'line'` but aren't the chart's own
+primary line — trendline, metric range boundary, and the hover highlight-overlay duplicate — identified
+by name suffix (`Trendline<N>`, `MetricRange<N>_line`, `_highlightOverlayLine`), so those don't thicken
+either unless a future feature explicitly asks for it.


### PR DESCRIPTION
 ## Description

  Extends the S2 hover-animation engine (previously line-only) to bar marks, across all four
  bar variants (simple, dodged, stacked, trellised) and every existing trigger (direct hover,
  axis-label/dimension hover, controlled highlight, popover selection, legend hover). Bar
  animation is opt-in via `animations={true}` — default behavior is unchanged. Also scopes
  legend-hover stroke-width thickening to the chart's own line mark, excluding trendline/metric-
  range/overlay lines.

  ## Related Issue

  <!-- link the tracking issue here -->

  ## Motivation and Context

  Line already animates hover state with a smooth fade instead of an instant show/hide; bar had
  no equivalent.

  ## How Has This Been Tested?

  - New unit tests for the animation gate, composite per-bar identity, and dual-facet regression.
  - New `BarHoverAnimation` story + integration tests covering both animated and
    `animations={false}` paths for every trigger, across all bar variants.
  - Existing Bar/ChartInspect/Legend/Chart/ChartPopover integration tests updated for
    async opacity settling.
  - Full `yarn test` suite passing as of the last full run; a couple of unit tests were touched
    again after that for a follow-up fix (opt-in default) — recommend a fresh `yarn test` before
    merging.
  - Manual verification in Storybook (`yarn storybook:s2`).

  ## Screenshots (if appropriate):

  <!-- add before/after or a short clip of the hover animation if useful -->

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.