### PR TITLE
Sankey mark s2

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -248,6 +248,20 @@ export const DEFAULT_VENN_METRIC = 'size';
 /** default key in data for the label inside the venn*/
 export const DEFAULT_VENN_LABEL = 'label';
 
+// sankey constants
+/** default key in data for the source node of a sankey link */
+export const DEFAULT_SANKEY_SOURCE = 'source';
+/** default key in data for the target node of a sankey link */
+export const DEFAULT_SANKEY_TARGET = 'target';
+/** default key in data for the value (thickness) of a sankey link */
+export const DEFAULT_SANKEY_VALUE = 'value';
+/** default key used to color sankey nodes/links, refers to the derived node id */
+export const DEFAULT_SANKEY_COLOR = 'id';
+/** fixed pixel width of a sankey node rect */
+export const SANKEY_NODE_WIDTH = 24;
+/** minimum vertical pixel gap between two nodes in the same column */
+export const SANKEY_NODE_PADDING = 8;
+
 // ratio that each opacity is divded by when hovering or highlighting from legend
 // TODO: invert this ratio so we don't have to do 1 / HIGHLIGHT_CONTRAST_RATIO every time
 /**

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -78,13 +78,8 @@ export default function useSpec({
     });
 
     return buildSpec(chartOptions);
-    // chartHeight/chartWidth are intentionally excluded below (AN-445759): resizing must not rebuild
-    // the spec/re-embed the view (it causes flicker) for the vast majority of marks, which position
-    // themselves via Vega's own responsive width/height signals, not literal JS numbers. They're
-    // still read above so marks that *do* need literal pixel dimensions at spec-build time (Venn,
-    // Sankey) get real values on the initial build, rather than each falling back to its own
-    // internal default -- but a resize alone won't refresh that geometry, same as it wouldn't for
-    // any other mark relying on this pattern.
+    // chartHeight/chartWidth intentionally excluded (AN-445759): a resize alone must not re-embed the
+    // view (flicker) -- marks needing literal pixel dims (Venn, Sankey) only get them on initial build.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     UNSAFE_vegaSpec,

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -23,6 +23,8 @@ export default function useSpec({
   animations,
   animationTypes,
   backgroundColor,
+  chartHeight,
+  chartWidth,
   children,
   colors,
   colorScheme,
@@ -56,6 +58,8 @@ export default function useSpec({
       animations,
       animationTypes,
       backgroundColor,
+      chartHeight,
+      chartWidth,
       children,
       colors,
       colorScheme,
@@ -74,6 +78,14 @@ export default function useSpec({
     });
 
     return buildSpec(chartOptions);
+    // chartHeight/chartWidth are intentionally excluded below (AN-445759): resizing must not rebuild
+    // the spec/re-embed the view (it causes flicker) for the vast majority of marks, which position
+    // themselves via Vega's own responsive width/height signals, not literal JS numbers. They're
+    // still read above so marks that *do* need literal pixel dimensions at spec-build time (Venn,
+    // Sankey) get real values on the initial build, rather than each falling back to its own
+    // internal default -- but a resize alone won't refresh that geometry, same as it wouldn't for
+    // any other mark relying on this pattern.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     UNSAFE_vegaSpec,
     animations,

--- a/packages/react-spectrum-charts-s2/src/pre-alpha/components/Sankey/Sankey.tsx
+++ b/packages/react-spectrum-charts-s2/src/pre-alpha/components/Sankey/Sankey.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { FC } from 'react';
+
+import { DEFAULT_SANKEY_COLOR, DEFAULT_SANKEY_SOURCE, DEFAULT_SANKEY_TARGET, DEFAULT_SANKEY_VALUE } from '@spectrum-charts/constants';
+
+import { SankeyProps } from '../../../types';
+
+// destructure props here and set defaults so that storybook can pick them up
+const Sankey: FC<SankeyProps> = ({
+  children,
+  color = DEFAULT_SANKEY_COLOR,
+  name,
+  source = DEFAULT_SANKEY_SOURCE,
+  target = DEFAULT_SANKEY_TARGET,
+  value = DEFAULT_SANKEY_VALUE,
+}) => {
+  return null;
+};
+
+// displayName is used to validate the component type in the spec builder
+Sankey.displayName = 'Sankey';
+
+export { Sankey };

--- a/packages/react-spectrum-charts-s2/src/pre-alpha/components/Sankey/index.ts
+++ b/packages/react-spectrum-charts-s2/src/pre-alpha/components/Sankey/index.ts
@@ -10,15 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './Area';
-export * from './Bullet';
-export * from './Combo';
-export * from './Donut';
-export * from './DonutSummary';
 export * from './Sankey';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
@@ -24,7 +24,6 @@ import {
   LinePointAnnotationOptions,
   MarkOptions,
   ReferenceLineOptions,
-  SankeyOptions,
   ScatterAnnotationOptions,
   ScatterPathOptions,
   SegmentLabelOptions,

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/childrenAdapter.ts
@@ -24,6 +24,7 @@ import {
   LinePointAnnotationOptions,
   MarkOptions,
   ReferenceLineOptions,
+  SankeyOptions,
   ScatterAnnotationOptions,
   ScatterPathOptions,
   SegmentLabelOptions,
@@ -51,6 +52,7 @@ import {
   Combo,
   Donut,
   DonutSummary,
+  Sankey,
   Scatter,
   ScatterAnnotation,
   ScatterPath,
@@ -76,6 +78,7 @@ import {
   LinePointAnnotationProps,
   LineProps,
   ReferenceLineProps,
+  SankeyProps,
   ScatterAnnotationProps,
   ScatterPathProps,
   ScatterProps,
@@ -95,6 +98,7 @@ import { getComboOptions } from './comboAdapter';
 import { getDonutOptions } from './donutAdapter';
 import { getLegendOptions } from './legendAdapter';
 import { getLineOptions } from './lineAdapter';
+import { getSankeyOptions } from './sankeyAdapter';
 import { getScatterOptions } from './scatterAdapter';
 import { getTrendlineOptions } from './trendlineAdapter';
 
@@ -216,6 +220,10 @@ export const childrenToOptions = (
 
       case ReferenceLine.displayName:
         referenceLines.push(child.props as ReferenceLineProps);
+        break;
+
+      case Sankey.displayName:
+        marks.push(getSankeyOptions(child.props as SankeyProps));
         break;
 
       case Scatter.displayName:

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/sankeyAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/sankeyAdapter.ts
@@ -9,16 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { SankeyOptions } from '@spectrum-charts/vega-spec-builder-s2';
 
-export * from './Area';
-export * from './Bullet';
-export * from './Combo';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Sankey';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
+import { SankeyProps } from '../types';
+import { childrenToOptions } from './childrenAdapter';
+
+export const getSankeyOptions = ({ children, ...sankeyProps }: SankeyProps): SankeyOptions => {
+  const { chartInspects, chartPopovers } = childrenToOptions(children);
+  return {
+    ...sankeyProps,
+    chartInspects,
+    chartPopovers,
+    markType: 'sankey',
+  };
+};

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Datum } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Chart } from '../../../Chart';
+import { ChartInspect, ChartPopover } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { Sankey } from '../../../pre-alpha';
+import { bindWithProps } from '../../../test-utils';
+import { ChartProps, SankeyProps } from '../../../types';
+import {
+  basicSankeyData,
+  singleChainSankeyData,
+  threeColumnSankeyData,
+  twoColumnSankeyData,
+  workspaceFlowSankeyData,
+} from './data';
+
+export default {
+  title: 'React Spectrum Charts 2/Pre-Alpha/Sankey/Features',
+  component: Sankey,
+};
+
+const defaultChartProps: ChartProps = {
+  data: basicSankeyData,
+  width: 500,
+  height: 350,
+  // `buildSpec`'s own default (`'categorical12'`) resolves to the Spectrum *1* categorical palette
+  // (see packages/themes/src/categoricalColorPalette.ts) -- every S2 mark shares that default today
+  // (e.g. Donut's own stories don't override it either), so this isn't a Sankey-specific issue, but
+  // it's worth pointing this story at the real Spectrum 2 tokens explicitly rather than reproducing it.
+  colors: 's2Categorical12',
+};
+
+// factory so each story can point at its own dataset (and, optionally, its own color scale) while
+// sharing the same chart shell/args wiring
+const makeSankeyStory = (
+  data: ChartProps['data'],
+  colors?: ChartProps['colors']
+): StoryFn<SankeyProps & { width?: number; height?: number }> => {
+  const SankeyStory: StoryFn<SankeyProps & { width?: number; height?: number }> = (args): ReactElement => {
+    const { width, height, ...sankeyProps } = args;
+    const chartProps = useChartProps({
+      ...defaultChartProps,
+      ...(colors ? { colors } : {}),
+      data,
+      width: width ?? 500,
+      height: height ?? 350,
+    });
+    return (
+      <Chart {...chartProps}>
+        {/* 14px matches DIRECT_LABEL_FONT_SIZE_S -- reusing Line's direct-label font-size option
+            (getDirectLabelFontSizeProductionRule) rather than a Sankey-specific size. */}
+        <Sankey fontSize={14} {...sankeyProps} />
+      </Chart>
+    );
+  };
+  return SankeyStory;
+};
+
+const SankeyStory = makeSankeyStory(basicSankeyData);
+
+// content shared by the node and link inspects/popovers -- branches on the datum shape since both
+// layers share a single set of interactive children (see sankeySpecBuilder.ts for why)
+const dialogContent = (datum: Datum) => {
+  if ('sourceId' in datum) {
+    return (
+      <div>
+        <div>
+          {String(datum.sourceId)} → {String(datum.targetId)}
+        </div>
+        <div>Value: {String(datum.value)}</div>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div>{String(datum.id)}</div>
+      <div>Value: {String(datum.value)}</div>
+    </div>
+  );
+};
+
+const interactiveChildren = [
+  <ChartInspect key={0}>{dialogContent}</ChartInspect>,
+  <ChartPopover width="auto" key={1}>
+    {dialogContent}
+  </ChartPopover>,
+];
+
+// Right-click is just the `rightClick` prop on the same ChartPopover every other mark uses (see
+// ChartPopover.story.tsx's own `RightClick` story) -- the click/contextmenu event wiring lives in
+// useNewChartView.tsx/usePopovers.tsx, both generic over any mark's children, so Sankey gets it for
+// free with no sankey-specific code. This story only proves that's true for both node and link marks.
+const rightClickChildren = [
+  <ChartPopover width="auto" rightClick key={0}>
+    {dialogContent}
+  </ChartPopover>,
+];
+
+const Basic = bindWithProps(SankeyStory);
+Basic.args = {};
+
+const NodeAndLinkInspect = bindWithProps(SankeyStory);
+NodeAndLinkInspect.args = {
+  children: interactiveChildren,
+};
+
+const RightClickInspect = bindWithProps(SankeyStory);
+RightClickInspect.args = {
+  children: rightClickChildren,
+};
+
+// Closest analog to the canonical Kibana/Elastic Sankey example -- a single source column fanning
+// out into a single destination column, no re-branching. Good first story to look at.
+const TwoColumnFlow = bindWithProps(makeSankeyStory(twoColumnSankeyData));
+TwoColumnFlow.args = {};
+
+// The simplest possible Sankey: one unbranched path, so it renders as a single band that narrows
+// step to step (100 -> 80 -> 60) with nothing else in any column competing for space.
+const SingleChain = bindWithProps(makeSankeyStory(singleChainSankeyData));
+SingleChain.args = {};
+
+// A clean 3-column flow (traffic source -> device -> outcome) where every column has multiple
+// nodes, so it branches and merges at each step rather than narrowing to a single node anywhere.
+const ThreeColumnFlow = bindWithProps(makeSankeyStory(threeColumnSankeyData));
+ThreeColumnFlow.args = {};
+
+// Approximates Analysis Workspace's own Flow visualization look: a "*"-prefixed root node, large
+// comma-formatted path-view counts under each node name, and "+N more" long-tail aggregate nodes.
+// Wider/taller than the other stories since Workspace's real node names run long. Uses the built-in
+// s2Categorical16 palette (a real, designed S2 palette, like the shared s2Categorical12 the other
+// stories use, just the next size up) rather than a hand-picked set of individual hue tokens.
+const workspaceFlowColors: ChartProps['colors'] = 's2Categorical16';
+const WorkspaceFlowExample = bindWithProps(makeSankeyStory(workspaceFlowSankeyData, workspaceFlowColors));
+// Workspace's own Flow chart doesn't fit its data into a fixed height -- it grows the canvas to fit
+// the data and lets the outer viewport scroll instead (CloudViz.js's `_measureChart`/`_sizeChart`).
+// RSC's <Chart> only supports a fixed height, so 650px is an approximation of the room Workspace
+// would actually give this data, rather than the tighter 450px used by the other stories.
+WorkspaceFlowExample.args = { width: 900, height: 650 };
+
+export {
+  Basic,
+  NodeAndLinkInspect,
+  RightClickInspect,
+  SingleChain,
+  ThreeColumnFlow,
+  TwoColumnFlow,
+  WorkspaceFlowExample,
+};

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
@@ -38,10 +38,8 @@ const defaultChartProps: ChartProps = {
   data: basicSankeyData,
   width: 500,
   height: 350,
-  // `buildSpec`'s own default (`'categorical12'`) resolves to the Spectrum *1* categorical palette
-  // (see packages/themes/src/categoricalColorPalette.ts) -- every S2 mark shares that default today
-  // (e.g. Donut's own stories don't override it either), so this isn't a Sankey-specific issue, but
-  // it's worth pointing this story at the real Spectrum 2 tokens explicitly rather than reproducing it.
+  // `buildSpec`'s default resolves to the Spectrum 1 palette (a shared S2-wide gap, not Sankey-specific)
+  // -- point this story at real Spectrum 2 tokens explicitly instead.
   colors: 's2Categorical12',
 };
 
@@ -62,8 +60,7 @@ const makeSankeyStory = (
     });
     return (
       <Chart {...chartProps}>
-        {/* 14px matches DIRECT_LABEL_FONT_SIZE_S -- reusing Line's direct-label font-size option
-            (getDirectLabelFontSizeProductionRule) rather than a Sankey-specific size. */}
+        {/* 14px matches DIRECT_LABEL_FONT_SIZE_S -- reuses Line's font-size option, not a Sankey-specific size. */}
         <Sankey fontSize={14} {...sankeyProps} />
       </Chart>
     );
@@ -73,8 +70,7 @@ const makeSankeyStory = (
 
 const SankeyStory = makeSankeyStory(basicSankeyData);
 
-// content shared by the node and link inspects/popovers -- branches on the datum shape since both
-// layers share a single set of interactive children (see sankeySpecBuilder.ts for why)
+// shared by node and link inspects/popovers -- branches on datum shape since both layers share one set of children
 const dialogContent = (datum: Datum) => {
   if ('sourceId' in datum) {
     return (
@@ -101,10 +97,8 @@ const interactiveChildren = [
   </ChartPopover>,
 ];
 
-// Right-click is just the `rightClick` prop on the same ChartPopover every other mark uses (see
-// ChartPopover.story.tsx's own `RightClick` story) -- the click/contextmenu event wiring lives in
-// useNewChartView.tsx/usePopovers.tsx, both generic over any mark's children, so Sankey gets it for
-// free with no sankey-specific code. This story only proves that's true for both node and link marks.
+// Right-click is just `rightClick` on the same ChartPopover every mark uses (see ChartPopover.story.tsx) --
+// generic click/contextmenu wiring, no sankey-specific code needed. This proves it for both layers.
 const rightClickChildren = [
   <ChartPopover width="auto" rightClick key={0}>
     {dialogContent}
@@ -124,32 +118,26 @@ RightClickInspect.args = {
   children: rightClickChildren,
 };
 
-// Closest analog to the canonical Kibana/Elastic Sankey example -- a single source column fanning
-// out into a single destination column, no re-branching. Good first story to look at.
+// Closest analog to the canonical Kibana/Elastic Sankey example -- one source column fanning into
+// one destination column, no re-branching.
 const TwoColumnFlow = bindWithProps(makeSankeyStory(twoColumnSankeyData));
 TwoColumnFlow.args = {};
 
-// The simplest possible Sankey: one unbranched path, so it renders as a single band that narrows
-// step to step (100 -> 80 -> 60) with nothing else in any column competing for space.
+// Simplest possible Sankey: one unbranched path, narrowing step to step (100 -> 80 -> 60).
 const SingleChain = bindWithProps(makeSankeyStory(singleChainSankeyData));
 SingleChain.args = {};
 
-// A clean 3-column flow (traffic source -> device -> outcome) where every column has multiple
-// nodes, so it branches and merges at each step rather than narrowing to a single node anywhere.
+// Clean 3-column flow (traffic source -> device -> outcome) that branches and merges at each step.
 const ThreeColumnFlow = bindWithProps(makeSankeyStory(threeColumnSankeyData));
 ThreeColumnFlow.args = {};
 
-// Approximates Analysis Workspace's own Flow visualization look: a "*"-prefixed root node, large
-// comma-formatted path-view counts under each node name, and "+N more" long-tail aggregate nodes.
-// Wider/taller than the other stories since Workspace's real node names run long. Uses the built-in
-// s2Categorical16 palette (a real, designed S2 palette, like the shared s2Categorical12 the other
-// stories use, just the next size up) rather than a hand-picked set of individual hue tokens.
+// Approximates Analysis Workspace's Flow visualization: a "*"-prefixed root node, comma-formatted
+// counts under each name, and "+N more" long-tail nodes. Uses the built-in s2Categorical16 palette
+// (next size up from the other stories' s2Categorical12).
 const workspaceFlowColors: ChartProps['colors'] = 's2Categorical16';
 const WorkspaceFlowExample = bindWithProps(makeSankeyStory(workspaceFlowSankeyData, workspaceFlowColors));
-// Workspace's own Flow chart doesn't fit its data into a fixed height -- it grows the canvas to fit
-// the data and lets the outer viewport scroll instead (CloudViz.js's `_measureChart`/`_sizeChart`).
-// RSC's <Chart> only supports a fixed height, so 650px is an approximation of the room Workspace
-// would actually give this data, rather than the tighter 450px used by the other stories.
+// Workspace grows its canvas to fit the data instead of a fixed height; <Chart> only supports fixed
+// height, so 650px approximates the room Workspace would give this data.
 WorkspaceFlowExample.args = { width: 900, height: 650 };
 
 export {

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.story.tsx
@@ -38,13 +38,11 @@ const defaultChartProps: ChartProps = {
   data: basicSankeyData,
   width: 500,
   height: 350,
-  // `buildSpec`'s default resolves to the Spectrum 1 palette (a shared S2-wide gap, not Sankey-specific)
-  // -- point this story at real Spectrum 2 tokens explicitly instead.
+  // buildSpec defaults to the S1 palette (a shared S2-wide gap) -- use real S2 tokens here instead.
   colors: 's2Categorical12',
 };
 
-// factory so each story can point at its own dataset (and, optionally, its own color scale) while
-// sharing the same chart shell/args wiring
+// factory so each story can point at its own dataset (and, optionally, color scale) while sharing the chart shell.
 const makeSankeyStory = (
   data: ChartProps['data'],
   colors?: ChartProps['colors']
@@ -97,8 +95,7 @@ const interactiveChildren = [
   </ChartPopover>,
 ];
 
-// Right-click is just `rightClick` on the same ChartPopover every mark uses (see ChartPopover.story.tsx) --
-// generic click/contextmenu wiring, no sankey-specific code needed. This proves it for both layers.
+// Just `rightClick` on the same ChartPopover every mark uses -- no sankey-specific wiring needed.
 const rightClickChildren = [
   <ChartPopover width="auto" rightClick key={0}>
     {dialogContent}
@@ -118,8 +115,7 @@ RightClickInspect.args = {
   children: rightClickChildren,
 };
 
-// Closest analog to the canonical Kibana/Elastic Sankey example -- one source column fanning into
-// one destination column, no re-branching.
+// Closest analog to the canonical Kibana/Elastic Sankey example -- one source column fanning into one destination.
 const TwoColumnFlow = bindWithProps(makeSankeyStory(twoColumnSankeyData));
 TwoColumnFlow.args = {};
 
@@ -131,13 +127,10 @@ SingleChain.args = {};
 const ThreeColumnFlow = bindWithProps(makeSankeyStory(threeColumnSankeyData));
 ThreeColumnFlow.args = {};
 
-// Approximates Analysis Workspace's Flow visualization: a "*"-prefixed root node, comma-formatted
-// counts under each name, and "+N more" long-tail nodes. Uses the built-in s2Categorical16 palette
-// (next size up from the other stories' s2Categorical12).
+// Approximates Analysis Workspace's Flow visualization: root node, comma-formatted counts, "+N more" nodes.
 const workspaceFlowColors: ChartProps['colors'] = 's2Categorical16';
 const WorkspaceFlowExample = bindWithProps(makeSankeyStory(workspaceFlowSankeyData, workspaceFlowColors));
-// Workspace grows its canvas to fit the data instead of a fixed height; <Chart> only supports fixed
-// height, so 650px approximates the room Workspace would give this data.
+// 650px approximates the canvas height Workspace would grow to fit this data (Chart only supports a fixed height).
 WorkspaceFlowExample.args = { width: 900, height: 650 };
 
 export {

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.test.tsx
@@ -40,8 +40,7 @@ describe('Sankey', () => {
     const chart = await findChart();
     expect(chart).toBeInTheDocument();
 
-    // Home, Ad Campaign, Search, Product, Cart, Wishlist, Checkout, Abandoned -- Vega's SVG renderer
-    // draws rect marks as <path> elements too, so both queries use the default 'path' tagName.
+    // Home, Ad Campaign, Search, Product, Cart, Wishlist, Checkout, Abandoned -- rects render as <path> in Vega's SVG output.
     const nodes = await findAllMarksByGroupName(chart, 'sankey0');
     expect(nodes.length).toEqual(8);
 
@@ -49,9 +48,8 @@ describe('Sankey', () => {
     expect(links.length).toEqual(basicSankeyData.length);
   });
 
-  // Regression test: chartWidth/chartHeight must reach the spec builder as the chart's *actual*
-  // rendered size (500x350 here), not silently fall back to addSankey's internal 100x100 default --
-  // see useSpec.tsx, which used to drop chartWidth/chartHeight before forwarding to buildSpec().
+  // Regression: chartWidth/chartHeight must reach the spec builder as the chart's real size (500x350),
+  // not addSankey's 100x100 fallback -- useSpec.tsx used to drop them before forwarding to buildSpec().
   test('Basic lays nodes out across the full chart width, not a 100px fallback', async () => {
     render(<Basic {...Basic.args} />);
     const chart = await findChart();
@@ -62,8 +60,7 @@ describe('Sankey', () => {
       return match ? parseFloat(match[1]) : NaN;
     });
 
-    // 5 columns spread across a 500px-wide chart (minus the 24px node width) should reach well past
-    // the 100px-wide box addSankey falls back to when chartWidth isn't supplied at all.
+    // 5 columns across a 500px chart should reach well past the 100px fallback box.
     expect(Math.max(...xPositions)).toBeGreaterThan(300);
   });
 
@@ -123,9 +120,8 @@ describe('Sankey', () => {
     const links = await findAllMarksByGroupName(chart, 'sankey0_links');
     expect(links.length).toEqual(workspaceFlowSankeyData.length);
 
-    // each label renders as a background-halo + foreground pair (see getSankeyNodeLabelMarkPair in
-    // sankeyUtils.ts), so every label's text is duplicated in the DOM -- assert presence via
-    // findAllByText rather than findByText, which throws on more than one match.
+    // Each label renders as a halo + foreground pair, so its text is duplicated in the DOM --
+    // use findAllByText, not findByText (which throws on more than one match).
     expect(await screen.findAllByText('* Project Load')).toHaveLength(2);
     expect(await screen.findAllByText('+466 more')).toHaveLength(2);
     expect(await screen.findAllByText('+430 more')).toHaveLength(2);
@@ -133,9 +129,7 @@ describe('Sankey', () => {
     expect(await screen.findAllByText('1,389,000')).toHaveLength(2);
   });
 
-  // Right-click support is generic RSC plumbing (usePopovers.tsx/useNewChartView.tsx walk the child
-  // tree for any ChartPopover regardless of which mark it's nested under), not sankey-specific code --
-  // this just confirms that holds for both the node and link marks.
+  // Right-click support is generic RSC plumbing, not sankey-specific -- confirms it holds for both layers.
   test('RightClickInspect opens the popover on right click (not left click) for both nodes and links', async () => {
     render(<RightClickInspect {...RightClickInspect.args} />);
     const chart = await findChart();

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/Sankey.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import userEvent from '@testing-library/user-event';
+
+import { Sankey } from '../../../pre-alpha/components/Sankey';
+import { findAllMarksByGroupName, findChart, render, rightClickNthElement, screen, waitFor } from '../../../test-utils';
+import {
+  basicSankeyData,
+  singleChainSankeyData,
+  threeColumnSankeyData,
+  twoColumnSankeyData,
+  workspaceFlowSankeyData,
+} from './data';
+import {
+  Basic,
+  RightClickInspect,
+  SingleChain,
+  ThreeColumnFlow,
+  TwoColumnFlow,
+  WorkspaceFlowExample,
+} from './Sankey.story';
+
+describe('Sankey', () => {
+  // Sankey is not a real React component. This test just provides test coverage for sonarqube
+  test('Sankey pseudo element', () => {
+    render(<Sankey />);
+  });
+
+  test('Basic renders one rect per unique node and one ribbon per edge', async () => {
+    render(<Basic {...Basic.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // Home, Ad Campaign, Search, Product, Cart, Wishlist, Checkout, Abandoned -- Vega's SVG renderer
+    // draws rect marks as <path> elements too, so both queries use the default 'path' tagName.
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    expect(nodes.length).toEqual(8);
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    expect(links.length).toEqual(basicSankeyData.length);
+  });
+
+  // Regression test: chartWidth/chartHeight must reach the spec builder as the chart's *actual*
+  // rendered size (500x350 here), not silently fall back to addSankey's internal 100x100 default --
+  // see useSpec.tsx, which used to drop chartWidth/chartHeight before forwarding to buildSpec().
+  test('Basic lays nodes out across the full chart width, not a 100px fallback', async () => {
+    render(<Basic {...Basic.args} />);
+    const chart = await findChart();
+
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    const xPositions = nodes.map((node) => {
+      const match = node.getAttribute('d')?.match(/^M(-?\d+(?:\.\d+)?),/);
+      return match ? parseFloat(match[1]) : NaN;
+    });
+
+    // 5 columns spread across a 500px-wide chart (minus the 24px node width) should reach well past
+    // the 100px-wide box addSankey falls back to when chartWidth isn't supplied at all.
+    expect(Math.max(...xPositions)).toBeGreaterThan(300);
+  });
+
+  test('TwoColumnFlow renders one rect per browser/OS and one ribbon per edge', async () => {
+    render(<TwoColumnFlow {...TwoColumnFlow.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // Chrome, Safari, Firefox, Windows, macOS, Linux, iOS
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    expect(nodes.length).toEqual(7);
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    expect(links.length).toEqual(twoColumnSankeyData.length);
+  });
+
+  test('SingleChain renders one rect per step and one ribbon per edge', async () => {
+    render(<SingleChain {...SingleChain.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    expect(nodes.length).toEqual(4);
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    expect(links.length).toEqual(singleChainSankeyData.length);
+  });
+
+  test('ThreeColumnFlow renders one rect per source/device/outcome and one ribbon per edge, across exactly 3 columns', async () => {
+    render(<ThreeColumnFlow {...ThreeColumnFlow.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // Organic Search, Paid Search, Social, Desktop, Mobile, Purchase, Bounce
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    expect(nodes.length).toEqual(7);
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    expect(links.length).toEqual(threeColumnSankeyData.length);
+
+    const xPositions = nodes.map((node) => {
+      const match = node.getAttribute('d')?.match(/^M(-?\d+(?:\.\d+)?),/);
+      return match ? parseFloat(match[1]) : NaN;
+    });
+    expect(new Set(xPositions).size).toEqual(3);
+  });
+
+  test('WorkspaceFlowExample renders the root node, a comma-formatted value under it, and the long-tail nodes', async () => {
+    render(<WorkspaceFlowExample {...WorkspaceFlowExample.args} />);
+    const chart = await findChart();
+    expect(chart).toBeInTheDocument();
+
+    // "* Project Load", 6 col1 nodes, 3 col2 nodes
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    expect(nodes.length).toEqual(10);
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    expect(links.length).toEqual(workspaceFlowSankeyData.length);
+
+    // each label renders as a background-halo + foreground pair (see getSankeyNodeLabelMarkPair in
+    // sankeyUtils.ts), so every label's text is duplicated in the DOM -- assert presence via
+    // findAllByText rather than findByText, which throws on more than one match.
+    expect(await screen.findAllByText('* Project Load')).toHaveLength(2);
+    expect(await screen.findAllByText('+466 more')).toHaveLength(2);
+    expect(await screen.findAllByText('+430 more')).toHaveLength(2);
+    // the root node's value label, comma-formatted (sum of its outgoing edges)
+    expect(await screen.findAllByText('1,389,000')).toHaveLength(2);
+  });
+
+  // Right-click support is generic RSC plumbing (usePopovers.tsx/useNewChartView.tsx walk the child
+  // tree for any ChartPopover regardless of which mark it's nested under), not sankey-specific code --
+  // this just confirms that holds for both the node and link marks.
+  test('RightClickInspect opens the popover on right click (not left click) for both nodes and links', async () => {
+    render(<RightClickInspect {...RightClickInspect.args} />);
+    const chart = await findChart();
+
+    const nodes = await findAllMarksByGroupName(chart, 'sankey0');
+    await rightClickNthElement(nodes, 0);
+    let popover = await screen.findByTestId('rsc-popover');
+    await waitFor(() => expect(popover).toBeInTheDocument());
+    await userEvent.click(chart);
+    await waitFor(() => expect(popover).not.toBeInTheDocument());
+
+    const links = await findAllMarksByGroupName(chart, 'sankey0_links');
+    await rightClickNthElement(links, 0);
+    popover = await screen.findByTestId('rsc-popover');
+    await waitFor(() => expect(popover).toBeInTheDocument());
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/data.ts
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/data.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// A branching pathing-style flow with multiple nodes per column (2 entry points, 2 columns that
+// narrow through a single hub, then re-branch), so the story actually shows the classic Sankey
+// look of parallel bands rather than a single dominant node per column.
+export const basicSankeyData = [
+  { source: 'Home', target: 'Search', value: 8 },
+  { source: 'Home', target: 'Product', value: 12 },
+  { source: 'Ad Campaign', target: 'Search', value: 5 },
+  { source: 'Ad Campaign', target: 'Product', value: 3 },
+  { source: 'Search', target: 'Product', value: 6 },
+  { source: 'Search', target: 'Cart', value: 2 },
+  { source: 'Product', target: 'Cart', value: 10 },
+  { source: 'Product', target: 'Wishlist', value: 4 },
+  { source: 'Cart', target: 'Checkout', value: 9 },
+  { source: 'Cart', target: 'Abandoned', value: 3 },
+  { source: 'Wishlist', target: 'Checkout', value: 2 },
+];
+
+// The classic two-column ("two stack") flow, closest to the canonical Kibana/Elastic Sankey example
+// (https://www.elastic.co/blog/sankey-visualization-with-vega-in-kibana): a single source column
+// flowing into a single destination column, no re-branching in between. Good first example to look
+// at since there's only one thing happening -- browsers fanning out into operating systems.
+export const twoColumnSankeyData = [
+  { source: 'Chrome', target: 'Windows', value: 40 },
+  { source: 'Chrome', target: 'macOS', value: 25 },
+  { source: 'Chrome', target: 'Linux', value: 5 },
+  { source: 'Safari', target: 'macOS', value: 30 },
+  { source: 'Safari', target: 'iOS', value: 20 },
+  { source: 'Firefox', target: 'Windows', value: 15 },
+  { source: 'Firefox', target: 'Linux', value: 10 },
+];
+
+// The simplest possible Sankey: a single, unbranched path. One node per column by construction, so
+// (as expected -- see the note in sankeyUtils.ts on the global value-to-pixel scale) each node fills
+// its entire column since there's nothing else in that column competing for space.
+export const singleChainSankeyData = [
+  { source: 'Step 1: Visit', target: 'Step 2: Add to cart', value: 100 },
+  { source: 'Step 2: Add to cart', target: 'Step 3: Checkout', value: 80 },
+  { source: 'Step 3: Checkout', target: 'Step 4: Purchase', value: 60 },
+];
+
+// Approximates a real Analysis Workspace Flow visualization: a single "*"-prefixed focus/root node
+// (Workspace's own convention for a pinned entry point), large comma-formatted path-view counts, and
+// a "+N more" aggregate node per column standing in for the long tail beyond Workspace's configured
+// "items expanded per column" -- see FlowConfigAdvancedSettings.js in aaui-web-spa, and the research
+// doc at planning/research/sankey-workspace-flow-feasibility/sankey-workspace-flow-feasibility.md.
+// Node/edge values aren't meant to reconcile exactly column to column, just to be Workspace-scale.
+export const workspaceFlowSankeyData = [
+  { source: '* Project Load', target: 'Project Loaded without Anomaly Detection', value: 524000 },
+  { source: '* Project Load', target: 'Project Fully Loaded', value: 200000 },
+  { source: '* Project Load', target: 'Frames Per Second', value: 167000 },
+  { source: '* Project Load', target: 'Table of Contents opened', value: 79000 },
+  { source: '* Project Load', target: 'Open component rail', value: 78000 },
+  { source: '* Project Load', target: '+466 more', value: 341000 },
+
+  { source: 'Project Loaded without Anomaly Detection', target: 'Project Fully Loaded (2)', value: 262000 },
+  { source: 'Project Loaded without Anomaly Detection', target: 'Frames Per Second (2)', value: 157000 },
+  { source: 'Project Loaded without Anomaly Detection', target: '+430 more', value: 105000 },
+
+  { source: 'Project Fully Loaded', target: 'Project Fully Loaded (2)', value: 100000 },
+  { source: 'Project Fully Loaded', target: 'Frames Per Second (2)', value: 60000 },
+  { source: 'Project Fully Loaded', target: '+430 more', value: 40000 },
+
+  { source: 'Frames Per Second', target: 'Project Fully Loaded (2)', value: 83000 },
+  { source: 'Frames Per Second', target: 'Frames Per Second (2)', value: 50000 },
+  { source: 'Frames Per Second', target: '+430 more', value: 34000 },
+
+  { source: 'Table of Contents opened', target: 'Project Fully Loaded (2)', value: 39000 },
+  { source: 'Table of Contents opened', target: 'Frames Per Second (2)', value: 24000 },
+  { source: 'Table of Contents opened', target: '+430 more', value: 16000 },
+
+  { source: 'Open component rail', target: 'Project Fully Loaded (2)', value: 39000 },
+  { source: 'Open component rail', target: 'Frames Per Second (2)', value: 23000 },
+  { source: 'Open component rail', target: '+430 more', value: 16000 },
+
+  { source: '+466 more', target: 'Project Fully Loaded (2)', value: 170000 },
+  { source: '+466 more', target: 'Frames Per Second (2)', value: 102000 },
+  { source: '+466 more', target: '+430 more', value: 69000 },
+];
+
+// A clean 3-column flow with multiple nodes per column throughout (3 -> 2 -> 2), so every column
+// actually branches/merges rather than narrowing to a single node: traffic source -> device -> outcome.
+export const threeColumnSankeyData = [
+  { source: 'Organic Search', target: 'Desktop', value: 30 },
+  { source: 'Organic Search', target: 'Mobile', value: 20 },
+  { source: 'Paid Search', target: 'Desktop', value: 15 },
+  { source: 'Paid Search', target: 'Mobile', value: 25 },
+  { source: 'Social', target: 'Mobile', value: 10 },
+  { source: 'Desktop', target: 'Purchase', value: 25 },
+  { source: 'Desktop', target: 'Bounce', value: 20 },
+  { source: 'Mobile', target: 'Purchase', value: 20 },
+  { source: 'Mobile', target: 'Bounce', value: 35 },
+];

--- a/packages/react-spectrum-charts-s2/src/stories/components/Sankey/data.ts
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Sankey/data.ts
@@ -10,9 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-// A branching pathing-style flow with multiple nodes per column (2 entry points, 2 columns that
-// narrow through a single hub, then re-branch), so the story actually shows the classic Sankey
-// look of parallel bands rather than a single dominant node per column.
+// A branching pathing-style flow with multiple nodes per column, showing parallel bands rather than one dominant node.
 export const basicSankeyData = [
   { source: 'Home', target: 'Search', value: 8 },
   { source: 'Home', target: 'Product', value: 12 },
@@ -27,10 +25,7 @@ export const basicSankeyData = [
   { source: 'Wishlist', target: 'Checkout', value: 2 },
 ];
 
-// The classic two-column ("two stack") flow, closest to the canonical Kibana/Elastic Sankey example
-// (https://www.elastic.co/blog/sankey-visualization-with-vega-in-kibana): a single source column
-// flowing into a single destination column, no re-branching in between. Good first example to look
-// at since there's only one thing happening -- browsers fanning out into operating systems.
+// The classic two-column ("two stack") flow, closest to the canonical Kibana/Elastic Sankey example.
 export const twoColumnSankeyData = [
   { source: 'Chrome', target: 'Windows', value: 40 },
   { source: 'Chrome', target: 'macOS', value: 25 },
@@ -41,21 +36,14 @@ export const twoColumnSankeyData = [
   { source: 'Firefox', target: 'Linux', value: 10 },
 ];
 
-// The simplest possible Sankey: a single, unbranched path. One node per column by construction, so
-// (as expected -- see the note in sankeyUtils.ts on the global value-to-pixel scale) each node fills
-// its entire column since there's nothing else in that column competing for space.
+// The simplest possible Sankey: a single, unbranched path, one node per column.
 export const singleChainSankeyData = [
   { source: 'Step 1: Visit', target: 'Step 2: Add to cart', value: 100 },
   { source: 'Step 2: Add to cart', target: 'Step 3: Checkout', value: 80 },
   { source: 'Step 3: Checkout', target: 'Step 4: Purchase', value: 60 },
 ];
 
-// Approximates a real Analysis Workspace Flow visualization: a single "*"-prefixed focus/root node
-// (Workspace's own convention for a pinned entry point), large comma-formatted path-view counts, and
-// a "+N more" aggregate node per column standing in for the long tail beyond Workspace's configured
-// "items expanded per column" -- see FlowConfigAdvancedSettings.js in aaui-web-spa, and the research
-// doc at planning/research/sankey-workspace-flow-feasibility/sankey-workspace-flow-feasibility.md.
-// Node/edge values aren't meant to reconcile exactly column to column, just to be Workspace-scale.
+// Approximates a real Analysis Workspace Flow visualization at Workspace-scale values (see planning/research/sankey-workspace-flow-feasibility/).
 export const workspaceFlowSankeyData = [
   { source: '* Project Load', target: 'Project Loaded without Anomaly Detection', value: 524000 },
   { source: '* Project Load', target: 'Project Fully Loaded', value: 200000 },
@@ -89,8 +77,7 @@ export const workspaceFlowSankeyData = [
   { source: '+466 more', target: '+430 more', value: 69000 },
 ];
 
-// A clean 3-column flow with multiple nodes per column throughout (3 -> 2 -> 2), so every column
-// actually branches/merges rather than narrowing to a single node: traffic source -> device -> outcome.
+// A clean 3-column flow (traffic source -> device -> outcome) that branches/merges at every column.
 export const threeColumnSankeyData = [
   { source: 'Organic Search', target: 'Desktop', value: 30 },
   { source: 'Organic Search', target: 'Mobile', value: 20 },

--- a/packages/react-spectrum-charts-s2/src/types/marks/index.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/index.ts
@@ -16,6 +16,7 @@ export * from './bullet.types';
 export * from './combo.types';
 export * from './donut.types';
 export * from './line.types';
+export * from './sankey.types';
 export * from './scatter.types';
 
 export * from './supplemental';

--- a/packages/react-spectrum-charts-s2/src/types/marks/sankey.types.ts
+++ b/packages/react-spectrum-charts-s2/src/types/marks/sankey.types.ts
@@ -9,16 +9,15 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { JSXElementConstructor, ReactElement } from 'react';
 
-export * from './Area';
-export * from './Bullet';
-export * from './Combo';
-export * from './Donut';
-export * from './DonutSummary';
-export * from './Sankey';
-export * from './Scatter';
-export * from './ScatterAnnotation';
-export * from './ScatterPath';
-export * from './SegmentLabel';
-export * from './Trendline';
-export * from './TrendlineAnnotation';
+import { SankeyOptions } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { ChartPopoverElement, ChartInspectElement } from '../dialogs';
+import { Children } from '../util.types';
+
+export interface SankeyProps extends Omit<SankeyOptions, 'chartPopovers' | 'chartInspects' | 'markType'> {
+  children?: Children<ChartPopoverElement | ChartInspectElement>;
+}
+
+export type SankeyElement = ReactElement<SankeyProps, JSXElementConstructor<SankeyProps>>;

--- a/packages/react-spectrum-charts-s2/src/utils/utils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.ts
@@ -46,6 +46,7 @@ import {
   Combo,
   Donut,
   DonutSummary,
+  Sankey,
   Scatter,
   ScatterAnnotation,
   ScatterPath,
@@ -72,6 +73,7 @@ import {
   LineForecastElement,
   LineDirectLabelElement,
   LineElement,
+  SankeyElement,
   ScatterAnnotationElement,
   ScatterElement,
   ScatterPathElement,
@@ -103,6 +105,7 @@ type RscElement =
   | DonutElement
   | LegendElement
   | LineElement
+  | SankeyElement
   | ScatterElement
   | TitleElement;
 
@@ -117,6 +120,7 @@ type ElementCounts = {
   donut: number;
   legend: number;
   line: number;
+  sankey: number;
   scatter: number;
 };
 
@@ -159,6 +163,7 @@ export const sanitizeChildren = (children: unknown): (ChartChildElement | MarkCh
     LineForecast.displayName,
     LinePointAnnotation.displayName,
     ReferenceLine.displayName,
+    Sankey.displayName,
     Scatter.displayName,
     ScatterAnnotation.displayName,
     ScatterPath.displayName,
@@ -185,6 +190,7 @@ export const sanitizeRscChartChildren = (children: unknown): ChartChildElement[]
     Donut.displayName,
     Legend.displayName,
     Line.displayName,
+    Sankey.displayName,
     Scatter.displayName,
     Title.displayName,
   ]);
@@ -389,6 +395,9 @@ const getElementName = (element: unknown, elementCounts: ElementCounts) => {
     case Line.displayName:
       elementCounts.line++;
       return getComponentName(element as LineElement, `line${elementCounts.line}`);
+    case Sankey.displayName:
+      elementCounts.sankey++;
+      return getComponentName(element as SankeyElement, `sankey${elementCounts.sankey}`);
     case Scatter.displayName:
       elementCounts.scatter++;
       return getComponentName(element as ScatterElement, `scatter${elementCounts.scatter}`);
@@ -416,6 +425,7 @@ const initElementCounts = (): ElementCounts => ({
   donut: -1,
   legend: -1,
   line: -1,
+  sankey: -1,
   scatter: -1,
 });
 

--- a/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/barDirectLabel/barDirectLabelUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { ColorValueRef, Mark, TextMark } from 'vega';
+import { ColorValueRef, Mark } from 'vega';
 
 import {
   BACKGROUND_COLOR,
@@ -20,7 +20,12 @@ import {
 } from '@spectrum-charts/constants';
 
 import { getOrientationProperties } from '../bar/barUtils';
-import { getColorProductionRule, getDirectLabelFontSizeProductionRule, getMarkOpacity } from '../marks/markUtils';
+import {
+  getColorProductionRule,
+  getDirectLabelFontSizeProductionRule,
+  getDirectLabelTextMarkPair,
+  getMarkOpacity,
+} from '../marks/markUtils';
 import { escapeD3FormatSpecifier, getD3FormatSpecifierFromNumberFormat } from '../specUtils';
 import { BarDirectLabelOptions, BarDirectLabelPositionType, BarDirectLabelSpecOptions, BarSpecOptions } from '../types';
 
@@ -209,12 +214,10 @@ export const getBarDirectLabelMarks = (labelOptions: BarDirectLabelSpecOptions, 
         fontWeight: { value: DIRECT_LABEL_FONT_WEIGHT },
       };
 
-  const backgroundMark: TextMark = {
-    name: `${barName}DirectLabel${index}_bg`,
-    type: 'text',
-    from: { data: FILTERED_TABLE },
-    interactive: false,
-    encode: {
+  const [backgroundMark, mainMark] = getDirectLabelTextMarkPair(
+    `${barName}DirectLabel${index}`,
+    FILTERED_TABLE,
+    {
       enter: {
         ...baseEnter,
         stroke: { signal: BACKGROUND_COLOR },
@@ -228,14 +231,7 @@ export const getBarDirectLabelMarks = (labelOptions: BarDirectLabelSpecOptions, 
         fontSize: fontSizeEncoding,
       },
     },
-  };
-
-  const mainMark: TextMark = {
-    name: `${barName}DirectLabel${index}`,
-    type: 'text',
-    from: { data: FILTERED_TABLE },
-    interactive: false,
-    encode: {
+    {
       enter: {
         ...baseEnter,
         fill: seriesFill,
@@ -244,8 +240,8 @@ export const getBarDirectLabelMarks = (labelOptions: BarDirectLabelSpecOptions, 
         opacity: getMarkOpacity(barOptions),
         fontSize: fontSizeEncoding,
       },
-    },
-  };
+    }
+  );
 
   // background halo only needed where a label can sit outside the bar: end-outside, or adaptive when it spills
   const hasOutsideLabel = position === 'end-outside' || Boolean(isInsideTest);

--- a/packages/vega-spec-builder-s2/src/chartInspect/chartInspectUtils.ts
+++ b/packages/vega-spec-builder-s2/src/chartInspect/chartInspectUtils.ts
@@ -33,6 +33,7 @@ import {
   ChartInspectSpecOptions,
   DonutSpecOptions,
   LineSpecOptions,
+  SankeySpecOptions,
   ScatterSpecOptions,
   VennSpecOptions,
 } from '../types';
@@ -43,6 +44,7 @@ type InspectParentOptions =
   | BulletSpecOptions
   | DonutSpecOptions
   | LineSpecOptions
+  | SankeySpecOptions
   | ScatterSpecOptions
   | VennSpecOptions;
 
@@ -87,7 +89,12 @@ export const addInspectData = (data: Data[], markOptions: InspectParentOptions, 
     if (!filteredTable.transform) {
       filteredTable.transform = [];
     }
-    if (highlightBy === 'dimension' && markOptions.markType !== 'donut' && markOptions.markType !== 'venn') {
+    if (
+      highlightBy === 'dimension' &&
+      markOptions.markType !== 'donut' &&
+      markOptions.markType !== 'sankey' &&
+      markOptions.markType !== 'venn'
+    ) {
       filteredTable.transform.push(getGroupIdTransform([markOptions.dimension], markName));
     } else if (highlightBy === 'series') {
       filteredTable.transform.push(getGroupIdTransform([SERIES_ID], markName));

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -63,6 +63,7 @@ import { getLegendHighlightSignals, setHoverOpacityForMarks, setHoverStrokeWidth
 import { addLegend } from './legend/legendSpecBuilder';
 import { addLine } from './line/lineSpecBuilder';
 import { getOrdinalScale } from './scale/scaleSpecBuilder';
+import { addSankey } from './sankey/sankeySpecBuilder';
 import { addScatter } from './scatter/scatterSpecBuilder';
 import { getGenericValueSignal } from './signal/signalSpecBuilder';
 import {
@@ -151,7 +152,7 @@ export function buildSpec({
   spec.signals = getDefaultSignals(options);
   spec.scales = getDefaultScales(colors, colorScheme, lineTypes, lineWidths, opacities, symbolShapes, symbolSizes);
 
-  let { areaCount, barCount, bulletCount, comboCount, donutCount, lineCount, scatterCount, vennCount } =
+  let { areaCount, barCount, bulletCount, comboCount, donutCount, lineCount, sankeyCount, scatterCount, vennCount } =
     initializeComponentCounts();
   const legendHighlightSignals = getLegendHighlightSignals(legends);
   const specOptions = {
@@ -184,6 +185,9 @@ export function buildSpec({
       case 'line':
         lineCount++;
         return addLine(acc, { ...mark, ...specOptions, index: lineCount, data });
+      case 'sankey':
+        sankeyCount++;
+        return addSankey(acc, { ...mark, ...specOptions, index: sankeyCount, data, chartWidth, chartHeight });
       case 'scatter':
         scatterCount++;
         return addScatter(acc, { ...mark, ...specOptions, index: scatterCount });
@@ -258,6 +262,7 @@ const initializeComponentCounts = () => {
     donutCount: -1,
     bulletCount: -1,
     lineCount: -1,
+    sankeyCount: -1,
     scatterCount: -1,
     vennCount: -1,
   };

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.ts
@@ -65,6 +65,7 @@ import {
   MetricRangeOptions,
   OpacityFacet,
   ProductionRuleTests,
+  SankeySpecOptions,
   ScaleType,
   ScatterSpecOptions,
   SymbolSizeFacet,
@@ -432,7 +433,7 @@ const getHoverSizeSignal = (size: number): SignalRef => ({
  * @returns
  */
 export const getMarkOpacity = (
-  options: BarSpecOptions | DonutSpecOptions | VennSpecOptions
+  options: BarSpecOptions | DonutSpecOptions | SankeySpecOptions | VennSpecOptions
 ): ({ test?: string } & NumericValueRef)[] => {
   const { highlightedItem, idKey, name: markName } = options;
   const rules: ({ test?: string } & NumericValueRef)[] = [DEFAULT_OPACITY_RULE];

--- a/packages/vega-spec-builder-s2/src/marks/markUtils.ts
+++ b/packages/vega-spec-builder-s2/src/marks/markUtils.ts
@@ -20,6 +20,7 @@ import {
   ProductionRule,
   SignalRef,
   SymbolMark,
+  TextMark,
 } from 'vega';
 
 import {
@@ -264,6 +265,39 @@ export const getStrokeDashProductionRule = (lineType: LineTypeFacet | DualFacet)
 
 export const getDirectLabelFontSizeProductionRule = (fontSize?: number): { signal: string } | { value: number } =>
   fontSize == null ? { signal: CHART_SIZE_FONT_SIZE } : { value: fontSize };
+
+/**
+ * Builds a background-halo + foreground text mark pair, deduping the shared mark envelope.
+ * @param name foreground mark name; background mark is named `${name}_bg`
+ * @param dataSource `from.data` shared by both marks
+ * @param background enter/update encode for the halo mark
+ * @param foreground enter/update encode for the foreground mark
+ * @returns [backgroundMark, foregroundMark]
+ */
+export const getDirectLabelTextMarkPair = (
+  name: string,
+  dataSource: string,
+  background: { enter: EncodeEntry; update?: EncodeEntry },
+  foreground: { enter: EncodeEntry; update?: EncodeEntry }
+): [TextMark, TextMark] => {
+  const backgroundMark: TextMark = {
+    name: `${name}_bg`,
+    type: 'text',
+    from: { data: dataSource },
+    interactive: false,
+    encode: background,
+  };
+
+  const foregroundMark: TextMark = {
+    name,
+    type: 'text',
+    from: { data: dataSource },
+    interactive: false,
+    encode: foreground,
+  };
+
+  return [backgroundMark, foregroundMark];
+};
 
 export const getHighlightOpacityValue = (
   opacityValue: { signal: string } | { value: number } = DEFAULT_OPACITY_RULE

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
@@ -44,7 +44,7 @@ describe('addData', () => {
     expect(nodesData?.values?.[0]).toHaveProperty(customSankeyOptions.idKey);
   });
 
-  test('halves labelLimit only for the two columns sharing the last-column label flip gap, so neither can grow far enough to collide with the other', () => {
+  test('halves labelLimit only for the two columns sharing the last-column label flip gap', () => {
     const data = addData(initializeSpec({}, { data: sankeyData }).data ?? [], customSankeyOptions);
     const nodesData = data.find((d) => d.name === `${customSankeyOptions.name}_nodes`) as ValuesData | undefined;
     const nodeRows = (nodesData?.values ?? []) as { id: string; labelLimit: number }[];
@@ -61,7 +61,7 @@ describe('addData', () => {
     expect(limitById.Cart).toBeLessThan(limitById.Home);
   });
 
-  test('right-aligns the label to the left of the node for the last column only, so it never gets clipped past the chart edge', () => {
+  test('right-aligns the label to the left of the node for the last column only', () => {
     const data = addData(initializeSpec({}, { data: sankeyData }).data ?? [], customSankeyOptions);
     const nodesData = data.find((d) => d.name === `${customSankeyOptions.name}_nodes`) as ValuesData | undefined;
     const nodeRows = (nodesData?.values ?? []) as { id: string; x: number; labelX: number; labelAlign: string }[];

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
@@ -28,7 +28,7 @@ describe('addData', () => {
     expect(nodesData?.values).toHaveLength(5);
     expect(linksData?.values).toHaveLength(sankeyData.length);
 
-    // every link row carries the original edge under table_data, mirroring Venn's lookup-back convention
+    // every link row carries the original edge under table_data (mirrors Venn's lookup-back convention)
     expect(linksData?.values?.[0]).toHaveProperty('table_data');
     expect(linksData?.values?.[0]).toHaveProperty('path');
     expect(linksData?.values?.[0]).toHaveProperty(customSankeyOptions.idKey);
@@ -55,8 +55,7 @@ describe('addData', () => {
     expect(limitById.Search).toBe(limitById.Product);
     expect(limitById.Home).toBeGreaterThan(0);
 
-    // Cart (second-to-last) and Checkout (last) share one gap, growing toward each other, so both
-    // get the smaller, halved limit -- and it really is smaller than the uncontested columns' limit
+    // Cart and Checkout share one gap growing toward each other, so both get the smaller, halved limit
     expect(limitById.Cart).toBe(limitById.Checkout);
     expect(limitById.Cart).toBeGreaterThan(0);
     expect(limitById.Cart).toBeLessThan(limitById.Home);

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.test.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ValuesData } from 'vega';
+
+import { COLOR_SCALE, HOVERED_ITEM, TABLE } from '@spectrum-charts/constants';
+
+import { defaultSignals } from '../specTestUtils';
+import { initializeSpec } from '../specUtils';
+import { addData, addMarks, addSankey, addScales, addSignals } from './sankeySpecBuilder';
+import { customSankeyOptions, data as sankeyData, defaultSankeyOptions } from './sankeyTestUtils';
+
+describe('addData', () => {
+  test('adds a nodes and a links data source, sized to the input edges', () => {
+    const data = addData(initializeSpec({}, { data: sankeyData }).data ?? [], customSankeyOptions);
+
+    const nodesData = data.find((d) => d.name === `${customSankeyOptions.name}_nodes`) as ValuesData | undefined;
+    const linksData = data.find((d) => d.name === `${customSankeyOptions.name}_linksData`) as ValuesData | undefined;
+
+    expect(nodesData?.values).toHaveLength(5);
+    expect(linksData?.values).toHaveLength(sankeyData.length);
+
+    // every link row carries the original edge under table_data, mirroring Venn's lookup-back convention
+    expect(linksData?.values?.[0]).toHaveProperty('table_data');
+    expect(linksData?.values?.[0]).toHaveProperty('path');
+    expect(linksData?.values?.[0]).toHaveProperty(customSankeyOptions.idKey);
+
+    expect(nodesData?.values?.[0]).toHaveProperty('id');
+    expect(nodesData?.values?.[0]).toHaveProperty('x');
+    expect(nodesData?.values?.[0]).toHaveProperty('y');
+    expect(nodesData?.values?.[0]).toHaveProperty('labelX');
+    expect(nodesData?.values?.[0]).toHaveProperty('labelY');
+    expect(nodesData?.values?.[0]).toHaveProperty('labelAlign');
+    expect(nodesData?.values?.[0]).toHaveProperty('labelLimit');
+    expect(nodesData?.values?.[0]).toHaveProperty('formattedValue');
+    expect(nodesData?.values?.[0]).toHaveProperty(customSankeyOptions.idKey);
+  });
+
+  test('halves labelLimit only for the two columns sharing the last-column label flip gap, so neither can grow far enough to collide with the other', () => {
+    const data = addData(initializeSpec({}, { data: sankeyData }).data ?? [], customSankeyOptions);
+    const nodesData = data.find((d) => d.name === `${customSankeyOptions.name}_nodes`) as ValuesData | undefined;
+    const nodeRows = (nodesData?.values ?? []) as { id: string; labelLimit: number }[];
+    const limitById = Object.fromEntries(nodeRows.map((row) => [row.id, row.labelLimit]));
+
+    // Home/Search/Product (columns 0-2) have no competing label growing into their gap
+    expect(limitById.Home).toBe(limitById.Search);
+    expect(limitById.Search).toBe(limitById.Product);
+    expect(limitById.Home).toBeGreaterThan(0);
+
+    // Cart (second-to-last) and Checkout (last) share one gap, growing toward each other, so both
+    // get the smaller, halved limit -- and it really is smaller than the uncontested columns' limit
+    expect(limitById.Cart).toBe(limitById.Checkout);
+    expect(limitById.Cart).toBeGreaterThan(0);
+    expect(limitById.Cart).toBeLessThan(limitById.Home);
+  });
+
+  test('right-aligns the label to the left of the node for the last column only, so it never gets clipped past the chart edge', () => {
+    const data = addData(initializeSpec({}, { data: sankeyData }).data ?? [], customSankeyOptions);
+    const nodesData = data.find((d) => d.name === `${customSankeyOptions.name}_nodes`) as ValuesData | undefined;
+    const nodeRows = (nodesData?.values ?? []) as { id: string; x: number; labelX: number; labelAlign: string }[];
+
+    // Checkout is the last (rightmost) node in the sankeyTestUtils fixture
+    const checkout = nodeRows.find((row) => row.id === 'Checkout');
+    expect(checkout?.labelAlign).toBe('right');
+    expect(checkout?.labelX).toBeLessThan(checkout?.x ?? 0);
+
+    // Home is the first (leftmost) node -- label stays to the right, as before
+    const home = nodeRows.find((row) => row.id === 'Home');
+    expect(home?.labelAlign).toBe('left');
+    expect(home?.labelX).toBeGreaterThan(home?.x ?? 0);
+  });
+
+  test('returns empty nodes/links data sources when there is no data', () => {
+    const data = addData(initializeSpec({}, { data: [] }).data ?? [], defaultSankeyOptions);
+
+    const nodesData = data.find((d) => d.name === `${defaultSankeyOptions.name}_nodes`) as ValuesData | undefined;
+    const linksData = data.find((d) => d.name === `${defaultSankeyOptions.name}_linksData`) as ValuesData | undefined;
+
+    expect(nodesData?.values).toEqual([]);
+    expect(linksData?.values).toEqual([]);
+  });
+});
+
+describe('addSignal', () => {
+  test('should add hover events for both the node and link layers when inspect is present', () => {
+    const signals = addSignals(defaultSignals, {
+      ...customSankeyOptions,
+      chartInspects: [{}],
+    });
+
+    expect(signals).toHaveLength(defaultSignals.length + 1);
+
+    const hoveredItemSignal = signals.find((signal) => signal.name.includes(HOVERED_ITEM));
+
+    expect(hoveredItemSignal).toBeDefined();
+    expect(hoveredItemSignal?.on).toHaveLength(4);
+    expect(hoveredItemSignal?.on?.[0]).toHaveProperty('events', '@sankey:mouseover');
+    expect(hoveredItemSignal?.on?.[1]).toHaveProperty('events', '@sankey:mouseout');
+    expect(hoveredItemSignal?.on?.[2]).toHaveProperty('events', '@sankey_links:mouseover');
+    expect(hoveredItemSignal?.on?.[3]).toHaveProperty('events', '@sankey_links:mouseout');
+  });
+
+  test('should not add signals when there is no inspect or popover', () => {
+    const signals = addSignals(defaultSignals, customSankeyOptions);
+    expect(signals).toHaveLength(defaultSignals.length);
+  });
+});
+
+describe('addScales', () => {
+  test('should add the color scale, domained off this component\'s own nodes data (not TABLE)', () => {
+    const scales = addScales([], customSankeyOptions);
+    expect(scales).toHaveLength(1);
+    expect(scales[0]).toHaveProperty('name', COLOR_SCALE);
+    expect(scales[0].domain).toEqual({ data: `${customSankeyOptions.name}_nodes`, field: customSankeyOptions.color });
+  });
+});
+
+describe('addMarks', () => {
+  test('adds the link mark, the node mark, then bg/fg pairs for the name and value labels', () => {
+    const marks = addMarks([], customSankeyOptions);
+    // path (links), rect (nodes), [name bg, name fg], [value bg, value fg]
+    expect(marks).toHaveLength(6);
+    expect(marks[0]).toHaveProperty('type', 'path');
+    expect(marks[1]).toHaveProperty('type', 'rect');
+    expect(marks.slice(2)).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'text' })]));
+    expect(marks.slice(2)).toHaveLength(4);
+    marks.slice(2).forEach((mark) => expect(mark).toHaveProperty('type', 'text'));
+
+    // background halo marks come before their foreground counterpart within each pair
+    expect(marks[2].name).toMatch(/_label_bg$/);
+    expect(marks[3].name).toMatch(/_label$/);
+    expect(marks[4].name).toMatch(/_valueLabel_bg$/);
+    expect(marks[5].name).toMatch(/_valueLabel$/);
+  });
+});
+
+describe('sankeySpecBuilder', () => {
+  test('should add sankey correctly', () => {
+    const props = customSankeyOptions;
+    const spec = { data: [{ name: TABLE }], usermeta: {} };
+    const result = addSankey(spec, props);
+
+    const expectedSpec = {
+      data: addData(spec.data ?? [], props),
+      scales: addScales([], props),
+      marks: addMarks([], props),
+      signals: addSignals([], props),
+      usermeta: {},
+    };
+
+    expect(result).toEqual(expectedSpec);
+  });
+
+  test('should add sankey correctly with default values', () => {
+    const props = defaultSankeyOptions;
+    const spec = { data: [{ name: TABLE }], usermeta: {} };
+
+    const result = addSankey(spec, {
+      markType: 'sankey',
+      idKey: 'rscMarkId',
+    });
+
+    const expectedSpec = {
+      data: addData(spec.data ?? [], props),
+      scales: addScales([], props),
+      marks: addMarks([], props),
+      signals: addSignals([], props),
+      usermeta: {},
+    };
+
+    expect(result).toEqual(expectedSpec);
+  });
+});

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
@@ -100,11 +100,8 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
   const { chartHeight, chartWidth, idKey, name } = props;
   const edges = getSankeyEdges(props);
   const { nodes, links, columnSpacing } = buildSankeyLayout(edges, chartWidth, chartHeight);
-  // Last-column labels flip to the node's left (standard Sankey convention) so they don't clip past
-  // the chart edge. That makes the last and second-to-last columns' labels grow toward each other
-  // across one shared gap -- every other gap only has one label growing into it. `labelLimit` caps
-  // each label to the room available (Vega truncates with an ellipsis): the full gap normally, half
-  // the gap for the two columns sharing one, so neither can reach the other's text.
+  // Last-column labels flip left so they don't clip past the chart edge; `labelLimit` halves the gap
+  // for the last two columns (now growing toward each other) so neither label reaches the other's.
   const maxColumn = Math.max(0, ...nodes.map((node) => node.column));
   const fullGapLimit = Math.max(0, columnSpacing - SANKEY_NODE_WIDTH - 8);
   const sharedGapLimit = Math.max(0, (columnSpacing - SANKEY_NODE_WIDTH) / 2 - 4);
@@ -135,8 +132,7 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
     targetId: link.target.id,
     value: link.value,
     path: getRibbonPath(link),
-    // original edge row, nested to avoid colliding with the computed fields above -- mirrors Venn's
-    // `table_data` lookup-back convention for tooltip/popover passthrough.
+    // original edge row, nested to avoid colliding with the computed fields above -- mirrors Venn's `table_data`.
     table_data: link.datum,
   }));
 
@@ -144,8 +140,7 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
 });
 
 export const addMarks = produce<Mark[], [SankeySpecOptions]>((marks, props) => {
-  // Links before nodes (ribbons sit under node rects), before both label pairs (name above center,
-  // value below, matching Workspace's Flow). Each label is a halo + foreground pair (getSankeyNodeLabelMarkPair).
+  // Draw order: links under nodes, both label pairs (name, then value) on top.
   marks.push(
     getSankeyLinkMark(props),
     getSankeyNodeMark(props),
@@ -154,9 +149,7 @@ export const addMarks = produce<Mark[], [SankeySpecOptions]>((marks, props) => {
   );
 });
 
-// Unlike Venn (whose `color` field lands on the shared TABLE, so the generic
-// `addFieldToFacetScaleDomain` helper works), a Sankey node's `id` only exists on its own
-// precomputed `${name}_nodes` data -- no 1:1 TABLE row per node. Domain points there directly instead.
+// Domains off `${name}_nodes` directly, not TABLE -- a Sankey node has no 1:1 TABLE row.
 export const addScales = produce<Scale[], [SankeySpecOptions]>((scales, { color, name }) => {
   const index = getScaleIndexByName(scales, COLOR_SCALE);
   scales[index] = { ...scales[index], domain: { data: getSankeyNodeDataName(name), field: color } };
@@ -166,8 +159,7 @@ export const addSignals = produce<Signal[], [SankeySpecOptions]>((signals, props
   const { chartInspects, name } = props;
 
   if (!isInteractive(props)) return;
-  // Both layers write into the same `${name}_hoveredItem` signal -- mirrors Venn's dual
-  // `addHoveredItemSignal` call for `circles`/`intersections`.
+  // Both layers write into the same signal -- mirrors Venn's dual call for `circles`/`intersections`.
   addHoveredItemSignal(signals, name, undefined, 1, chartInspects[0]?.excludeDataKeys);
   addHoveredItemSignal(signals, name, getSankeyLinkMarkName(name), 1, chartInspects[0]?.excludeDataKeys);
 });

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
@@ -100,15 +100,11 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
   const { chartHeight, chartWidth, idKey, name } = props;
   const edges = getSankeyEdges(props);
   const { nodes, links, columnSpacing } = buildSankeyLayout(edges, chartWidth, chartHeight);
-  // last-column nodes have no room to their right within the chart, so their label sits to the
-  // left of the node instead (standard Sankey/D3 convention) -- otherwise it gets clipped past the
-  // chart's edge, since a right-hand label offset assumes there's space to the right of the node.
-  // That flip means the last column's labels and the second-to-last column's labels now grow toward
-  // each other across the same gap -- every other gap only ever has one label growing into it (the
-  // column to its left, growing right), so it's only this one gap where two labels can collide.
-  // `labelLimit` caps each label to the actual room available (Vega's text `limit` encoding
-  // truncates with an ellipsis): the full gap for columns with no competing label, or half the gap
-  // for the two columns that share one, so neither can grow far enough to reach the other's text.
+  // Last-column labels flip to the node's left (standard Sankey convention) so they don't clip past
+  // the chart edge. That makes the last and second-to-last columns' labels grow toward each other
+  // across one shared gap -- every other gap only has one label growing into it. `labelLimit` caps
+  // each label to the room available (Vega truncates with an ellipsis): the full gap normally, half
+  // the gap for the two columns sharing one, so neither can reach the other's text.
   const maxColumn = Math.max(0, ...nodes.map((node) => node.column));
   const fullGapLimit = Math.max(0, columnSpacing - SANKEY_NODE_WIDTH - 8);
   const sharedGapLimit = Math.max(0, (columnSpacing - SANKEY_NODE_WIDTH) / 2 - 4);
@@ -139,8 +135,8 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
     targetId: link.target.id,
     value: link.value,
     path: getRibbonPath(link),
-    // original edge row, nested (rather than spread) to avoid colliding with the computed fields
-    // above -- mirrors Venn's `table_data` lookup-back convention for tooltip/popover passthrough.
+    // original edge row, nested to avoid colliding with the computed fields above -- mirrors Venn's
+    // `table_data` lookup-back convention for tooltip/popover passthrough.
     table_data: link.datum,
   }));
 
@@ -148,10 +144,8 @@ export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
 });
 
 export const addMarks = produce<Mark[], [SankeySpecOptions]>((marks, props) => {
-  // links painted before nodes so ribbons sit under the node rects, before both label pairs
-  // (name above center, value below -- matches Workspace's Flow visualization convention). Each
-  // label is a background-halo + foreground pair (see getSankeyNodeLabelMarkPair in sankeyUtils.ts),
-  // the same two-mark technique Line's direct labels use, so labels stay legible over colored ribbons.
+  // Links before nodes (ribbons sit under node rects), before both label pairs (name above center,
+  // value below, matching Workspace's Flow). Each label is a halo + foreground pair (getSankeyNodeLabelMarkPair).
   marks.push(
     getSankeyLinkMark(props),
     getSankeyNodeMark(props),
@@ -160,11 +154,9 @@ export const addMarks = produce<Mark[], [SankeySpecOptions]>((marks, props) => {
   );
 });
 
-// Unlike Venn (whose `color` field is computed directly onto the shared TABLE via a formula
-// transform, so the generic TABLE-anchored `addFieldToFacetScaleDomain` helper works), a Sankey
-// node's `id` only exists on its own precomputed `${name}_nodes` data -- there's no 1:1 TABLE row
-// per node (a node is derived from potentially many edge rows). So the color scale's domain is
-// pointed directly at that data source instead of going through the TABLE-only helper.
+// Unlike Venn (whose `color` field lands on the shared TABLE, so the generic
+// `addFieldToFacetScaleDomain` helper works), a Sankey node's `id` only exists on its own
+// precomputed `${name}_nodes` data -- no 1:1 TABLE row per node. Domain points there directly instead.
 export const addScales = produce<Scale[], [SankeySpecOptions]>((scales, { color, name }) => {
   const index = getScaleIndexByName(scales, COLOR_SCALE);
   scales[index] = { ...scales[index], domain: { data: getSankeyNodeDataName(name), field: color } };
@@ -174,8 +166,8 @@ export const addSignals = produce<Signal[], [SankeySpecOptions]>((signals, props
   const { chartInspects, name } = props;
 
   if (!isInteractive(props)) return;
-  // both layers write into the same `${name}_hoveredItem` signal (whichever was hovered most
-  // recently wins) -- mirrors Venn's dual `addHoveredItemSignal` call for `circles`/`intersections`.
+  // Both layers write into the same `${name}_hoveredItem` signal -- mirrors Venn's dual
+  // `addHoveredItemSignal` call for `circles`/`intersections`.
   addHoveredItemSignal(signals, name, undefined, 1, chartInspects[0]?.excludeDataKeys);
   addHoveredItemSignal(signals, name, getSankeyLinkMarkName(name), 1, chartInspects[0]?.excludeDataKeys);
 });

--- a/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeySpecBuilder.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { produce } from 'immer';
+import { Data, Mark, Scale, Signal } from 'vega';
+
+import {
+  COLOR_SCALE,
+  DEFAULT_COLOR_SCHEME,
+  DEFAULT_SANKEY_COLOR,
+  DEFAULT_SANKEY_SOURCE,
+  DEFAULT_SANKEY_TARGET,
+  DEFAULT_SANKEY_VALUE,
+  SANKEY_NODE_WIDTH,
+} from '@spectrum-charts/constants';
+import { toCamelCase } from '@spectrum-charts/utils';
+
+import { isInteractive } from '../marks/markUtils';
+import { getScaleIndexByName } from '../scale/scaleSpecBuilder';
+import { addHoveredItemSignal } from '../signal/signalSpecBuilder';
+import { ChartData, ColorScheme, HighlightedItem, ScSpec, SankeyOptions, SankeySpecOptions } from '../types';
+import {
+  buildSankeyLayout,
+  getSankeyEdges,
+  getSankeyLinkDataName,
+  getSankeyLinkMark,
+  getSankeyLinkMarkId,
+  getSankeyLinkMarkName,
+  getSankeyNodeDataName,
+  getSankeyNodeLabelMarks,
+  getSankeyNodeMark,
+  getSankeyNodeMarkId,
+  getSankeyNodeValueLabelMarks,
+  getRibbonPath,
+} from './sankeyUtils';
+
+export const addSankey = produce<
+  ScSpec,
+  [
+    SankeyOptions & {
+      colorScheme?: ColorScheme;
+      highlightedItem?: HighlightedItem;
+      idKey: string;
+      index?: number;
+      chartHeight?: number;
+      chartWidth?: number;
+      data?: ChartData[];
+    }
+  ]
+>(
+  (
+    spec,
+    {
+      chartPopovers = [],
+      chartInspects = [],
+      color = DEFAULT_SANKEY_COLOR,
+      colorScheme = DEFAULT_COLOR_SCHEME,
+      index = 0,
+      source = DEFAULT_SANKEY_SOURCE,
+      target = DEFAULT_SANKEY_TARGET,
+      value = DEFAULT_SANKEY_VALUE,
+      name,
+      chartHeight = 100,
+      chartWidth = 100,
+      data = [],
+      ...props
+    }
+  ) => {
+    const sankeyProps: SankeySpecOptions = {
+      chartPopovers,
+      chartInspects,
+      chartHeight,
+      chartWidth,
+      data,
+      index,
+      colorScheme,
+      color,
+      source,
+      target,
+      value,
+      name: toCamelCase(name ?? `sankey${index}`),
+      ...props,
+    };
+    spec.data = addData(spec.data ?? [], sankeyProps);
+    spec.signals = addSignals(spec.signals ?? [], sankeyProps);
+    spec.scales = addScales(spec.scales ?? [], sankeyProps);
+    spec.marks = addMarks(spec.marks ?? [], sankeyProps);
+  }
+);
+
+export const addData = produce<Data[], [SankeySpecOptions]>((data, props) => {
+  const { chartHeight, chartWidth, idKey, name } = props;
+  const edges = getSankeyEdges(props);
+  const { nodes, links, columnSpacing } = buildSankeyLayout(edges, chartWidth, chartHeight);
+  // last-column nodes have no room to their right within the chart, so their label sits to the
+  // left of the node instead (standard Sankey/D3 convention) -- otherwise it gets clipped past the
+  // chart's edge, since a right-hand label offset assumes there's space to the right of the node.
+  // That flip means the last column's labels and the second-to-last column's labels now grow toward
+  // each other across the same gap -- every other gap only ever has one label growing into it (the
+  // column to its left, growing right), so it's only this one gap where two labels can collide.
+  // `labelLimit` caps each label to the actual room available (Vega's text `limit` encoding
+  // truncates with an ellipsis): the full gap for columns with no competing label, or half the gap
+  // for the two columns that share one, so neither can grow far enough to reach the other's text.
+  const maxColumn = Math.max(0, ...nodes.map((node) => node.column));
+  const fullGapLimit = Math.max(0, columnSpacing - SANKEY_NODE_WIDTH - 8);
+  const sharedGapLimit = Math.max(0, (columnSpacing - SANKEY_NODE_WIDTH) / 2 - 4);
+
+  const nodeRows = nodes.map((node) => {
+    const isLastColumn = node.column === maxColumn;
+    const sharesGapWithFlippedLabel = node.column >= maxColumn - 1;
+    const labelLimit = sharesGapWithFlippedLabel ? sharedGapLimit : fullGapLimit;
+    return {
+      [idKey]: getSankeyNodeMarkId(name, node.id),
+      id: node.id,
+      value: node.value,
+      x: node.x,
+      y: node.y,
+      dx: node.dx,
+      dy: node.dy,
+      labelX: isLastColumn ? node.x - 4 : node.x + node.dx + 4,
+      labelY: node.y + node.dy / 2,
+      labelAlign: isLastColumn ? 'right' : 'left',
+      labelLimit,
+      formattedValue: node.value.toLocaleString(),
+    };
+  });
+
+  const linkRows = links.map((link, i) => ({
+    [idKey]: getSankeyLinkMarkId(name, i),
+    sourceId: link.source.id,
+    targetId: link.target.id,
+    value: link.value,
+    path: getRibbonPath(link),
+    // original edge row, nested (rather than spread) to avoid colliding with the computed fields
+    // above -- mirrors Venn's `table_data` lookup-back convention for tooltip/popover passthrough.
+    table_data: link.datum,
+  }));
+
+  data.push({ name: getSankeyNodeDataName(name), values: nodeRows }, { name: getSankeyLinkDataName(name), values: linkRows });
+});
+
+export const addMarks = produce<Mark[], [SankeySpecOptions]>((marks, props) => {
+  // links painted before nodes so ribbons sit under the node rects, before both label pairs
+  // (name above center, value below -- matches Workspace's Flow visualization convention). Each
+  // label is a background-halo + foreground pair (see getSankeyNodeLabelMarkPair in sankeyUtils.ts),
+  // the same two-mark technique Line's direct labels use, so labels stay legible over colored ribbons.
+  marks.push(
+    getSankeyLinkMark(props),
+    getSankeyNodeMark(props),
+    ...getSankeyNodeLabelMarks(props),
+    ...getSankeyNodeValueLabelMarks(props)
+  );
+});
+
+// Unlike Venn (whose `color` field is computed directly onto the shared TABLE via a formula
+// transform, so the generic TABLE-anchored `addFieldToFacetScaleDomain` helper works), a Sankey
+// node's `id` only exists on its own precomputed `${name}_nodes` data -- there's no 1:1 TABLE row
+// per node (a node is derived from potentially many edge rows). So the color scale's domain is
+// pointed directly at that data source instead of going through the TABLE-only helper.
+export const addScales = produce<Scale[], [SankeySpecOptions]>((scales, { color, name }) => {
+  const index = getScaleIndexByName(scales, COLOR_SCALE);
+  scales[index] = { ...scales[index], domain: { data: getSankeyNodeDataName(name), field: color } };
+});
+
+export const addSignals = produce<Signal[], [SankeySpecOptions]>((signals, props) => {
+  const { chartInspects, name } = props;
+
+  if (!isInteractive(props)) return;
+  // both layers write into the same `${name}_hoveredItem` signal (whichever was hovered most
+  // recently wins) -- mirrors Venn's dual `addHoveredItemSignal` call for `circles`/`intersections`.
+  addHoveredItemSignal(signals, name, undefined, 1, chartInspects[0]?.excludeDataKeys);
+  addHoveredItemSignal(signals, name, getSankeyLinkMarkName(name), 1, chartInspects[0]?.excludeDataKeys);
+});

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyTestUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyTestUtils.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { DEFAULT_SANKEY_COLOR, DEFAULT_SANKEY_SOURCE, DEFAULT_SANKEY_TARGET, DEFAULT_SANKEY_VALUE } from '@spectrum-charts/constants';
+
+import { SankeySpecOptions } from '../types';
+
+export const data = [
+  { source: 'Home', target: 'Product', value: 10 },
+  { source: 'Home', target: 'Search', value: 6 },
+  { source: 'Product', target: 'Cart', value: 7 },
+  { source: 'Search', target: 'Product', value: 4 },
+  { source: 'Cart', target: 'Checkout', value: 5 },
+];
+
+/** A -> B -> C -> A: every node is part of a cycle, so nothing has an in-degree-0 entry point. */
+export const cyclicData = [
+  { source: 'A', target: 'B', value: 3 },
+  { source: 'B', target: 'C', value: 3 },
+  { source: 'C', target: 'A', value: 1 },
+];
+
+/** "Orphan" has no edges at all; "SourceOnly" only ever appears as a source; "SinkOnly" only as a target. */
+export const sourceAndSinkOnlyData = [
+  { source: 'SourceOnly', target: 'Middle', value: 2 },
+  { source: 'Middle', target: 'SinkOnly', value: 2 },
+];
+
+export const customSankeyOptions: SankeySpecOptions = {
+  chartInspects: [],
+  chartPopovers: [],
+  data,
+  colorScheme: 'light',
+  idKey: 'rscMarkId',
+  index: 0,
+  markType: 'sankey',
+  chartWidth: 400,
+  chartHeight: 300,
+  name: 'sankey',
+  color: DEFAULT_SANKEY_COLOR,
+  source: DEFAULT_SANKEY_SOURCE,
+  target: DEFAULT_SANKEY_TARGET,
+  value: DEFAULT_SANKEY_VALUE,
+};
+
+export const defaultSankeyOptions: SankeySpecOptions = {
+  chartHeight: 100,
+  chartWidth: 100,
+  colorScheme: 'light',
+  data: [],
+  idKey: 'rscMarkId',
+  index: 0,
+  markType: 'sankey',
+  chartPopovers: [],
+  chartInspects: [],
+  color: DEFAULT_SANKEY_COLOR,
+  source: DEFAULT_SANKEY_SOURCE,
+  target: DEFAULT_SANKEY_TARGET,
+  value: DEFAULT_SANKEY_VALUE,
+  name: 'sankey0',
+};

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
@@ -9,12 +9,28 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { cyclicData, data as sankeyData, sourceAndSinkOnlyData } from './sankeyTestUtils';
+import { cyclicData, customSankeyOptions, data as sankeyData, sourceAndSinkOnlyData } from './sankeyTestUtils';
 import { assignColumns, buildSankeyLayout, getRibbonPath, getSankeyEdges } from './sankeyUtils';
-import { customSankeyOptions } from './sankeyTestUtils';
 
 const toEdges = (rows: { source: string; target: string; value: number }[]) =>
   getSankeyEdges({ ...customSankeyOptions, data: rows });
+
+describe('getSankeyEdges', () => {
+  test('drops rows with a negative, NaN, or non-finite value, keeping well-formed rows', () => {
+    const edges = getSankeyEdges({
+      ...customSankeyOptions,
+      data: [
+        { source: 'A', target: 'B', value: 5 },
+        { source: 'A', target: 'C', value: -1 },
+        { source: 'A', target: 'D', value: NaN },
+        { source: 'A', target: 'E', value: Infinity },
+        { source: 'A', target: 'F', value: 0 },
+      ],
+    });
+
+    expect(edges.map((edge) => edge.target).sort()).toEqual(['B', 'F']);
+  });
+});
 
 describe('assignColumns', () => {
   test('layers a chain by the longest path from a source (a node is one column past its deepest dependency)', () => {
@@ -23,8 +39,7 @@ describe('assignColumns', () => {
 
     expect(columns.get('Home')).toBe(0);
     expect(columns.get('Search')).toBe(1);
-    // Product is reachable directly from Home (column 0) and from Search (column 1) -- it takes the
-    // deeper of the two plus one, not the shallower, so a longer upstream chain doesn't get skipped.
+    // Product is reachable from Home (0) and Search (1) -- takes the deeper path plus one.
     expect(columns.get('Product')).toBe(2);
     expect(columns.get('Cart')).toBe(3);
     expect(columns.get('Checkout')).toBe(4);
@@ -46,7 +61,7 @@ describe('assignColumns', () => {
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(columns.size).toBe(3);
-    // every node has a defined, non-negative column -- the layering terminated instead of looping forever
+    // every node has a defined column -- layering terminated instead of looping forever
     expect(columns.get('A')).toBeGreaterThanOrEqual(0);
     expect(columns.get('B')).toBeGreaterThanOrEqual(0);
     expect(columns.get('C')).toBeGreaterThanOrEqual(0);

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { cyclicData, data as sankeyData, sourceAndSinkOnlyData } from './sankeyTestUtils';
+import { assignColumns, buildSankeyLayout, getRibbonPath, getSankeyEdges } from './sankeyUtils';
+import { customSankeyOptions } from './sankeyTestUtils';
+
+const toEdges = (rows: { source: string; target: string; value: number }[]) =>
+  getSankeyEdges({ ...customSankeyOptions, data: rows });
+
+describe('assignColumns', () => {
+  test('layers a chain by the longest path from a source (a node is one column past its deepest dependency)', () => {
+    const edges = toEdges(sankeyData);
+    const columns = assignColumns(edges);
+
+    expect(columns.get('Home')).toBe(0);
+    expect(columns.get('Search')).toBe(1);
+    // Product is reachable directly from Home (column 0) and from Search (column 1) -- it takes the
+    // deeper of the two plus one, not the shallower, so a longer upstream chain doesn't get skipped.
+    expect(columns.get('Product')).toBe(2);
+    expect(columns.get('Cart')).toBe(3);
+    expect(columns.get('Checkout')).toBe(4);
+  });
+
+  test('places a source-only node at column 0 and a sink-only node at the deepest column', () => {
+    const edges = toEdges(sourceAndSinkOnlyData);
+    const columns = assignColumns(edges);
+
+    expect(columns.get('SourceOnly')).toBe(0);
+    expect(columns.get('Middle')).toBe(1);
+    expect(columns.get('SinkOnly')).toBe(2);
+  });
+
+  test('detects a cycle, drops the back edge from layering, and still assigns every node a column', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const edges = toEdges(cyclicData);
+    const columns = assignColumns(edges);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(columns.size).toBe(3);
+    // every node has a defined, non-negative column -- the layering terminated instead of looping forever
+    expect(columns.get('A')).toBeGreaterThanOrEqual(0);
+    expect(columns.get('B')).toBeGreaterThanOrEqual(0);
+    expect(columns.get('C')).toBeGreaterThanOrEqual(0);
+
+    warnSpy.mockRestore();
+  });
+
+  test('respects explicitColumns overrides', () => {
+    const edges = toEdges(sankeyData);
+    const columns = assignColumns(edges, { Home: 5 });
+    expect(columns.get('Home')).toBe(5);
+  });
+});
+
+describe('buildSankeyLayout', () => {
+  test('produces one node per unique id and one link per edge', () => {
+    const edges = toEdges(sankeyData);
+    const { nodes, links } = buildSankeyLayout(edges, 400, 300);
+
+    expect(nodes).toHaveLength(5); // Home, Product, Search, Cart, Checkout -- no duplicates
+    expect(links).toHaveLength(sankeyData.length);
+  });
+
+  test('a node value is the max of its outgoing and incoming totals', () => {
+    const edges = toEdges(sankeyData);
+    const { nodes } = buildSankeyLayout(edges, 400, 300);
+
+    const product = nodes.find((node) => node.id === 'Product');
+    // incoming: Home->Product (10) + Search->Product (4) = 14; outgoing: Product->Cart (7)
+    expect(product?.value).toBe(14);
+  });
+
+  test('nodes in the same column fit within chartHeight and never overlap', () => {
+    const edges = toEdges(sankeyData);
+    const chartHeight = 300;
+    const { nodes } = buildSankeyLayout(edges, 400, chartHeight);
+
+    const byColumn = new Map<number, typeof nodes>();
+    nodes.forEach((node) => byColumn.set(node.column, [...(byColumn.get(node.column) ?? []), node]));
+
+    byColumn.forEach((columnNodes) => {
+      const sorted = [...columnNodes].sort((a, b) => a.y - b.y);
+      sorted.forEach((node) => {
+        expect(node.y).toBeGreaterThanOrEqual(0);
+        expect(node.y + node.dy).toBeLessThanOrEqual(chartHeight + 0.01);
+      });
+      for (let i = 1; i < sorted.length; i++) {
+        expect(sorted[i].y).toBeGreaterThanOrEqual(sorted[i - 1].y + sorted[i - 1].dy - 0.01);
+      }
+    });
+  });
+
+  test('an isolated node with no edges is not produced (every node comes from an edge)', () => {
+    const edges = toEdges([{ source: 'A', target: 'B', value: 1 }]);
+    const { nodes } = buildSankeyLayout(edges, 200, 200);
+    expect(nodes.map((node) => node.id).sort()).toEqual(['A', 'B']);
+  });
+});
+
+describe('getRibbonPath', () => {
+  test('returns an SVG path string starting at the source node edge', () => {
+    const edges = toEdges(sankeyData);
+    const { links } = buildSankeyLayout(edges, 400, 300);
+    const path = getRibbonPath(links[0]);
+
+    expect(path).toMatch(/^M-?\d+(\.\d+)?,-?\d+(\.\d+)?C/);
+    expect(path.endsWith('Z')).toBe(true);
+  });
+});

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { cyclicData, customSankeyOptions, data as sankeyData, sourceAndSinkOnlyData } from './sankeyTestUtils';
-import { assignColumns, buildSankeyLayout, getRibbonPath, getSankeyEdges } from './sankeyUtils';
+import { assignColumns, buildSankeyLayout, getRibbonPath, getSankeyEdges, getSankeyLinkMark } from './sankeyUtils';
 
 const toEdges = (rows: { source: string; target: string; value: number }[]) =>
   getSankeyEdges({ ...customSankeyOptions, data: rows });
@@ -119,6 +119,12 @@ describe('buildSankeyLayout', () => {
     const { nodes } = buildSankeyLayout(edges, 200, 200);
     expect(nodes.map((node) => node.id).sort()).toEqual(['A', 'B']);
   });
+
+  test('rounds node.x to a whole pixel', () => {
+    const edges = toEdges(sankeyData);
+    const { nodes } = buildSankeyLayout(edges, 400, 300);
+    nodes.forEach((node) => expect(Number.isInteger(node.x)).toBe(true));
+  });
 });
 
 describe('getRibbonPath', () => {
@@ -129,5 +135,12 @@ describe('getRibbonPath', () => {
 
     expect(path).toMatch(/^M-?\d+(\.\d+)?,-?\d+(\.\d+)?C/);
     expect(path.endsWith('Z')).toBe(true);
+  });
+});
+
+describe('getSankeyLinkMark', () => {
+  test('forces a transparent stroke', () => {
+    const mark = getSankeyLinkMark(customSankeyOptions);
+    expect(mark.encode?.enter).toHaveProperty('stroke', { value: 'transparent' });
   });
 });

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
@@ -354,8 +354,10 @@ const resolveCollisions = (nodesByColumn: SankeyLayoutNode[][], chartHeight: num
     });
 
     const overflow = y0 - SANKEY_NODE_PADDING - chartHeight;
-    if (overflow > 0) {
-      let yBound = (sorted[sorted.length - 1].y -= overflow);
+    const lastNode = sorted.at(-1);
+    if (overflow > 0 && lastNode) {
+      lastNode.y -= overflow;
+      let yBound = lastNode.y;
       for (let i = sorted.length - 2; i >= 0; i--) {
         const node = sorted[i];
         const dy = node.y + node.dy + SANKEY_NODE_PADDING - yBound;

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
@@ -24,16 +24,12 @@ import {
 import { SankeySpecOptions } from '../types';
 
 /**
- * Layout math ported from Workspace's own production Sankey renderer
- * (aaui-web-spa `packages/ui-core/src/CloudViz.js:25637`, `d3.pathing()`), rewritten dependency-free
- * (no d3) since Vega has no sankey/flow-layout transform of its own. Unlike the source implementation
- * -- which receives pre-assigned node columns from Workspace's checkpoint-tree model -- this module
- * also has to derive columns itself (`assignColumns`) from a flat source/target/value edge list, since
- * that's the only input a generic chart-library mark can assume.
- *
- * Workspace's original also modeled "entry"/"exit" stub links (flow entering/leaving a partially-loaded
- * window). That concept doesn't apply here: every edge in a fully-specified source/target/value list has
- * both ends, so those stub-curve branches of the original `link()` generator are intentionally not ported.
+ * Layout math ported from Workspace's Sankey renderer (aaui-web-spa `CloudViz.js:25637`,
+ * `d3.pathing()`), rewritten dependency-free since Vega has no flow-layout transform. Unlike the
+ * source, which gets pre-assigned columns from Workspace's own data model, this also derives columns
+ * itself (`assignColumns`) from a flat source/target/value edge list. Workspace's "entry"/"exit" stub
+ * links (for partially-loaded windows) don't apply to a fully-specified edge list, so those branches
+ * of the original `link()` generator aren't ported.
  */
 
 const CURVATURE = 0.5;
@@ -76,15 +72,22 @@ export interface SankeyLayoutNode {
 }
 
 /**
- * Reads the source/target/value edges out of the chart data using the configured field names,
- * dropping any row that's missing one of the three.
+ * Reads source/target/value edges from the chart data, dropping rows missing a source/target or
+ * with a non-finite or negative value (which would corrupt the shared `ky` scale factor).
  */
 export const getSankeyEdges = (options: SankeySpecOptions): SankeyEdgeInput[] => {
   const { data, source, target, value } = options;
   const unsafeData = data as unknown as Record<string, unknown>[];
 
   return unsafeData
-    .filter((datum) => datum[source] != null && datum[target] != null && typeof datum[value] === 'number')
+    .filter(
+      (datum) =>
+        datum[source] != null &&
+        datum[target] != null &&
+        typeof datum[value] === 'number' &&
+        Number.isFinite(datum[value]) &&
+        (datum[value] as number) >= 0
+    )
     .map((datum) => ({
       source: String(datum[source]),
       target: String(datum[target]),
@@ -94,17 +97,15 @@ export const getSankeyEdges = (options: SankeySpecOptions): SankeyEdgeInput[] =>
 };
 
 /**
- * Assigns each node to a column via topological layering: a node's column is one greater than the
- * deepest column of any node that flows into it, and nodes with no incoming edges start at column 0.
+ * Assigns each node to a column via topological layering: a node's column is one past the deepest
+ * column of any node flowing into it; nodes with no incoming edges start at column 0.
  *
- * A cycle (A -> B -> A) can't be topologically layered -- the back-edge that closes the cycle is
- * detected via DFS, dropped from the layering graph (so the algorithm terminates), and reported via
- * `console.warn` rather than silently mis-laying the diagram. The edge itself is still rendered
- * (`buildLayout` doesn't filter edges based on this), it just doesn't influence column assignment.
+ * Cycles (A -> B -> A) can't be topologically layered. The closing back-edge is detected via DFS,
+ * dropped from layering (so this terminates), and reported via `console.warn` -- the edge is still
+ * rendered, it just doesn't affect column assignment.
  *
- * `explicitColumns`, if provided, overrides the computed column for any node id present in the map --
- * a hook for a future consumer (e.g. Workspace) that already knows column identity from its own
- * incrementally-fetched, checkpoint-tree data model and shouldn't need topological inference at all.
+ * `explicitColumns` overrides the computed column for any node id present in the map -- a hook for a
+ * future consumer that already knows column identity and doesn't need topological inference.
  */
 export const assignColumns = (
   edges: SankeyEdgeInput[],
@@ -147,7 +148,7 @@ export const assignColumns = (
     frontier = nextFrontier;
   }
 
-  // any node still not visited is part of an all-cycle component with no clean entry point -- place at column 0
+  // a node still unvisited is part of an all-cycle component with no entry point -- place at column 0
   nodeIds.forEach((id) => {
     if (!columns.has(id)) columns.set(id, 0);
   });
@@ -211,10 +212,9 @@ const computeNodeValue = (node: SankeyLayoutNode): number =>
 const sum = <T>(items: T[], accessor: (item: T) => number): number => items.reduce((total, item) => total + accessor(item), 0);
 
 /**
- * Builds the full node/link layout: columns, x/y positions, node/ribbon sizing, and vertical ordering
- * (via the ported relaxation + collision-resolution passes). Positions and sizes are literal pixel
- * values -- Vega scales aren't used for them, matching Venn's precomputed-geometry convention
- * (`venn/vennUtils.ts`), since Vega has no sankey/flow-layout transform to delegate to.
+ * Builds the full node/link layout: columns, x/y positions, sizing, and vertical ordering. Positions
+ * and sizes are literal pixel values, not Vega scales -- matching Venn's precomputed-geometry
+ * convention (`venn/vennUtils.ts`).
  */
 export const buildSankeyLayout = (
   edges: SankeyEdgeInput[],
@@ -276,11 +276,8 @@ const computeNodeBreadths = (nodes: SankeyLayoutNode[], chartWidth: number): num
 
 /**
  * Assigns y positions and node/link thicknesses, ported from `computeNodeDepths`/`initializeNodeDepth`
- * plus the `relaxLeftToRight`/`relaxRightToLeft`/`resolveCollisions` crossing-reduction passes.
- *
- * The pre-alpha spec for this mark explicitly scoped out crossing minimization ("no crossing-minimization
- * pass... ribbons may visually cross"). This implementation deliberately keeps it, since Workspace's
- * existing, tested reference implementation already solves it at negligible marginal cost.
+ * plus the relaxation/collision passes below. Crossing minimization is kept (unlike the pre-alpha
+ * spec's scoped-out plan) since Workspace's tested implementation already handles it cheaply.
  */
 const computeNodeDepths = (nodes: SankeyLayoutNode[], chartHeight: number): void => {
   const nodesByColumn = groupByColumn(nodes);
@@ -395,20 +392,15 @@ const computeLinkDepths = (nodes: SankeyLayoutNode[]): void => {
 const MAX_CURVE_BOOST = 15;
 
 /**
- * Cubic-bezier ribbon path between a link's source and target node edges, ported from `d3.pathing()`'s
- * `link()` generator (only the "both ends present" branch -- see the module-level comment on why the
- * entry/exit stub-curve branches aren't applicable to a generic edge list).
+ * Cubic-bezier ribbon path between a link's source and target edges, ported from `d3.pathing()`'s
+ * `link()` generator (the "both ends present" branch only -- see the module comment on stub curves).
  *
- * One deliberate departure from the original: `d3.pathing()` only shifts the bottom edge's control
- * points (`shortLinkOffset`) for links thinner than 15px, so the top and bottom edges of a *thick*
- * ribbon are perfectly parallel copies of each other -- fine in Workspace's own chart, which grows the
- * canvas to fit the data (see CloudViz.js's `_measureChart`/`_sizeChart`) rather than fitting the data
- * into a fixed height, so a dominant link rarely has to be as thick, proportionally, as it can be here.
- * Since this mark *is* fit into a fixed `chartHeight`, a very thick link (e.g. a root/entry node's
- * total outflow) reads as a rigid trapezoid instead of a ribbon. Capping the same offset at
- * `MAX_CURVE_BOOST` for every link -- instead of zeroing it out above 15px -- keeps thin links
- * identical to the original and gives thick links a small, proportionally-negligible independent bend
- * on their bottom edge, enough to read as a ribbon rather than a block.
+ * Departure from the original: `d3.pathing()` only bends the bottom edge (`shortLinkOffset`) below
+ * 15px thickness, so a thick ribbon's top and bottom edges run perfectly parallel -- fine in
+ * Workspace's chart, which grows the canvas to fit the data instead of a fixed height. Here, fit into
+ * a fixed `chartHeight`, a thick link (e.g. a root node's total outflow) would read as a rigid
+ * trapezoid. Capping the bend at `MAX_CURVE_BOOST` instead of zeroing it out keeps thin links
+ * unchanged while giving thick ones enough independent bend to read as a ribbon.
  */
 export const getRibbonPath = (link: SankeyLayoutLink): string => {
   const curveHeight = Math.max(1, link.dy);
@@ -439,18 +431,16 @@ export const getSankeyLinkMark = (options: SankeySpecOptions): PathMark => {
 
   return {
     type: 'path',
-    // The mark's own name and its underlying data source name must be two distinct strings: Vega
-    // registers mark names and dataset names in the same namespace, so reusing one string for both
-    // (as an earlier version of this file did) throws "Duplicate data set name" at parse time.
+    // Mark name and data-source name must differ -- Vega shares one namespace for both, and reusing
+    // a string for each throws "Duplicate data set name" at parse time.
     name: getSankeyLinkMarkName(name),
     from: { data: getSankeyLinkDataName(name) },
     encode: {
       enter: {
         path: { field: 'path' },
         fill: getColorProductionRule('sourceId', colorScheme),
-        // componentInfo in the inspect/popover signal is keyed by the parent name (not the layer's own
-        // mark name) so a single <ChartInspect>/<ChartPopover> under <Sankey name="..."> handles both
-        // layers -- matches Venn's `getInterserctionMark`, which does the same for its second layer.
+        // Keyed by the parent name (not this layer's mark name) so one <ChartInspect>/<ChartPopover>
+        // under <Sankey name="..."> covers both layers -- matches Venn's `getInterserctionMark`.
         tooltip: getInspectEncoding(chartInspects, name),
       },
       update: {
@@ -489,24 +479,16 @@ export const getSankeyNodeMark = (options: SankeySpecOptions): RectMark => {
 const NODE_LABEL_NAME_DY = -7;
 /** Vertical offset, in pixels, of the node value label below the node's vertical center. */
 const NODE_LABEL_VALUE_DY = 9;
-/** Halo stroke width, scaled down from `DIRECT_LABEL_BACKGROUND_STROKE_WIDTH` (4px, tuned for the
- * larger direct-label font) so it doesn't blob out this mark's much smaller label text. */
+/** Halo stroke width, scaled down from `DIRECT_LABEL_BACKGROUND_STROKE_WIDTH` (4px) for this mark's smaller text. */
 const NODE_LABEL_HALO_STROKE_WIDTH = 2;
-/** Halo opacity -- softens it to a glow rather than a hard-edged block wherever a label lands on
- * plain chart background instead of a colored ribbon (see the comment where this is used). */
+/** Halo opacity -- softens it to a glow rather than a hard-edged block on plain background. */
 const NODE_LABEL_HALO_OPACITY = 0.65;
 
-/**
- * Shared enter-encode fields for a node label's background-halo and foreground text marks --
- * everything except `fill`/`stroke`, which differ between the two.
- */
+/** Shared enter-encode fields for a label's background-halo and foreground text marks (everything except `fill`/`stroke`). */
 const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry => ({
-  // `labelX`/`labelY`/`labelAlign`/`labelLimit` are precomputed alongside the rest of the layout in
-  // `sankeySpecBuilder.ts`'s addData (rather than derived here via encoding math), to stay consistent
-  // with the "everything precomputed in JS" convention this mark follows. `labelAlign` flips for the
-  // last column (no room to its right within the chart), and `labelLimit` caps each label to the
-  // actual gap between columns via Vega's own text truncation (ellipsizes automatically) so adjacent
-  // columns' labels -- which now grow toward each other around that flip -- can't collide.
+  // labelX/labelY/labelAlign/labelLimit are precomputed in addData, per this mark's "everything
+  // precomputed in JS" convention. labelAlign flips for the last column (no room to its right);
+  // labelLimit caps each label to the gap between columns so the two flipped-and-facing labels can't collide.
   x: { field: 'labelX' },
   y: { field: 'labelY' },
   dy: { value: dy },
@@ -517,14 +499,10 @@ const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry
 });
 
 /**
- * A label pair -- a background "halo" text mark (stroked in the chart's background color) plus a
- * foreground fill text mark on top -- so labels stay legible sitting directly on top of colored,
- * crossing ribbons. Same two-mark halo technique `getLineDirectLabelMarks` uses for line series'
- * end-of-line labels (lineDirectLabel/lineDirectLabelUtils.ts), reused here for consistency rather
- * than inventing a different labeling convention for this mark. Font size also reuses that same
- * mechanism (`getDirectLabelFontSizeProductionRule`): `options.fontSize` overrides it (the story sets
- * this to 14, matching `DIRECT_LABEL_FONT_SIZE_S`), otherwise it scales with chart width via the
- * shared `CHART_SIZE_FONT_SIZE` signal, same as Line's direct labels.
+ * A background-halo + foreground text mark pair, so labels stay legible over colored ribbons. Same
+ * two-mark technique `getLineDirectLabelMarks` uses (lineDirectLabelUtils.ts), reused for consistency.
+ * Font size also reuses `getDirectLabelFontSizeProductionRule`: `options.fontSize` overrides it,
+ * otherwise it scales with chart width via the shared `CHART_SIZE_FONT_SIZE` signal.
  */
 const getSankeyNodeLabelMarkPair = (
   options: SankeySpecOptions,
@@ -535,15 +513,9 @@ const getSankeyNodeLabelMarkPair = (
   fontSizeEncoding: ProductionRule<NumericValueRef>
 ): TextMark[] => {
   const { name } = options;
-  // Deliberately NOT derived from `backgroundColor`/`colorScheme`, unlike Line's direct labels
-  // (which this halo technique is otherwise copied from): those labels sit in the chart margin, on
-  // the actual chart background, so a background-matching halo makes sense there. These labels sit
-  // on top of arbitrarily-colored ribbons/nodes instead, where a scheme-matched light-mode halo
-  // (white) blends into lighter ribbon colors, and dark-mode's scheme-matched dark text similarly
-  // fails against the palette's darker colors -- so the pairing needs to work against arbitrary
-  // colors, not the page background. Forcing the 'dark' variant of these tokens regardless of the
-  // chart's actual colorScheme (dark halo + light text) reuses that already-legible combination
-  // universally, rather than inventing new one-off colors.
+  // Unlike Line's direct labels, not derived from colorScheme: these labels sit on arbitrary ribbon
+  // colors, not the chart background, where a scheme-matched halo (light or dark) can blend into the
+  // palette. Forcing the 'dark' variant (dark halo + light text) is legible against any color.
   const resolvedBg = getS2ColorValue('gray-25', 'dark');
   const baseEnter = getSankeyNodeLabelBaseEnter(textField, dy);
 
@@ -555,12 +527,8 @@ const getSankeyNodeLabelMarkPair = (
     encode: {
       enter: {
         ...baseEnter,
-        // `fill` must be set explicitly here -- SVG's default text fill is solid black, so without
-        // this the halo rendered as an (almost-but-not-quite-matching) solid black text-shaped block
-        // sitting behind the foreground text, not a halo, which read as a stray dark box wherever a
-        // label landed on plain chart background rather than a colored ribbon. `fillOpacity`/
-        // `strokeOpacity` soften it further so it reads as a soft glow, not a hard-edged block, in
-        // that same case.
+        // `fill` must be explicit -- SVG defaults text fill to solid black, which without this
+        // renders as a stray dark block instead of a halo. fillOpacity/strokeOpacity soften it to a glow.
         fill: { value: resolvedBg },
         fillOpacity: { value: NODE_LABEL_HALO_OPACITY },
         stroke: { value: resolvedBg },
@@ -585,8 +553,7 @@ const getSankeyNodeLabelMarkPair = (
   return [backgroundTextMark, foregroundTextMark];
 };
 
-// Both label fills below force the 'dark' scheme variant of these gray tokens regardless of the
-// chart's actual colorScheme -- see the comment in getSankeyNodeLabelMarkPair for why.
+// Both fills below force the 'dark' scheme variant regardless of colorScheme -- see getSankeyNodeLabelMarkPair.
 export const getSankeyNodeLabelMarks = (options: SankeySpecOptions): TextMark[] =>
   getSankeyNodeLabelMarkPair(
     options,
@@ -605,9 +572,8 @@ export const getSankeyNodeValueLabelMarks = (options: SankeySpecOptions): TextMa
     'formattedValue',
     NODE_LABEL_VALUE_DY,
     getS2ColorValue('gray-700', 'dark'),
-    // one size smaller than the name label when an explicit override is set; otherwise the value
-    // label falls back to the same chart-width-responsive signal as the name label (no offset --
-    // offsetting a signal expression isn't worth the added complexity for the default/unset case).
+    // one size smaller than the name label when overridden; otherwise falls back to the same
+    // responsive signal as the name label (not worth offsetting a signal expression).
     options.fontSize !== undefined
       ? { value: options.fontSize - 1 }
       : getDirectLabelFontSizeProductionRule(options.fontSize)

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { EncodeEntry, NumericValueRef, PathMark, ProductionRule, RectMark, TextMark } from 'vega';
+import { EncodeEntry, PathMark, RectMark, TextMark } from 'vega';
 
 import { SANKEY_NODE_PADDING, SANKEY_NODE_WIDTH } from '@spectrum-charts/constants';
 import { getS2ColorValue } from '@spectrum-charts/themes';
@@ -18,6 +18,7 @@ import {
   getColorProductionRule,
   getCursor,
   getDirectLabelFontSizeProductionRule,
+  getDirectLabelTextMarkPair,
   getInspectEncoding,
   getMarkOpacity,
 } from '../marks/markUtils';
@@ -265,12 +266,13 @@ export const buildSankeyLayout = (
 /**
  * Assigns x positions from each node's column, ported from `computeNodeBreadths`/`scaleNodeBreadths`.
  * Returns the column spacing so callers can size labels to fit the actual gap between columns.
+ * `node.x` is rounded to a whole pixel to avoid an anti-aliasing seam against touching ribbons.
  */
 const computeNodeBreadths = (nodes: SankeyLayoutNode[], chartWidth: number): number => {
   const numColumns = new Set(nodes.map((node) => node.column)).size;
   const availableWidth = Math.max(chartWidth - SANKEY_NODE_WIDTH, 0);
   const columnSpacing = numColumns > 1 ? availableWidth / (numColumns - 1) : availableWidth;
-  nodes.forEach((node) => (node.x = node.column * columnSpacing));
+  nodes.forEach((node) => (node.x = Math.round(node.column * columnSpacing)));
   return columnSpacing;
 };
 
@@ -439,6 +441,8 @@ export const getSankeyLinkMark = (options: SankeySpecOptions): PathMark => {
       enter: {
         path: { field: 'path' },
         fill: getColorProductionRule('sourceId', colorScheme),
+        // Without this, path marks inherit the theme's default stroke, showing as a seam at each node.
+        stroke: { value: 'transparent' },
         // Keyed by the parent name (not this layer's mark name) so one <ChartInspect>/<ChartPopover>
         // under <Sankey name="..."> covers both layers -- matches Venn's `getInterserctionMark`.
         tooltip: getInspectEncoding(chartInspects, name),
@@ -481,8 +485,6 @@ const NODE_LABEL_NAME_DY = -7;
 const NODE_LABEL_VALUE_DY = 9;
 /** Halo stroke width, scaled down from `DIRECT_LABEL_BACKGROUND_STROKE_WIDTH` (4px) for this mark's smaller text. */
 const NODE_LABEL_HALO_STROKE_WIDTH = 2;
-/** Halo opacity -- softens it to a glow rather than a hard-edged block on plain background. */
-const NODE_LABEL_HALO_OPACITY = 0.65;
 
 /** Shared enter-encode fields for a label's background-halo and foreground text marks (everything except `fill`/`stroke`). */
 const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry => ({
@@ -510,7 +512,7 @@ const getSankeyNodeLabelMarkPair = (
   textField: string,
   dy: number,
   fillColor: string,
-  fontSizeEncoding: ProductionRule<NumericValueRef>
+  fontSizeEncoding: { signal: string } | { value: number }
 ): TextMark[] => {
   const { name } = options;
   // Unlike Line's direct labels, not derived from colorScheme: these labels sit on arbitrary ribbon
@@ -519,38 +521,23 @@ const getSankeyNodeLabelMarkPair = (
   const resolvedBg = getS2ColorValue('gray-25', 'dark');
   const baseEnter = getSankeyNodeLabelBaseEnter(textField, dy);
 
-  const backgroundTextMark: TextMark = {
-    name: `${name}_${markNameSuffix}_bg`,
-    type: 'text',
-    from: { data: getSankeyNodeDataName(name) },
-    interactive: false,
-    encode: {
+  return getDirectLabelTextMarkPair(
+    `${name}_${markNameSuffix}`,
+    getSankeyNodeDataName(name),
+    {
       enter: {
         ...baseEnter,
-        // `fill` must be explicit -- SVG defaults text fill to solid black, which without this
-        // renders as a stray dark block instead of a halo. fillOpacity/strokeOpacity soften it to a glow.
         fill: { value: resolvedBg },
-        fillOpacity: { value: NODE_LABEL_HALO_OPACITY },
         stroke: { value: resolvedBg },
-        strokeOpacity: { value: NODE_LABEL_HALO_OPACITY },
         strokeWidth: { value: NODE_LABEL_HALO_STROKE_WIDTH },
       },
       update: { fontSize: fontSizeEncoding },
     },
-  };
-
-  const foregroundTextMark: TextMark = {
-    name: `${name}_${markNameSuffix}`,
-    type: 'text',
-    from: { data: getSankeyNodeDataName(name) },
-    interactive: false,
-    encode: {
+    {
       enter: { ...baseEnter, fill: { value: fillColor } },
       update: { fontSize: fontSizeEncoding },
-    },
-  };
-
-  return [backgroundTextMark, foregroundTextMark];
+    }
+  );
 };
 
 // Both fills below force the 'dark' scheme variant regardless of colorScheme -- see getSankeyNodeLabelMarkPair.
@@ -571,7 +558,8 @@ export const getSankeyNodeValueLabelMarks = (options: SankeySpecOptions): TextMa
     'valueLabel',
     'formattedValue',
     NODE_LABEL_VALUE_DY,
-    getS2ColorValue('gray-700', 'dark'),
+    // same fill as the name label -- gray-700 read as a gold-ish tint over saturated ribbons.
+    getS2ColorValue('gray-800', 'dark'),
     // one size smaller than the name label when overridden; otherwise falls back to the same
     // responsive signal as the name label (not worth offsetting a signal expression).
     options.fontSize !== undefined

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
@@ -1,0 +1,621 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { EncodeEntry, NumericValueRef, PathMark, ProductionRule, RectMark, TextMark } from 'vega';
+
+import { SANKEY_NODE_PADDING, SANKEY_NODE_WIDTH } from '@spectrum-charts/constants';
+import { getS2ColorValue } from '@spectrum-charts/themes';
+
+import {
+  getColorProductionRule,
+  getCursor,
+  getDirectLabelFontSizeProductionRule,
+  getInspectEncoding,
+  getMarkOpacity,
+} from '../marks/markUtils';
+import { SankeySpecOptions } from '../types';
+
+/**
+ * Layout math ported from Workspace's own production Sankey renderer
+ * (aaui-web-spa `packages/ui-core/src/CloudViz.js:25637`, `d3.pathing()`), rewritten dependency-free
+ * (no d3) since Vega has no sankey/flow-layout transform of its own. Unlike the source implementation
+ * -- which receives pre-assigned node columns from Workspace's checkpoint-tree model -- this module
+ * also has to derive columns itself (`assignColumns`) from a flat source/target/value edge list, since
+ * that's the only input a generic chart-library mark can assume.
+ *
+ * Workspace's original also modeled "entry"/"exit" stub links (flow entering/leaving a partially-loaded
+ * window). That concept doesn't apply here: every edge in a fully-specified source/target/value list has
+ * both ends, so those stub-curve branches of the original `link()` generator are intentionally not ported.
+ */
+
+const CURVATURE = 0.5;
+/** Number of left-right/right-left relaxation passes used to reduce ribbon crossings. */
+const RELAXATION_ITERATIONS = 32;
+
+export interface SankeyEdgeInput {
+  source: string;
+  target: string;
+  value: number;
+  /** the original data row this edge came from, kept for tooltip passthrough */
+  datum: Record<string, unknown>;
+}
+
+export interface SankeyLayoutLink {
+  source: SankeyLayoutNode;
+  target: SankeyLayoutNode;
+  value: number;
+  /** vertical offset of this link within its source node */
+  sy: number;
+  /** vertical offset of this link within its target node */
+  ty: number;
+  /** thickness of the ribbon, in pixels */
+  dy: number;
+  datum: Record<string, unknown>;
+}
+
+export interface SankeyLayoutNode {
+  id: string;
+  column: number;
+  value: number;
+  x: number;
+  y: number;
+  /** node width, in pixels */
+  dx: number;
+  /** node height, in pixels */
+  dy: number;
+  sourceLinks: SankeyLayoutLink[];
+  targetLinks: SankeyLayoutLink[];
+}
+
+/**
+ * Reads the source/target/value edges out of the chart data using the configured field names,
+ * dropping any row that's missing one of the three.
+ */
+export const getSankeyEdges = (options: SankeySpecOptions): SankeyEdgeInput[] => {
+  const { data, source, target, value } = options;
+  const unsafeData = data as unknown as Record<string, unknown>[];
+
+  return unsafeData
+    .filter((datum) => datum[source] != null && datum[target] != null && typeof datum[value] === 'number')
+    .map((datum) => ({
+      source: String(datum[source]),
+      target: String(datum[target]),
+      value: datum[value] as number,
+      datum,
+    }));
+};
+
+/**
+ * Assigns each node to a column via topological layering: a node's column is one greater than the
+ * deepest column of any node that flows into it, and nodes with no incoming edges start at column 0.
+ *
+ * A cycle (A -> B -> A) can't be topologically layered -- the back-edge that closes the cycle is
+ * detected via DFS, dropped from the layering graph (so the algorithm terminates), and reported via
+ * `console.warn` rather than silently mis-laying the diagram. The edge itself is still rendered
+ * (`buildLayout` doesn't filter edges based on this), it just doesn't influence column assignment.
+ *
+ * `explicitColumns`, if provided, overrides the computed column for any node id present in the map --
+ * a hook for a future consumer (e.g. Workspace) that already knows column identity from its own
+ * incrementally-fetched, checkpoint-tree data model and shouldn't need topological inference at all.
+ */
+export const assignColumns = (
+  edges: SankeyEdgeInput[],
+  explicitColumns?: Record<string, number>
+): Map<string, number> => {
+  const nodeIds = getUniqueNodeIds(edges);
+  const backEdges = findBackEdges(nodeIds, edges);
+  const layeringEdges = edges.filter((edge) => !backEdges.has(edge));
+
+  if (backEdges.size) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Sankey: ${backEdges.size} cyclic edge(s) detected and excluded from column layering (still rendered): ` +
+        [...backEdges].map((edge) => `${edge.source} -> ${edge.target}`).join(', ')
+    );
+  }
+
+  const outEdgesByNode = groupEdgesBySource(layeringEdges);
+  const inDegree = new Map<string, number>();
+  nodeIds.forEach((id) => inDegree.set(id, 0));
+  layeringEdges.forEach((edge) => inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1));
+
+  const columns = new Map<string, number>();
+  let frontier = nodeIds.filter((id) => inDegree.get(id) === 0);
+  frontier.forEach((id) => columns.set(id, 0));
+
+  while (frontier.length) {
+    const nextFrontier: string[] = [];
+    frontier.forEach((id) => {
+      const column = columns.get(id) ?? 0;
+      (outEdgesByNode.get(id) ?? []).forEach((edge) => {
+        const remaining = (inDegree.get(edge.target) ?? 0) - 1;
+        inDegree.set(edge.target, remaining);
+        columns.set(edge.target, Math.max(columns.get(edge.target) ?? 0, column + 1));
+        if (remaining === 0) {
+          nextFrontier.push(edge.target);
+        }
+      });
+    });
+    frontier = nextFrontier;
+  }
+
+  // any node still not visited is part of an all-cycle component with no clean entry point -- place at column 0
+  nodeIds.forEach((id) => {
+    if (!columns.has(id)) columns.set(id, 0);
+  });
+
+  if (explicitColumns) {
+    Object.entries(explicitColumns).forEach(([id, column]) => columns.set(id, column));
+  }
+
+  return columns;
+};
+
+const getUniqueNodeIds = (edges: SankeyEdgeInput[]): string[] => {
+  const ids = new Set<string>();
+  edges.forEach((edge) => {
+    ids.add(edge.source);
+    ids.add(edge.target);
+  });
+  return [...ids];
+};
+
+const groupEdgesBySource = (edges: SankeyEdgeInput[]): Map<string, SankeyEdgeInput[]> => {
+  const map = new Map<string, SankeyEdgeInput[]>();
+  edges.forEach((edge) => {
+    const group = map.get(edge.source) ?? [];
+    group.push(edge);
+    map.set(edge.source, group);
+  });
+  return map;
+};
+
+/** DFS-based cycle detection; returns the set of edges that close a cycle (the "back edges"). */
+const findBackEdges = (nodeIds: string[], edges: SankeyEdgeInput[]): Set<SankeyEdgeInput> => {
+  const outEdges = groupEdgesBySource(edges);
+  const state = new Map<string, 'visiting' | 'done'>();
+  const backEdges = new Set<SankeyEdgeInput>();
+
+  const visit = (id: string) => {
+    state.set(id, 'visiting');
+    (outEdges.get(id) ?? []).forEach((edge) => {
+      const targetState = state.get(edge.target);
+      if (targetState === 'visiting') {
+        backEdges.add(edge);
+      } else if (targetState !== 'done') {
+        visit(edge.target);
+      }
+    });
+    state.set(id, 'done');
+  };
+
+  nodeIds.forEach((id) => {
+    if (!state.has(id)) visit(id);
+  });
+
+  return backEdges;
+};
+
+/** value = max(sum of outgoing, sum of incoming), ported from `d3.pathing()`'s `computeNodeValues`. */
+const computeNodeValue = (node: SankeyLayoutNode): number =>
+  Math.max(sum(node.sourceLinks, (link) => link.value), sum(node.targetLinks, (link) => link.value));
+
+const sum = <T>(items: T[], accessor: (item: T) => number): number => items.reduce((total, item) => total + accessor(item), 0);
+
+/**
+ * Builds the full node/link layout: columns, x/y positions, node/ribbon sizing, and vertical ordering
+ * (via the ported relaxation + collision-resolution passes). Positions and sizes are literal pixel
+ * values -- Vega scales aren't used for them, matching Venn's precomputed-geometry convention
+ * (`venn/vennUtils.ts`), since Vega has no sankey/flow-layout transform to delegate to.
+ */
+export const buildSankeyLayout = (
+  edges: SankeyEdgeInput[],
+  chartWidth: number,
+  chartHeight: number,
+  explicitColumns?: Record<string, number>
+): { nodes: SankeyLayoutNode[]; links: SankeyLayoutLink[]; columnSpacing: number } => {
+  const columns = assignColumns(edges, explicitColumns);
+  const nodesById = new Map<string, SankeyLayoutNode>();
+  const getNode = (id: string): SankeyLayoutNode => {
+    let node = nodesById.get(id);
+    if (!node) {
+      node = {
+        id,
+        column: columns.get(id) ?? 0,
+        value: 0,
+        x: 0,
+        y: 0,
+        dx: SANKEY_NODE_WIDTH,
+        dy: 0,
+        sourceLinks: [],
+        targetLinks: [],
+      };
+      nodesById.set(id, node);
+    }
+    return node;
+  };
+
+  const links: SankeyLayoutLink[] = edges.map((edge) => {
+    const source = getNode(edge.source);
+    const target = getNode(edge.target);
+    const link: SankeyLayoutLink = { source, target, value: edge.value, sy: 0, ty: 0, dy: 0, datum: edge.datum };
+    source.sourceLinks.push(link);
+    target.targetLinks.push(link);
+    return link;
+  });
+
+  const nodes = [...nodesById.values()];
+  nodes.forEach((node) => (node.value = computeNodeValue(node)));
+
+  const columnSpacing = computeNodeBreadths(nodes, chartWidth);
+  computeNodeDepths(nodes, chartHeight);
+  computeLinkDepths(nodes);
+
+  return { nodes, links, columnSpacing };
+};
+
+/**
+ * Assigns x positions from each node's column, ported from `computeNodeBreadths`/`scaleNodeBreadths`.
+ * Returns the column spacing so callers can size labels to fit the actual gap between columns.
+ */
+const computeNodeBreadths = (nodes: SankeyLayoutNode[], chartWidth: number): number => {
+  const numColumns = new Set(nodes.map((node) => node.column)).size;
+  const availableWidth = Math.max(chartWidth - SANKEY_NODE_WIDTH, 0);
+  const columnSpacing = numColumns > 1 ? availableWidth / (numColumns - 1) : availableWidth;
+  nodes.forEach((node) => (node.x = node.column * columnSpacing));
+  return columnSpacing;
+};
+
+/**
+ * Assigns y positions and node/link thicknesses, ported from `computeNodeDepths`/`initializeNodeDepth`
+ * plus the `relaxLeftToRight`/`relaxRightToLeft`/`resolveCollisions` crossing-reduction passes.
+ *
+ * The pre-alpha spec for this mark explicitly scoped out crossing minimization ("no crossing-minimization
+ * pass... ribbons may visually cross"). This implementation deliberately keeps it, since Workspace's
+ * existing, tested reference implementation already solves it at negligible marginal cost.
+ */
+const computeNodeDepths = (nodes: SankeyLayoutNode[], chartHeight: number): void => {
+  const nodesByColumn = groupByColumn(nodes);
+
+  const ky = Math.min(
+    ...nodesByColumn.map((columnNodes) => {
+      const columnValue = sum(columnNodes, (node) => node.value) || 1;
+      return (chartHeight - (columnNodes.length - 1) * SANKEY_NODE_PADDING) / columnValue;
+    })
+  );
+
+  nodesByColumn.forEach((columnNodes) => {
+    columnNodes.forEach((node, i) => {
+      node.y = i;
+      node.dy = Math.max(0, node.value * ky);
+      [...node.sourceLinks, ...node.targetLinks].forEach((link) => (link.dy = link.value * ky));
+    });
+  });
+
+  resolveCollisions(nodesByColumn, chartHeight);
+  for (let iteration = 0, alpha = 1; iteration < RELAXATION_ITERATIONS; iteration++) {
+    alpha *= 0.99;
+    relaxRightToLeft(nodesByColumn, alpha);
+    resolveCollisions(nodesByColumn, chartHeight);
+    relaxLeftToRight(nodesByColumn, alpha);
+    resolveCollisions(nodesByColumn, chartHeight);
+  }
+};
+
+const groupByColumn = (nodes: SankeyLayoutNode[]): SankeyLayoutNode[][] => {
+  const byColumn = new Map<number, SankeyLayoutNode[]>();
+  nodes.forEach((node) => {
+    const group = byColumn.get(node.column) ?? [];
+    group.push(node);
+    byColumn.set(node.column, group);
+  });
+  return [...byColumn.entries()].sort(([a], [b]) => a - b).map(([, group]) => group);
+};
+
+const center = (node: SankeyLayoutNode): number => node.y + node.dy / 2;
+
+const relaxLeftToRight = (nodesByColumn: SankeyLayoutNode[][], alpha: number): void => {
+  nodesByColumn.forEach((columnNodes) => {
+    columnNodes.forEach((node) => {
+      if (!node.targetLinks.length) return;
+      const weightedY = sum(node.targetLinks, (link) => center(link.source) * link.value);
+      const totalValue = sum(node.targetLinks, (link) => link.value);
+      node.y += (weightedY / totalValue - center(node)) * alpha;
+    });
+  });
+};
+
+const relaxRightToLeft = (nodesByColumn: SankeyLayoutNode[][], alpha: number): void => {
+  [...nodesByColumn].reverse().forEach((columnNodes) => {
+    columnNodes.forEach((node) => {
+      if (!node.sourceLinks.length) return;
+      const weightedY = sum(node.sourceLinks, (link) => center(link.target) * link.value);
+      const totalValue = sum(node.sourceLinks, (link) => link.value);
+      node.y += (weightedY / totalValue - center(node)) * alpha;
+    });
+  });
+};
+
+const resolveCollisions = (nodesByColumn: SankeyLayoutNode[][], chartHeight: number): void => {
+  nodesByColumn.forEach((columnNodes) => {
+    const sorted = [...columnNodes].sort((a, b) => a.y - b.y);
+    let y0 = 0;
+    sorted.forEach((node) => {
+      const dy = y0 - node.y;
+      if (dy > 0) node.y += dy;
+      y0 = node.y + node.dy + SANKEY_NODE_PADDING;
+    });
+
+    const overflow = y0 - SANKEY_NODE_PADDING - chartHeight;
+    if (overflow > 0) {
+      let yBound = (sorted[sorted.length - 1].y -= overflow);
+      for (let i = sorted.length - 2; i >= 0; i--) {
+        const node = sorted[i];
+        const dy = node.y + node.dy + SANKEY_NODE_PADDING - yBound;
+        if (dy > 0) node.y -= dy;
+        yBound = node.y;
+      }
+    }
+  });
+};
+
+/**
+ * Assigns each link's vertical offset within its source/target node (`sy`/`ty`), ordering the stack
+ * by the connected node's position so parallel ribbons don't cross their own siblings unnecessarily.
+ * Ported from `computeLinkDepths` (minus the entry/exit-stub bookkeeping -- not applicable here).
+ */
+const computeLinkDepths = (nodes: SankeyLayoutNode[]): void => {
+  nodes.forEach((node) => {
+    node.sourceLinks.sort((a, b) => a.target.y - b.target.y);
+    node.targetLinks.sort((a, b) => a.source.y - b.source.y);
+  });
+  nodes.forEach((node) => {
+    let sy = 0;
+    let ty = 0;
+    node.sourceLinks.forEach((link) => {
+      link.sy = sy;
+      sy += link.dy;
+    });
+    node.targetLinks.forEach((link) => {
+      link.ty = ty;
+      ty += link.dy;
+    });
+  });
+};
+
+/** Cap, in pixels, on how much the bottom edge's control points can shift relative to the top edge's. */
+const MAX_CURVE_BOOST = 15;
+
+/**
+ * Cubic-bezier ribbon path between a link's source and target node edges, ported from `d3.pathing()`'s
+ * `link()` generator (only the "both ends present" branch -- see the module-level comment on why the
+ * entry/exit stub-curve branches aren't applicable to a generic edge list).
+ *
+ * One deliberate departure from the original: `d3.pathing()` only shifts the bottom edge's control
+ * points (`shortLinkOffset`) for links thinner than 15px, so the top and bottom edges of a *thick*
+ * ribbon are perfectly parallel copies of each other -- fine in Workspace's own chart, which grows the
+ * canvas to fit the data (see CloudViz.js's `_measureChart`/`_sizeChart`) rather than fitting the data
+ * into a fixed height, so a dominant link rarely has to be as thick, proportionally, as it can be here.
+ * Since this mark *is* fit into a fixed `chartHeight`, a very thick link (e.g. a root/entry node's
+ * total outflow) reads as a rigid trapezoid instead of a ribbon. Capping the same offset at
+ * `MAX_CURVE_BOOST` for every link -- instead of zeroing it out above 15px -- keeps thin links
+ * identical to the original and gives thick links a small, proportionally-negligible independent bend
+ * on their bottom edge, enough to read as a ribbon rather than a block.
+ */
+export const getRibbonPath = (link: SankeyLayoutLink): string => {
+  const curveHeight = Math.max(1, link.dy);
+  const x0 = link.source.x + link.source.dx;
+  const x1 = link.target.x;
+  const x2 = lerp(x0, x1, CURVATURE);
+  const x3 = lerp(x0, x1, 1 - CURVATURE);
+  const curveBoost = Math.min(curveHeight, MAX_CURVE_BOOST);
+  const shortLinkOffset = link.source.y < link.target.y ? -curveBoost : curveBoost;
+  const x4 = x3 + shortLinkOffset;
+  const x5 = x2 + shortLinkOffset;
+  const y0 = link.source.y + link.sy;
+  const y1 = link.target.y + link.ty;
+  const y2 = y1 + curveHeight;
+  const y3 = y0 + curveHeight;
+
+  return `M${x0},${y0}C${x2},${y0} ${x3},${y1} ${x1},${y1}v${curveHeight}C${x4},${y2} ${x5},${y3} ${x0},${y3}Z`;
+};
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+// ---------------------------------------------------------------------------------------------------
+// Mark builders
+// ---------------------------------------------------------------------------------------------------
+
+export const getSankeyLinkMark = (options: SankeySpecOptions): PathMark => {
+  const { chartInspects, chartPopovers, colorScheme, name } = options;
+
+  return {
+    type: 'path',
+    // The mark's own name and its underlying data source name must be two distinct strings: Vega
+    // registers mark names and dataset names in the same namespace, so reusing one string for both
+    // (as an earlier version of this file did) throws "Duplicate data set name" at parse time.
+    name: getSankeyLinkMarkName(name),
+    from: { data: getSankeyLinkDataName(name) },
+    encode: {
+      enter: {
+        path: { field: 'path' },
+        fill: getColorProductionRule('sourceId', colorScheme),
+        // componentInfo in the inspect/popover signal is keyed by the parent name (not the layer's own
+        // mark name) so a single <ChartInspect>/<ChartPopover> under <Sankey name="..."> handles both
+        // layers -- matches Venn's `getInterserctionMark`, which does the same for its second layer.
+        tooltip: getInspectEncoding(chartInspects, name),
+      },
+      update: {
+        opacity: getMarkOpacity(options),
+        cursor: getCursor(chartPopovers),
+      },
+    },
+  };
+};
+
+export const getSankeyNodeMark = (options: SankeySpecOptions): RectMark => {
+  const { chartInspects, chartPopovers, color, colorScheme, name } = options;
+
+  return {
+    type: 'rect',
+    name,
+    from: { data: getSankeyNodeDataName(name) },
+    encode: {
+      enter: {
+        x: { field: 'x' },
+        y: { field: 'y' },
+        width: { field: 'dx' },
+        height: { field: 'dy' },
+        fill: getColorProductionRule(color, colorScheme),
+        tooltip: getInspectEncoding(chartInspects, name),
+      },
+      update: {
+        opacity: getMarkOpacity(options),
+        cursor: getCursor(chartPopovers),
+      },
+    },
+  };
+};
+
+/** Vertical offset, in pixels, of the node name label above the node's vertical center. */
+const NODE_LABEL_NAME_DY = -7;
+/** Vertical offset, in pixels, of the node value label below the node's vertical center. */
+const NODE_LABEL_VALUE_DY = 9;
+/** Halo stroke width, scaled down from `DIRECT_LABEL_BACKGROUND_STROKE_WIDTH` (4px, tuned for the
+ * larger direct-label font) so it doesn't blob out this mark's much smaller label text. */
+const NODE_LABEL_HALO_STROKE_WIDTH = 2;
+/** Halo opacity -- softens it to a glow rather than a hard-edged block wherever a label lands on
+ * plain chart background instead of a colored ribbon (see the comment where this is used). */
+const NODE_LABEL_HALO_OPACITY = 0.65;
+
+/**
+ * Shared enter-encode fields for a node label's background-halo and foreground text marks --
+ * everything except `fill`/`stroke`, which differ between the two.
+ */
+const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry => ({
+  // `labelX`/`labelY`/`labelAlign`/`labelLimit` are precomputed alongside the rest of the layout in
+  // `sankeySpecBuilder.ts`'s addData (rather than derived here via encoding math), to stay consistent
+  // with the "everything precomputed in JS" convention this mark follows. `labelAlign` flips for the
+  // last column (no room to its right within the chart), and `labelLimit` caps each label to the
+  // actual gap between columns via Vega's own text truncation (ellipsizes automatically) so adjacent
+  // columns' labels -- which now grow toward each other around that flip -- can't collide.
+  x: { field: 'labelX' },
+  y: { field: 'labelY' },
+  dy: { value: dy },
+  text: { field: textField },
+  align: { field: 'labelAlign' },
+  baseline: { value: 'middle' },
+  limit: { field: 'labelLimit' },
+});
+
+/**
+ * A label pair -- a background "halo" text mark (stroked in the chart's background color) plus a
+ * foreground fill text mark on top -- so labels stay legible sitting directly on top of colored,
+ * crossing ribbons. Same two-mark halo technique `getLineDirectLabelMarks` uses for line series'
+ * end-of-line labels (lineDirectLabel/lineDirectLabelUtils.ts), reused here for consistency rather
+ * than inventing a different labeling convention for this mark. Font size also reuses that same
+ * mechanism (`getDirectLabelFontSizeProductionRule`): `options.fontSize` overrides it (the story sets
+ * this to 14, matching `DIRECT_LABEL_FONT_SIZE_S`), otherwise it scales with chart width via the
+ * shared `CHART_SIZE_FONT_SIZE` signal, same as Line's direct labels.
+ */
+const getSankeyNodeLabelMarkPair = (
+  options: SankeySpecOptions,
+  markNameSuffix: string,
+  textField: string,
+  dy: number,
+  fillColor: string,
+  fontSizeEncoding: ProductionRule<NumericValueRef>
+): TextMark[] => {
+  const { name } = options;
+  // Deliberately NOT derived from `backgroundColor`/`colorScheme`, unlike Line's direct labels
+  // (which this halo technique is otherwise copied from): those labels sit in the chart margin, on
+  // the actual chart background, so a background-matching halo makes sense there. These labels sit
+  // on top of arbitrarily-colored ribbons/nodes instead, where a scheme-matched light-mode halo
+  // (white) blends into lighter ribbon colors, and dark-mode's scheme-matched dark text similarly
+  // fails against the palette's darker colors -- so the pairing needs to work against arbitrary
+  // colors, not the page background. Forcing the 'dark' variant of these tokens regardless of the
+  // chart's actual colorScheme (dark halo + light text) reuses that already-legible combination
+  // universally, rather than inventing new one-off colors.
+  const resolvedBg = getS2ColorValue('gray-25', 'dark');
+  const baseEnter = getSankeyNodeLabelBaseEnter(textField, dy);
+
+  const backgroundTextMark: TextMark = {
+    name: `${name}_${markNameSuffix}_bg`,
+    type: 'text',
+    from: { data: getSankeyNodeDataName(name) },
+    interactive: false,
+    encode: {
+      enter: {
+        ...baseEnter,
+        // `fill` must be set explicitly here -- SVG's default text fill is solid black, so without
+        // this the halo rendered as an (almost-but-not-quite-matching) solid black text-shaped block
+        // sitting behind the foreground text, not a halo, which read as a stray dark box wherever a
+        // label landed on plain chart background rather than a colored ribbon. `fillOpacity`/
+        // `strokeOpacity` soften it further so it reads as a soft glow, not a hard-edged block, in
+        // that same case.
+        fill: { value: resolvedBg },
+        fillOpacity: { value: NODE_LABEL_HALO_OPACITY },
+        stroke: { value: resolvedBg },
+        strokeOpacity: { value: NODE_LABEL_HALO_OPACITY },
+        strokeWidth: { value: NODE_LABEL_HALO_STROKE_WIDTH },
+      },
+      update: { fontSize: fontSizeEncoding },
+    },
+  };
+
+  const foregroundTextMark: TextMark = {
+    name: `${name}_${markNameSuffix}`,
+    type: 'text',
+    from: { data: getSankeyNodeDataName(name) },
+    interactive: false,
+    encode: {
+      enter: { ...baseEnter, fill: { value: fillColor } },
+      update: { fontSize: fontSizeEncoding },
+    },
+  };
+
+  return [backgroundTextMark, foregroundTextMark];
+};
+
+// Both label fills below force the 'dark' scheme variant of these gray tokens regardless of the
+// chart's actual colorScheme -- see the comment in getSankeyNodeLabelMarkPair for why.
+export const getSankeyNodeLabelMarks = (options: SankeySpecOptions): TextMark[] =>
+  getSankeyNodeLabelMarkPair(
+    options,
+    'label',
+    'id',
+    NODE_LABEL_NAME_DY,
+    getS2ColorValue('gray-800', 'dark'),
+    getDirectLabelFontSizeProductionRule(options.fontSize)
+  );
+
+/** Value label under each node's name -- Workspace's Flow visualization always shows this. */
+export const getSankeyNodeValueLabelMarks = (options: SankeySpecOptions): TextMark[] =>
+  getSankeyNodeLabelMarkPair(
+    options,
+    'valueLabel',
+    'formattedValue',
+    NODE_LABEL_VALUE_DY,
+    getS2ColorValue('gray-700', 'dark'),
+    // one size smaller than the name label when an explicit override is set; otherwise the value
+    // label falls back to the same chart-width-responsive signal as the name label (no offset --
+    // offsetting a signal expression isn't worth the added complexity for the default/unset case).
+    options.fontSize !== undefined
+      ? { value: options.fontSize - 1 }
+      : getDirectLabelFontSizeProductionRule(options.fontSize)
+  );
+
+export const getSankeyNodeDataName = (name: string): string => `${name}_nodes`;
+export const getSankeyLinkMarkName = (name: string): string => `${name}_links`;
+export const getSankeyLinkDataName = (name: string): string => `${name}_linksData`;
+
+export const getSankeyNodeMarkId = (name: string, nodeId: string): string => `${name}_node_${nodeId}`;
+export const getSankeyLinkMarkId = (name: string, linkIndex: number): string => `${name}_link_${linkIndex}`;

--- a/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
+++ b/packages/vega-spec-builder-s2/src/sankey/sankeyUtils.ts
@@ -24,14 +24,7 @@ import {
 } from '../marks/markUtils';
 import { SankeySpecOptions } from '../types';
 
-/**
- * Layout math ported from Workspace's Sankey renderer (aaui-web-spa `CloudViz.js:25637`,
- * `d3.pathing()`), rewritten dependency-free since Vega has no flow-layout transform. Unlike the
- * source, which gets pre-assigned columns from Workspace's own data model, this also derives columns
- * itself (`assignColumns`) from a flat source/target/value edge list. Workspace's "entry"/"exit" stub
- * links (for partially-loaded windows) don't apply to a fully-specified edge list, so those branches
- * of the original `link()` generator aren't ported.
- */
+/** Layout math ported from Workspace's Sankey renderer (aaui-web-spa `CloudViz.js:25637`, `d3.pathing()`), rewritten dependency-free. */
 
 const CURVATURE = 0.5;
 /** Number of left-right/right-left relaxation passes used to reduce ribbon crossings. */
@@ -72,10 +65,7 @@ export interface SankeyLayoutNode {
   targetLinks: SankeyLayoutLink[];
 }
 
-/**
- * Reads source/target/value edges from the chart data, dropping rows missing a source/target or
- * with a non-finite or negative value (which would corrupt the shared `ky` scale factor).
- */
+/** Reads source/target/value edges, dropping rows with a missing source/target or a non-finite/negative value. */
 export const getSankeyEdges = (options: SankeySpecOptions): SankeyEdgeInput[] => {
   const { data, source, target, value } = options;
   const unsafeData = data as unknown as Record<string, unknown>[];
@@ -97,17 +87,7 @@ export const getSankeyEdges = (options: SankeySpecOptions): SankeyEdgeInput[] =>
     }));
 };
 
-/**
- * Assigns each node to a column via topological layering: a node's column is one past the deepest
- * column of any node flowing into it; nodes with no incoming edges start at column 0.
- *
- * Cycles (A -> B -> A) can't be topologically layered. The closing back-edge is detected via DFS,
- * dropped from layering (so this terminates), and reported via `console.warn` -- the edge is still
- * rendered, it just doesn't affect column assignment.
- *
- * `explicitColumns` overrides the computed column for any node id present in the map -- a hook for a
- * future consumer that already knows column identity and doesn't need topological inference.
- */
+/** Assigns each node to a column via topological layering; cycles are DFS-detected and excluded so this terminates. */
 export const assignColumns = (
   edges: SankeyEdgeInput[],
   explicitColumns?: Record<string, number>
@@ -212,11 +192,7 @@ const computeNodeValue = (node: SankeyLayoutNode): number =>
 
 const sum = <T>(items: T[], accessor: (item: T) => number): number => items.reduce((total, item) => total + accessor(item), 0);
 
-/**
- * Builds the full node/link layout: columns, x/y positions, sizing, and vertical ordering. Positions
- * and sizes are literal pixel values, not Vega scales -- matching Venn's precomputed-geometry
- * convention (`venn/vennUtils.ts`).
- */
+/** Builds the full node/link layout (columns, x/y, sizing) as literal pixel values, matching Venn's precomputed-geometry convention. */
 export const buildSankeyLayout = (
   edges: SankeyEdgeInput[],
   chartWidth: number,
@@ -263,11 +239,7 @@ export const buildSankeyLayout = (
   return { nodes, links, columnSpacing };
 };
 
-/**
- * Assigns x positions from each node's column, ported from `computeNodeBreadths`/`scaleNodeBreadths`.
- * Returns the column spacing so callers can size labels to fit the actual gap between columns.
- * `node.x` is rounded to a whole pixel to avoid an anti-aliasing seam against touching ribbons.
- */
+/** Assigns x positions from each node's column; returns the column spacing so labels can size to the gap. `node.x` is rounded to a whole pixel to avoid an anti-aliasing seam against touching ribbons. */
 const computeNodeBreadths = (nodes: SankeyLayoutNode[], chartWidth: number): number => {
   const numColumns = new Set(nodes.map((node) => node.column)).size;
   const availableWidth = Math.max(chartWidth - SANKEY_NODE_WIDTH, 0);
@@ -276,11 +248,7 @@ const computeNodeBreadths = (nodes: SankeyLayoutNode[], chartWidth: number): num
   return columnSpacing;
 };
 
-/**
- * Assigns y positions and node/link thicknesses, ported from `computeNodeDepths`/`initializeNodeDepth`
- * plus the relaxation/collision passes below. Crossing minimization is kept (unlike the pre-alpha
- * spec's scoped-out plan) since Workspace's tested implementation already handles it cheaply.
- */
+/** Assigns y positions and node/link thicknesses, then runs relaxation/collision passes to reduce crossings. */
 const computeNodeDepths = (nodes: SankeyLayoutNode[], chartHeight: number): void => {
   const nodesByColumn = groupByColumn(nodes);
 
@@ -368,11 +336,7 @@ const resolveCollisions = (nodesByColumn: SankeyLayoutNode[][], chartHeight: num
   });
 };
 
-/**
- * Assigns each link's vertical offset within its source/target node (`sy`/`ty`), ordering the stack
- * by the connected node's position so parallel ribbons don't cross their own siblings unnecessarily.
- * Ported from `computeLinkDepths` (minus the entry/exit-stub bookkeeping -- not applicable here).
- */
+/** Assigns each link's vertical offset within its source/target node (`sy`/`ty`), ordered by connected node position. */
 const computeLinkDepths = (nodes: SankeyLayoutNode[]): void => {
   nodes.forEach((node) => {
     node.sourceLinks.sort((a, b) => a.target.y - b.target.y);
@@ -395,17 +359,7 @@ const computeLinkDepths = (nodes: SankeyLayoutNode[]): void => {
 /** Cap, in pixels, on how much the bottom edge's control points can shift relative to the top edge's. */
 const MAX_CURVE_BOOST = 15;
 
-/**
- * Cubic-bezier ribbon path between a link's source and target edges, ported from `d3.pathing()`'s
- * `link()` generator (the "both ends present" branch only -- see the module comment on stub curves).
- *
- * Departure from the original: `d3.pathing()` only bends the bottom edge (`shortLinkOffset`) below
- * 15px thickness, so a thick ribbon's top and bottom edges run perfectly parallel -- fine in
- * Workspace's chart, which grows the canvas to fit the data instead of a fixed height. Here, fit into
- * a fixed `chartHeight`, a thick link (e.g. a root node's total outflow) would read as a rigid
- * trapezoid. Capping the bend at `MAX_CURVE_BOOST` instead of zeroing it out keeps thin links
- * unchanged while giving thick ones enough independent bend to read as a ribbon.
- */
+/** Cubic-bezier ribbon path between a link's source and target edges, capping the bend at `MAX_CURVE_BOOST` so thick ribbons still read as a ribbon rather than a rigid trapezoid. */
 export const getRibbonPath = (link: SankeyLayoutLink): string => {
   const curveHeight = Math.max(1, link.dy);
   const x0 = link.source.x + link.source.dx;
@@ -435,8 +389,7 @@ export const getSankeyLinkMark = (options: SankeySpecOptions): PathMark => {
 
   return {
     type: 'path',
-    // Mark name and data-source name must differ -- Vega shares one namespace for both, and reusing
-    // a string for each throws "Duplicate data set name" at parse time.
+    // Mark and data-source names must differ -- Vega shares one namespace for both.
     name: getSankeyLinkMarkName(name),
     from: { data: getSankeyLinkDataName(name) },
     encode: {
@@ -445,8 +398,7 @@ export const getSankeyLinkMark = (options: SankeySpecOptions): PathMark => {
         fill: getColorProductionRule('sourceId', colorScheme),
         // Without this, path marks inherit the theme's default stroke, showing as a seam at each node.
         stroke: { value: 'transparent' },
-        // Keyed by the parent name (not this layer's mark name) so one <ChartInspect>/<ChartPopover>
-        // under <Sankey name="..."> covers both layers -- matches Venn's `getInterserctionMark`.
+        // Keyed by the parent name so one <ChartInspect>/<ChartPopover> covers both layers.
         tooltip: getInspectEncoding(chartInspects, name),
       },
       update: {
@@ -490,9 +442,7 @@ const NODE_LABEL_HALO_STROKE_WIDTH = 2;
 
 /** Shared enter-encode fields for a label's background-halo and foreground text marks (everything except `fill`/`stroke`). */
 const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry => ({
-  // labelX/labelY/labelAlign/labelLimit are precomputed in addData, per this mark's "everything
-  // precomputed in JS" convention. labelAlign flips for the last column (no room to its right);
-  // labelLimit caps each label to the gap between columns so the two flipped-and-facing labels can't collide.
+  // labelX/labelY/labelAlign/labelLimit are precomputed in addData (see that function's comments).
   x: { field: 'labelX' },
   y: { field: 'labelY' },
   dy: { value: dy },
@@ -502,12 +452,7 @@ const getSankeyNodeLabelBaseEnter = (textField: string, dy: number): EncodeEntry
   limit: { field: 'labelLimit' },
 });
 
-/**
- * A background-halo + foreground text mark pair, so labels stay legible over colored ribbons. Same
- * two-mark technique `getLineDirectLabelMarks` uses (lineDirectLabelUtils.ts), reused for consistency.
- * Font size also reuses `getDirectLabelFontSizeProductionRule`: `options.fontSize` overrides it,
- * otherwise it scales with chart width via the shared `CHART_SIZE_FONT_SIZE` signal.
- */
+/** A background-halo + foreground text mark pair, so labels stay legible over colored ribbons -- same technique as `getLineDirectLabelMarks`. */
 const getSankeyNodeLabelMarkPair = (
   options: SankeySpecOptions,
   markNameSuffix: string,
@@ -517,9 +462,7 @@ const getSankeyNodeLabelMarkPair = (
   fontSizeEncoding: { signal: string } | { value: number }
 ): TextMark[] => {
   const { name } = options;
-  // Unlike Line's direct labels, not derived from colorScheme: these labels sit on arbitrary ribbon
-  // colors, not the chart background, where a scheme-matched halo (light or dark) can blend into the
-  // palette. Forcing the 'dark' variant (dark halo + light text) is legible against any color.
+  // Forced 'dark' regardless of colorScheme -- legible against any ribbon color, unlike Line's chart-background-matched halo.
   const resolvedBg = getS2ColorValue('gray-25', 'dark');
   const baseEnter = getSankeyNodeLabelBaseEnter(textField, dy);
 
@@ -562,8 +505,7 @@ export const getSankeyNodeValueLabelMarks = (options: SankeySpecOptions): TextMa
     NODE_LABEL_VALUE_DY,
     // same fill as the name label -- gray-700 read as a gold-ish tint over saturated ribbons.
     getS2ColorValue('gray-800', 'dark'),
-    // one size smaller than the name label when overridden; otherwise falls back to the same
-    // responsive signal as the name label (not worth offsetting a signal expression).
+    // one size smaller than the name label, only when overridden (not worth offsetting a signal).
     options.fontSize !== undefined
       ? { value: options.fontSize - 1 }
       : getDirectLabelFontSizeProductionRule(options.fontSize)

--- a/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
@@ -23,6 +23,7 @@ import {
   ComboOptions,
   DonutOptions,
   LineOptions,
+  SankeyOptions,
   ScatterOptions,
   VennOptions,
 } from './marks';
@@ -61,6 +62,7 @@ export type MarkOptions =
   | ComboOptions
   | DonutOptions
   | LineOptions
+  | SankeyOptions
   | ScatterOptions
   | VennOptions;
 

--- a/packages/vega-spec-builder-s2/src/types/marks/index.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/index.ts
@@ -17,6 +17,7 @@ export * from './bulletSpec.types';
 export * from './comboSpec.types';
 export * from './donutSpec.types';
 export * from './lineSpec.types';
+export * from './sankeySpec.types';
 export * from './scatterSpec.types';
 export * from './vennSpec.types';
 

--- a/packages/vega-spec-builder-s2/src/types/marks/sankeySpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/sankeySpec.types.ts
@@ -30,11 +30,7 @@ export interface SankeyOptions {
   color?: string;
   /** Sets the name of the component. */
   name?: string;
-  /**
-   * Override the node name label's font size in pixels (the value label below it renders 1px
-   * smaller). When omitted, font size scales automatically with chart size, same as Line's direct
-   * labels (see `getDirectLabelFontSizeProductionRule`).
-   */
+  /** Override the name label's font size in pixels (value label renders 1px smaller). Defaults to scaling with chart size. */
   fontSize?: number;
 
   // children
@@ -45,7 +41,6 @@ export interface SankeyOptions {
 type SankeyOptionsWithDefaults = 'chartPopovers' | 'chartInspects' | 'color' | 'name' | 'source' | 'target' | 'value';
 
 export interface SankeySpecOptions extends PartiallyRequired<SankeyOptions, SankeyOptionsWithDefaults> {
-  backgroundColor?: string;
   chartHeight: number;
   chartWidth: number;
   colorScheme: ColorScheme;

--- a/packages/vega-spec-builder-s2/src/types/marks/sankeySpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/sankeySpec.types.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import {
+  ChartData,
+  ChartPopoverOptions,
+  ChartInspectOptions,
+  ColorScheme,
+  HighlightedItem,
+  PartiallyRequired,
+} from '../../types';
+
+export interface SankeyOptions {
+  markType: 'sankey';
+  /** Key in the data for the source node of a flow edge */
+  source?: string;
+  /** Key in the data for the target node of a flow edge */
+  target?: string;
+  /** Key in the data for the value (thickness) of a flow edge */
+  value?: string;
+  /** Key used to color nodes (and, by extension, the ribbons flowing out of them). Refers to the derived node id. */
+  color?: string;
+  /** Sets the name of the component. */
+  name?: string;
+  /**
+   * Override the node name label's font size in pixels (the value label below it renders 1px
+   * smaller). When omitted, font size scales automatically with chart size, same as Line's direct
+   * labels (see `getDirectLabelFontSizeProductionRule`).
+   */
+  fontSize?: number;
+
+  // children
+  chartPopovers?: ChartPopoverOptions[];
+  chartInspects?: ChartInspectOptions[];
+}
+
+type SankeyOptionsWithDefaults = 'chartPopovers' | 'chartInspects' | 'color' | 'name' | 'source' | 'target' | 'value';
+
+export interface SankeySpecOptions extends PartiallyRequired<SankeyOptions, SankeyOptionsWithDefaults> {
+  backgroundColor?: string;
+  chartHeight: number;
+  chartWidth: number;
+  colorScheme: ColorScheme;
+  data: ChartData[];
+  highlightedItem?: HighlightedItem;
+  idKey: string;
+  index: number;
+  markType: 'sankey';
+}

--- a/planning/research/sankey-workspace-flow-feasibility/sankey-workspace-flow-feasibility.md
+++ b/planning/research/sankey-workspace-flow-feasibility/sankey-workspace-flow-feasibility.md
@@ -1,0 +1,268 @@
+# Sankey Mark Feasibility — Grounded in Workspace's Flow Visualization
+
+A feasibility and design study for a Sankey/flow mark in React Spectrum Charts (RSC), grounded in two
+concrete reference points: (1) the full feature set of Adobe Analytics Workspace's existing "Flow"
+visualization (a production Sankey-style diagram, in `aaui-web-spa`), and (2) RSC's *actual* shipped-mark
+architecture (Bar, Combo, Donut, Venn, the interactive-mark system) — as opposed to relying on the
+pre-alpha planning spec (`planning/specs/pre-alpha/sankey/add-sankey-mark.json`) as the sole design input.
+Written 2026-08-26.
+
+---
+
+## 1. Why Workspace's Flow visualization is a useful reference
+
+Workspace's Flow is a mature, production Sankey-style diagram (Analysis Workspace → Freeform panel →
+"Flow" visualization type) that has been in the field long enough to have solved most of the hard edge
+cases a generic Sankey mark would need to handle. Its full feature inventory (from code + tests + public
+docs cross-check) breaks down as follows.
+
+### 1.1 Feature inventory (aaui-web-spa)
+
+**Anchor / configuration** — entry dimension ("Starts with"), exit dimension ("Ends with"), focus
+dimension item ("Contains"), pathing dimension, build/cancel/reset with live validation. Calculated
+metrics are explicitly disallowed as anchors; pathing dimension defaults to "Page" when a metric anchor
+is used.
+
+**Advanced settings** — wrap labels (disable truncation), include repeat instances (auto-disabled for
+multi-valued dimensions), limit to first/last occurrence, number of columns (2–5, or 3–5 for focus flows),
+items expanded per column (1–10, 5 shown by default), flow container (Visits/Visitors, or a B2B
+account-hierarchy picker). Docs note number-of-columns × items-per-column determines the number of
+underlying backend requests — i.e. these caps exist for query-cost reasons, not just visual ones.
+
+**Node & column interactions** — click to expand/collapse a node or an entire column, "show next/previous
+column" buttons, drag-and-drop dimensions/metrics onto columns with compatibility checks, root/focus-node
+flagging (`*` prefix + "Path views" label), fixed-character-count label truncation (12 chars, 7-char tail)
+unless wrap-labels is on, undo/redo for pivot/focus changes.
+
+**Right-click context menu** — Focus on this node, Start over, Create segment for this path, Breakdown
+(submenu), Filter/Edit/Remove column filter, Exclude item / Restore excluded items, Trend, Show
+next/previous column, Hide column, dynamically-appended audience/publishing integrations.
+
+**Chart rendering** — Sankey node/link SVG with metric-driven sizing, independent node and link ("path")
+hover tooltips, an "Intelligent Captions" AI-narrative button.
+
+**Non-chart layers** — AI Assistant / MCP tools (`aauiFlow_set`/`aauiFlow_expand`) for natural-language
+creation, org/user default-container preferences, a `cja-b2b-account-hierarchy` feature flag gating the
+container picker.
+
+### 1.2 What this implies for a chart-library Sankey mark
+
+Roughly a third of this list is generic chart-rendering surface (node/link geometry, value-proportional
+sizing, tooltips, click-driven highlight, progressive reveal, label wrapping, color/theme) — a reasonable
+scope for a chart-library mark. The rest — anchor/query semantics, the context-menu action set, undo/redo,
+AI/MCP integration, preferences — is inherently host-application business logic tied to Workspace's
+dimension/reportlet/segment model, and shouldn't be a chart library's concern regardless of what renders
+the diagram.
+
+| Feature | Where it belongs | Why |
+|---|---|---|
+| Node rects sized by flow value | Chart mark | Core rendering primitive, generic across any node-link data |
+| Ribbon/link thickness proportional to value | Chart mark | Same — value-driven ribbon geometry |
+| Separate node & link tooltips | Chart mark | Matches RSC's existing `ChartTooltip` per-mark pattern |
+| Node/link click-to-pin highlight | Chart mark | Generic interaction primitive |
+| Progressive node/column expansion | Chart mark, host supplies data | Host fetches more data and feeds it in; mark just renders what it's given |
+| Wrap labels / truncation | Chart mark | Generic label-formatting concern |
+| Show/hide tooltips | Chart mark (already implicit) | Opt-in via mounting a tooltip child, no extra work |
+| Color scale / theme | Chart mark | Reuses existing color-scale infra |
+| Column count / explicit column assignment | Host app → fed into mark as pre-computed structure | Tied to the host's query-cost model; see §3 |
+| Anchor/query semantics, flow container, repeat-instance rules | Host app only | Business/query configuration, not a charting concern |
+| Right-click menu actions (breakdown, filter, exclude, trend, segment creation, publishing) | Host app only | Needs the host's segment builder, sub-panel routing, publishing integrations |
+| Undo/redo, AI/MCP integration, preferences, viz chrome (title/annotations) | Host app only | App-level state/automation/config, unrelated to chart rendering |
+
+---
+
+## 2. RSC's actual architecture (not the pre-alpha spec)
+
+The pre-alpha spec (`planning/specs/pre-alpha/sankey/add-sankey-mark.json`, status `approved`, complexity
+5/5 — the highest in the planning set) proposes a from-scratch layout algorithm and treats several things
+as settled defaults. Reading the actual shipped marks gives a better-grounded design:
+
+- **Raw Vega, not Vega-Lite.** Every mark builder (`addBar`, `addLine`, `addDonut`, …) in
+  `packages/vega-spec-builder/` mutates a raw Vega `Spec` object directly (via `immer`'s `produce`),
+  rendered through `vega-embed`. `vega-lite` is a peer dependency but isn't actually used by any spec
+  builder — worth flagging as possibly stale.
+- **Two live patterns for non-trivial geometry.** Donut computes arc angles via a declarative Vega `pie`
+  transform + `formula` derived fields (`donutSpecBuilder.ts:128-151`) — fully expressible in Vega's own
+  dataflow. Venn, by contrast, precomputes circle-packing/intersection geometry in a plain JS function
+  (`getVennSolution`) and ships literal `{x, y, r, path}` values to Vega as a static `values:` data source
+  (`vennSpecBuilder.ts:104-143`), bypassing Vega scales entirely for position. **Sankey layout belongs in
+  the Venn bucket** — there's no Vega transform equivalent for column assignment + value-proportional
+  vertical packing + variable-width curved ribbons (`linkpath` only draws a single-width connector line,
+  not a value-sized filled band).
+- **Combo proves multi-sub-mark composition works today.** `addCombo` (`comboSpecBuilder.ts:22-100`)
+  reduces over heterogeneous sub-marks, calling `addBar`/`addLine` back-to-back against one shared `spec`
+  object. Each sub-call independently computes its own `interactiveMarkName` and registers into
+  `usermeta.interactiveMarks` — i.e. **two peer interactive sub-marks under one logical chart element is
+  already a proven mechanism**, not something requiring new architecture. This directly answers the
+  pre-alpha spec's `openQuestions` item asking whether the interactive-mark system needs changes to
+  support a node layer + a link layer: it doesn't.
+- **Tooltip/popover wiring is generic over any `{chartTooltips, chartPopovers, name}`-shaped options
+  object** (`chartTooltipUtils.ts`, `chartPopoverUtils.ts`) — a node-layer and link-layer options object
+  can each carry their own tooltip/popover config with zero changes to that machinery.
+- **Right-click support already exists end-to-end** (`hasOnContextMenu` in `isInteractive`,
+  `ContextMenuMode`, `ChartPopover`'s `rightClick` prop wired through a hidden trigger button in
+  `ChartDialog`) — but it's hand-wired per mark (bar/line today), not a "any mark gets a menu for free"
+  primitive, and there's no floating cursor-anchored menu UX, only the popover's anchored dialog.
+- **Theming is a clean, reusable mechanism**: `colorScheme: 'light'|'dark'` flows through
+  `getSpectrum2VegaConfig`/`getColorProductionRule`/`getS2ColorValue` — a new mark just accepts
+  `colorScheme` in its options like every other mark does.
+- **Static export already works**: `ChartHandle.getSvg`/`download`/`getBase64Png` wrap Vega's own
+  `View.toSVG()`/`toImageURL('png')` — no new work needed for image export.
+
+---
+
+## 3. Proposed design (where it departs from the pre-alpha spec)
+
+**Public API**: keep a single render-null `<Sankey>` component (matching the Donut/Bullet rc-status
+precedent) — no need for a two-child public API the way Combo has one, since node+link is inherent to
+what "Sankey" means.
+
+**Internal architecture**: follow Combo's pattern, not a monolithic `addMarks`. `addSankey` calls
+`addSankeyLinks(spec, …)` then `addSankeyNodes(spec, …)` against the same shared spec object (links under
+nodes), each independently wiring its own interactive-mark name and tooltip/popover config. Low risk —
+Combo already proves the mechanism.
+
+**Layout math**: don't invent `assignColumns`/`packNodesInColumn`/`buildRibbonPath` from scratch as the
+spec proposes. A production-hardened reference implementation already exists — Workspace's own
+`d3.pathing()` (`aaui-web-spa/packages/ui-core/src/CloudViz.js:25637`), a hand-maintained fork of the
+classic Bostock d3-sankey algorithm. Port its logic (not its d3 dependency — see §4) as a pure JS/TS
+layout function that outputs literal node `{x, y, width, height}` and link path strings, following Venn's
+JS-precompute-then-ship-as-static-values pattern:
+  - `computeNodeValues` — node value = `max(sum of outgoing links, sum of incoming links)`, overridable by
+    an explicit `total` field.
+  - A single `ky` scale factor per render = `(available column height − padding) / that column's total
+    node value`; node height = `value * ky` (with a floor), link thickness = `value * ky`.
+  - A cubic-Bézier ribbon generator (curvature 0.5, control points via linear interpolation) with
+    already-solved entry/exit stub-curve special cases (source or target is null).
+  - A `relaxLeftToRight`/`relaxRightToLeft` + collision-resolution pass to reduce (not eliminate) visual
+    crossing — **depart from the spec's "no crossing minimization" default**: this pass is existing,
+    tested code, so shipping a deliberately worse layout than what Workspace users already have isn't
+    justified.
+
+**Column assignment — the one real design change worth proposing upstream**: the spec assumes columns are
+always inferred via topological layering over a fully-loaded graph. A host like Workspace can't satisfy
+that — its columns come from sequential, incrementally-fetched backend queries, and column identity is a
+query-time concept, not something inferable from edges alone. Recommendation: accept an **optional
+explicit `column` field per node** — if present, use it directly (serves incrementally-loaded
+consumers); if absent, fall back to topological inference (serves simple, fully-loaded-graph consumers).
+Strict superset of the current spec, small and well-scoped.
+
+**Progressive expansion**: model as an externally-controlled data/`expandedNodes` prop — the consumer
+fetches more data and re-renders — rather than mark-internal hop-expansion signal state. Matches how
+Combo/Bar already expose `highlightedItem` as a controlled prop instead of owning selection state
+internally, and keeps the mark a pure function of props.
+
+**Net effect on the spec's complexity-5 rating**: the score assumes layout, ribbon geometry, and
+progressive expansion are all unsolved research. With a working reference implementation available, the
+genuinely novel RSC-specific work shrinks to: (1) dual-interactive-sub-mark wiring (low risk, proven by
+Combo), (2) the explicit-vs-inferred column option (small, scoped), (3) porting the layout+ribbon math into
+the Venn-style JS-precompute shape (mechanical port + tests, not new algorithm design). The spec's cyclic
+source/target open question is largely moot for a checkpoint-tree-style host (inherently acyclic); still
+worth a defensive drop-back-edge-with-warning for other consumers.
+
+---
+
+## 4. Does RSC use d3? (matters for porting the layout math)
+
+Checked directly rather than assumed. RSC's own source code has **no direct d3 usage for layout or
+geometry** — the only direct import anywhere is `d3-format` (2 files, `expressionFunctions.ts` in both
+`vega-spec-builder` and `vega-spec-builder-s2`), used purely for locale-aware number formatting.
+
+`d3-array`, `d3-interpolate`, `d3-shape`, `d3-force`, `d3-scale`, `d3-quadtree` etc. *are* present in
+`node_modules`, but only as **transitive** dependencies of Vega itself (e.g. `vega-statistics` declares
+`d3-array` in its own dependencies). RSC's code never imports them, and — tellingly — **Venn's own
+geometry code doesn't either**, even though d3-array/d3-shape are sitting right there in the tree. The
+established convention in this codebase is to write custom precomputed-geometry math in plain TypeScript.
+
+Workspace's `d3.pathing()` only uses a handful of d3 calls: `d3.sum`, `d3.min`, `d3.max`,
+`d3.nest().key().sortKeys(d3.ascending).entries()` (grouping — itself an old, since-removed d3 v3/v4 API),
+and `d3.interpolateNumber`. Every one is a few lines of dependency-free TypeScript (`reduce` for
+sum/min/max, a `Map`-based group-by-then-sort, linear interpolation is a one-liner). **Conclusion: port the
+algorithm, not the d3 calls** — rewrite this layout math as plain TS, consistent with how Venn already
+handles its own non-trivial geometry, rather than adding `d3-array`/`d3-interpolate` as new direct
+dependencies just to reuse a handful of one-liners.
+
+---
+
+## 5. Dependencies & gotchas for building this in RSC
+
+Verified directly against RSC source, ordered by severity. (One item — a React-17-vs-19 host compatibility
+question — is intentionally omitted here because it's about a *specific* downstream consumer's upgrade
+timeline, not a property of RSC itself; it would apply to any host still on React 17 and should be
+revisited if/when a specific integration is planned.)
+
+1. **No incremental view-update path (the standout finding).** `VegaChart` fully destroys and recreates
+   the Vega `View` on every spec/data change
+   (`packages/react-spectrum-charts-s2/src/VegaChart.tsx:124-174`) — there is no `view.change()`/patch
+   code path anywhere in the library. A "progressive column/node expansion" interaction (adding
+   nodes/links to an already-rendered chart) would, as RSC is architected today, force a full re-embed
+   with no smooth transition. The existing hover/draw-in animation engines
+   (`hoverAnimationUtils.ts`, `drawInAnimationUtils.ts`) only animate a static spec's own properties
+   (opacity, stroke, draw-in cutoff) — they don't address structural data growth. This is genuinely new
+   engineering, and it's a library-wide gap, not Sankey-specific; the pre-alpha spec's `openQuestions`
+   don't mention it at all.
+
+2. **No existing many-element-mark precedent.** No current mark renders anywhere near a Sankey's likely
+   element count (on the order of 100 marks for a modestly-sized flow). Docs recommend Canvas rendering
+   only above ~10K rows (`packages/docs/docs/api/Chart.md:3-13`), so this is comfortably under that
+   threshold — likely fine on the default SVG renderer, just untested territory in this codebase.
+   `renderer="canvas"` is available as a documented fallback if ever needed.
+
+3. **Right-click menus are achievable but bespoke per mark, not generic.** `isInteractive`/
+   `getInteractiveMarkName` already treat `hasOnContextMenu` as first-class
+   (`markUtils.ts:194-215`, `:527-545`), and `ChartPopover` has a `rightClick` prop wired through a hidden
+   trigger button in `ChartDialog` (`RscChart.tsx:159-166,203-209`). But there's no shared "any mark gets
+   a context menu for free" primitive, and no floating cursor-anchored menu UX exists — only the popover's
+   anchored-dialog positioning, which a Sankey context menu would extend rather than reuse wholesale.
+
+4. **Accessibility is essentially unaddressed at the mark level.** The only ARIA-related code found
+   actively opts an element *out* of the accessibility tree (`aria-hidden="true"`, `tabIndex={-1}` on the
+   hidden popover trigger, `RscChart.tsx:206-207`). No keyboard handlers exist anywhere in the
+   mark/interaction system. Docs claim keyboard-navigation and screen-reader support
+   (`packages/docs/docs/api/visualizations/Line.md:268-275`) that isn't backed by any code found. Real
+   a11y parity for a Sankey (likely required for enterprise adoption) is net-new work.
+
+5. **No RTL/bidi support at all.** Locale handling (`packages/locales/src/locale.ts`) covers number/date
+   formatting only — no `dir`, no mirroring, no RTL concept anywhere in the repo. A left-to-right flow
+   diagram would need entirely new logic to mirror for RTL locales, with zero existing primitives to hook
+   into.
+
+6. **Label-truncation utilities exist but assume the wrong layout shape.** `getLabelWidth` (canvas
+   `measureText`, `expressionFunctions.ts:256-270`) and the legend's `fitsWhenWrapped`/`getFairShareWidth`
+   wrap-fit logic (`legendUtils.ts:195-268`) are real, reusable pixel-measurement primitives, but they're
+   shaped for legend/axis layout constraints, not a Sankey node's dynamic per-node width. Expect to reuse
+   `getLabelWidth` as a primitive and write new fitting logic on top, not reuse the wrap-fit logic
+   wholesale.
+
+7. **No visual-regression safety net.** CI (`.github/workflows/pr-checks.yml`) runs lint/Jest/Sonar/
+   build/Storybook-build only — no Chromatic/Percy/pixel-diffing. Layout correctness (node packing,
+   ribbon geometry) would rely entirely on unit tests during development.
+
+8. **`vega-embed` is peer-only, unpinned anywhere in RSC's own repo** — a latent version-drift risk for
+   any new mark touching `View` APIs (export, resize, signal updates), relevant here since a Sankey mark
+   would lean on `View` for its export path.
+
+**Non-issues, checked and confirmed fine:** theming (light/dark) has a clean reusable mechanism already;
+static PNG/SVG export works today with zero new work.
+
+**Net read**: item 1 (no incremental view-update path) is the one finding that most changes the calculus —
+progressive expansion isn't just a data-modeling question (§3's column-assignment discussion), it also
+needs RSC to solve a library-wide architectural gap. Items 2, 4, 5, 6, 7 are real but second-order —
+additional engineering cost, not blockers to scoping the work.
+
+---
+
+## 6. Bottom line
+
+A Sankey mark is technically feasible in RSC, and roughly a third of Workspace Flow's feature set (node/
+link rendering, tooltips, click-to-pin, progressive expansion, label wrapping, theming) maps cleanly onto
+what a chart-library mark should own — with a working reference implementation (Workspace's own
+`d3.pathing()`) available to de-risk the layout algorithm, rather than treating it as unsolved research the
+way the pre-alpha spec's complexity-5 rating implies. The remaining two-thirds of Flow's feature set is
+host-application business logic (anchor/query semantics, the context-menu action set, undo/redo, AI/MCP
+integration, preferences) and should stay there regardless of what renders the diagram. The two things
+most worth raising with the RSC team before implementation starts: (a) the mark's planned topological
+auto-column-assignment doesn't fit a server-driven, incrementally-loaded host — an optional explicit
+`column` field is a small, strict-superset fix — and (b) RSC has no incremental Vega-view-update path
+today, which progressive node/column expansion will need regardless of which specific mark surfaces it
+first.


### PR DESCRIPTION
Adds a Sankey/Flow mark to React Spectrum Charts **S2** (`vega-spec-builder-s2` + `react-spectrum-charts-s2`), following the same conventions as Donut/Venn rather than the unimplemented pre-alpha spec (`planning/specs/pre-alpha/sankey/add-sankey-mark.json`), which this PR intentionally departs from based on the research in `planning/research/sankey-workspace-flow-feasibility/`.

## Description

- **Layout (`vega-spec-builder-s2/src/sankey/sankeyUtils.ts`)**: topological column assignment with cycle detection (back edges are dropped from layering, still rendered, and reported via `console.warn`), value-proportional node/link sizing, iterative left-right/right-left relaxation to reduce ribbon crossings, and a cubic-bezier ribbon path generator.
- **Spec builder (`sankeySpecBuilder.ts`)**: `addSankey`/`addData`/`addMarks`/`addScales`/`addSignals`, wired into `chartSpecBuilder.ts` the same way every other mark is.
- **React layer**: a `pre-alpha/components/Sankey` component, `sankeyAdapter.ts`, and the usual children-adapter/`utils.ts` allow-list wiring — mirrors `Donut` exactly.
- **Interactivity**: `ChartInspect`/`ChartPopover` (click-to-pin and right-click) work on both the node and link layers out of the box, reusing the same generic, mark-agnostic plumbing every other mark already has — no sankey-specific code was needed for this.
- **Labels**: node name/value labels reuse Line's direct-label halo technique (background + foreground text pair) and the shared `getDirectLabelFontSizeProductionRule` font-size mechanism, rather than a bespoke sizing signal.
- **Stories**: `Basic`, `TwoColumnFlow`, `SingleChain`, `ThreeColumnFlow`, `NodeAndLinkInspect`, `RightClickInspect`, and `WorkspaceFlowExample` (approximates Analysis Workspace's own Flow visualization: root node, comma-formatted counts, "+N more" long-tail nodes, `s2Categorical16` palette).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- New unit tests for the layout algorithm (column assignment incl. cycles, node/link sizing, ribbon geometry) and the spec builder (`addData`/`addMarks`/`addScales`/`addSignals`).
- End-to-end jsdom tests rendering through real Vega for every story, including a right-click regression test on both node and link marks.
- Full `vega-spec-builder-s2` + `react-spectrum-charts-s2` suites pass (2139/2139); `tsc --noEmit` clean on both packages (no new errors vs. baseline); `eslint` clean.
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
