### PR TITLE
fix: horizontal bar accessibility update

### DIFF
--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
@@ -68,6 +68,7 @@ const defaultDodgedStackedEnterEncodings: RectEncodeEntry = {
 
 const defaultBackgroundMark: Mark = {
   name: 'bar0_background',
+  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -83,6 +84,7 @@ const defaultBackgroundMark: Mark = {
 
 const defaultMark: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -105,6 +107,7 @@ const defaultMark: Mark = {
 
 const defaultMarkWithInspect: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: true,
@@ -141,6 +144,7 @@ const defaultMarkWithInspect: Mark = {
 
 const defaultDodgedStackedBackgroundMark: Mark = {
   name: 'bar0_background',
+  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -155,6 +159,7 @@ const defaultDodgedStackedBackgroundMark: Mark = {
 
 const defaultDodgedStackedMark: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
@@ -44,6 +44,7 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         // background bars
         {
           name: `${name}_background`,
+          description: `${name}_background`,
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: false,
@@ -60,6 +61,7 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         // bars
         {
           name,
+          description: name,
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: isInteractive(options),
@@ -76,9 +78,7 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         },
         ...getAnnotationMarks(options, `${name}_facet`, `${name}_position`, `${name}_dodgeGroup`),
         // visible outline drawn on top of the bars so it is never occluded by adjacent marks
-        ...(showItemSelectionRing
-          ? [getBarItemSelectionRing(options, `${name}_facet`, ringDimensionEncodings)]
-          : []),
+        ...(showItemSelectionRing ? [getBarItemSelectionRing(options, `${name}_facet`, ringDimensionEncodings)] : []),
       ],
     },
   ];

--- a/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder/src/bar/dodgedBarUtils.test.ts
@@ -67,6 +67,7 @@ const defaultDodgedStackedEnterEncodings: RectEncodeEntry = {
 
 const defaultBackgroundMark: Mark = {
   name: 'bar0_background',
+  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -82,6 +83,7 @@ const defaultBackgroundMark: Mark = {
 
 const defaultMark: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -104,6 +106,7 @@ const defaultMark: Mark = {
 
 const defaultMarkWithTooltip: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: true,
@@ -136,6 +139,7 @@ const defaultMarkWithTooltip: Mark = {
 
 const defaultDodgedStackedBackgroundMark: Mark = {
   name: 'bar0_background',
+  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -150,6 +154,7 @@ const defaultDodgedStackedBackgroundMark: Mark = {
 
 const defaultDodgedStackedMark: Mark = {
   name: 'bar0',
+  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,

--- a/packages/vega-spec-builder/src/bar/dodgedBarUtils.ts
+++ b/packages/vega-spec-builder/src/bar/dodgedBarUtils.ts
@@ -36,6 +36,7 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         // background bars
         {
           name: `${name}_background`,
+          description: `${name}_background`,
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: false,
@@ -55,6 +56,7 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: isInteractive(options),
+          description: name,
           encode: {
             enter: {
               ...getBaseBarEnterEncodings(options),


### PR DESCRIPTION
## Description

Added description to the dodgedBar background bar and bar marks to fix the accessibility issue, "Ensure <svg> elements with an img, graphics-document or graphics-symbol role have accessible text". I added descriptions similar to the descriptions that are used for the stackedBar background bar and bar marks.

## Related Issue

Create a horizontal bar chart. In the developer tools run the Axe DevTools scan on page. The Axe DevTools show there is a serious issue related to the fact that the bars in the horizontal bart chart need to "Ensure <svg> elements with an img, graphics-document or graphics-symbol role have accessible text"

## Motivation and Context

Improves accessibility

## How Has This Been Tested?

`yarn test` All tests passed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
