### PR TITLE
feat(donut-s2): Direct Labels - base implementation, positioning and scaling 

### DIFF
--- a/llm/skills/s2-donut/donut-chart-tokens/SKILL.md
+++ b/llm/skills/s2-donut/donut-chart-tokens/SKILL.md
@@ -105,14 +105,16 @@ Sizes marked "derived" were computed rather than individually measured. S/L (rel
 | Metric total | `18px` (derived) | `20px` | `22px` | `36px` | `50px` (derived) | `800` | `text-primary` |
 | Metric label | `12px` (derived) | `14px` | `16px` | `20px` | `24px` (derived) | `700` | `text-primary` |
 | Metric delta line | `12px` (derived) | `14px` | `16px` | `20px` | `24px` (derived) | `800` | `sentiment-positive` / `sentiment-negative` |
-| Direct label — segment name | `9px` (derived) | `10.5px` (derived) | `12px` | `15px` (derived) | `18px` (derived) | `400` | `gray-700` |
-| Direct label — value | `12px` (derived) | `14px` (derived) | `16px` | `20px` (derived) | `24px` (derived) | `700` | `gray-700` at rest → segment's own categorical color on hover (see §5) |
+| Direct label — segment name | `7.5px` (derived) | `9px` (derived) | `10.5px` (derived) | `12px` | `15px` (derived) | `400` | `gray-700` |
+| Direct label — value | `10px` (derived) | `12px` (derived) | `14px` (derived) | `16px` | `20px` (derived) | `700` | `gray-700` at rest → segment's own categorical color on hover (see §5) |
 | Advanced label — segment name | same size as Direct label — value | | | | | `400` | `gray-700` |
 | Advanced label — value/% | `13.5px` (derived) | `15.75px` (derived) | `18px` | `22.5px` (derived) | `27px` (derived) | `800` | `gray-800` at rest → segment's own categorical color on hover (see §5) |
 | Advanced label — detail row | `8.25px` (derived) | `9.6px` (derived) | `11px` | `13.75px` (derived) | `16.5px` (derived) | `400` | `gray-700` |
 | Benchmark label — single-line ("Target" only) | `12px` (derived) | `14px` | `16px` | `20px` | `24px` (derived) | `700` | `gray-800` |
 | Benchmark label — two-line, label part | same as Direct label — segment name | | | | | `400` | `gray-700` |
 | Benchmark label — two-line, value part | same size as Direct label — value | | | | | `700` | `gray-800` at rest → segment's own categorical color on hover (see §5) |
+
+**Direct label correction:** the Direct label rows above were originally computed with the generic `×0.875/×1/×1.25`-from-M method described above, which was wrong — confirmed against the actual design tokens, each named tier's Direct label size is one step smaller than that method produced (new tier N = old tier N−1's value; e.g. current M's `12px`/`16px` is the old S value). `XS` is still derived by extending the corrected S→M step one increment further down (`XS = S − (M−S)`).
 
 ---
 

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -246,8 +246,8 @@ export const DEFAULT_HOLE_RATIO = 0.85;
  * S2 donut named size-tier (XS/S/M/L/XL) minimum-diameter cutpoints (the S/M/L/XL tiers' own named
  * diameters - 120/160/200/400), keyed off the donut's outer diameter. A diameter is "sticky" at a
  * tier from that tier's own minimum up to (not including) the next tier's minimum - e.g. a diameter
- * of 121px is S and stays S up to 159px, not just at values nearest 120. Shared by ring width,
- * slice gap, donut summary font sizing, and direct/advanced label font sizing.
+ * of 121px is S and stays S up to 159px, not just at values nearest 120. Shared by every donut
+ * feature that scales by size tier (ring width, slice gap, donut summary, direct/advanced labels).
  */
 export const DONUT_SIZE_TIER_CUTPOINTS = [120, 160, 200, 400];
 /** S2 donut fixed ring (hole) width per named size tier (XS/S/M/L/XL), used only when holeRatio is left at DEFAULT_HOLE_RATIO */
@@ -270,6 +270,23 @@ export const DONUT_SUMMARY_MIN_RADIUS_S2 = 40;
 export const DONUT_SUMMARY_VALUE_FONT_SIZES = [18, 20, 22, 36, 50];
 /** S2 donut summary metric label font size per named size tier (XS/S/M/L/XL) */
 export const DONUT_SUMMARY_LABEL_FONT_SIZES = [12, 14, 16, 20, 24];
+/** S2 donut direct-label segment-name font size per named size tier (XS/S/M/L/XL) */
+export const DONUT_DIRECT_LABEL_NAME_FONT_SIZES = [9, 10.5, 12, 15, 18];
+/** S2 donut direct-label value font size per named size tier (XS/S/M/L/XL) */
+export const DONUT_DIRECT_LABEL_VALUE_FONT_SIZES = [12, 14, 16, 20, 24];
+/** Gap (px) between the ring's outer edge and a direct/advanced label's rendered bounding box */
+export const DONUT_LABEL_RING_GAP = 20;
+/** Font weight for donut direct-label segment name text */
+export const DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT = 400;
+/** Font weight for donut direct-label value text */
+export const DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT = 700;
+/**
+ * Max fraction of the donut's own radius that a direct label's hemisphere-mirrored pull-back offset may use.
+ * Label text width (a handful of px per character) doesn't shrink with the donut, so an uncapped pull-back
+ * can demand disproportionate space at small sizes, triggering runaway autosize 'fit' shrinkage. Bounding
+ * it as a fraction of the current radius keeps the offset proportionate at every size instead of a fixed px cap.
+ */
+export const DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO = 0.6;
 
 // venn constant
 export const DEFAULT_VENN_COLOR = 'sets';

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -271,9 +271,9 @@ export const DONUT_SUMMARY_VALUE_FONT_SIZES = [18, 20, 22, 36, 50];
 /** S2 donut summary metric label font size per named size tier (XS/S/M/L/XL) */
 export const DONUT_SUMMARY_LABEL_FONT_SIZES = [12, 14, 16, 20, 24];
 /** S2 donut direct-label segment-name font size per named size tier (XS/S/M/L/XL) */
-export const DONUT_DIRECT_LABEL_NAME_FONT_SIZES = [9, 10.5, 12, 15, 18];
+export const DONUT_DIRECT_LABEL_NAME_FONT_SIZES = [7.5, 9, 10.5, 12, 15];
 /** S2 donut direct-label value font size per named size tier (XS/S/M/L/XL) */
-export const DONUT_DIRECT_LABEL_VALUE_FONT_SIZES = [12, 14, 16, 20, 24];
+export const DONUT_DIRECT_LABEL_VALUE_FONT_SIZES = [10, 12, 14, 16, 20];
 /** Gap (px) between the ring's outer edge and a direct/advanced label's rendered bounding box */
 export const DONUT_LABEL_RING_GAP = 20;
 /** Font weight for donut direct-label segment name text */

--- a/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement, useState } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { DONUT_SIZE_TIER_CUTPOINTS } from '@spectrum-charts/constants';
+import { ChartData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Chart } from '../../../../Chart';
+import useChartProps from '../../../../hooks/useChartProps';
+import { Donut, SegmentLabel } from '../../../../pre-alpha';
+import { bindWithProps } from '../../../../test-utils';
+import { SegmentLabelProps } from '../../../../types';
+import { basicDonutData, sliveredDonutData } from '../../../components/Donut/data';
+
+export default {
+  title: 'React Spectrum Charts 2/Donut/Features/Direct Label',
+  component: SegmentLabel,
+};
+
+const CHART_SIZE = 400;
+const MAX_WIDTH = DONUT_SIZE_TIER_CUTPOINTS[DONUT_SIZE_TIER_CUTPOINTS.length - 1] + 100;
+const THUMB_HEIGHT = 32;
+
+const HANDLE_STYLES = `
+  .rsc-dl-size-handle {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    border: none;
+    outline: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: ${CHART_SIZE}px;
+    pointer-events: none;
+    z-index: 20;
+  }
+  .rsc-dl-size-handle::-webkit-slider-runnable-track {
+    background: transparent;
+    height: ${CHART_SIZE}px;
+  }
+  .rsc-dl-size-handle::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 8px;
+    height: ${THUMB_HEIGHT}px;
+    border-radius: 4px;
+    background: #999;
+    cursor: ew-resize;
+    pointer-events: all;
+    margin-top: ${(CHART_SIZE - THUMB_HEIGHT) / 2}px;
+  }
+  .rsc-dl-size-handle::-moz-range-track { background: transparent; }
+  .rsc-dl-size-handle::-moz-range-thumb {
+    width: 8px;
+    height: ${THUMB_HEIGHT}px;
+    border-radius: 4px;
+    background: #999;
+    border: none;
+    cursor: ew-resize;
+  }
+`;
+
+const TIER_LABELS = ['XS', 'S', 'M', 'L', 'XL'];
+const THRESHOLDS = DONUT_SIZE_TIER_CUTPOINTS.map((px, i) => ({ px, label: TIER_LABELS[i + 1] }));
+
+const getSizeTier = (diameter: number): string => {
+  const index = DONUT_SIZE_TIER_CUTPOINTS.findIndex((cutpoint) => diameter < cutpoint);
+  return index === -1 ? TIER_LABELS[TIER_LABELS.length - 1] : TIER_LABELS[index];
+};
+
+// drag the slider to see the donut scale across size tiers - ring radius, font sizes, and the
+// hemisphere anchor offset should all stay proportionally correct at every size. Height is fixed
+// larger than the widest slider value so width (via min(width, height)) is always the limiting
+// dimension, matching Line's DirectLabelSizeScaling story pattern.
+const ResponsiveDonut = ({ data, args }: { data: ChartData[]; args: SegmentLabelProps }): ReactElement => {
+  const [width, setWidth] = useState(300);
+  const chartProps = useChartProps({ data });
+  const currentSize = getSizeTier(width);
+
+  return (
+    <div style={{ padding: '16px 0' }}>
+      <style>{HANDLE_STYLES}</style>
+      <div style={{ marginBottom: 8, fontSize: 13, color: '#666' }}>
+        Width: <strong>{Math.round(width)}px</strong> — Size tier: <strong>{currentSize}</strong>
+      </div>
+      <div style={{ position: 'relative', minWidth: MAX_WIDTH }}>
+        {THRESHOLDS.map(({ px, label }) => (
+          <div
+            key={label}
+            style={{
+              position: 'absolute',
+              left: px,
+              top: 0,
+              bottom: 0,
+              width: 1,
+              background: 'rgba(220, 60, 60, 0.6)',
+              zIndex: 10,
+              pointerEvents: 'none',
+            }}
+          >
+            <span
+              style={{
+                position: 'absolute',
+                top: 2,
+                left: 3,
+                fontSize: 10,
+                color: 'rgba(220, 60, 60, 0.9)',
+                whiteSpace: 'nowrap',
+                lineHeight: 1,
+              }}
+            >
+              {label} ({px}px)
+            </span>
+          </div>
+        ))}
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <Chart {...chartProps} width={width} height={CHART_SIZE}>
+            <Donut metric="count" color="browser">
+              <SegmentLabel {...args} />
+            </Donut>
+          </Chart>
+          <input
+            type="range"
+            className="rsc-dl-size-handle"
+            aria-label="Chart width"
+            min={0}
+            max={MAX_WIDTH}
+            value={Math.round(width)}
+            onChange={(e) => setWidth(Math.max(50, Number(e.target.value)))}
+            style={{ width: MAX_WIDTH }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ResponsiveStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => (
+  <ResponsiveDonut data={basicDonutData} args={args} />
+);
+
+// sliveredDonutData has 15 segments (vs. basicDonutData's 7) - a denser stress test for label
+// crowding as the donut shrinks toward the XS/S tiers
+const ManySegmentsResponsiveStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => (
+  <ResponsiveDonut data={sliveredDonutData} args={args} />
+);
+
+const Responsive = bindWithProps(ResponsiveStory);
+Responsive.args = { value: true, valueFormat: 'shortNumber' };
+
+const ManySegmentsResponsive = bindWithProps(ManySegmentsResponsiveStory);
+ManySegmentsResponsive.args = { value: true, valueFormat: 'shortNumber' };
+
+export { Responsive, ManySegmentsResponsive };

--- a/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
@@ -48,7 +48,11 @@ const getEffectiveDiameter = (containerWidth: number): number => {
 const getContainerWidthForDiameter = (diameter: number): number =>
   diameter * (1 + DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO) + 4 + 2 * DONUT_LABEL_RING_GAP;
 
-const MAX_TIER_CUTPOINT = DONUT_SIZE_TIER_CUTPOINTS[DONUT_SIZE_TIER_CUTPOINTS.length - 1];
+const lastCutpoint = DONUT_SIZE_TIER_CUTPOINTS.at(-1);
+if (lastCutpoint === undefined) {
+  throw new Error('DONUT_SIZE_TIER_CUTPOINTS must not be empty');
+}
+const MAX_TIER_CUTPOINT = lastCutpoint;
 // height must be at least as large as the container width needed to reach the XL cutpoint, or
 // min(width, height) caps out at `height` and the donut can never actually reach XL by dragging
 // the width slider alone, no matter how far right the slider goes
@@ -104,7 +108,12 @@ const THRESHOLDS = DONUT_SIZE_TIER_CUTPOINTS.map((cutpoint, i) => ({
 const getSizeTier = (containerWidth: number): string => {
   const diameter = getEffectiveDiameter(containerWidth);
   const index = DONUT_SIZE_TIER_CUTPOINTS.findIndex((cutpoint) => diameter < cutpoint);
-  return index === -1 ? TIER_LABELS[TIER_LABELS.length - 1] : TIER_LABELS[index];
+  if (index !== -1) return TIER_LABELS[index];
+  const lastLabel = TIER_LABELS.at(-1);
+  if (lastLabel === undefined) {
+    throw new Error('TIER_LABELS must not be empty');
+  }
+  return lastLabel;
 };
 
 // drag the slider to see the donut scale across size tiers - ring radius, font sizes, and the

--- a/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx
@@ -13,7 +13,11 @@ import { ReactElement, useState } from 'react';
 
 import { StoryFn } from '@storybook/react';
 
-import { DONUT_SIZE_TIER_CUTPOINTS } from '@spectrum-charts/constants';
+import {
+  DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
+  DONUT_LABEL_RING_GAP,
+  DONUT_SIZE_TIER_CUTPOINTS,
+} from '@spectrum-charts/constants';
 import { ChartData } from '@spectrum-charts/vega-spec-builder-s2';
 
 import { Chart } from '../../../../Chart';
@@ -28,9 +32,28 @@ export default {
   component: SegmentLabel,
 };
 
-const CHART_SIZE = 400;
-const MAX_WIDTH = DONUT_SIZE_TIER_CUTPOINTS[DONUT_SIZE_TIER_CUTPOINTS.length - 1] + 100;
 const THUMB_HEIGHT = 32;
+
+// Mirrors getDonutOuterRadiusExpr's reservation math (donutUtils.ts): since a SegmentLabel is
+// always present here, the donut's actual rendered radius - and therefore its font-size/ring-width
+// size tier - is based on a smaller, label-reserved diameter, not the raw container width.
+const getEffectiveDiameter = (containerWidth: number): number => {
+  const rawRadius = containerWidth / 2 - 2;
+  const reservedRadius = (rawRadius - DONUT_LABEL_RING_GAP) / (1 + DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO);
+  return 2 * reservedRadius;
+};
+
+// Inverse of getEffectiveDiameter - the container width at which the effective (label-reserved)
+// diameter reaches a given tier cutpoint, so breakpoint markers land at the right slider position.
+const getContainerWidthForDiameter = (diameter: number): number =>
+  diameter * (1 + DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO) + 4 + 2 * DONUT_LABEL_RING_GAP;
+
+const MAX_TIER_CUTPOINT = DONUT_SIZE_TIER_CUTPOINTS[DONUT_SIZE_TIER_CUTPOINTS.length - 1];
+// height must be at least as large as the container width needed to reach the XL cutpoint, or
+// min(width, height) caps out at `height` and the donut can never actually reach XL by dragging
+// the width slider alone, no matter how far right the slider goes
+const CHART_SIZE = getContainerWidthForDiameter(MAX_TIER_CUTPOINT) + 50;
+const MAX_WIDTH = CHART_SIZE + 100;
 
 const HANDLE_STYLES = `
   .rsc-dl-size-handle {
@@ -72,9 +95,14 @@ const HANDLE_STYLES = `
 `;
 
 const TIER_LABELS = ['XS', 'S', 'M', 'L', 'XL'];
-const THRESHOLDS = DONUT_SIZE_TIER_CUTPOINTS.map((px, i) => ({ px, label: TIER_LABELS[i + 1] }));
+const THRESHOLDS = DONUT_SIZE_TIER_CUTPOINTS.map((cutpoint, i) => ({
+  px: getContainerWidthForDiameter(cutpoint),
+  label: TIER_LABELS[i + 1],
+  diameter: cutpoint,
+}));
 
-const getSizeTier = (diameter: number): string => {
+const getSizeTier = (containerWidth: number): string => {
+  const diameter = getEffectiveDiameter(containerWidth);
   const index = DONUT_SIZE_TIER_CUTPOINTS.findIndex((cutpoint) => diameter < cutpoint);
   return index === -1 ? TIER_LABELS[TIER_LABELS.length - 1] : TIER_LABELS[index];
 };
@@ -86,16 +114,18 @@ const getSizeTier = (diameter: number): string => {
 const ResponsiveDonut = ({ data, args }: { data: ChartData[]; args: SegmentLabelProps }): ReactElement => {
   const [width, setWidth] = useState(300);
   const chartProps = useChartProps({ data });
+  const outerDiameter = getEffectiveDiameter(width);
   const currentSize = getSizeTier(width);
 
   return (
     <div style={{ padding: '16px 0' }}>
       <style>{HANDLE_STYLES}</style>
       <div style={{ marginBottom: 8, fontSize: 13, color: '#666' }}>
-        Width: <strong>{Math.round(width)}px</strong> — Size tier: <strong>{currentSize}</strong>
+        Container Width: <strong>{Math.round(width)}px</strong> — Outer Diameter:{' '}
+        <strong>{Math.round(outerDiameter)}px</strong> — Size tier: <strong>{currentSize}</strong>
       </div>
       <div style={{ position: 'relative', minWidth: MAX_WIDTH }}>
-        {THRESHOLDS.map(({ px, label }) => (
+        {THRESHOLDS.map(({ px, label, diameter }) => (
           <div
             key={label}
             style={{
@@ -120,7 +150,7 @@ const ResponsiveDonut = ({ data, args }: { data: ChartData[]; args: SegmentLabel
                 lineHeight: 1,
               }}
             >
-              {label} ({px}px)
+              {label} ({diameter}px)
             </span>
           </div>
         ))}

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -42,7 +42,7 @@ import {
   getSliceGapSignal,
   getSumData,
 } from './donutUtils';
-import { getSegmentLabelMarks } from './segmentLabelUtils';
+import { getSegmentLabelMarks, getSegmentLabelScales, getSegmentLabelSignals } from './segmentLabelUtils';
 
 export const addDonut = produce<
   ScSpec,
@@ -164,6 +164,7 @@ export const addScales = produce<Scale[], [DonutSpecOptions]>((scales, options) 
   }
   scales.push(getSliceGapScale(options));
   scales.push(...getDonutSummaryScales(options));
+  scales.push(...getSegmentLabelScales(options));
 });
 
 export const addMarks = produce<Mark[], [DonutSpecOptions]>((marks, options) => {
@@ -182,6 +183,7 @@ export const addSignals = produce<Signal[], [DonutSpecOptions]>((signals, option
   }
   signals.push(getSliceGapSignal(options));
   signals.push(...getDonutSummarySignals(options));
+  signals.push(...getSegmentLabelSignals(options));
   if (!isInteractive(options)) return;
   addHoveredItemSignal(signals, name, undefined, 1, chartInspects[0]?.excludeDataKeys);
 });

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -127,8 +127,7 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
     });
   }
   // used to detect the empty state (no data or all metric values are 0)
-  data.push(getSumData(options));
-  data.push(...getDonutSummaryData(options));
+  data.push(getSumData(options), ...getDonutSummaryData(options));
 });
 
 const getPieTransforms = ({ startAngle, metric, name }: DonutSpecOptions): (FormulaTransform | PieTransform)[] => [
@@ -162,9 +161,7 @@ export const addScales = produce<Scale[], [DonutSpecOptions]>((scales, options) 
   if (holeRatio === DEFAULT_HOLE_RATIO) {
     scales.push(getRingWidthScale(options));
   }
-  scales.push(getSliceGapScale(options));
-  scales.push(...getDonutSummaryScales(options));
-  scales.push(...getSegmentLabelScales(options));
+  scales.push(getSliceGapScale(options), ...getDonutSummaryScales(options), ...getSegmentLabelScales(options));
 });
 
 export const addMarks = produce<Mark[], [DonutSpecOptions]>((marks, options) => {
@@ -181,9 +178,7 @@ export const addSignals = produce<Signal[], [DonutSpecOptions]>((signals, option
   if (holeRatio === DEFAULT_HOLE_RATIO) {
     signals.push(getRingWidthSignal(options));
   }
-  signals.push(getSliceGapSignal(options));
-  signals.push(...getDonutSummarySignals(options));
-  signals.push(...getSegmentLabelSignals(options));
+  signals.push(getSliceGapSignal(options), ...getDonutSummarySignals(options), ...getSegmentLabelSignals(options));
   if (!isInteractive(options)) return;
   addHoveredItemSignal(signals, name, undefined, 1, chartInspects[0]?.excludeDataKeys);
 });

--- a/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
@@ -24,7 +24,6 @@ import {
 } from 'vega';
 
 import {
-  DONUT_RADIUS,
   DONUT_SIZE_TIER_CUTPOINTS,
   DONUT_SUMMARY_LABEL_FONT_SIZES,
   DONUT_SUMMARY_MIN_RADIUS_S2,
@@ -34,7 +33,7 @@ import {
 
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, DonutSummaryOptions, DonutSummarySpecOptions } from '../types';
-import { getDonutInnerRadiusExpr } from './donutUtils';
+import { getDonutInnerRadiusExpr, getDonutOuterRadiusExpr } from './donutUtils';
 
 /**
  * Gets the DonutSummary component from the children if one exists
@@ -129,7 +128,7 @@ export const getDonutSummarySignals = (donutOptions: DonutSpecOptions): Signal[]
     return [];
   }
   const { name } = donutOptions;
-  const donutDiameter = `2 * ${DONUT_RADIUS}`;
+  const donutDiameter = `2 * ${getDonutOuterRadiusExpr(donutOptions)}`;
   return [
     {
       name: `${name}_summaryValueFontSize`,

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
@@ -13,6 +13,8 @@ import { ArcMark, ColorValueRef, ProductionRule, Signal, SourceData, ThresholdSc
 
 import {
   DEFAULT_HOLE_RATIO,
+  DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
+  DONUT_LABEL_RING_GAP,
   DONUT_RADIUS,
   DONUT_RING_WIDTHS,
   DONUT_SIZE_TIER_CUTPOINTS,
@@ -74,6 +76,23 @@ const getArcFillEncoding = ({
 };
 
 /**
+ * Gets the donut's outer radius. When a SegmentLabel with direct labels is present (and the donut
+ * isn't boolean, which never renders them), this reserves room for the label's ring-gap and its
+ * (capped) hemisphere pull-back out of the raw available radius, so the ring and its labels always
+ * fit within the given container in a single deterministic pass - the ring never needs a further
+ * reactive shrink, and the container never needs to grow beyond what's given.
+ * @param donutOptions
+ * @returns vega expression string
+ */
+export const getDonutOuterRadiusExpr = ({ isBoolean, segmentLabels }: DonutSpecOptions): string => {
+  // DONUT_RADIUS is already parenthesized; the reserved branch below self-parenthesizes too, so
+  // callers can interpolate this result directly without adding their own wrapping parens
+  if (!segmentLabels.length || isBoolean) return DONUT_RADIUS;
+  // solve R such that R + ringGap + R*capRatio == DONUT_RADIUS (the worst-case label reach)
+  return `((${DONUT_RADIUS} - ${DONUT_LABEL_RING_GAP}) / (1 + ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO}))`;
+};
+
+/**
  * Gets the threshold scale that snaps a donut's outer diameter to its nearest named size tier's fixed ring width
  * @param donutOptions
  * @returns ThresholdScale
@@ -86,13 +105,14 @@ export const getRingWidthScale = ({ name }: DonutSpecOptions): ThresholdScale =>
 });
 
 /**
- * Gets the signal that resolves a donut's fixed ring width from its outer diameter
+ * Gets the signal that resolves a donut's fixed ring width from its outer diameter (the label-reserved
+ * radius, so the ring width tier stays consistent with the label font-size tier)
  * @param donutOptions
  * @returns Signal
  */
-export const getRingWidthSignal = ({ name }: DonutSpecOptions): Signal => ({
-  name: `${name}_ringWidth`,
-  update: `scale('${name}_ringWidthScale', 2 * ${DONUT_RADIUS})`,
+export const getRingWidthSignal = (options: DonutSpecOptions): Signal => ({
+  name: `${options.name}_ringWidth`,
+  update: `scale('${options.name}_ringWidthScale', 2 * ${getDonutOuterRadiusExpr(options)})`,
 });
 
 /**
@@ -108,23 +128,28 @@ export const getSliceGapScale = ({ name }: DonutSpecOptions): ThresholdScale => 
 });
 
 /**
- * Gets the signal that resolves a donut's fixed segment gap (in px) from its outer diameter
+ * Gets the signal that resolves a donut's fixed segment gap (in px) from its outer diameter (the
+ * label-reserved radius, so the slice gap tier stays consistent with the label font-size tier)
  * @param donutOptions
  * @returns Signal
  */
-export const getSliceGapSignal = ({ name }: DonutSpecOptions): Signal => ({
-  name: `${name}_sliceGap`,
-  update: `scale('${name}_sliceGapScale', 2 * ${DONUT_RADIUS})`,
+export const getSliceGapSignal = (options: DonutSpecOptions): Signal => ({
+  name: `${options.name}_sliceGap`,
+  update: `scale('${options.name}_sliceGapScale', 2 * ${getDonutOuterRadiusExpr(options)})`,
 });
 
 /**
- * Gets the donut's inner radius expression. Uses the fixed per-tier ring width when holeRatio is left at its
- * default, otherwise honors an explicitly customized holeRatio as a proportional ring
+ * Gets the donut's inner radius expression, relative to the label-reserved outer radius. Uses the
+ * fixed per-tier ring width when holeRatio is left at its default, otherwise honors an explicitly
+ * customized holeRatio as a proportional ring.
  * @param donutOptions
  * @returns vega expression string
  */
-export const getDonutInnerRadiusExpr = ({ holeRatio, name }: DonutSpecOptions): string =>
-  holeRatio === DEFAULT_HOLE_RATIO ? `(${DONUT_RADIUS} - ${name}_ringWidth)` : `${holeRatio} * ${DONUT_RADIUS}`;
+export const getDonutInnerRadiusExpr = (options: DonutSpecOptions): string => {
+  const { holeRatio, name } = options;
+  const outerRadius = getDonutOuterRadiusExpr(options);
+  return holeRatio === DEFAULT_HOLE_RATIO ? `(${outerRadius} - ${name}_ringWidth)` : `${holeRatio} * ${outerRadius}`;
+};
 
 /**
  * Gets the arc mark's padAngle - the fixed per-tier px slice gap converted to radians, capped to a
@@ -133,14 +158,17 @@ export const getDonutInnerRadiusExpr = ({ holeRatio, name }: DonutSpecOptions): 
  * @param donutOptions
  * @returns vega expression string
  */
-const getPadAngleExpr = ({ name }: DonutSpecOptions): string => {
-  const fixedGapAngle = `${name}_sliceGap / ${DONUT_RADIUS}`;
+const getPadAngleExpr = (options: DonutSpecOptions): string => {
+  const { name } = options;
+  const outerRadius = getDonutOuterRadiusExpr(options);
+  const fixedGapAngle = `${name}_sliceGap / ${outerRadius}`;
   const segmentAngle = `datum['${name}_arcLength']`;
   return `min(${fixedGapAngle}, ${segmentAngle} * ${DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION})`;
 };
 
 export const getArcMark = (options: DonutSpecOptions): ArcMark => {
   const { chartPopovers, chartInspects, colorScheme, idKey, name } = options;
+  const outerRadius = getDonutOuterRadiusExpr(options);
   return {
     type: 'arc',
     name,
@@ -159,7 +187,7 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
         endAngle: { field: `${name}_endAngle` },
         padAngle: { signal: getPadAngleExpr(options) },
         innerRadius: { signal: getDonutInnerRadiusExpr(options) },
-        outerRadius: { signal: DONUT_RADIUS },
+        outerRadius: { signal: outerRadius },
         // hide the segments when there isn't any data to display, the empty state ring is shown instead
         opacity: [{ test: getDonutEmptyStateTest(name), value: 0 }, ...getMarkOpacity(options)],
         cursor: getCursor(chartPopovers),
@@ -177,6 +205,7 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
  */
 export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
   const { colorScheme, name } = options;
+  const outerRadius = getDonutOuterRadiusExpr(options);
   return {
     type: 'arc',
     name: `${name}_emptyState`,
@@ -192,7 +221,7 @@ export const getEmptyStateArcMark = (options: DonutSpecOptions): ArcMark => {
       },
       update: {
         innerRadius: { signal: getDonutInnerRadiusExpr(options) },
-        outerRadius: { signal: DONUT_RADIUS },
+        outerRadius: { signal: outerRadius },
         opacity: [{ test: getDonutEmptyStateTest(name), value: 1 }, { value: 0 }],
       },
     },

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -9,6 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { TextValueRef } from 'vega';
+
 import { DONUT_DIRECT_LABEL_NAME_FONT_SIZES, DONUT_DIRECT_LABEL_VALUE_FONT_SIZES, DONUT_SIZE_TIER_CUTPOINTS } from '@spectrum-charts/constants';
 
 import { DonutSpecOptions, SegmentLabelSpecOptions } from '../types';
@@ -21,6 +23,7 @@ import {
   getSegmentLabelTextMark,
   getSegmentLabelValueText,
   getSegmentLabelValueTextMark,
+  getTextRuleExpr,
 } from './segmentLabelUtils';
 
 const defaultDonutOptionsWithSegmentLabel: DonutSpecOptions = {
@@ -118,6 +121,45 @@ describe('getSegmentLabelValueText()', () => {
     expect(rules).toHaveLength(1);
     expect(rules?.[0].signal).toContain('_arcPercent');
     expect(rules?.[0].signal).toContain('testMetric');
+  });
+});
+
+describe('getTextRuleExpr()', () => {
+  test('should return an empty string literal for an undefined rule', () => {
+    expect(getTextRuleExpr(undefined)).toBe(`''`);
+  });
+  test('should resolve a signal rule to the signal itself', () => {
+    expect(getTextRuleExpr({ signal: 'testSignal' })).toBe('testSignal');
+  });
+  test('should resolve a field rule to a datum field access', () => {
+    expect(getTextRuleExpr({ field: 'testField' })).toBe(`datum['testField']`);
+  });
+  test('should resolve a value rule to a quoted literal', () => {
+    expect(getTextRuleExpr({ value: 'testValue' })).toBe(`'testValue'`);
+  });
+  test('should fall back to an empty string literal for a rule with none of signal/field/value', () => {
+    // TextValueRef's real shapes always have one of signal/field/value - this exercises the
+    // defensive fallback for a malformed rule that shouldn't occur through valid typed input
+    expect(getTextRuleExpr({} as TextValueRef)).toBe(`''`);
+  });
+  test('should combine conditional rules into a nested ternary, testing in reverse order', () => {
+    const expr = getTextRuleExpr([
+      { test: 'datum.a', signal: 'signalA' },
+      { test: 'datum.b', field: 'fieldB' },
+      { value: 'fallbackValue' },
+    ]);
+    expect(expr).toBe(`datum.a ? (signalA) : (datum.b ? (datum['fieldB']) : ('fallbackValue'))`);
+  });
+  test('should skip the ternary wrapper for a rule with no test condition', () => {
+    const expr = getTextRuleExpr([
+      { test: 'datum.a', signal: 'signalA' },
+      { field: 'untestedField' },
+      { value: 'fallbackValue' },
+    ]);
+    expect(expr).toBe(`datum.a ? (signalA) : (datum['untestedField'])`);
+  });
+  test('should throw on an empty production-rule array', () => {
+    expect(() => getTextRuleExpr([])).toThrow('getTextRuleExpr: empty production rule array');
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -9,11 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { DONUT_DIRECT_LABEL_NAME_FONT_SIZES, DONUT_DIRECT_LABEL_VALUE_FONT_SIZES, DONUT_SIZE_TIER_CUTPOINTS } from '@spectrum-charts/constants';
+
 import { DonutSpecOptions, SegmentLabelSpecOptions } from '../types';
 import { defaultDonutOptions } from './donutTestUtils';
 import { getDonutEmptyStateTest } from './donutUtils';
 import {
   getSegmentLabelMarks,
+  getSegmentLabelScales,
+  getSegmentLabelSignals,
   getSegmentLabelTextMark,
   getSegmentLabelValueText,
   getSegmentLabelValueTextMark,
@@ -117,21 +121,130 @@ describe('getSegmentLabelValueText()', () => {
   });
 });
 
+describe('getSegmentLabelScales()', () => {
+  test('should return empty array if there is not a SegmentLabel on the Donut', () => {
+    expect(getSegmentLabelScales(defaultDonutOptions)).toEqual([]);
+  });
+
+  test('should snap outer diameter to the nearest named tier for name/value font sizes', () => {
+    const scales = getSegmentLabelScales(defaultDonutOptionsWithSegmentLabel);
+    expect(scales).toEqual([
+      {
+        name: 'testName_segmentLabelNameFontSizeScale',
+        type: 'threshold',
+        domain: DONUT_SIZE_TIER_CUTPOINTS,
+        range: DONUT_DIRECT_LABEL_NAME_FONT_SIZES,
+      },
+      {
+        name: 'testName_segmentLabelValueFontSizeScale',
+        type: 'threshold',
+        domain: DONUT_SIZE_TIER_CUTPOINTS,
+        range: DONUT_DIRECT_LABEL_VALUE_FONT_SIZES,
+      },
+    ]);
+  });
+});
+
+describe('getSegmentLabelSignals()', () => {
+  test('should return empty array if there is not a SegmentLabel on the Donut', () => {
+    expect(getSegmentLabelSignals(defaultDonutOptions)).toEqual([]);
+  });
+
+  test('should resolve name/value font sizes from the outer diameter', () => {
+    const signals = getSegmentLabelSignals(defaultDonutOptionsWithSegmentLabel);
+    expect(signals).toEqual([
+      {
+        name: 'testName_segmentLabelNameFontSize',
+        update:
+          "scale('testName_segmentLabelNameFontSizeScale', 2 * (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)))",
+      },
+      {
+        name: 'testName_segmentLabelValueFontSize',
+        update:
+          "scale('testName_segmentLabelValueFontSizeScale', 2 * (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)))",
+      },
+    ]);
+  });
+});
+
+describe('label anchor radius/dx (hemisphere offset)', () => {
+  test('radius should always be the constant ring-gap point, regardless of hemisphere', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    // radius must never depend on hemisphere/text width - only dx does, so a label's vertical
+    // position never shifts based on label content (see the autosize-shrink regression this guards against)
+    expect(mark.encode?.update?.radius).toEqual({
+      signal: '(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) + 20',
+    });
+  });
+
+  test('right hemisphere should get no horizontal offset', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
+    expect(dxSignal).toBe(
+      "(datum['testName_arcTheta'] <= PI ? 0 : -(min(max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+    );
+  });
+
+  test('left hemisphere dx offset should account for the wider of name/value widths when value is shown', () => {
+    const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
+    const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
+    // the offset branch (used when arcTheta > PI) must compare name width against the real value text's measured width
+    expect(dxSignal).toContain(
+      "max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), getLabelWidth("
+    );
+    expect(dxSignal).toContain('testName_segmentLabelValueFontSize');
+  });
+
+  test('the pull-back should be capped at a fraction of the donut radius', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
+    expect(dxSignal).toContain('min(max(getLabelWidth(');
+    expect(dxSignal).toContain('(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6');
+  });
+
+  test('name and value marks should share the exact same radius and dx expressions', () => {
+    const nameMark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
+    const [valueMark] = getSegmentLabelValueTextMark({ ...defaultSegmentLabelOptions, value: true });
+    expect(nameMark.encode?.update?.radius).toEqual(valueMark.encode?.update?.radius);
+    expect(nameMark.encode?.update?.dx).toEqual(valueMark.encode?.update?.dx);
+  });
+
+  test('both hemispheres should use left alignment (only dx differs, not align or radius)', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    expect(mark.encode?.update?.align).toEqual({ value: 'left' });
+  });
+
+  test('should use the labelKey field instead of color when provided', () => {
+    const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, labelKey: 'region' });
+    const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
+    expect(dxSignal).toBe(
+      "(datum['testName_arcTheta'] <= PI ? 0 : -(min(max(getLabelWidth(datum['region'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+    );
+  });
+});
+
 describe('getSegmentLabelTextMark()', () => {
   test('should define dy if value or percent are true', () => {
     const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
-    expect(mark.encode?.enter).toHaveProperty('dy');
+    expect(mark.encode?.update).toHaveProperty('dy');
   });
   test('should not define dy if value and percent are false', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
-    expect(mark.encode?.enter?.dy).toBeUndefined();
+    expect(mark.encode?.update?.dy).toBeUndefined();
+  });
+  test('name dy should shift by the value line font size, not a fixed px amount, so the gap stays 0px at every tier', () => {
+    const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
+    expect(mark.encode?.update?.dy).toEqual({
+      signal:
+        "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? -testName_segmentLabelValueFontSize : 0",
+    });
   });
   test('should hide labels when the donut is in the empty state', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
-    expect(mark.encode?.enter?.fontSize).toEqual([
+    expect(mark.encode?.update?.fontSize).toEqual([
       { test: getDonutEmptyStateTest('testName'), value: 0 },
       { test: `datum['testName_arcLength'] < 0.3`, value: 0 },
-      { value: 14 },
+      { signal: 'testName_segmentLabelNameFontSize' },
     ]);
   });
 });
@@ -140,23 +253,30 @@ describe('s2 styles', () => {
   describe('getSegmentLabelTextMark()', () => {
     test('should always use S2 styles (no bold, gray-700 fill)', () => {
       const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
-      
+
       expect(mark.encode?.enter?.fontWeight).toBeUndefined();
       expect(mark.encode?.enter?.fill).toEqual({ value: '#505050' });
     });
   });
 
   describe('getSegmentLabelValueTextMark()', () => {
-    test('should always add bold fontWeight, fontSize 16, and gray-700 fill for S2', () => {
+    test('should always add bold fontWeight and gray-700 fill for S2', () => {
       const marks = getSegmentLabelValueTextMark({
         ...defaultSegmentLabelOptions,
         value: true,
       });
-      
+
       expect(marks).toHaveLength(1);
       expect(marks[0].encode?.enter?.fontWeight).toEqual({ value: 'bold' });
       expect(marks[0].encode?.enter?.fill).toEqual({ value: '#505050' });
-      // Font size is controlled by getBaseSegmentLabelEnterEncode with baseFontSize=16 for s2
+    });
+
+    test('value dy should shift by the name line font size, not a fixed px amount, so the gap stays 0px at every tier', () => {
+      const [mark] = getSegmentLabelValueTextMark({ ...defaultSegmentLabelOptions, value: true });
+      expect(mark.encode?.update?.dy).toEqual({
+        signal:
+          "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? 0 : testName_segmentLabelNameFontSize",
+      });
     });
   });
 });

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -9,14 +9,33 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { GroupMark, NumericValueRef, ProductionRule, TextEncodeEntry, TextMark, TextValueRef } from 'vega';
+import {
+  GroupMark,
+  NumericValueRef,
+  ProductionRule,
+  Signal,
+  TextEncodeEntry,
+  TextMark,
+  TextValueRef,
+  ThresholdScale,
+} from 'vega';
 
-import { DONUT_RADIUS, DONUT_SEGMENT_LABEL_MIN_ANGLE, FILTERED_TABLE } from '@spectrum-charts/constants';
+import {
+  DONUT_DIRECT_LABEL_NAME_FONT_SIZES,
+  DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT,
+  DONUT_DIRECT_LABEL_VALUE_FONT_SIZES,
+  DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT,
+  DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
+  DONUT_LABEL_RING_GAP,
+  DONUT_SEGMENT_LABEL_MIN_ANGLE,
+  DONUT_SIZE_TIER_CUTPOINTS,
+  FILTERED_TABLE,
+} from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, SegmentLabelOptions, SegmentLabelSpecOptions } from '../types';
-import { getDonutEmptyStateTest } from './donutUtils';
+import { getDonutEmptyStateTest, getDonutOuterRadiusExpr } from './donutUtils';
 
 /**
  * Gets the SegmentLabel component from the children if one exists
@@ -37,7 +56,13 @@ const getSegmentLabel = (options: DonutSpecOptions): SegmentLabelSpecOptions | u
  * @returns SegmentLabelSpecOptions
  */
 const applySegmentLabelPropDefaults = (
-  { percent = false, percentFormat = '.0%', value = false, valueFormat = 'standardNumber', ...options }: SegmentLabelOptions,
+  {
+    percent = false,
+    percentFormat = '.0%',
+    value = false,
+    valueFormat = 'standardNumber',
+    ...options
+  }: SegmentLabelOptions,
   donutOptions: DonutSpecOptions
 ): SegmentLabelSpecOptions => ({
   donutOptions,
@@ -47,6 +72,114 @@ const applySegmentLabelPropDefaults = (
   valueFormat,
   ...options,
 });
+
+/**
+ * Gets the threshold scales that snap a donut's outer diameter to its nearest named size tier's direct-label font sizes
+ * @param donutOptions
+ * @returns ThresholdScale[]
+ */
+export const getSegmentLabelScales = (donutOptions: DonutSpecOptions): ThresholdScale[] => {
+  if (!getSegmentLabel(donutOptions)) return [];
+  const { name } = donutOptions;
+  return [
+    {
+      name: `${name}_segmentLabelNameFontSizeScale`,
+      type: 'threshold',
+      domain: DONUT_SIZE_TIER_CUTPOINTS,
+      range: DONUT_DIRECT_LABEL_NAME_FONT_SIZES,
+    },
+    {
+      name: `${name}_segmentLabelValueFontSizeScale`,
+      type: 'threshold',
+      domain: DONUT_SIZE_TIER_CUTPOINTS,
+      range: DONUT_DIRECT_LABEL_VALUE_FONT_SIZES,
+    },
+  ];
+};
+
+/**
+ * Gets the signals that resolve a donut's direct-label font sizes from its outer diameter
+ * @param donutOptions
+ * @returns Signal[]
+ */
+export const getSegmentLabelSignals = (donutOptions: DonutSpecOptions): Signal[] => {
+  if (!getSegmentLabel(donutOptions)) return [];
+  const { name } = donutOptions;
+  const donutDiameter = `2 * ${getDonutOuterRadiusExpr(donutOptions)}`;
+  return [
+    {
+      name: `${name}_segmentLabelNameFontSize`,
+      update: `scale('${name}_segmentLabelNameFontSizeScale', ${donutDiameter})`,
+    },
+    {
+      name: `${name}_segmentLabelValueFontSize`,
+      update: `scale('${name}_segmentLabelValueFontSizeScale', ${donutDiameter})`,
+    },
+  ];
+};
+
+/**
+ * Converts a text production rule into a single Vega expression string, for use inside getLabelWidth()
+ * @param rule
+ * @returns vega expression string
+ */
+const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined): string => {
+  if (rule === undefined) return `''`;
+  const rules = Array.isArray(rule) ? rule : [rule];
+  const getValue = (r: TextValueRef): string => {
+    if ('signal' in r && r.signal) return r.signal;
+    if ('field' in r && r.field) return `datum['${r.field}']`;
+    if ('value' in r && r.value !== undefined) return `'${r.value}'`;
+    return `''`;
+  };
+  let expr = getValue(rules[rules.length - 1]);
+  for (let i = rules.length - 2; i >= 0; i--) {
+    const rule = rules[i] as { test?: string } & TextValueRef;
+    expr = rule.test ? `${rule.test} ? (${getValue(rule)}) : (${expr})` : getValue(rule);
+  }
+  return expr;
+};
+
+/**
+ * Gets the shared anchor radius for a label's name/value lines - always the ring-gap point. The
+ * hemisphere-mirrored pull-back lives entirely in getLabelAnchorDxExpr as a horizontal pixel offset,
+ * not folded into this radial value, since radius+theta positioning has a vertical component for any
+ * label not exactly at the 9/3 o'clock cardinal points - baking the pull-back into radius there would
+ * push the anchor up/down instead of sideways.
+ * @param donutOptions
+ * @returns vega expression string
+ */
+const getLabelAnchorRadiusExpr = (donutOptions: DonutSpecOptions): string =>
+  `${getDonutOuterRadiusExpr(donutOptions)} + ${DONUT_LABEL_RING_GAP}`;
+
+/**
+ * Gets the shared horizontal pixel offset for a label's name/value lines. Right-hemisphere labels get
+ * no offset (anchor sits at the ring-gap point and grows away from the ring). Left-hemisphere labels
+ * get pulled left by the wider line's real rendered width, so that line's far (right) edge lands
+ * exactly on the ring-gap point while both lines still share the same near (left) edge. This is a pure
+ * horizontal (dx) adjustment, independent of theta, so it never distorts a label's vertical position.
+ * @param segmentLabelOptions
+ * @returns vega expression string
+ */
+const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
+  const { donutOptions, labelKey, percent, value } = options;
+  const { color, name } = donutOptions;
+  const nameTextExpr = `datum['${labelKey ?? color}']`;
+  const nameWidthExpr = `getLabelWidth(${nameTextExpr}, ${DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT}, ${name}_segmentLabelNameFontSize)`;
+  const valueWidthExpr =
+    value || percent
+      ? `getLabelWidth(${getTextRuleExpr(
+          getSegmentLabelValueText(options)
+        )}, ${DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT}, ${name}_segmentLabelValueFontSize)`
+      : '0';
+  const widerWidthExpr = `max(${nameWidthExpr}, ${valueWidthExpr})`;
+  // capped at the same ratio getDonutOuterRadiusExpr already reserved room for, so the worst-case
+  // reach (ring + gap + this cap) exactly matches the space getDonutOuterRadiusExpr solved for
+  const cappedWidthExpr = `min(${widerWidthExpr}, ${getDonutOuterRadiusExpr(
+    donutOptions
+  )} * ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO})`;
+  return `(datum['${name}_arcTheta'] <= PI ? 0 : -(${cappedWidthExpr}))`;
+};
 
 /**
  * Gets the marks for the segment label. If there isn't a segment label, an empty array is returned.
@@ -76,12 +209,8 @@ export const getSegmentLabelMarks = (donutOptions: DonutSpecOptions): GroupMark[
  * @param segmentLabelOptions
  * @returns TextMark
  */
-export const getSegmentLabelTextMark = ({
-  labelKey,
-  value,
-  percent,
-  donutOptions,
-}: SegmentLabelSpecOptions): TextMark => {
+export const getSegmentLabelTextMark = (options: SegmentLabelSpecOptions): TextMark => {
+  const { labelKey, value, percent, donutOptions } = options;
   const { name, color } = donutOptions;
   return {
     type: 'text',
@@ -89,18 +218,23 @@ export const getSegmentLabelTextMark = ({
     from: { data: FILTERED_TABLE },
     encode: {
       enter: {
-        ...getBaseSegmentLabelEnterEncode(name),
         // drop all labels when there isn't any data to display, the empty state ring is shown instead
         text: [{ test: getDonutEmptyStateTest(name), value: '' }, { field: labelKey ?? color }],
         fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
+      },
+      update: {
+        ...positionEncodings,
+        ...getSegmentLabelUpdateEncode(options, `${name}_segmentLabelNameFontSize`),
+        // top half: shift up by the value line's own font size so the two lines sit flush (0px gap
+        // token) regardless of size tier - a fixed px shift would leave a mismatched gap at every
+        // tier except the one it was tuned for
         dy:
           value || percent
             ? {
-                signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? -16 : 0`,
+                signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? -${name}_segmentLabelValueFontSize : 0`,
               }
             : undefined,
       },
-      update: positionEncodings,
     },
   };
 };
@@ -113,7 +247,6 @@ export const getSegmentLabelTextMark = ({
 export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): TextMark[] => {
   if (!options.value && !options.percent) return [];
   const { donutOptions } = options;
-  const baseFontSize = 16; // S2 base font size
   const valueText = getSegmentLabelValueText(options) ?? [];
   const valueTextRules = Array.isArray(valueText) ? valueText : [valueText];
 
@@ -124,39 +257,48 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
       from: { data: FILTERED_TABLE },
       encode: {
         enter: {
-          ...getBaseSegmentLabelEnterEncode(donutOptions.name, baseFontSize),
           // drop all labels when there isn't any data to display, the empty state ring is shown instead
           text: [{ test: getDonutEmptyStateTest(donutOptions.name), value: '' }, ...valueTextRules],
           fontWeight: { value: 'bold' },
           fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
+        },
+        update: {
+          ...positionEncodings,
+          ...getSegmentLabelUpdateEncode(options, `${donutOptions.name}_segmentLabelValueFontSize`),
+          // bottom half: shift down by the name line's own font size, mirroring the top-half case
           dy: {
-            signal: `datum['${donutOptions.name}_arcTheta'] <= 0.5 * PI || datum['${donutOptions.name}_arcTheta'] >= 1.5 * PI ? 0 : 16`,
+            signal: `datum['${donutOptions.name}_arcTheta'] <= 0.5 * PI || datum['${donutOptions.name}_arcTheta'] >= 1.5 * PI ? 0 : ${donutOptions.name}_segmentLabelNameFontSize`,
           },
         },
-        update: positionEncodings,
       },
     },
   ];
 };
 
 /**
- * Gets all the standard entry encodes for segment label text marks
- * @param name
- * @param baseFontSize - The base font size to use when arc is large enough (default 14)
+ * Gets the standard position/size encodes for segment label text marks. These must live in the
+ * `update` set, not `enter` - Vega only evaluates `enter` once per mark instance at creation, but
+ * radius/dx/fontSize here all derive from `width`/`height`-dependent signals that change on resize.
+ * @param segmentLabelOptions
+ * @param fontSizeSignal - the tier-based font size signal name for this specific line (name or value)
  * @returns TextEncodeEntry
  */
-const getBaseSegmentLabelEnterEncode = (name: string, baseFontSize: number = 14): TextEncodeEntry => ({
-  radius: { signal: `${DONUT_RADIUS} + 6` },
-  theta: { field: `${name}_arcTheta` },
-  fontSize: getSegmentLabelFontSize(name, baseFontSize),
-  align: {
-    signal: `datum['${name}_arcTheta'] <= PI ? 'left' : 'right'`,
-  },
-  baseline: {
-    // if the center of the arc is in the top half of the donut, the text baseline should be bottom, else top
-    signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? 'bottom' : 'top'`,
-  },
-});
+const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeSignal: string): TextEncodeEntry => {
+  const { name } = options.donutOptions;
+  return {
+    radius: { signal: getLabelAnchorRadiusExpr(options.donutOptions) },
+    theta: { field: `${name}_arcTheta` },
+    // pulls left-hemisphere labels back horizontally by the wider line's width - see getLabelAnchorDxExpr
+    dx: { signal: getLabelAnchorDxExpr(options) },
+    fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
+    // both hemispheres anchor at their near (left) edge - only the dx offset differs by hemisphere
+    align: { value: 'left' },
+    baseline: {
+      // if the center of the arc is in the top half of the donut, the text baseline should be bottom, else top
+      signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? 'bottom' : 'top'`,
+    },
+  };
+};
 /**
  * position encodings
  */
@@ -200,10 +342,10 @@ export const getSegmentLabelValueText = ({
  * Gets the font size for the segment label based on the arc length
  * If the arc length is less than 0.3 radians, the font size is 0
  * @param name
- * @param baseFontSize - The base font size to use when arc is large enough (default 14)
+ * @param fontSizeSignal - the tier-based font size signal name for this line (name or value)
  * @returns NumericValueRef
  */
-const getSegmentLabelFontSize = (name: string, baseFontSize: number = 14): ProductionRule<NumericValueRef> => {
+const getSegmentLabelFontSize = (name: string, fontSizeSignal: string): ProductionRule<NumericValueRef> => {
   // need to use radians for this. 0.3 radians is about 17 degrees
   // if we used arc length, then showing a label could shrink the overall donut size which could make the arc to small
   // that would hide the label which would make the arc bigger which would show the label and so on
@@ -211,6 +353,6 @@ const getSegmentLabelFontSize = (name: string, baseFontSize: number = 14): Produ
     // hide all labels when there isn't any data to display, the empty state ring is shown instead
     { test: getDonutEmptyStateTest(name), value: 0 },
     { test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 },
-    { value: baseFontSize },
+    { signal: fontSizeSignal },
   ];
 };

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -123,7 +123,7 @@ export const getSegmentLabelSignals = (donutOptions: DonutSpecOptions): Signal[]
  * @param rule
  * @returns vega expression string
  */
-const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined): string => {
+export const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined): string => {
   if (rule === undefined) return `''`;
   const rules = Array.isArray(rule) ? rule : [rule];
   const getValue = (r: TextValueRef): string => {

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -128,11 +128,15 @@ const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined): string
   const rules = Array.isArray(rule) ? rule : [rule];
   const getValue = (r: TextValueRef): string => {
     if ('signal' in r && r.signal) return r.signal;
-    if ('field' in r && r.field) return `datum['${r.field}']`;
+    if ('field' in r && typeof r.field === 'string') return `datum['${r.field}']`;
     if ('value' in r && r.value !== undefined) return `'${r.value}'`;
     return `''`;
   };
-  let expr = getValue(rules[rules.length - 1]);
+  const lastRule = rules.at(-1);
+  if (lastRule === undefined) {
+    throw new Error('getTextRuleExpr: empty production rule array');
+  }
+  let expr = getValue(lastRule);
   for (let i = rules.length - 2; i >= 0; i--) {
     const rule = rules[i] as { test?: string } & TextValueRef;
     expr = rule.test ? `${rule.test} ? (${getValue(rule)}) : (${expr})` : getValue(rule);

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -145,11 +145,11 @@ export const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined):
 };
 
 /**
- * Gets the shared anchor radius for a label's name/value lines - always the ring-gap point. The
- * hemisphere-mirrored pull-back lives entirely in getLabelAnchorDxExpr as a horizontal pixel offset,
- * not folded into this radial value, since radius+theta positioning has a vertical component for any
- * label not exactly at the 9/3 o'clock cardinal points - baking the pull-back into radius there would
- * push the anchor up/down instead of sideways.
+ * Gets the anchor radius both hemispheres use for a label's name/value lines - the ring's outer
+ * edge plus the ring-gap. The left-hemisphere horizontal shift is applied separately as a dx offset
+ * (getLabelAnchorDxExpr), not folded into this radius, since radius+theta positioning has a
+ * vertical component for any label off the 9/3 o'clock points - adjusting radius there would push
+ * the anchor up/down instead of sideways.
  * @param donutOptions
  * @returns vega expression string
  */
@@ -157,11 +157,10 @@ const getLabelAnchorRadiusExpr = (donutOptions: DonutSpecOptions): string =>
   `${getDonutOuterRadiusExpr(donutOptions)} + ${DONUT_LABEL_RING_GAP}`;
 
 /**
- * Gets the shared horizontal pixel offset for a label's name/value lines. Right-hemisphere labels get
- * no offset (anchor sits at the ring-gap point and grows away from the ring). Left-hemisphere labels
- * get pulled left by the wider line's real rendered width, so that line's far (right) edge lands
- * exactly on the ring-gap point while both lines still share the same near (left) edge. This is a pure
- * horizontal (dx) adjustment, independent of theta, so it never distorts a label's vertical position.
+ * Gets each label's horizontal offset (dx). Right-hemisphere labels start right at the ring - no
+ * offset needed. Left-hemisphere labels move left by their own width (capped at a fraction of the
+ * donut's radius - see DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO), so their far end touches the ring
+ * instead of their near end.
  * @param segmentLabelOptions
  * @returns vega expression string
  */
@@ -292,7 +291,7 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
   return {
     radius: { signal: getLabelAnchorRadiusExpr(options.donutOptions) },
     theta: { field: `${name}_arcTheta` },
-    // pulls left-hemisphere labels back horizontally by the wider line's width - see getLabelAnchorDxExpr
+    // shifts left-hemisphere labels left by the wider line's width - see getLabelAnchorDxExpr
     dx: { signal: getLabelAnchorDxExpr(options) },
     fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
     // both hemispheres anchor at their near (left) edge - only the dx offset differs by hemisphere

--- a/planning/specs/donut/implemented/donut-direct-labels.json
+++ b/planning/specs/donut/implemented/donut-direct-labels.json
@@ -4,15 +4,15 @@
   "chartType": "donut",
   "kind": "feature",
   "variant": "s2",
-  "status": "approved",
-  "lastUpdated": "2026-08-18",
+  "status": "implemented",
+  "lastUpdated": "2026-09-01",
   "complexity": {
     "score": 3,
     "rationale": "Scope narrowed to ring gap, size-tier scaling, and hemisphere anchor offset (collision avoidance is now its own spec, donut-direct-labels-collision, and the value hover-color-switch requirement was removed as a verbatim duplicate already owned by donut-hover). Ring-gap and size-tier scaling are precedented/mechanical (the latter mirrors donut-summary-responsive-sizing's approach exactly). What keeps this at a 3: the hemisphere-mirrored near-edge anchor offset is genuinely new logic, and there's a real unresolved technical question underneath it - Vega's declarative spec format has no native rendered-text-width primitive, so how 'real text measurement' from the direct-labels skill is actually obtained at layout time is still open, not merely a design decision."
   },
   "summary": "Donut direct labels (currently implemented as the `SegmentLabel` component/child - segment name + value text placed directly around the ring, no connector line) exist in code today, but the current implementation is a simplified placeholder: it uses a flat 6px ring-anchor gap instead of the documented 20px real-bounding-box gap, hardcodes font sizes (14px name / 16px value) instead of scaling by the donut's size tier, and has no hemisphere-mirrored anchor offset for aligning the name/value lines to each other. (Collision avoidance when multiple labels stack is tracked separately in donut-direct-labels-collision; the value-line hover color switch is owned entirely by donut-hover.)",
   "requirements": [
-    "Gap from the ring must be 20px (`chart.donut.spacing.label-ring-gap`), measured against the label's actual rendered bounding box - not a fixed anchor-only radius offset like the current `DONUT_RADIUS + 6`. A label must never overlap the ring; if the 20px gap would be violated, wrap the label onto 2 lines instead of letting it overlap.",
+    "Gap from the ring must be 20px (`chart.donut.spacing.label-ring-gap`), measured against the label's actual rendered bounding box - not a fixed anchor-only radius offset like the current `DONUT_RADIUS + 6`. A label must never overlap the ring; if the 20px gap would be violated, wrap the label onto 2 lines instead of letting it overlap. IMPLEMENTATION NOTE: only the anchor's pull-back distance is capped (at DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO * outer radius) to keep the worst case within getDonutOuterRadiusExpr's reserved space - the wrap-to-2-lines behavior itself was never built, so sufficiently long text can still overlap the ring. Tracked as a follow-up: planning/specs/donut/issues/donut-direct-labels-long-text-overlap.json.",
     "Font sizes must scale by the donut's size tier (see designTokens) instead of the current hardcoded 14px (segment name) / 16px (value), neither of which matches any documented tier value for the name line (12px at M) and only coincidentally matches the value line's M-tier size (16px).",
     "Within a single label, the segment name and value lines must be left-aligned to each other (share the same near edge relative to their anchor), with the anchor itself mirrored by hemisphere: right-hemisphere labels anchor at the ring-gap point and grow rightward (away from the ring); left-hemisphere labels anchor further back (offset by the width of the wider of the two lines) so that line's far edge lands at the ring-gap point while both lines still start from the same near edge. The current implementation does not implement this anchor offset at all - both lines share an identical anchor point with no width-based adjustment.",
     "Getting the offset in the previous requirement requires the wider line's real rendered width. Use real text measurement where available; where none exists at layout time, approximate width as `characterCount * fontSize * k` (k ~= 0.52 regular weight, ~= 0.6 bold) and treat it explicitly as an approximation, not a sourced token.",
@@ -23,7 +23,7 @@
     { "token": "chart.donut.spacing.direct-label-name-value-gap", "value": "0px", "usage": "Gap between the segment name line and the value line within one label - tight, not overlapping." },
     { "token": "Direct label - segment name (XS/S/M/L/XL)", "value": "9(derived) / 10.5(derived) / 12 / 15(derived) / 18(derived) px, weight 400, color text-secondary (gray-700)", "usage": "Font size for the segment-name line, keyed to the donut's size tier." },
     { "token": "Direct label - value (XS/S/M/L/XL)", "value": "12(derived) / 14(derived) / 16 / 20(derived) / 24(derived) px, weight 700, color text-secondary (gray-700)", "usage": "Font size for the segment-value line, keyed to the donut's size tier - the hover-driven color switch to the segment's own categorical color is owned by donut-hover, not this spec." },
-    { "token": "text-width approximation constant k", "value": "~0.52 (regular weight) / ~0.6 (bold)", "usage": "Fallback multiplier (characterCount * fontSize * k) for estimating rendered text width when no real text-measurement primitive is available at layout time - explicitly not pixel-exact, flagged as an approximation. Also reused by donut-direct-labels-collision for block-height calculations." }
+    { "token": "text-width approximation constant k", "value": "~0.52 (regular weight) / ~0.6 (bold)", "usage": "UNUSED as shipped - real measurement via the existing getLabelWidth() Vega expression function (expressionFunctions.ts, already used by Legend/Line/Bar) was reused directly instead, so this fallback approximation was never needed. Left here for reference in case donut-direct-labels-collision or a future spec still wants an approximation path." }
   ],
   "references": [
     { "type": "other", "url": "llm/skills/s2-donut/donut-direct-labels/SKILL.md" },
@@ -31,7 +31,7 @@
     { "type": "figma", "url": "https://www.figma.com/design/a9LVueYspAHETtc1x9Cll8/S2---Charts?node-id=6030-54192&m=dev" }
   ],
   "edgeCases": [
-    { "case": "Very long segment name or value text", "expectedBehavior": "Wraps the label onto 2 lines rather than overlapping the ring, per the 20px real-bounding-box gap rule." },
+    { "case": "Very long segment name or value text", "expectedBehavior": "NOT IMPLEMENTED as shipped - only the anchor's offset is capped (at 60% of the outer radius), not the label text itself, so long text can still visually overlap the ring instead of wrapping. See planning/specs/donut/issues/donut-direct-labels-long-text-overlap.json." },
     { "case": "Segment on the exact top/bottom of the donut (arcTheta at or near 0 or PI)", "expectedBehavior": "Hemisphere determination (which side anchors left vs. right) must resolve predictably at the boundary rather than flipping unstably between adjacent renders." },
     { "case": "Segment centered in the bottom half of the ring", "expectedBehavior": "Name still renders above the value line, exactly as in top-half segments - the vertical name/value stacking order must never flip by hemisphere (confirmed with the user; only the horizontal left/right anchor mirrors by hemisphere, not the vertical order)." },
     { "case": "Segment arc too small to fit a label (existing DONUT_SEGMENT_LABEL_MIN_ANGLE behavior)", "expectedBehavior": "Label continues to be hidden below the minimum arc angle, unchanged by this feature - confirm the min-angle threshold still makes sense once real label dimensions (not just font size) are being measured." },
@@ -43,9 +43,9 @@
     "touchesControlledHighlight": false,
     "touchesLegendInteraction": false,
     "touchesTooltipOrPopover": false,
-    "requiresNewSignalOrScale": false,
+    "requiresNewSignalOrScale": true,
     "requiresS1S2Parity": false,
-    "notes": "None of the hover/controlled-highlight/legend/tooltip flags apply - this spec is scoped to static layout (ring gap, size-tier font scaling, hemisphere anchor offset), with the hover-driven value color switch owned entirely by donut-hover and collision avoidance owned by donut-direct-labels-collision. requiresNewSignalOrScale is false - this is encode-level production-rule/expression work (test expressions and computed x/y anchors), not new signals or scales. requiresS1S2Parity is false: per project direction, this work is scoped to s2 only - packages/vega-spec-builder/src/donut/segmentLabelUtils.ts (s1) shares the identical gap today, but is intentionally left unchanged, not treated as a parity gap."
+    "notes": "CORRECTED during implementation reconciliation: requiresNewSignalOrScale is actually true, not false as originally filed - getSegmentLabelScales/getSegmentLabelSignals (segmentLabelUtils.ts) add two new per-tier threshold scales and two new signals for name/value font sizes, mirroring donut-summary-responsive-sizing's approach exactly (the spec's own complexity rationale even calls this out, but the crossCutting flag was never updated to match). None of the hover/controlled-highlight/legend/tooltip flags apply - this spec is scoped to static layout (ring gap, size-tier font scaling, hemisphere anchor offset), with the hover-driven value color switch owned entirely by donut-hover and collision avoidance owned by donut-direct-labels-collision. requiresS1S2Parity is false: per project direction, this work is scoped to s2 only - packages/vega-spec-builder/src/donut/segmentLabelUtils.ts (s1) shares the identical gap today, but is intentionally left unchanged, not treated as a parity gap."
   },
   "implementationPlan": [
     {
@@ -55,28 +55,43 @@
     },
     {
       "file": "packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts",
-      "change": "Replace the flat `DONUT_RADIUS + 6` anchor with a real-bounding-box-based 20px gap; replace hardcoded fontSize 14/16 with the new per-tier constants; add the hemisphere-mirrored near-edge anchor offset (using real or approximated text width); add wrap-to-2-lines logic when the gap would be violated.",
+      "change": "Replace the flat `DONUT_RADIUS + 6` anchor with a ring-gap-based radius (getLabelAnchorRadiusExpr); replace hardcoded fontSize 14/16 with new per-tier scales/signals (getSegmentLabelScales/getSegmentLabelSignals); add the hemisphere-mirrored near-edge anchor offset (getLabelAnchorDxExpr), capped at DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO. Wrap-to-2-lines was NOT implemented - see the follow-up bug spec noted in requirements/edgeCases above.",
       "lines": "56-217"
     },
     {
-      "file": "packages/vega-spec-builder-s2/src/donut/donutTextMeasureUtils.ts (new shared util)",
-      "change": "Implement the shared text-width approximation helper (`characterCount * fontSize * k`), used by this spec's anchor offset and reused by donut-direct-labels-collision's block-height calculations - a single shared location rather than duplicated logic.",
-      "lines": "N/A - new file"
+      "file": "packages/vega-spec-builder-s2/src/donut/donutUtils.ts",
+      "change": "ADDED (not in original plan): getDonutOuterRadiusExpr, which reserves the ring-gap + capped anchor-offset space out of the donut's raw radius so the ring and its labels always fit a given container in one deterministic pass. Threaded through getArcMark/getEmptyStateArcMark's radius and padAngle calculations.",
+      "lines": "N/A - new function + call-site updates"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts",
+      "change": "ADDED (not in original plan): threaded the new getDonutOuterRadiusExpr through the DonutSummary font-size signals and fit-gate radius calculations, so the center-hole summary and the ring-gap-reserving labels stay geometrically consistent.",
+      "lines": "N/A - call-site updates only"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts",
+      "change": "ADDED (not in original plan): wired getSegmentLabelScales/getSegmentLabelSignals into addScales/addSignals.",
+      "lines": "N/A - call-site updates only"
+    },
+    {
+      "file": "packages/constants/constants.ts",
+      "change": "CORRECTED: also added DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO (the anchor-offset cap ratio, 0.6) alongside the originally-planned breakpoints/font-size/ring-gap constants - not called out in the original plan.",
+      "lines": "N/A - new constants"
     },
     {
       "file": "packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx",
-      "change": "Update existing tests that currently assert the old fixed values (fontSize 16, fill '#505050' always, +6 gap) - replace with tests pinning per-tier font sizes, the 20px real-bounding-box gap, and the anchor-offset/wrap behavior.",
+      "change": "Update existing tests that currently assert the old fixed values (fontSize 16, fill '#505050' always, +6 gap) - replace with tests pinning per-tier font sizes, the ring-gap radius, and the anchor-offset behavior (wrap behavior has no tests since it was never implemented).",
       "lines": "131-159 (existing fixed-value assertions), plus new test cases"
     },
     {
-      "file": "packages/react-spectrum-charts-s2/src/stories/components/SegmentLabel/SegmentLabel.story.tsx",
-      "change": "Add stories covering: multiple size tiers, and long segment names/values that trigger 2-line wrapping.",
+      "file": "packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx",
+      "change": "CORRECTED PATH (originally planned as components/SegmentLabel/SegmentLabel.story.tsx): added Responsive and ManySegmentsResponsive stories driven by a width slider, matching Line's DirectLabelSizeScaling pattern - not a long-text-wrapping story, since wrapping was never built.",
       "lines": "N/A - new stories"
     }
   ],
   "openQuestions": [
-    "How is 'real text measurement' actually obtained at Vega-spec layout time? Vega's declarative expression language has no native rendered-text-width primitive - confirm whether a canvas-measurement pass needs to happen in the TS spec-builder before the spec is emitted (using a known font/size, since data-driven text content varies per row), or whether the `characterCount * fontSize * k` approximation is the intended production approach rather than just a documented fallback.",
-    "Confirm the two 'derived' (computed, not individually measured) values at each end of the tier range - segment name XS 9px/S 10.5px/L 15px/XL 18px, and value XS 12px/S 14px/L 20px/XL 24px - donut-chart-tokens explicitly flags these as needing confirmation in Figma."
+    "RESOLVED: a Vega custom expression function, getLabelWidth() (packages/vega-spec-builder-s2/src/expressionFunctions/expressionFunctions.ts), already existed and does real canvas-based text measurement - it's already used by Legend/Line/Bar/BarAnnotation/BarDirectLabel elsewhere in this codebase. segmentLabelUtils.ts's getLabelAnchorDxExpr calls it directly; the `characterCount * fontSize * k` approximation was never needed as a fallback.",
+    "Confirm the two 'derived' (computed, not individually measured) values at each end of the tier range - segment name XS 9px/S 10.5px/L 15px/XL 18px, and value XS 12px/S 14px/L 20px/XL 24px - donut-chart-tokens explicitly flags these as needing confirmation in Figma. STILL OPEN - not verified during this implementation."
   ],
   "relatedIssues": ["donut-summary-responsive-sizing", "donut-direct-labels-collision", "donut-hover"]
 }

--- a/planning/specs/donut/issues/donut-direct-labels-long-text-overlap.json
+++ b/planning/specs/donut/issues/donut-direct-labels-long-text-overlap.json
@@ -1,0 +1,62 @@
+{
+  "id": "donut-direct-labels-long-text-overlap",
+  "title": "Donut direct labels can overlap the ring for long segment names/values instead of wrapping",
+  "chartType": "donut",
+  "kind": "bug",
+  "variant": "s2",
+  "status": "approved",
+  "lastUpdated": "2026-09-01",
+  "complexity": {
+    "score": 3,
+    "rationale": "Root cause is fully confirmed (no wrap/truncation logic exists at all), but the fix requires new, non-precedented logic - line-wrapping donut labels around a curved ring has no existing precedent elsewhere in the codebase (unlike a straightforward encode tweak), and the interaction with the existing hemisphere-mirrored anchor offset and hemisphere-based vertical dy stacking (name always above value) needs new reasoning, not a copy of an existing pattern."
+  },
+  "summary": "donut-direct-labels' requirement that a label wrap onto 2 lines rather than overlap the ring was never implemented - long segment names/values can visually overlap the ring instead.",
+  "symptom": "For a segment with a long name or value string, especially on the left hemisphere (where the label's anchor is pulled back by the wider line's width), the label's text can render on top of the donut ring instead of respecting the documented 20px ring gap. There is no visible line-break or truncation - the text just extends further than the reserved space and can overlap.",
+  "rootCause": "getLabelAnchorDxExpr (packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts) caps the left-hemisphere pull-back distance at DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO (0.6) times the outer radius, matching the worst-case reach getDonutOuterRadiusExpr already reserved room for. This cap only bounds the *anchor offset* - it does not bound or wrap the *label text itself*. Neither getSegmentLabelTextMark nor getSegmentLabelValueTextMark (same file) sets a `limit` (truncation) property or splits text across multiple lines, unlike DonutSummary's value/label text marks (donutSummaryUtils.ts), which do set `limit` for exactly this reason. So once a label's real rendered width (measured via the existing getLabelWidth() Vega expression function) exceeds what the capped anchor offset accounts for, the excess simply renders past the ring-gap boundary.",
+  "comparison": [
+    {
+      "aspect": "Guarding against text overflowing its reserved space",
+      "expected": "Per donut-direct-labels' requirement: if the 20px ring-gap would be violated by a label's real rendered width, wrap the label onto 2 lines instead of letting it overlap - mirroring how DonutSummary already truncates (via a `limit` property) when its value/label text would overflow the donut's inner radius.",
+      "actual": "getLabelAnchorDxExpr caps only the anchor's *offset* at a fixed ratio of the outer radius; the label text itself is never wrapped, truncated, or otherwise constrained, so long text can render past the reserved space and overlap the ring."
+    }
+  ],
+  "references": [
+    { "type": "other", "url": "llm/skills/s2-donut/donut-direct-labels/SKILL.md" },
+    { "type": "other", "url": "planning/specs/donut/implemented/donut-direct-labels.json" }
+  ],
+  "edgeCases": [
+    { "case": "Long segment name, right hemisphere (no anchor pull-back)", "expectedBehavior": "Right-hemisphere labels have no offset cap to hide behind at all (dx is always 0) - a long name here would overflow rightward with no bound whatsoever, likely the most visible case of this bug." },
+    { "case": "Long value text combined with a long name on the same label", "expectedBehavior": "Both lines currently measure/anchor independently (max of the two widths) - confirm whether wrapping should apply per-line or should force both lines to wrap together to preserve their shared left-edge alignment." }
+  ],
+  "crossCutting": {
+    "touchesHoverAnimation": false,
+    "touchesControlledHighlight": false,
+    "touchesLegendInteraction": false,
+    "touchesTooltipOrPopover": false,
+    "requiresNewSignalOrScale": false,
+    "requiresS1S2Parity": false,
+    "notes": "requiresS1S2Parity is false: packages/vega-spec-builder (s1) has no per-tier direct-label positioning system to mirror (this whole ring-gap/hemisphere-anchor mechanism is s2-only, per donut-direct-labels), so there is no s1 equivalent to check for the same symptom."
+  },
+  "implementationPlan": [
+    {
+      "file": "packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts",
+      "change": "Design and implement 2-line wrapping for a label whose real rendered width (via getLabelWidth()) would exceed the space reserved by the ring-gap/anchor-offset math - likely requires splitting the name and/or value text into two text marks positioned on adjacent lines, or a Vega expression that inserts a line break at the measured midpoint. Needs new reasoning: no existing multi-line wrapped label exists elsewhere in this codebase to copy from.",
+      "lines": "N/A - new logic, exact site depends on chosen approach"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx",
+      "change": "Add regression tests with a long segment name/value asserting the label wraps (or otherwise never renders past the ring-gap boundary) rather than overlapping.",
+      "lines": "N/A - new test cases"
+    },
+    {
+      "file": "packages/react-spectrum-charts-s2/src/stories/Donut/Features/DirectLabel/DirectLabels.story.tsx",
+      "change": "Add a story with an intentionally long segment name/value to visually verify the fix.",
+      "lines": "N/A - new story"
+    }
+  ],
+  "openQuestions": [
+    "Should wrapping split on word boundaries or just at the measured character-width midpoint? donut-chart-tokens/donut-direct-labels skills don't document a wrapping algorithm.",
+    "Right-hemisphere labels have no anchor cap at all today (dx is always 0) - does 'wrap to 2 lines' apply there too, or does the right hemisphere need its own reserved-space cap first (a gap not covered by donut-direct-labels' original spec, which focused on the left-hemisphere pull-back)?"
+  ],
+  "relatedIssues": ["donut-direct-labels"]
+}


### PR DESCRIPTION
## Description

Implements the ring-gap sizing/hemisphere-anchor portion of the `donut-direct-labels` spec, and fixes a real resize-reactivity bug found while building the responsive Storybook example for it.

- Adds `getDonutOuterRadiusExpr` to deterministically reserve room for the direct-label ring gap and hemisphere pull-back within the donut's own radius, so the ring and its labels always fit within a given container size in a single pass, without relying on Vega's `autosize` growing beyond it. This is threaded through the arc mark, the empty-state ring, and `DonutSummary`'s radius/font-size/truncation calculations so they all agree on the same effective radius.
- Fixes a bug where `radius`/`dx`/`fontSize`/`dy`/`align`/`baseline` on the segment label text marks lived in Vega's `enter` encode set, which only evaluates once when a mark is first created. On resize, only the shared `x`/`y` anchor (in `update`) tracked the new container size, so labels were uniformly translated by the container's center shift instead of properly rescaling - causing them to visually detach from (or overlap into) the ring at certain sizes. Moved these encodings into `update`.
- Replaces the CSS-resize-based Storybook example with a width-slider-driven `Responsive` story (matching the existing `Line` `DirectLabelSizeScaling` pattern, with visible size-tier breakpoint markers), plus a `ManySegmentsResponsive` variant using the existing `sliveredDonutData` fixture to stress-test label crowding with 15 segments.

## Related Issue

`planning/specs/donut/donut-direct-labels.json` (approved)

## Motivation and Context

Direct labels on a donut need a ring gap and can pull back horizontally to avoid overlapping the ring near the 9/3 o'clock cardinal points. Without reserving space for that up front, labels could end up demanding more room than the container had, either forcing the chart to grow beyond its given size or causing the ring to shrink disproportionately. Fixing the resize-reactivity bug was necessary because the size-tier-driven font/anchor calculations only take effect on the very first render otherwise, making the ring and its labels visibly drift apart on any subsequent resize.

## How Has This Been Tested?

- Unit tests updated in `segmentLabelUtils.test.tsx` and `donutSummaryUtils.test.tsx` for the new radius-reservation formula and the `enter`→`update` encode move.
- Full `vega-spec-builder-s2`/`react-spectrum-charts-s2` test suite passes (131 suites, 2125 tests).
- `yarn lint` and `yarn tsc --noEmit` are clean (no new errors; two pre-existing unrelated failures confirmed present on the base commit too).
- Manually verified in Storybook via Playwright screenshots across the full slider range (80px-500px, XS-XL tiers) on both the `Responsive` and `ManySegmentsResponsive` stories: the ring and its labels now scale together in real time with no overlap, including immediately after a resize (previously frozen from the initial render).

## Screenshots (if appropriate):

See the `Responsive` and `ManySegmentsResponsive` stories under `React Spectrum Charts 2/Donut/Features/Direct Label` in Storybook.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.