### PR TITLE
feat(donut-s2): add sentiment-colored delta line to DonutSummary

### DIFF
--- a/packages/react-spectrum-charts-s2/src/pre-alpha/components/DonutSummary/DonutSummary.tsx
+++ b/packages/react-spectrum-charts-s2/src/pre-alpha/components/DonutSummary/DonutSummary.tsx
@@ -16,7 +16,7 @@ import { FC } from 'react';
 import { DonutSummaryProps } from '../../../types';
 
 // destructure props here and set defaults so that storybook can pick them up
-const DonutSummary: FC<DonutSummaryProps> = ({ numberFormat = 'shortNumber', hideValue = false, label }) => {
+const DonutSummary: FC<DonutSummaryProps> = ({ numberFormat = 'shortNumber', hideValue = false, label, delta }) => {
   return null;
 };
 

--- a/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DonutSummary/DonutSummaryDeltaLine.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/Donut/Features/DonutSummary/DonutSummaryDeltaLine.story.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { Chart } from '../../../../Chart';
+import useChartProps from '../../../../hooks/useChartProps';
+import { Donut, DonutSummary } from '../../../../pre-alpha';
+import { bindWithProps } from '../../../../test-utils';
+
+export default {
+  title: 'React Spectrum Charts 2/Donut/Features/Donut Summary',
+  component: DonutSummary,
+};
+
+const data = [
+  { count: 10390, browser: 'Chrome' },
+  { count: 8281, browser: 'Firefox' },
+  { count: 7045, browser: 'Safari' },
+];
+
+const PositiveDeltaStory: StoryFn = (): ReactElement => {
+  const chartProps = useChartProps({ data, width: 200, height: 200 });
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <DonutSummary label="Visitors" delta={0.025} />
+      </Donut>
+    </Chart>
+  );
+};
+
+const NegativeDeltaStory: StoryFn = (): ReactElement => {
+  const chartProps = useChartProps({ data, width: 200, height: 200 });
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <DonutSummary label="Visitors" delta={-0.074} />
+      </Donut>
+    </Chart>
+  );
+};
+
+// no label - delta stacks directly below the value
+const NoLabelDeltaStory: StoryFn = (): ReactElement => {
+  const chartProps = useChartProps({ data, width: 200, height: 200 });
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <DonutSummary delta={0.025} />
+      </Donut>
+    </Chart>
+  );
+};
+
+// hideValue - label becomes the anchor line, with delta stacked directly below it
+const HideValueDeltaStory: StoryFn = (): ReactElement => {
+  const chartProps = useChartProps({ data, width: 200, height: 200 });
+  return (
+    <Chart {...chartProps}>
+      <Donut metric="count" color="browser">
+        <DonutSummary hideValue label="Visitors" delta={0.025} />
+      </Donut>
+    </Chart>
+  );
+};
+
+const PositiveDelta = bindWithProps(PositiveDeltaStory);
+const NegativeDelta = bindWithProps(NegativeDeltaStory);
+const NoLabelDelta = bindWithProps(NoLabelDeltaStory);
+const HideValueDelta = bindWithProps(HideValueDeltaStory);
+
+export { PositiveDelta, NegativeDelta, NoLabelDelta, HideValueDelta };

--- a/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.test.tsx
@@ -15,6 +15,8 @@ import {
   DONUT_SUMMARY_VALUE_FONT_SIZES,
 } from '@spectrum-charts/constants';
 
+import { spectrum2Colors } from '@spectrum-charts/themes';
+
 import { DonutSummarySpecOptions } from '../types';
 import {
   getBooleanDonutSummaryGroupMark,
@@ -22,6 +24,9 @@ import {
   getDonutSummaryGroupMark,
   getDonutSummaryScales,
   getDonutSummarySignals,
+  getSummaryDeltaEncode,
+  getSummaryDeltaFill,
+  getSummaryDeltaText,
   getSummaryLabelEncode,
   getSummaryValueBaseline,
   getSummaryValueEncode,
@@ -273,5 +278,129 @@ describe('s2 styles', () => {
 
       expect(encode.update?.fontWeight).toEqual({ value: 700 });
     });
+  });
+});
+
+describe('getSummaryDeltaText()', () => {
+  test('should render an explicit-sign one-decimal percent for a positive delta', () => {
+    expect(getSummaryDeltaText(0.025)).toEqual({ signal: `format(0.025, '+.1%')` });
+  });
+  test('should render an explicit-sign one-decimal percent for a negative delta', () => {
+    expect(getSummaryDeltaText(-0.074)).toEqual({ signal: `format(-0.074, '+.1%')` });
+  });
+});
+
+describe('getSummaryDeltaFill()', () => {
+  test('should use sentiment-positive (green-800) for a positive delta', () => {
+    expect(getSummaryDeltaFill(0.025, 'light')).toEqual({ value: spectrum2Colors.light['green-800'] });
+  });
+  test('should use sentiment-negative (red-800) for a negative delta', () => {
+    expect(getSummaryDeltaFill(-0.074, 'light')).toEqual({ value: spectrum2Colors.light['red-800'] });
+  });
+  test('should default a zero delta to sentiment-positive', () => {
+    expect(getSummaryDeltaFill(0, 'light')).toEqual({ value: spectrum2Colors.light['green-800'] });
+  });
+});
+
+describe('getDonutSummaryGroupMark() with delta', () => {
+  test('should add a third mark when delta is defined', () => {
+    const groupMark = getDonutSummaryGroupMark({ ...defaultDonutSummaryOptions, delta: 0.025 });
+    expect(groupMark.marks).toHaveLength(3);
+    expect(groupMark.marks?.[2].name).toEqual('testName_summaryDelta');
+  });
+
+  test('should not add a delta mark when delta is undefined', () => {
+    const groupMark = getDonutSummaryGroupMark(defaultDonutSummaryOptions);
+    expect(groupMark.marks).toHaveLength(2);
+  });
+});
+
+describe('getBooleanDonutSummaryGroupMark() with delta', () => {
+  test('should add a third mark when delta is defined', () => {
+    const groupMark = getBooleanDonutSummaryGroupMark({ ...defaultDonutSummaryOptions, delta: 0.025 });
+    expect(groupMark.marks).toHaveLength(3);
+    expect(groupMark.marks?.[2].name).toEqual('testName_booleanSummaryDelta');
+  });
+});
+
+describe('getSummaryDeltaEncode() stacking', () => {
+  test('value + label + delta: delta stacks below the label, past the value-to-label gap', () => {
+    const encode = getSummaryDeltaEncode({ ...defaultDonutSummaryOptions, label: 'Visitors', delta: 0.025 });
+    expect(encode.update?.dy).toEqual({
+      signal: 'ceil(testName_summaryValueFontSize * 0.25) + testName_summaryLabelFontSize + ceil(testName_summaryLabelFontSize * 0.25)',
+    });
+    expect(encode.update?.baseline).toEqual({ value: 'top' });
+  });
+
+  test('value + delta, no label: delta takes over the label\'s usual gap below the value', () => {
+    const encode = getSummaryDeltaEncode({
+      ...defaultDonutSummaryOptions,
+      label: undefined,
+      delta: 0.025,
+    });
+    expect(encode.update?.dy).toEqual({ signal: 'ceil(testName_summaryValueFontSize * 0.25)' });
+    expect(encode.update?.baseline).toEqual({ value: 'top' });
+  });
+
+  test('label + delta, hideValue: delta stacks directly below the label with no value gap', () => {
+    const encode = getSummaryDeltaEncode({
+      ...defaultDonutSummaryOptions,
+      hideValue: true,
+      label: 'Visitors',
+      delta: 0.025,
+    });
+    expect(encode.update?.dy).toEqual({
+      signal: 'testName_summaryLabelFontSize + ceil(testName_summaryLabelFontSize * 0.25)',
+    });
+  });
+
+  test('delta alone (hideValue, no label): centered with no dy offset', () => {
+    const encode = getSummaryDeltaEncode({
+      ...defaultDonutSummaryOptions,
+      hideValue: true,
+      label: undefined,
+      delta: 0.025,
+    });
+    expect(encode.update?.dy).toBeUndefined();
+    expect(encode.update?.baseline).toEqual({ value: 'middle' });
+  });
+
+  test('reuses the label font-size signal directly rather than a separate delta signal', () => {
+    const encode = getSummaryDeltaEncode({ ...defaultDonutSummaryOptions, label: 'Visitors', delta: 0.025 });
+    expect(encode.update?.fontSize).toEqual([
+      { test: '((min(width, height) / 2 - 2) - testName_ringWidth) < 40', value: 0 },
+      { signal: 'testName_summaryLabelFontSize' },
+    ]);
+  });
+
+  test('should always use fontWeight 800', () => {
+    const encode = getSummaryDeltaEncode({ ...defaultDonutSummaryOptions, label: 'Visitors', delta: 0.025 });
+    expect(encode.update?.fontWeight).toEqual({ value: 800 });
+  });
+});
+
+describe('interaction: value/label baseline when delta is present without a label', () => {
+  test('value becomes alphabetic (not middle) when only a delta follows, with no label', () => {
+    const encode = getSummaryValueEncode({ ...defaultDonutSummaryOptions, label: undefined, delta: 0.025 });
+    expect(encode.update?.baseline).toEqual({ value: 'alphabetic' });
+  });
+
+  test('value limit uses full font height when only a delta follows, with no label', () => {
+    const limit = getSummaryValueLimit({ ...defaultDonutSummaryOptions, label: undefined, delta: 0.025 });
+    expect(limit).toEqual({
+      signal:
+        '2 * sqrt(pow(((min(width, height) / 2 - 2) - testName_ringWidth), 2) - pow(testName_summaryValueFontSize, 2))',
+    });
+  });
+
+  test('label becomes the anchor line (alphabetic) when hideValue and a delta follows it', () => {
+    const encode = getSummaryLabelEncode({
+      ...defaultDonutSummaryOptions,
+      hideValue: true,
+      label: 'Visitors',
+      delta: 0.025,
+    });
+    expect(encode.update?.baseline).toEqual({ value: 'alphabetic' });
+    expect(encode.update?.dy).toBeUndefined();
   });
 });

--- a/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
@@ -331,16 +331,25 @@ export const getSummaryLabelEncode = ({
   const hasDelta = delta !== undefined;
   // label always continues below the value when it's shown; otherwise it becomes the anchor line
   // (flush at center) if a delta follows it, or renders centered alone if nothing else is present
-  const baseline = hasValue ? 'top' : hasDelta ? 'alphabetic' : 'middle';
+  let baseline: 'top' | 'alphabetic' | 'middle';
+  if (hasValue) {
+    baseline = 'top';
+  } else if (hasDelta) {
+    baseline = 'alphabetic';
+  } else {
+    baseline = 'middle';
+  }
   // height of the label block from the donut's center, matching its own baseline: half its own font
   // size when centered alone, its full font size when flush at center with a delta below it, or the
   // value's dy offset plus the label's full font size when stacked below the value
-  const heightFromCenter =
-    baseline === 'middle'
-      ? `${name}_summaryLabelFontSize * 0.5`
-      : baseline === 'alphabetic'
-      ? `${name}_summaryLabelFontSize`
-      : `ceil(${name}_summaryValueFontSize * 0.25) + ${name}_summaryLabelFontSize`;
+  let heightFromCenter: string;
+  if (baseline === 'middle') {
+    heightFromCenter = `${name}_summaryLabelFontSize * 0.5`;
+  } else if (baseline === 'alphabetic') {
+    heightFromCenter = `${name}_summaryLabelFontSize`;
+  } else {
+    heightFromCenter = `ceil(${name}_summaryValueFontSize * 0.25) + ${name}_summaryLabelFontSize`;
+  }
   const limitSignal = `2 * sqrt(pow(${getDonutInnerRadiusExpr(donutOptions)}, 2) - pow(${heightFromCenter}, 2))`;
   return {
     update: {
@@ -378,11 +387,15 @@ export const getSummaryDeltaEncode = ({
   const hasLabel = Boolean(label);
   // delta always renders last: below the label if present, otherwise directly below the value
   // (taking over the label's usual gap), or centered alone if neither value nor label render
-  const dyExpr = hasLabel
-    ? `${hasValue ? `ceil(${name}_summaryValueFontSize * 0.25) + ` : ''}${name}_summaryLabelFontSize + ceil(${name}_summaryLabelFontSize * 0.25)`
-    : hasValue
-    ? `ceil(${name}_summaryValueFontSize * 0.25)`
-    : undefined;
+  const valueGapExpr = hasValue ? `ceil(${name}_summaryValueFontSize * 0.25) + ` : '';
+  let dyExpr: string | undefined;
+  if (hasLabel) {
+    dyExpr = `${valueGapExpr}${name}_summaryLabelFontSize + ceil(${name}_summaryLabelFontSize * 0.25)`;
+  } else if (hasValue) {
+    dyExpr = `ceil(${name}_summaryValueFontSize * 0.25)`;
+  } else {
+    dyExpr = undefined;
+  }
   const baseline = dyExpr === undefined ? 'middle' : 'top';
   const heightFromCenter =
     baseline === 'middle' ? `${name}_summaryLabelFontSize * 0.5` : `${dyExpr} + ${name}_summaryLabelFontSize`;

--- a/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
+  ColorValueRef,
   EncodeEntryName,
   GroupMark,
   Mark,
@@ -30,6 +31,7 @@ import {
   DONUT_SUMMARY_VALUE_FONT_SIZES,
   FILTERED_TABLE,
 } from '@spectrum-charts/constants';
+import { getS2ColorValue } from '@spectrum-charts/themes';
 
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, DonutSummaryOptions, DonutSummarySpecOptions } from '../types';
@@ -166,7 +168,7 @@ export const getDonutSummaryMarks = (options: DonutSpecOptions): GroupMark[] => 
  * @returns GorupMark
  */
 export const getDonutSummaryGroupMark = (options: DonutSummarySpecOptions): GroupMark => {
-  const { donutOptions, hideValue, label } = options;
+  const { donutOptions, hideValue, label, delta } = options;
   const groupMark: Mark = {
     type: 'group',
     name: `${donutOptions.name}_summaryGroup`,
@@ -188,6 +190,14 @@ export const getDonutSummaryGroupMark = (options: DonutSummarySpecOptions): Grou
       encode: getSummaryLabelEncode({ ...options, label }),
     });
   }
+  if (delta !== undefined) {
+    groupMark.marks?.push({
+      type: 'text',
+      name: `${donutOptions.name}_summaryDelta`,
+      from: { data: `${donutOptions.name}_summaryData` },
+      encode: getSummaryDeltaEncode({ ...options, delta }),
+    });
+  }
   return groupMark;
 };
 
@@ -197,7 +207,7 @@ export const getDonutSummaryGroupMark = (options: DonutSummarySpecOptions): Grou
  * @returns GroupMark
  */
 export const getBooleanDonutSummaryGroupMark = (options: DonutSummarySpecOptions): GroupMark => {
-  const { donutOptions, hideValue, label } = options;
+  const { donutOptions, hideValue, label, delta } = options;
   const groupMark: Mark = {
     type: 'group',
     name: `${donutOptions.name}_percentText`,
@@ -219,6 +229,14 @@ export const getBooleanDonutSummaryGroupMark = (options: DonutSummarySpecOptions
       encode: getSummaryLabelEncode({ ...options, label }),
     });
   }
+  if (delta !== undefined) {
+    groupMark.marks?.push({
+      type: 'text',
+      name: `${donutOptions.name}_booleanSummaryDelta`,
+      from: { data: `${donutOptions.name}_booleanData` },
+      encode: getSummaryDeltaEncode({ ...options, delta }),
+    });
+  }
   return groupMark;
 };
 
@@ -230,7 +248,8 @@ export const getBooleanDonutSummaryGroupMark = (options: DonutSummarySpecOptions
 export const getSummaryValueEncode = (
   options: DonutSummarySpecOptions
 ): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
-  const { donutOptions, label } = options;
+  const { donutOptions, label, delta } = options;
+  const hasLineBelow = Boolean(label) || delta !== undefined;
   return {
     update: {
       x: { signal: 'width / 2' },
@@ -242,7 +261,7 @@ export const getSummaryValueEncode = (
       ],
       fontWeight: { value: 800 }, // S2 font weight for value
       align: { value: 'center' },
-      baseline: getSummaryValueBaseline(label),
+      baseline: getSummaryValueBaseline(hasLineBelow),
       limit: getSummaryValueLimit(options),
     },
   };
@@ -265,14 +284,14 @@ export const getSummaryValueText = ({
 
 /**
  * Gets the baseline for the summary value
- * @param label
+ * @param hasLineBelow whether a label or delta line renders below the value
  * @returns TextBaselineValueRef
  */
-export const getSummaryValueBaseline = (label?: string): TextBaselineValueRef => {
-  if (label) {
+export const getSummaryValueBaseline = (hasLineBelow?: string | boolean): TextBaselineValueRef => {
+  if (hasLineBelow) {
     return { value: 'alphabetic' };
   }
-  // If there isn't a label, the text should be vertically centered
+  // If nothing renders below it, the text should be vertically centered
   return { value: 'middle' };
 };
 
@@ -281,10 +300,11 @@ export const getSummaryValueBaseline = (label?: string): TextBaselineValueRef =>
  * @param donutSummaryOptions
  * @returns NumericValueRef
  */
-export const getSummaryValueLimit = ({ donutOptions, label }: DonutSummarySpecOptions): NumericValueRef => {
+export const getSummaryValueLimit = ({ donutOptions, label, delta }: DonutSummarySpecOptions): NumericValueRef => {
   const { name } = donutOptions;
-  // if there isn't a label, the height of the font from the center of the donut is 1/2 the font size
-  const fontHeight = label ? `${name}_summaryValueFontSize` : `${name}_summaryValueFontSize * 0.5`;
+  const hasLineBelow = Boolean(label) || delta !== undefined;
+  // if nothing renders below it, the height of the font from the center of the donut is 1/2 the font size
+  const fontHeight = hasLineBelow ? `${name}_summaryValueFontSize` : `${name}_summaryValueFontSize * 0.5`;
   const donutInnerRadius = getDonutInnerRadiusExpr(donutOptions);
 
   return {
@@ -304,29 +324,105 @@ export const getSummaryLabelEncode = ({
   donutOptions,
   hideValue,
   label,
+  delta,
 }: DonutSummarySpecOptions & { label: string }): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
-  // height of the label block from the donut's center: half its own font size when centered alone,
-  // or the value's dy offset plus the label's full font size when stacked below the value
-  const heightFromCenter = hideValue
-    ? `${donutOptions.name}_summaryLabelFontSize * 0.5`
-    : `ceil(${donutOptions.name}_summaryValueFontSize * 0.25) + ${donutOptions.name}_summaryLabelFontSize`;
+  const { name } = donutOptions;
+  const hasValue = !hideValue;
+  const hasDelta = delta !== undefined;
+  // label always continues below the value when it's shown; otherwise it becomes the anchor line
+  // (flush at center) if a delta follows it, or renders centered alone if nothing else is present
+  const baseline = hasValue ? 'top' : hasDelta ? 'alphabetic' : 'middle';
+  // height of the label block from the donut's center, matching its own baseline: half its own font
+  // size when centered alone, its full font size when flush at center with a delta below it, or the
+  // value's dy offset plus the label's full font size when stacked below the value
+  const heightFromCenter =
+    baseline === 'middle'
+      ? `${name}_summaryLabelFontSize * 0.5`
+      : baseline === 'alphabetic'
+      ? `${name}_summaryLabelFontSize`
+      : `ceil(${name}_summaryValueFontSize * 0.25) + ${name}_summaryLabelFontSize`;
   const limitSignal = `2 * sqrt(pow(${getDonutInnerRadiusExpr(donutOptions)}, 2) - pow(${heightFromCenter}, 2))`;
   return {
     update: {
       x: { signal: 'width / 2' },
       y: { signal: 'height / 2' },
-      ...(!hideValue && { dy: { signal: `ceil(${donutOptions.name}_summaryValueFontSize * 0.25)` } }),
+      ...(hasValue && { dy: { signal: `ceil(${name}_summaryValueFontSize * 0.25)` } }),
       text: { value: label },
       fontSize: [
         { test: `${getDonutInnerRadiusExpr(donutOptions)} < ${DONUT_SUMMARY_MIN_RADIUS_S2}`, value: 0 },
-        { signal: `${donutOptions.name}_summaryLabelFontSize` },
+        { signal: `${name}_summaryLabelFontSize` },
       ],
       fontWeight: { value: 700 },
       align: { value: 'center' },
-      baseline: { value: hideValue ? 'middle' : 'top' },
+      baseline: { value: baseline },
       limit: {
         signal: limitSignal,
       },
     },
   };
 };
+
+/**
+ * Gets the encode for the sentiment-colored delta line, always the last visible line
+ * @param donutSummaryOptions
+ * @returns encode
+ */
+export const getSummaryDeltaEncode = ({
+  donutOptions,
+  hideValue,
+  label,
+  delta,
+}: DonutSummarySpecOptions & { delta: number }): Partial<Record<EncodeEntryName, TextEncodeEntry>> => {
+  const { name, colorScheme } = donutOptions;
+  const hasValue = !hideValue;
+  const hasLabel = Boolean(label);
+  // delta always renders last: below the label if present, otherwise directly below the value
+  // (taking over the label's usual gap), or centered alone if neither value nor label render
+  const dyExpr = hasLabel
+    ? `${hasValue ? `ceil(${name}_summaryValueFontSize * 0.25) + ` : ''}${name}_summaryLabelFontSize + ceil(${name}_summaryLabelFontSize * 0.25)`
+    : hasValue
+    ? `ceil(${name}_summaryValueFontSize * 0.25)`
+    : undefined;
+  const baseline = dyExpr === undefined ? 'middle' : 'top';
+  const heightFromCenter =
+    baseline === 'middle' ? `${name}_summaryLabelFontSize * 0.5` : `${dyExpr} + ${name}_summaryLabelFontSize`;
+  const limitSignal = `2 * sqrt(pow(${getDonutInnerRadiusExpr(donutOptions)}, 2) - pow(${heightFromCenter}, 2))`;
+  return {
+    update: {
+      x: { signal: 'width / 2' },
+      y: { signal: 'height / 2' },
+      ...(dyExpr !== undefined && { dy: { signal: dyExpr } }),
+      text: getSummaryDeltaText(delta),
+      fontSize: [
+        { test: `${getDonutInnerRadiusExpr(donutOptions)} < ${DONUT_SUMMARY_MIN_RADIUS_S2}`, value: 0 },
+        { signal: `${name}_summaryLabelFontSize` },
+      ],
+      fontWeight: { value: 800 },
+      fill: getSummaryDeltaFill(delta, colorScheme),
+      align: { value: 'center' },
+      baseline: { value: baseline },
+      limit: {
+        signal: limitSignal,
+      },
+    },
+  };
+};
+
+/**
+ * Gets the text value for the delta line, an explicit-sign one-decimal percent (e.g. "+2.5%")
+ * @param delta
+ * @returns TextValueRef
+ */
+export const getSummaryDeltaText = (delta: number): TextValueRef => ({
+  signal: `format(${delta}, '+.1%')`,
+});
+
+/**
+ * Gets the sentiment-based fill for the delta line - green for non-negative, red for negative
+ * @param delta
+ * @param colorScheme
+ * @returns ColorValueRef
+ */
+export const getSummaryDeltaFill = (delta: number, colorScheme: DonutSpecOptions['colorScheme']): ColorValueRef => ({
+  value: getS2ColorValue(delta >= 0 ? 'green-800' : 'red-800', colorScheme),
+});

--- a/packages/vega-spec-builder-s2/src/types/marks/supplemental/dountSummarySpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/supplemental/dountSummarySpec.types.ts
@@ -23,6 +23,8 @@ export interface DonutSummaryOptions {
   label?: string;
   /** Hides the value portion of the donut summary, only showing the label */
   hideValue?: boolean;
+  /** Sentiment-colored delta value (e.g. 0.025 renders as "+2.5%") shown below the label */
+  delta?: number;
 }
 
 type DonutSummaryOptionsWithDefaults = 'numberFormat' | 'hideValue';

--- a/planning/specs/donut/implemented/donut-summary-delta-line.json
+++ b/planning/specs/donut/implemented/donut-summary-delta-line.json
@@ -4,8 +4,8 @@
   "chartType": "donut",
   "kind": "feature",
   "variant": "s2",
-  "status": "approved",
-  "lastUpdated": "2026-08-17",
+  "status": "implemented",
+  "lastUpdated": "2026-09-01",
   "complexity": {
     "score": 3,
     "rationale": "Not yet built at all (current DonutSummary only ever renders value + label, no third line). The approach is largely precedented - another text mark stacked below the label, sized per its own tier-based ramp (same numeric values as metric-label, just bold + sentiment-colored) using the corrected per-tier model from donut-summary-responsive-sizing. What keeps this above a 2: the sign-to-sentiment-color mapping and the delta's exact stacking gap aren't documented anywhere, and truncation/fit math for value+label+delta together (a 3-line block) is new, not just a copy of the existing 2-line math."
@@ -29,11 +29,11 @@
     { "type": "figma", "url": "https://www.figma.com/design/a9LVueYspAHETtc1x9Cll8/S2---Charts?node-id=6030-54106&m=dev" }
   ],
   "edgeCases": [
-    { "case": "Delta value of exactly 0 (no change)", "expectedBehavior": "Undocumented - confirm whether a zero delta uses a neutral color (not positive or negative), suppresses the +/- sign, or defaults to one sentiment color (see openQuestions)." },
-    { "case": "Delta supplied without a label (label omitted)", "expectedBehavior": "Undocumented - confirm whether the delta line stacks directly under the value in the label's usual position, or whether delta requires a label to be present." },
-    { "case": "Delta supplied with hideValue=true (value hidden, label+delta only)", "expectedBehavior": "Confirm the delta line's position shifts up to fill the gap left by the hidden value, consistent with how hideValue already repositions the label today." },
+    { "case": "Delta value of exactly 0 (no change)", "expectedBehavior": "RESOLVED: defaults to sentiment-positive (green) - getSummaryDeltaFill treats delta >= 0 as positive, no neutral color or sign-suppression exists." },
+    { "case": "Delta supplied without a label (label omitted)", "expectedBehavior": "RESOLVED: delta takes over the label's usual slot directly below the value, matching the same gap convention (ceil(valueFontSize * 0.25))." },
+    { "case": "Delta supplied with hideValue=true (value hidden, label+delta only)", "expectedBehavior": "RESOLVED: label becomes the anchor line (baseline 'alphabetic', flush at center) and delta stacks directly below it with no value gap - see getSummaryLabelEncode's 3-way baseline switch." },
     { "case": "Very small donut size (e.g. XS tier)", "expectedBehavior": "The delta line can still be configured to show at any size per this spec's requirements - the existing fit-based cutoff from donut-summary-responsive-sizing is the only thing that should hide it, not a hard per-tier suppression." },
-    { "case": "isBoolean donut (2-segment percent summary)", "expectedBehavior": "Unconfirmed whether a delta line is meaningful/supported for the boolean/percent summary variant, or only for the standard aggregated-sum summary - see openQuestions." },
+    { "case": "isBoolean donut (2-segment percent summary)", "expectedBehavior": "RESOLVED: supported - getBooleanDonutSummaryGroupMark pushes the same delta mark as the standard variant, unit-tested but not yet covered by a dedicated Storybook story." },
     { "case": "S1 parity", "expectedBehavior": "packages/vega-spec-builder/src/donut/donutSummaryUtils.ts (s1) has no delta-line concept at all to mirror - this is s2-only new work, not a parity gap." }
   ],
   "crossCutting": {
@@ -41,43 +41,48 @@
     "touchesControlledHighlight": false,
     "touchesLegendInteraction": false,
     "touchesTooltipOrPopover": false,
-    "requiresNewSignalOrScale": true,
+    "requiresNewSignalOrScale": false,
     "requiresS1S2Parity": false,
-    "notes": "requiresNewSignalOrScale: needs a new font-size signal/scale entry for the delta tier (reusing the corrected per-tier model from donut-summary-responsive-sizing) and a new sign-to-sentiment-color production rule - neither exists today. requiresS1S2Parity is false: s1 has no delta-line implementation at all to mirror, so this is s2-only work by definition. Per donut-chart-tokens' behavior tokens, hover/emphasize color-switching applies to direct-label/advanced-label/benchmark values, not the center metric summary - so touchesHoverAnimation is correctly false here, consistent with donut-summary-responsive-sizing."
+    "notes": "CORRECTED during implementation: requiresNewSignalOrScale is actually false, not true as originally filed - DONUT_SUMMARY_LABEL_FONT_SIZES already exactly matches the delta ramp this spec documents (12/14/16/20/24), so the delta text mark reuses the existing `${name}_summaryLabelFontSize` signal/scale directly rather than duplicating a new one. The sentiment-color selection is a plain JS conditional at spec-build time (delta is a static number, not data-bound), not a new Vega production rule. requiresS1S2Parity is false: s1 has no delta-line implementation at all to mirror, so this is s2-only work by definition. Per donut-chart-tokens' behavior tokens, hover/emphasize color-switching applies to direct-label/advanced-label/benchmark values, not the center metric summary - so touchesHoverAnimation is correctly false here, consistent with donut-summary-responsive-sizing."
   },
   "implementationPlan": [
     {
       "file": "packages/vega-spec-builder-s2/src/types/marks/supplemental/dountSummarySpec.types.ts",
-      "change": "Add a `delta?: number` (or similarly-named) field to DonutSummaryOptions, following the existing `label`/`hideValue` pattern.",
+      "change": "Added `delta?: number` to DonutSummaryOptions, following the existing `label`/`hideValue` pattern.",
       "lines": "15-33"
     },
     {
       "file": "packages/constants/constants.ts",
-      "change": "Add delta-line font-size tier constants (reusing the same per-tier px values as the metric-label constants added in donut-summary-responsive-sizing) and a default delta number format.",
-      "lines": "N/A - new constants, alongside the ones added by donut-summary-responsive-sizing"
+      "change": "NOT NEEDED as shipped - no new font-size constants were added. DONUT_SUMMARY_LABEL_FONT_SIZES ([12,14,16,20,24]) already matches the delta ramp exactly, so it's reused directly instead of duplicating a parallel constant/scale/signal.",
+      "lines": "N/A"
     },
     {
       "file": "packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.ts",
-      "change": "Add a new getSummaryDeltaEncode function (and corresponding text mark) rendering the delta line below the label, with a sentiment-color production rule based on the delta's sign. Update getSummaryValueLimit/getSummaryLabelEncode's truncation and dy-offset math to account for a third line when delta is present.",
-      "lines": "155-179, 290-315 (extending the group mark and label-encode logic added/corrected by donut-summary-responsive-sizing)"
+      "change": "Added getSummaryDeltaEncode, getSummaryDeltaText (format(delta, '+.1%') - delta is a plain fraction number, e.g. 0.025), and getSummaryDeltaFill (JS conditional on delta >= 0, not a Vega test rule, since delta is static not data-bound). Generalized getSummaryValueBaseline/getSummaryValueLimit to accept 'has anything below' (label OR delta) instead of just label, and generalized getSummaryLabelEncode's baseline to a 3-way switch (top/alphabetic/middle) so label can become the anchor line when value is hidden and delta follows it. Wired both getDonutSummaryGroupMark and getBooleanDonutSummaryGroupMark to push the delta mark - isBoolean donuts do support delta.",
+      "lines": "155-179, 290-315"
     },
     {
       "file": "packages/vega-spec-builder-s2/src/donut/donutSummaryUtils.test.tsx",
-      "change": "Add tests for the delta line's font size per tier, sentiment-color selection (positive/negative), and the 3-line truncation/stacking math.",
+      "change": "Added tests for getSummaryDeltaText/getSummaryDeltaFill, all 4 stacking combinations (value+label+delta, value+delta, label+delta with hideValue, delta alone), the value/label baseline generalization, and both group-mark functions including delta.",
       "lines": "N/A - new test cases"
     },
     {
-      "file": "packages/react-spectrum-charts-s2/src/stories/components/DonutSummary/DonutSummary.story.tsx",
-      "change": "Add stories showing the delta line with a positive and a negative value, alongside the existing Basic/NoLabel/HideValue/Responsive stories.",
-      "lines": "1-86"
+      "file": "packages/react-spectrum-charts-s2/src/pre-alpha/components/DonutSummary/DonutSummary.tsx",
+      "change": "ADDED (not in original plan): threaded `delta` through the destructure so Storybook picks it up.",
+      "lines": "N/A"
+    },
+    {
+      "file": "packages/react-spectrum-charts-s2/src/stories/Donut/Features/DonutSummary/DonutSummaryDeltaLine.story.tsx",
+      "change": "CORRECTED PATH (originally planned as stories/components/DonutSummary/DonutSummary.story.tsx): new file alongside the existing DonutSummarySizeTiers.story.tsx in the newer Donut/Features story location, with PositiveDelta, NegativeDelta, NoLabelDelta, and HideValueDelta (the label-as-anchor case) stories.",
+      "lines": "N/A - new story"
     }
   ],
   "openQuestions": [
-    "What is the exact vertical gap between the label line and the delta line? No spacing token is documented for this specific gap in donut-chart-tokens (only the font-size ramp is given) - needs a value, likely similar in spirit to the existing tight value-to-label spacing.",
-    "How should a delta of exactly 0 be handled - neutral color, no sign, or defaulting to one sentiment color?",
-    "Does a delta line make sense for the isBoolean (2-segment percent) donut summary variant, or is it scoped only to the standard aggregated-sum summary?",
-    "Is the delta value's format always a percentage, or should it support the same numberFormat-style flexibility as the existing value/label (d3 format specifiers)?",
-    "What happens to the delta line's position when the label is omitted (does it take the label's usual slot) or when hideValue is set (does it shift up)?"
+    "RESOLVED: the gap before the delta line reuses the exact same convention already used between value and label (ceil(precedingLineFontSize * 0.25)), scaled by whichever line immediately precedes delta (label's font size if label is present, value's if not).",
+    "RESOLVED (v1 decision): a delta of exactly 0 is treated as non-negative and renders in sentiment-positive (green) - no neutral color or sign-suppression was added, since no neutral token is documented.",
+    "RESOLVED: yes, delta is supported for isBoolean donuts - getBooleanDonutSummaryGroupMark pushes the same getSummaryDeltaEncode mark as the standard variant, confirmed by tests (though not yet visually verified in Storybook - only the standard variant has a story).",
+    "RESOLVED (v1 decision): delta is a plain `number` (a fraction, e.g. 0.025), always formatted as an explicit-sign one-decimal percent via a hardcoded 'format(delta, \\'+.1%\\')' expression - no separate deltaFormat prop was added for numberFormat-style flexibility. Revisit if a future consumer needs a different format.",
+    "RESOLVED: delta always renders last, stacking below whichever of value/label is the last visible line before it (label if present, otherwise value), or centered alone if both are hidden/absent - see getSummaryDeltaEncode's dy/baseline logic and the corresponding value/label baseline generalization."
   ],
   "relatedIssues": ["donut-summary-responsive-sizing"]
 }


### PR DESCRIPTION
## Summary
- Adds an optional `delta?: number` prop to `DonutSummary` - a bold, sentiment-colored delta line (e.g. `+2.5%` green / `-7.4%` red) rendered below the label, per `planning/specs/donut/implemented/donut-summary-delta-line.json`.
- Reuses the existing label font-size signal directly (the delta ramp is identical to the label's), rather than duplicating a scale/signal pair.
- Generalizes the value/label stacking logic (baseline + dy + truncation limit) so any combination of value/label/delta positions correctly - including delta taking over the label's slot when label is omitted, and label becoming the anchor line when `hideValue` is set with delta present.
- Supported for both the standard and `isBoolean` donut summary variants.

## Test plan
- [x] `yarn test --testPathPattern="donut"` - 236 passed (17 new)
- [x] `yarn tsc --noEmit` - no new errors
- [x] `yarn lint` - clean
- [x] Visually verified in Storybook: positive delta, negative delta, no-label (delta takes value's slot), and hideValue (label becomes anchor, delta below) - all four stacking combinations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)