### PR TITLE
fix: stable chart ids between client and server render

### DIFF
--- a/packages/react-spectrum-charts-s2/package.json
+++ b/packages/react-spectrum-charts-s2/package.json
@@ -94,7 +94,6 @@
     "d3-format": "^3.1.0",
     "deepmerge": ">= 4.0.0",
     "immer": ">= 9.0.0",
-    "uuid": ">= 9.0.0",
     "vega-embed": ">= 7.1.0",
     "vega-tooltip": ">= 1.1.0"
   },

--- a/packages/react-spectrum-charts-s2/src/Chart.tsx
+++ b/packages/react-spectrum-charts-s2/src/Chart.tsx
@@ -9,9 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FC, Ref, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, Ref, useEffect, useId, useMemo, useRef, useState } from 'react';
 
-import { v4 as uuid } from 'uuid';
 import { View } from 'vega';
 
 import { Provider } from '@react-spectrum/s2';
@@ -57,8 +56,8 @@ export const Chart = ({ ref, ...props }: ChartProps & { ref?: Ref<ChartHandle> }
     ...otherProps
   } = applyChartPropsDefaults(props);
 
-  // uuid is used to make a unique id so there aren't duplicate ids if there is more than one Chart component in the document
-  const chartId = useRef<string>(`rsc-${uuid()}`);
+  // useId is stable across server and client renders; colons are stripped since chartId is used in unescaped CSS id selectors elsewhere
+  const chartId = `rsc-${useId().replace(/:/g, '')}`;
   // The view returned by vega. This is above RscChart so it can be used for downloading and copying to clipboard.
   const chartView = useRef<View | undefined>(undefined);
   const [containerWidth, setContainerWidth] = useState<number>(0);
@@ -117,12 +116,12 @@ export const Chart = ({ ref, ...props }: ChartProps & { ref?: Ref<ChartHandle> }
       colorScheme={colorScheme}
       UNSAFE_style={{ backgroundColor: 'transparent', height: '100%' }}
     >
-      <div ref={containerRef} id={chartId.current} data-testid={dataTestId} className="rsc-container">
+      <div ref={containerRef} id={chartId} data-testid={dataTestId} className="rsc-container">
         <div style={{ backgroundColor: getColorValue(backgroundColor, colorScheme) }}>
           {showPlaceholderContent ? (
             <PlaceholderContent loading={loading} data={data} height={chartHeight} emptyStateText={emptyStateText} />
           ) : (
-            <ChartProvider chartId={chartId.current} chartView={chartView}>
+            <ChartProvider chartId={chartId} chartView={chartView}>
               {chartContent}
             </ChartProvider>
           )}

--- a/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Chart.test.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { createRef } from 'react';
+import { renderToString } from 'react-dom/server';
 
 import { FADE_FACTOR } from '@spectrum-charts/constants';
 import { spectrum2Colors } from '@spectrum-charts/themes';
@@ -17,7 +18,15 @@ import { ChartHandle } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../Chart';
 import { Axis, Bar, ChartInspect, Line } from '../components';
-import { findChart, getAllMarksByGroupName, hoverNthElement, render, screen, waitFor } from '../test-utils';
+import {
+  findChart,
+  getAllMarksByGroupName,
+  getChartContainer,
+  hoverNthElement,
+  render,
+  screen,
+  waitFor,
+} from '../test-utils';
 import '../test-utils/__mocks__/matchMedia.mock.js';
 import { getElement } from '../utils';
 import { BackgroundColor, Basic, Config, Height, HighlightedItem, Locale, TooltipAnchor, Width } from './Chart.story';
@@ -406,6 +415,30 @@ describe('Chart', () => {
       expect(bars[14]).toHaveAttribute('opacity', '1');
       expect(bars[13]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
       expect(bars[15]).toHaveAttribute('opacity', `${FADE_FACTOR}`);
+    });
+  });
+
+  describe('chartId', () => {
+    test('container id is deterministic across separate SSR render passes', () => {
+      // simulates two independent server render passes producing the same tree; a random-id generator would diverge between them
+      const getContainerId = () => {
+        const html = renderToString(<Basic {...Basic.args} />);
+        return html.match(/id="(rsc-[^"]+)"/)?.[1];
+      };
+
+      const firstId = getContainerId();
+      const secondId = getContainerId();
+
+      expect(firstId).toBeDefined();
+      expect(firstId).toBe(secondId);
+    });
+
+    test('container id contains no characters that break unescaped CSS id selectors', async () => {
+      render(<Basic {...Basic.args} />);
+      const chart = await findChart();
+      const id = getChartContainer(chart)?.id;
+
+      expect(id).toMatch(/^[A-Za-z0-9_-]+$/);
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
id mismatch was causing server component rendering to fail. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
