### PR TITLE
feat(donut-s2): Hover - segment hover fade, direct-label color switch, and legend bidirectional highlight

### DIFF
--- a/packages/react-spectrum-charts-s2/src/stories/Donut/Features/Hover/DonutHover.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Donut/Features/Hover/DonutHover.story.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../../Chart';
+import { Legend } from '../../../../components';
+import useChartProps from '../../../../hooks/useChartProps';
+import { Donut, SegmentLabel } from '../../../../pre-alpha';
+import { bindWithProps } from '../../../../test-utils';
+import { basicDonutData } from '../../../components/Donut/data';
+
+export default {
+  title: 'React Spectrum Charts 2/Donut/Features/Hover',
+  component: SegmentLabel,
+};
+
+const defaultChartProps = { data: basicDonutData, width: 400, height: 400 };
+
+// no chartPopover/chartInspect configured - a SegmentLabel showing a value is enough on its own to
+// make the donut hover-interactive, matching the Figma reference
+const SimpleDirectLabelStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => {
+  const chartProps = useChartProps(defaultChartProps);
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <SegmentLabel {...args} />
+      </Donut>
+    </Chart>
+  );
+};
+
+// hovering an arc highlights the matching Legend entry, and hovering a Legend entry fades/highlights
+// the corresponding arc - both directions of the shared legendHighlightSignals mechanism
+const WithLegendStory: StoryFn<typeof SegmentLabel> = (args): ReactElement => {
+  const chartProps = useChartProps({ ...defaultChartProps, width: 500 });
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <SegmentLabel {...args} />
+      </Donut>
+      <Legend title="Browsers" position="right" highlight isToggleable />
+    </Chart>
+  );
+};
+
+const SimpleDirectLabel = bindWithProps(SimpleDirectLabelStory);
+SimpleDirectLabel.args = { value: true, valueFormat: 'shortNumber' };
+
+const WithLegend = bindWithProps(WithLegendStory);
+WithLegend.args = { value: true, valueFormat: 'shortNumber' };
+
+export { SimpleDirectLabel, WithLegend };

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.test.ts
@@ -45,6 +45,18 @@ describe('addData', () => {
     expect(sumData?.transform?.[0]).toHaveProperty('fields', ['testMetric']);
     expect(sumData?.transform?.[0]).toHaveProperty('ops', ['sum']);
   });
+
+  test('should add a SERIES_ID transform when interactive, so legend hover-highlight can match this donut', () => {
+    const interactiveOptions = { ...defaultDonutOptions, segmentLabels: [{ value: true }] };
+    const data = addData(initializeSpec().data ?? [], interactiveOptions);
+    expect(data[1].transform).toHaveLength(5);
+    expect(data[1].transform?.[4]).toEqual({ type: 'formula', as: 'rscSeriesId', expr: "datum.testColor" });
+  });
+
+  test('should not add a SERIES_ID transform when not interactive', () => {
+    const data = addData(initializeSpec().data ?? [], defaultDonutOptions);
+    expect(data[1].transform).toHaveLength(4);
+  });
 });
 
 describe('addSignals()', () => {

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -22,6 +22,7 @@ import {
 } from '@spectrum-charts/constants';
 import { toCamelCase } from '@spectrum-charts/utils';
 
+import { getSeriesIdTransform } from '../data/dataUtils';
 import { isInteractive } from '../marks/markUtils';
 import { addFieldToFacetScaleDomain } from '../scale/scaleSpecBuilder';
 import { addHoveredItemSignal } from '../signal/signalSpecBuilder';
@@ -101,12 +102,19 @@ export const addDonut = produce<
 );
 
 export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
-  const { name, isBoolean } = options;
+  const { color, legendHighlightSignals, name, isBoolean } = options;
   const filteredTableIndex = data.findIndex((d) => d.name === FILTERED_TABLE);
 
   //set up transform
   data[filteredTableIndex].transform = data[filteredTableIndex].transform ?? [];
   data[filteredTableIndex].transform?.push(...getPieTransforms(options));
+  // Needed for both hover directions with a paired Legend: this mark's own hover highlighting the
+  // legend (generic mark-hover loop in legendUtils.ts) and a legend hover fading this mark's arcs
+  // (getLegendHighlightOpacityRules in donutUtils.ts) - both match on datum[SERIES_ID], which donut's
+  // rows don't otherwise have, unlike Line/Bar.
+  if (isInteractive(options) || legendHighlightSignals?.length) {
+    data[filteredTableIndex].transform?.push(...getSeriesIdTransform([color]));
+  }
 
   if (isBoolean) {
     //select first data point for our boolean value

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -108,10 +108,8 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
   //set up transform
   data[filteredTableIndex].transform = data[filteredTableIndex].transform ?? [];
   data[filteredTableIndex].transform?.push(...getPieTransforms(options));
-  // Needed for both hover directions with a paired Legend: this mark's own hover highlighting the
-  // legend (generic mark-hover loop in legendUtils.ts) and a legend hover fading this mark's arcs
-  // (getLegendHighlightOpacityRules in donutUtils.ts) - both match on datum[SERIES_ID], which donut's
-  // rows don't otherwise have, unlike Line/Bar.
+  // Adds SERIES_ID so hovering an arc can highlight its legend entry and hovering a legend entry can
+  // fade this mark's arcs - donut rows don't have SERIES_ID by default like Line/Bar do
   if (isInteractive(options) || legendHighlightSignals?.length) {
     data[filteredTableIndex].transform?.push(...getSeriesIdTransform([color]));
   }

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
@@ -97,6 +97,22 @@ describe('getArcMark()', () => {
         "min(testName_sliceGap / (min(width, height) / 2 - 2), datum['testName_arcLength'] * 0.3333333333333333)",
     });
   });
+
+  test('should fade segments that do not match a hovered Legend entry', () => {
+    const arcMark = getArcMark({ ...defaultDonutOptions, legendHighlightSignals: ['legend0_hoveredSeries'] });
+    const opacity = arcMark.encode?.update?.opacity as { test?: string }[];
+    expect(opacity).toHaveLength(3);
+    expect(opacity[1]).toEqual({
+      test: "isValid(legend0_hoveredSeries) && legend0_hoveredSeries !== datum.rscSeriesId",
+      value: 0.2,
+    });
+  });
+
+  test('should not add any legend-highlight opacity rules when no Legend is paired', () => {
+    const arcMark = getArcMark(defaultDonutOptions);
+    const opacity = arcMark.encode?.update?.opacity as { test?: string }[];
+    expect(opacity.some((rule) => rule.test?.includes('hoveredSeries'))).toBe(false);
+  });
 });
 
 describe('getEmptyStateArcMark()', () => {

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ArcMark, ColorValueRef, ProductionRule, Signal, SourceData, ThresholdScale } from 'vega';
+import { ArcMark, ColorValueRef, NumericValueRef, ProductionRule, Signal, SourceData, ThresholdScale } from 'vega';
 
 import {
   DEFAULT_HOLE_RATIO,
@@ -20,8 +20,10 @@ import {
   DONUT_SIZE_TIER_CUTPOINTS,
   DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION,
   DONUT_SLICE_GAPS,
+  FADE_FACTOR,
   FILTERED_TABLE,
   SELECTED_ITEM,
+  SERIES_ID,
 } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
@@ -166,8 +168,22 @@ const getPadAngleExpr = (options: DonutSpecOptions): string => {
   return `min(${fixedGapAngle}, ${segmentAngle} * ${DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION})`;
 };
 
+/**
+ * Gets opacity rules that fade a segment when a paired Legend's hovered entry doesn't match it -
+ * the reverse direction of the arc's own hover fading the legend (legendUtils.ts). Each signal
+ * fades non-matching segments and falls through (to getMarkOpacity's own rules) otherwise, mirroring
+ * the CONTROLLED_HIGHLIGHTED_ITEM rule shape in addHoveredItemOpacityRules.
+ * @param legendHighlightSignals
+ * @returns opacity rules
+ */
+const getLegendHighlightOpacityRules = (legendHighlightSignals: string[] = []): ({ test: string } & NumericValueRef)[] =>
+  legendHighlightSignals.map((signal) => ({
+    test: `isValid(${signal}) && ${signal} !== datum.${SERIES_ID}`,
+    value: FADE_FACTOR,
+  }));
+
 export const getArcMark = (options: DonutSpecOptions): ArcMark => {
-  const { chartPopovers, chartInspects, colorScheme, idKey, name } = options;
+  const { chartPopovers, chartInspects, colorScheme, idKey, legendHighlightSignals, name } = options;
   const outerRadius = getDonutOuterRadiusExpr(options);
   return {
     type: 'arc',
@@ -189,7 +205,11 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
         innerRadius: { signal: getDonutInnerRadiusExpr(options) },
         outerRadius: { signal: outerRadius },
         // hide the segments when there isn't any data to display, the empty state ring is shown instead
-        opacity: [{ test: getDonutEmptyStateTest(name), value: 0 }, ...getMarkOpacity(options)],
+        opacity: [
+          { test: getDonutEmptyStateTest(name), value: 0 },
+          ...getLegendHighlightOpacityRules(legendHighlightSignals),
+          ...getMarkOpacity(options),
+        ],
         cursor: getCursor(chartPopovers),
         strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${idKey}`, value: 2 }, { value: 0 }],
       },

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -373,4 +373,24 @@ describe('hover behavior', () => {
       { value: '#505050' },
     ]);
   });
+
+  test("value line fill also switches to the segment's own categorical color when a paired Legend's hovered entry matches it", () => {
+    const [mark] = getSegmentLabelValueTextMark({
+      ...interactiveSegmentLabelOptions,
+      donutOptions: { ...interactiveDonutOptions, legendHighlightSignals: ['legend0_hoveredSeries'] },
+    });
+    expect(mark.encode?.update?.fill).toEqual([
+      {
+        test: "isValid(testName_hoveredItem) && testName_hoveredItem.rscMarkId === datum.rscMarkId",
+        scale: 'color',
+        field: 'testColor',
+      },
+      {
+        test: 'isValid(legend0_hoveredSeries) && legend0_hoveredSeries === datum.rscSeriesId',
+        scale: 'color',
+        field: 'testColor',
+      },
+      { value: '#505050' },
+    ]);
+  });
 });

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -302,7 +302,7 @@ describe('s2 styles', () => {
   });
 
   describe('getSegmentLabelValueTextMark()', () => {
-    test('should always add bold fontWeight and gray-700 fill for S2', () => {
+    test('should always add bold fontWeight, and default to gray-700 fill for S2', () => {
       const marks = getSegmentLabelValueTextMark({
         ...defaultSegmentLabelOptions,
         value: true,
@@ -310,7 +310,15 @@ describe('s2 styles', () => {
 
       expect(marks).toHaveLength(1);
       expect(marks[0].encode?.enter?.fontWeight).toEqual({ value: 'bold' });
-      expect(marks[0].encode?.enter?.fill).toEqual({ value: '#505050' });
+      // fill lives in `update` (not `enter`) since it must react to hover state - see 'hover behavior' below
+      expect(marks[0].encode?.update?.fill).toEqual([
+        {
+          test: "isValid(testName_hoveredItem) && testName_hoveredItem.rscMarkId === datum.rscMarkId",
+          scale: 'color',
+          field: 'testColor',
+        },
+        { value: '#505050' },
+      ]);
     });
 
     test('value dy should shift by the name line font size, not a fixed px amount, so the gap stays 0px at every tier', () => {
@@ -320,5 +328,49 @@ describe('s2 styles', () => {
           "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? 0 : testName_segmentLabelNameFontSize",
       });
     });
+  });
+});
+
+describe('hover behavior', () => {
+  // a SegmentLabel showing a value is what makes isInteractive() (and therefore getMarkOpacity()) treat
+  // this donut as interactive - see markUtils.test.ts for the isInteractive() coverage itself
+  const interactiveDonutOptions: DonutSpecOptions = {
+    ...defaultDonutOptionsWithSegmentLabel,
+    segmentLabels: [{ value: true }],
+  };
+  const interactiveSegmentLabelOptions: SegmentLabelSpecOptions = {
+    ...defaultSegmentLabelOptions,
+    donutOptions: interactiveDonutOptions,
+    value: true,
+  };
+
+  test('name line opacity fades with the arc, reusing getMarkOpacity - matches the arc mark exactly', () => {
+    const mark = getSegmentLabelTextMark(interactiveSegmentLabelOptions);
+    const opacity = mark.encode?.update?.opacity as { test?: string }[];
+    expect(opacity.some((rule) => rule.test?.includes('hoveredItem'))).toBe(true);
+  });
+
+  test('name line fill never changes with hover - only the value line does', () => {
+    const mark = getSegmentLabelTextMark(interactiveSegmentLabelOptions);
+    expect(mark.encode?.enter?.fill).toEqual({ value: '#505050' });
+    expect(mark.encode?.update?.fill).toBeUndefined();
+  });
+
+  test('value line opacity fades with the arc, reusing getMarkOpacity', () => {
+    const [mark] = getSegmentLabelValueTextMark(interactiveSegmentLabelOptions);
+    const opacity = mark.encode?.update?.opacity as { test?: string }[];
+    expect(opacity.some((rule) => rule.test?.includes('hoveredItem'))).toBe(true);
+  });
+
+  test("value line fill switches to the segment's own categorical color when that segment is hovered", () => {
+    const [mark] = getSegmentLabelValueTextMark(interactiveSegmentLabelOptions);
+    expect(mark.encode?.update?.fill).toEqual([
+      {
+        test: "isValid(testName_hoveredItem) && testName_hoveredItem.rscMarkId === datum.rscMarkId",
+        scale: 'color',
+        field: 'testColor',
+      },
+      { value: '#505050' },
+    ]);
   });
 });

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -32,6 +32,7 @@ import {
   DONUT_SIZE_TIER_CUTPOINTS,
   FILTERED_TABLE,
   HOVERED_ITEM,
+  SERIES_ID,
 } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
@@ -312,19 +313,25 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
 
 /**
  * Gets the fill for the segment label value line - switches to the hovered/highlighted segment's
- * own categorical color (matching the arc's color resolution), falling back to gray-700 otherwise.
- * The name line never changes color, only this value line does.
+ * own categorical color (matching the arc's color resolution) when either this donut's own arc is
+ * hovered or a paired Legend's hovered entry matches this segment, falling back to gray-700
+ * otherwise. The name line never changes color, only this value line does.
  * @param donutOptions
  * @returns ProductionRule<ColorValueRef>
  */
 const getSegmentLabelValueFill = (donutOptions: DonutSpecOptions): ProductionRule<ColorValueRef> => {
-  const { color, colorScheme, idKey, name } = donutOptions;
+  const { color, colorScheme, idKey, legendHighlightSignals, name } = donutOptions;
   const hoveredItemSignal = `${name}_${HOVERED_ITEM}`;
+  const colorRule = getColorProductionRule(color, colorScheme);
   return [
     {
       test: `isValid(${hoveredItemSignal}) && ${hoveredItemSignal}.${idKey} === datum.${idKey}`,
-      ...getColorProductionRule(color, colorScheme),
+      ...colorRule,
     },
+    ...(legendHighlightSignals ?? []).map((signal) => ({
+      test: `isValid(${signal}) && ${signal} === datum.${SERIES_ID}`,
+      ...colorRule,
+    })),
     { value: getS2ColorValue('gray-700', colorScheme) },
   ];
 };

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+  ColorValueRef,
   GroupMark,
   NumericValueRef,
   ProductionRule,
@@ -30,9 +31,11 @@ import {
   DONUT_SEGMENT_LABEL_MIN_ANGLE,
   DONUT_SIZE_TIER_CUTPOINTS,
   FILTERED_TABLE,
+  HOVERED_ITEM,
 } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
 
+import { getColorProductionRule, getMarkOpacity } from '../marks/markUtils';
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, SegmentLabelOptions, SegmentLabelSpecOptions } from '../types';
 import { getDonutEmptyStateTest, getDonutOuterRadiusExpr } from './donutUtils';
@@ -237,6 +240,9 @@ export const getSegmentLabelTextMark = (options: SegmentLabelSpecOptions): TextM
                 signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? -${name}_segmentLabelValueFontSize : 0`,
               }
             : undefined,
+        // fades in step with the arc's own hover/controlled-highlight fade (getMarkOpacity is the
+        // exact mechanism getArcMark uses) - the name line's color never switches, only its opacity
+        opacity: getMarkOpacity(donutOptions),
       },
     },
   };
@@ -263,7 +269,6 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
           // drop all labels when there isn't any data to display, the empty state ring is shown instead
           text: [{ test: getDonutEmptyStateTest(donutOptions.name), value: '' }, ...valueTextRules],
           fontWeight: { value: 'bold' },
-          fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
         },
         update: {
           ...positionEncodings,
@@ -272,6 +277,8 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
           dy: {
             signal: `datum['${donutOptions.name}_arcTheta'] <= 0.5 * PI || datum['${donutOptions.name}_arcTheta'] >= 1.5 * PI ? 0 : ${donutOptions.name}_segmentLabelNameFontSize`,
           },
+          fill: getSegmentLabelValueFill(donutOptions),
+          opacity: getMarkOpacity(donutOptions),
         },
       },
     },
@@ -302,6 +309,26 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
     },
   };
 };
+
+/**
+ * Gets the fill for the segment label value line - switches to the hovered/highlighted segment's
+ * own categorical color (matching the arc's color resolution), falling back to gray-700 otherwise.
+ * The name line never changes color, only this value line does.
+ * @param donutOptions
+ * @returns ProductionRule<ColorValueRef>
+ */
+const getSegmentLabelValueFill = (donutOptions: DonutSpecOptions): ProductionRule<ColorValueRef> => {
+  const { color, colorScheme, idKey, name } = donutOptions;
+  const hoveredItemSignal = `${name}_${HOVERED_ITEM}`;
+  return [
+    {
+      test: `isValid(${hoveredItemSignal}) && ${hoveredItemSignal}.${idKey} === datum.${idKey}`,
+      ...getColorProductionRule(color, colorScheme),
+    },
+    { value: getS2ColorValue('gray-700', colorScheme) },
+  ];
+};
+
 /**
  * position encodings
  */

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.test.ts
@@ -251,6 +251,14 @@ describe('isInteractive()', () => {
   test('should return true if hasOnClick', () => {
     expect(isInteractive({ hasOnClick: true })).toEqual(true);
   });
+
+  test('should return true for a donut SegmentLabel showing value/percent, even with no popover/inspect', () => {
+    expect(isInteractive({ segmentLabels: [{ value: true }] })).toEqual(true);
+    expect(isInteractive({ segmentLabels: [{ percent: true }] })).toEqual(true);
+    // a SegmentLabel that shows neither value nor percent has no hover-reactive content
+    expect(isInteractive({ segmentLabels: [{}] })).toEqual(false);
+    expect(isInteractive({ segmentLabels: [] })).toEqual(false);
+  });
 });
 
 describe('getCursor()', () => {

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.ts
@@ -67,6 +67,7 @@ import {
   ProductionRuleTests,
   ScaleType,
   ScatterSpecOptions,
+  SegmentLabelOptions,
   SymbolSizeFacet,
   TrendlineOptions,
   VennSpecOptions,
@@ -138,11 +139,13 @@ export const isInteractive = (options: {
   hasOnClick?: boolean;
   hasOnContextMenu?: boolean;
   metricRanges?: MetricRangeOptions[];
+  segmentLabels?: SegmentLabelOptions[];
   trendlines?: TrendlineOptions[];
 }): boolean => {
   const hasOnClick = 'hasOnClick' in options && options.hasOnClick;
   const hasOnContextMenu = 'hasOnContextMenu' in options && options.hasOnContextMenu;
   const metricRanges = ('metricRanges' in options && options.metricRanges) || [];
+  const segmentLabels = ('segmentLabels' in options && options.segmentLabels) || [];
   const trendlines = ('trendlines' in options && options.trendlines) || [];
 
   return (
@@ -151,7 +154,9 @@ export const isInteractive = (options: {
     hasPopover(options) ||
     hasInspect(options) ||
     trendlines.some((trendline) => trendline.displayOnHover) ||
-    metricRanges.some((metricRange) => metricRange.displayOnHover)
+    metricRanges.some((metricRange) => metricRange.displayOnHover) ||
+    // a direct label showing value/percent needs hover feedback even with no popover/inspect configured
+    segmentLabels.some((segmentLabel) => segmentLabel.value || segmentLabel.percent)
   );
 };
 

--- a/packages/vega-spec-builder-s2/src/types/marks/donutSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/donutSpec.types.ts
@@ -57,5 +57,6 @@ export interface DonutSpecOptions extends PartiallyRequired<DonutOptions, DonutO
   highlightedItem?: HighlightedItem;
   idKey: string;
   index: number;
+  legendHighlightSignals?: string[];
   markType: 'donut';
 }

--- a/planning/specs/donut/implemented/donut-hover.json
+++ b/planning/specs/donut/implemented/donut-hover.json
@@ -4,8 +4,8 @@
   "chartType": "donut",
   "kind": "feature",
   "variant": "s2",
-  "status": "approved",
-  "lastUpdated": "2026-08-18",
+  "status": "implemented",
+  "lastUpdated": "2026-09-01",
   "complexity": {
     "score": 3,
     "rationale": "Most of the underlying machinery already exists and is shared (arc opacity fade already works correctly via the existing getMarkOpacity/addHoveredItemOpacityRules mechanism; extending it to the label text marks and broadening the isInteractive gate both follow an existing precedented pattern used elsewhere for trendlines/metricRanges' displayOnHover). What pushes this to a 3 rather than a 2: the hovered-segment value-line color switch (fill driven by HOVERED_ITEM) has no precedent anywhere in the codebase, and the legend-sync requirement reuses an existing generic mechanism (legendHighlightSignals) that's already computed and passed into donut's options but never consumed - Line/Bar's consumption of it is a real, confirmed precedent for the legend-hover-to-mark-opacity direction, but the reverse direction the user specifically asked about (mark-hover-to-legend-highlight) still needs confirming before treating it as a fully precedented port."
@@ -72,9 +72,14 @@
       "lines": "145-159"
     },
     {
-      "file": "packages/react-spectrum-charts-s2/src/stories/components/SegmentLabel/SegmentLabel.story.tsx",
-      "change": "Add a hover story matching the Figma reference: SegmentLabel with value/percent, no popover configured, verifying hover fade + color-switch works without any interactive child other than the SegmentLabel itself.",
+      "file": "packages/react-spectrum-charts-s2/src/stories/Donut/Features/Hover/DonutHover.story.tsx",
+      "change": "CORRECTED PATH (originally planned as components/SegmentLabel/SegmentLabel.story.tsx): added a hover story matching the Figma reference - SegmentLabel with value/percent, no popover configured, plus a second story pairing the donut with a Legend to exercise the bidirectional legend-sync.",
       "lines": "N/A - new story"
+    },
+    {
+      "file": "packages/vega-spec-builder-s2/src/marks/markUtils.test.ts, donutSpecBuilder.test.ts, donutUtils.test.ts",
+      "change": "ADDED (not in original plan): companion test coverage for the isInteractive broadening and the SERIES_ID transform/legend-highlight opacity rules, alongside the segmentLabelUtils.test.tsx tests already planned.",
+      "lines": "N/A - new test cases"
     },
     {
       "file": "packages/vega-spec-builder-s2/src/types/marks/donutSpec.types.ts",
@@ -88,10 +93,10 @@
     }
   ],
   "openQuestions": [
-    "Should merely configuring a SegmentLabel with value/percent make the donut interactive-for-hover by default (matching the Figma reference), or should hover behavior remain gated behind an explicit popover/inspect/onClick as it is today - i.e. is this a new default behavior or should it require an opt-in?",
-    "Should the direct-label fade/color-switch also react to CONTROLLED_HIGHLIGHTED_ITEM (externally-driven highlight), matching the arc's existing shared mechanism, or should it be mouse-hover-only even though the underlying getMarkOpacity function doesn't distinguish between the two?",
-    "Confirm 'Emphasize' (the static per-segment property visible in Figma's donut component variants) is fully out of scope here and tracked as its own separate future feature, not partially addressed by this spec.",
-    "Confirm exactly which direction(s) Line/Bar's existing legendHighlightSignals mechanism implements today (research so far confirms legend-hover -> mark-opacity via getHighlightedSeriesOpacityRules/setHoverOpacityForMarks) - the user's ask is specifically the reverse direction (mark-hover -> legend-entry-highlight), which needs its own confirmation of precedent (or lack of one) before 'mirror Line/Bar' can be treated as a fully precedented port rather than partially new work."
+    "RESOLVED: a SegmentLabel configured to show value or percent makes the donut interactive-for-hover by default, no opt-in required - see the `segmentLabels.some((segmentLabel) => segmentLabel.value || segmentLabel.percent)` clause added to isInteractive (markUtils.ts).",
+    "RESOLVED: yes - the label fade reuses getMarkOpacity directly (the same shared mechanism the arc mark already uses), so it automatically reacts to CONTROLLED_HIGHLIGHTED_ITEM as well as real mouse hover, by construction rather than as a separate decision.",
+    "RESOLVED: Emphasize was confirmed out of scope here and built as its own separate spec/feature (donut-emphasize, since implemented) with a static gray-swap mechanism unrelated to this spec's opacity-fade approach.",
+    "RESOLVED: both directions were implemented. Legend-hover -> arc-fade via getLegendHighlightOpacityRules (donutUtils.ts). Arc-hover -> legend-highlight via the existing generic mark-hover loop in legendUtils.ts, which donut now participates in because getSeriesIdTransform (donutSpecBuilder.ts addData) adds the SERIES_ID field donut rows previously lacked - both directions match on datum[SERIES_ID]."
   ],
   "relatedIssues": ["donut-direct-labels", "donut-summary-responsive-sizing"]
 }


### PR DESCRIPTION
## Description

Implements the `donut-hover` spec: hovering a donut segment fades its siblings, switches the hovered segment's direct-label value to its own categorical color, and syncs highlight state bidirectionally with a paired `<Legend>`.

- Extends `isInteractive` so a donut with a `SegmentLabel` showing `value`/`percent` is hover-interactive on its own, with no popover/inspect required. Verified no other mark type declares a `segmentLabels` field, so this is a no-op everywhere else.
- Adds a `SERIES_ID` data transform (reusing the existing generic `getSeriesIdTransform` helper) whenever a donut is interactive or paired with a highlighting `Legend` - needed for both hover directions with a Legend to actually match rows, since donut's data never had this field before, unlike Line/Bar.
- Both `SegmentLabel` text marks now fade via the same `getMarkOpacity` mechanism the arc mark already used, and the value line switches to the hovered segment's own categorical color (the name line stays gray-700, unchanged) - matching the Figma reference exactly.
- Adds `legendHighlightSignals` to `DonutSpecOptions` and consumes it on the arc mark, fading non-matching segments when a paired Legend entry is hovered - the reverse direction of the arc's own hover already highlighting the legend generically via `userMeta.interactiveMarks`.
- Adds `Donut/Features/Hover` stories: a bare `SegmentLabel` case (no popover) and a `Legend`-paired case demonstrating both hover directions.

## Related Issue

`planning/specs/donut/donut-hover.json` (approved)

## Motivation and Context

Today a donut with only a direct label configured (no popover/inspect) produces no hover feedback at all, and even where hover exists (via a popover), the direct label's value never reflects which segment is hovered and never fades with its de-emphasized arc. Separately, a donut paired with a `<Legend>` never highlighted in either direction, unlike Line/Bar, because the generic `legendHighlightSignals` mechanism was already being spread into donut's options but silently dropped (untyped, unconsumed), and donut's data was missing the `SERIES_ID` field the legend's generic hover matching relies on.

## How Has This Been Tested?

- Unit tests added/updated in `markUtils.test.ts`, `donutSpecBuilder.test.ts`, `donutUtils.test.ts`, and a new `hover behavior` block in `segmentLabelUtils.test.tsx`.
- Full `vega-spec-builder-s2`/`react-spectrum-charts-s2` test suite passes (131 suites, 2120 tests).
- `yarn lint` and `yarn tsc --noEmit` are clean (no new errors; two pre-existing unrelated failures confirmed present on `main` too).
- Verified live in Storybook via Playwright, using precise on-pixel hover simulation (not bounding-box centers, which land inside a wedge's hole for thin rings): hovering an arc fades siblings to 0.2 opacity, keeps the hovered value's color, and highlights the matching legend entry; hovering a legend entry fades non-matching arcs. Both directions confirmed working end-to-end.

## Screenshots (if appropriate):

See the `SimpleDirectLabel` and `WithLegend` stories under `React Spectrum Charts 2/Donut/Features/Hover` in Storybook.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.