### PR TITLE
fix(donut-s2): Direct/Advanced label collision avoidance and ring-overlap truncation

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -307,6 +307,13 @@ export const DONUT_ADVANCED_LABEL_SWATCH_GAP = 8;
 export const DONUT_ADVANCED_LABEL_NAME_VALUE_GAP = 4;
 /** Gap (px) between the value/% row and the optional detail row - directly adjacent */
 export const DONUT_ADVANCED_LABEL_VALUE_DETAIL_GAP = 0;
+/**
+ * Buffer (px) added to a label block's own rendered height to compute the minimum vertical gap
+ * enforced between two labels stacked/colliding in the same hemisphere. Not a sourced token -
+ * roughly double the 8-10px inter-element gaps used elsewhere, chosen so adjacent labels get
+ * breathing room instead of touching edge-to-edge.
+ */
+export const DONUT_LABEL_COLLISION_MIN_GAP_BUFFER = 16;
 
 // venn constant
 export const DEFAULT_VENN_COLOR = 'sets';

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -286,8 +286,8 @@ export const DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT = 400;
 /** Font weight for donut direct-label value text */
 export const DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT = 700;
 /**
- * Max fraction of the donut's own radius that a direct label's hemisphere-mirrored pull-back offset may use.
- * Label text width (a handful of px per character) doesn't shrink with the donut, so an uncapped pull-back
+ * Max fraction of the donut's own radius that a direct label's hemisphere-mirrored shift offset may use.
+ * Label text width (a handful of px per character) doesn't shrink with the donut, so an uncapped shift
  * can demand disproportionate space at small sizes, triggering runaway autosize 'fit' shrinkage. Bounding
  * it as a fraction of the current radius keeps the offset proportionate at every size instead of a fixed px cap.
  */

--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -274,8 +274,13 @@ export const DONUT_SUMMARY_LABEL_FONT_SIZES = [12, 14, 16, 20, 24];
 export const DONUT_DIRECT_LABEL_NAME_FONT_SIZES = [7.5, 9, 10.5, 12, 15];
 /** S2 donut direct-label value font size per named size tier (XS/S/M/L/XL) */
 export const DONUT_DIRECT_LABEL_VALUE_FONT_SIZES = [10, 12, 14, 16, 20];
-/** Gap (px) between the ring's outer edge and a direct/advanced label's rendered bounding box */
+/** Gap (px) between the ring's outer edge and a direct label's rendered bounding box */
 export const DONUT_LABEL_RING_GAP = 20;
+/**
+ * Gap (px) between the ring's outer edge and an advanced label's rendered bounding box - larger
+ * than the direct-label ring gap since the taller swatch+multi-row block needs more breathing room.
+ */
+export const DONUT_ADVANCED_LABEL_RING_GAP = 20;
 /** Font weight for donut direct-label segment name text */
 export const DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT = 400;
 /** Font weight for donut direct-label value text */

--- a/packages/react-spectrum-charts-s2/src/stories/components/SegmentLabel/SegmentLabel.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/SegmentLabel/SegmentLabel.test.tsx
@@ -69,8 +69,9 @@ describe('SegmentLabel', () => {
     expect(chart).toBeInTheDocument();
 
     expect(screen.getByText('Safari')).toBeInTheDocument();
-    // unknown has a font size of 0 since it's segment is too thin
-    expect(screen.getByText('Unknown')).toHaveAttribute('font-size', '0px');
+    // thin segments are excluded from the label data source entirely (so they don't consume a
+    // collision-rank slot), not rendered with font-size 0
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
@@ -340,7 +340,7 @@ describe('truncation limit', () => {
   });
 
   test('value row does not reserve any extra width in its limit (trailing subtraction is 0)', () => {
-    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ value: true }] };
+    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ percent: true }] };
     const [, , valueMark] = getAdvancedLabelMarks(donutOptions)[0].marks as [SymbolMark, TextMark, TextMark];
     const limitSignal = (valueMark.encode?.update?.limit as { signal: string }).signal;
     expect(limitSignal).toContain('? 0 :');
@@ -350,7 +350,7 @@ describe('truncation limit', () => {
   });
 
   test('name and value rows should share the exact same underlying width comparisons in their limit', () => {
-    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ value: true }] };
+    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ percent: true }] };
     const marks = getAdvancedLabelMarks(donutOptions)[0].marks as [SymbolMark, TextMark, TextMark];
     const [, nameMark, valueMark] = marks;
     const nameLimit = (nameMark.encode?.update?.limit as { signal: string }).signal;

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
@@ -203,7 +203,7 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     expect(dxSignal).toContain('testName_advancedLabelDetailFontSize');
   });
 
-  test('the pull-back should be capped at however much room remains before the container edge', () => {
+  test('the shift should be capped at however much room remains before the container edge', () => {
     const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
     const dxSignal = (nameMark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toContain('min(max(');
@@ -301,7 +301,7 @@ describe('getAdvancedLabelSwatchMark()', () => {
     expect(xSignal.endsWith(`+ ${DONUT_ADVANCED_LABEL_SWATCH_SIZE / 2}`)).toBe(true);
   });
 
-  test('swatch and name row should share the exact same underlying hemisphere pull-back (dx) expression', () => {
+  test('swatch and name row should share the exact same underlying hemisphere shift (dx) expression', () => {
     const [swatchMark, nameMark] = getSwatchAndNameMarks(defaultDonutOptionsWithAdvancedLabel);
     const swatchXSignal = (swatchMark.encode?.update?.x as { signal: string }).signal;
     const nameDxSignal = (nameMark.encode?.update?.dx as { signal: string }).signal;

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
@@ -152,21 +152,29 @@ describe('getAdvancedLabelSignals()', () => {
   });
 });
 
-describe('label anchor radius/dx (hemisphere offset)', () => {
+describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offset)', () => {
   const getNameMark = (donutOptions: DonutSpecOptions): TextMark =>
     getAdvancedLabelMarks(donutOptions)[0].marks?.[1] as TextMark;
 
-  test('radius should always be the constant ring-gap point, regardless of hemisphere', () => {
+  test('y should come from the collision-adjusted field, not a polar radius/theta anchor', () => {
     const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
-    expect(nameMark.encode?.update?.radius).toEqual({
-      signal: '(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) + 20',
+    expect(nameMark.encode?.update?.y).toEqual({ field: 'testName_advancedLabel_adjustedY' });
+    expect(nameMark.encode?.update?.radius).toBeUndefined();
+    expect(nameMark.encode?.update?.theta).toBeUndefined();
+  });
+
+  test('x should place the anchor at the collision-adjusted ring half-width, mirrored by hemisphere', () => {
+    const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
+    expect(nameMark.encode?.update?.x).toEqual({
+      signal:
+        "datum['testName_advancedLabel_hemisphere'] === 'right' ? width / 2 + datum['testName_advancedLabel_collisionHalfWidth'] : width / 2 - datum['testName_advancedLabel_collisionHalfWidth']",
     });
   });
 
   test('right hemisphere should get no horizontal offset', () => {
     const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
     const dxSignal = (nameMark.encode?.update?.dx as { signal: string }).signal;
-    expect(dxSignal).toContain("datum['testName_arcTheta'] <= PI ? 0 : -(");
+    expect(dxSignal).toContain("datum['testName_advancedLabel_hemisphere'] === 'right' ? 0 : -(");
   });
 
   test('dx should account for the swatch+name width when no percent/detail rows are shown', () => {
@@ -220,11 +228,12 @@ describe('label anchor radius/dx (hemisphere offset)', () => {
     expect(nameMark.encode?.update?.align).toEqual({ value: 'left' });
   });
 
-  test('name and value marks should share the exact same radius', () => {
+  test('name and value marks should share the exact same x and y', () => {
     const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ percent: true }] };
     const marks = getAdvancedLabelMarks(donutOptions)[0].marks as [SymbolMark, TextMark, TextMark];
     const [, nameMark, valueMark] = marks;
-    expect(nameMark.encode?.update?.radius).toEqual(valueMark.encode?.update?.radius);
+    expect(nameMark.encode?.update?.x).toEqual(valueMark.encode?.update?.x);
+    expect(nameMark.encode?.update?.y).toEqual(valueMark.encode?.update?.y);
   });
 });
 
@@ -232,7 +241,7 @@ describe('vertical row-stacking cap (getAdvancedLabelRowDy)', () => {
   test('should not define dy on the name row when percent/detail are all false', () => {
     const nameMark = getAdvancedLabelMarks(defaultDonutOptionsWithAdvancedLabel)[0].marks?.[1] as TextMark;
     expect(nameMark.encode?.update?.dy).toEqual({
-      signal: "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? (0) : 0",
+      signal: "datum['testName_advancedLabel_adjustedY'] <= height / 2 ? (0) : 0",
     });
   });
 
@@ -280,7 +289,6 @@ describe('getAdvancedLabelSwatchMark()', () => {
     const [swatchMark] = getSwatchAndNameMarks(defaultDonutOptionsWithAdvancedLabel);
     expect(swatchMark.encode?.update?.size).toEqual([
       { test: expect.stringContaining('length'), value: 0 },
-      { test: expect.stringContaining('arcLength'), value: 0 },
       { signal: `${DONUT_ADVANCED_LABEL_SWATCH_SIZE * DONUT_ADVANCED_LABEL_SWATCH_SIZE}` },
     ]);
   });

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.test.tsx
@@ -203,11 +203,13 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     expect(dxSignal).toContain('testName_advancedLabelDetailFontSize');
   });
 
-  test('the pull-back should be capped at a fraction of the donut radius', () => {
+  test('the pull-back should be capped at however much room remains before the container edge', () => {
     const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
     const dxSignal = (nameMark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toContain('min(max(');
-    expect(dxSignal).toContain('(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6');
+    // the cap is per-label (available radius minus this label's own ring half-width at its actual
+    // Y), not a flat ratio of the ring's radius - see getAdvancedLabelWidthExprs
+    expect(dxSignal).toContain("(min(width, height) / 2 - 2) - datum['testName_advancedLabel_collisionHalfWidth']");
   });
 
   test('should use the labelKey field instead of color when provided', () => {
@@ -308,6 +310,56 @@ describe('getAdvancedLabelSwatchMark()', () => {
     const cappedWidthExpr = `16 + 8 + getLabelWidth(datum['testColor'], 400, testName_advancedLabelNameFontSize)`;
     expect(swatchXSignal).toContain(cappedWidthExpr);
     expect(nameDxSignal).toContain(cappedWidthExpr);
+  });
+});
+
+describe('truncation limit', () => {
+  const getNameMark = (donutOptions: DonutSpecOptions): TextMark =>
+    getAdvancedLabelMarks(donutOptions)[0].marks?.[1] as TextMark;
+
+  test('right hemisphere should never be truncated (limit 0, unlimited) regardless of content width', () => {
+    const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
+    const limitSignal = (nameMark.encode?.update?.limit as { signal: string }).signal;
+    expect(limitSignal).toContain("datum['testName_advancedLabel_hemisphere'] === 'right' ||");
+    expect(limitSignal).toMatch(/=== 'right'.*\? 0 :/);
+  });
+
+  test("left hemisphere should only apply a real limit when content exceeds the available reach, not the row's own natural width", () => {
+    const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
+    const limitSignal = (nameMark.encode?.update?.limit as { signal: string }).signal;
+    // guards against the razor's-edge case where limit equals the row's own exact width - see
+    // getAdvancedLabelLimitExpr's doc comment
+    expect(limitSignal).toContain('<= (');
+    expect(limitSignal).toContain('? 0 :');
+  });
+
+  test("name row's limit reserves the swatch + gap, so only the text portion is constrained", () => {
+    const nameMark = getNameMark(defaultDonutOptionsWithAdvancedLabel);
+    const limitSignal = (nameMark.encode?.update?.limit as { signal: string }).signal;
+    expect(limitSignal).toContain(`- (${DONUT_ADVANCED_LABEL_SWATCH_SIZE} + ${DONUT_ADVANCED_LABEL_SWATCH_GAP})`);
+  });
+
+  test('value row does not reserve any extra width in its limit (trailing subtraction is 0)', () => {
+    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ value: true }] };
+    const [, , valueMark] = getAdvancedLabelMarks(donutOptions)[0].marks as [SymbolMark, TextMark, TextMark];
+    const limitSignal = (valueMark.encode?.update?.limit as { signal: string }).signal;
+    expect(limitSignal).toContain('? 0 :');
+    // the trailing subtraction (extraReservedWidthExpr) must be 0 for the value row - unlike the
+    // name row, which reserves the swatch + gap out of the shared cap
+    expect(limitSignal.endsWith('- (0)')).toBe(true);
+  });
+
+  test('name and value rows should share the exact same underlying width comparisons in their limit', () => {
+    const donutOptions = { ...defaultDonutOptionsWithAdvancedLabel, advancedLabels: [{ value: true }] };
+    const marks = getAdvancedLabelMarks(donutOptions)[0].marks as [SymbolMark, TextMark, TextMark];
+    const [, nameMark, valueMark] = marks;
+    const nameLimit = (nameMark.encode?.update?.limit as { signal: string }).signal;
+    const valueLimit = (valueMark.encode?.update?.limit as { signal: string }).signal;
+    // both should gate on the identical widerWidth <= maxReach comparison, differing only in the
+    // trailing subtraction (name reserves the swatch+gap, value reserves nothing)
+    const [nameCondition] = nameLimit.split('? 0 :');
+    const [valueCondition] = valueLimit.split('? 0 :');
+    expect(nameCondition).toBe(valueCondition);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
@@ -9,7 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { GroupMark, ProductionRule, Signal, SymbolMark, TextEncodeEntry, TextMark, TextValueRef, ThresholdScale } from 'vega';
+import {
+  GroupMark,
+  ProductionRule,
+  Signal,
+  SourceData,
+  SymbolMark,
+  TextEncodeEntry,
+  TextMark,
+  TextValueRef,
+  ThresholdScale,
+} from 'vega';
 
 import {
   DONUT_ADVANCED_LABEL_DETAIL_FONT_SIZES,
@@ -22,6 +32,7 @@ import {
   DONUT_ADVANCED_LABEL_VALUE_DETAIL_GAP,
   DONUT_ADVANCED_LABEL_VALUE_FONT_SIZES,
   DONUT_ADVANCED_LABEL_VALUE_FONT_WEIGHT,
+  DONUT_LABEL_COLLISION_MIN_GAP_BUFFER,
   DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
   DONUT_LABEL_RING_GAP,
   DONUT_SEGMENT_LABEL_MIN_ANGLE,
@@ -34,8 +45,29 @@ import { getColorProductionRule, getMarkOpacity } from '../marks/markUtils';
 import { getPathFromSymbolShape } from '../specUtils';
 import { getTextNumberFormat } from '../textUtils';
 import { AdvancedLabelOptions, AdvancedLabelSpecOptions, DonutSpecOptions } from '../types';
+import {
+  getAdjustedYField,
+  getCollisionHalfWidthField,
+  getHemisphereField,
+  getLabelCollisionTransforms,
+} from './donutLabelCollisionUtils';
 import { getDonutEmptyStateTest, getDonutOuterRadiusExpr } from './donutUtils';
 import { getLabelValueFill, getTextRuleExpr } from './segmentLabelUtils';
+
+/** Unique field/data-source prefix for advanced labels' collision fields, distinct from segment labels' */
+const getAdvancedLabelFieldPrefix = (name: string): string => `${name}_advancedLabel`;
+
+/** Name of the derived, collision-adjusted data source advanced label marks read from */
+const getAdvancedLabelDataName = (name: string): string => `${name}_advancedLabelData`;
+
+/**
+ * Gets the expression testing whether a label's collision-adjusted (not original ideal) position
+ * falls in the top half of the donut - collision can push a label across the vertical midpoint, so
+ * the top/bottom split for dy/baseline must track where the label actually ends up, not its ideal angle
+ * @param fieldPrefix
+ * @returns vega expression string
+ */
+const getIsTopHalfExpr = (fieldPrefix: string): string => `datum['${getAdjustedYField(fieldPrefix)}'] <= height / 2`;
 
 /**
  * Gets the AdvancedLabel component from the children if one exists
@@ -130,6 +162,57 @@ export const getAdvancedLabelSignals = (donutOptions: DonutSpecOptions): Signal[
 };
 
 /**
+ * Gets the minimum vertical gap enforced between two colliding advanced labels - the swatch+text
+ * block's full rendered height (name + any visible rows below it) plus a stacking buffer. Uses the
+ * raw (unscaled) block height, not the vertical row-stacking cap's scaled-down height
+ * (getAdvancedLabelRowDy) - collision spacing is about how much room two DIFFERENT labels need
+ * between each other, which is unrelated to how one label's OWN rows compress to fit its own
+ * reserved space near the ring's top/bottom pole.
+ * @param advancedLabelOptions
+ * @returns vega expression string
+ */
+const getAdvancedLabelMinGapExpr = ({ donutOptions, percent, detail }: AdvancedLabelSpecOptions): string => {
+  const { name } = donutOptions;
+  const nameSize = `${name}_advancedLabelNameFontSize`;
+  const valueSize = `${name}_advancedLabelValueFontSize`;
+  const detailSize = `${name}_advancedLabelDetailFontSize`;
+  const valueHeight = percent ? ` + ${DONUT_ADVANCED_LABEL_NAME_VALUE_GAP} + ${valueSize}` : '';
+  const detailHeight = detail ? ` + ${DONUT_ADVANCED_LABEL_VALUE_DETAIL_GAP} + ${detailSize}` : '';
+  return `${nameSize}${valueHeight}${detailHeight} + ${DONUT_LABEL_COLLISION_MIN_GAP_BUFFER}`;
+};
+
+/**
+ * Gets the derived, collision-adjusted data source advanced label marks read from. Excludes
+ * segments below the min-angle threshold entirely, mirroring getSegmentLabelData.
+ * @param donutOptions
+ * @returns SourceData[]
+ */
+export const getAdvancedLabelData = (donutOptions: DonutSpecOptions): SourceData[] => {
+  const advancedLabel = getAdvancedLabel(donutOptions);
+  if (!advancedLabel) return [];
+  const { name } = donutOptions;
+  const arcThetaExpr = `datum['${name}_arcTheta']`;
+  const outerRadiusExpr = getDonutOuterRadiusExpr(donutOptions);
+  return [
+    {
+      name: getAdvancedLabelDataName(name),
+      source: FILTERED_TABLE,
+      transform: [
+        { type: 'filter', expr: `datum['${name}_arcLength'] >= ${DONUT_SEGMENT_LABEL_MIN_ANGLE}` },
+        ...getLabelCollisionTransforms(
+          getAdvancedLabelFieldPrefix(name),
+          arcThetaExpr,
+          getAdvancedLabelAnchorRadiusExpr(donutOptions),
+          outerRadiusExpr,
+          `${DONUT_LABEL_RING_GAP}`,
+          getAdvancedLabelMinGapExpr(advancedLabel)
+        ),
+      ],
+    },
+  ];
+};
+
+/**
  * Gets the text value ref for the advanced label's value/percent row (same shape as SegmentLabel's)
  * @param advancedLabelOptions
  * @returns TextValueRef
@@ -196,7 +279,8 @@ const getAdvancedLabelAnchorDxExpr = (options: AdvancedLabelSpecOptions): string
   const cappedWidthExpr = `min(${widerWidthExpr}, ${getDonutOuterRadiusExpr(
     donutOptions
   )} * ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO})`;
-  return `(datum['${name}_arcTheta'] <= PI ? 0 : -(${cappedWidthExpr}))`;
+  const hemisphereField = getHemisphereField(getAdvancedLabelFieldPrefix(name));
+  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${cappedWidthExpr}))`;
 };
 
 /**
@@ -260,7 +344,7 @@ const getAdvancedLabelRowDy = (
     topNameDy = '0';
   }
 
-  const isTopHalfExpr = `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI`;
+  const isTopHalfExpr = getIsTopHalfExpr(getAdvancedLabelFieldPrefix(name));
   return {
     name: `${isTopHalfExpr} ? (${topNameDy}) : 0`,
     value: percent ? `${isTopHalfExpr} ? (${topValueDy}) : (${bottomValueDy})` : undefined,
@@ -270,19 +354,27 @@ const getAdvancedLabelRowDy = (
 
 /**
  * Gets the shared x/align/baseline encodes common to every row and the swatch in an advanced label
- * block - all rows (and the swatch) share the same anchor x and hemisphere-mirrored dx.
+ * block - all rows (and the swatch) share the same collision-adjusted anchor x/y and
+ * hemisphere-mirrored dx. Position comes from the derived data source's per-hemisphere cascade
+ * fields (donutLabelCollisionUtils.ts), not a fixed radius+theta polar anchor, since the ring's
+ * horizontal half-width must be re-measured at each label's (possibly collision-shifted) Y.
  * @param advancedLabelOptions
  * @returns TextEncodeEntry
  */
 const getAdvancedLabelSharedEncode = (options: AdvancedLabelSpecOptions): TextEncodeEntry => {
   const { name } = options.donutOptions;
+  const fieldPrefix = getAdvancedLabelFieldPrefix(name);
+  const hemisphereField = getHemisphereField(fieldPrefix);
+  const halfWidthField = getCollisionHalfWidthField(fieldPrefix);
   return {
-    radius: { signal: getAdvancedLabelAnchorRadiusExpr(options.donutOptions) },
-    theta: { field: `${name}_arcTheta` },
+    x: {
+      signal: `datum['${hemisphereField}'] === 'right' ? width / 2 + datum['${halfWidthField}'] : width / 2 - datum['${halfWidthField}']`,
+    },
+    y: { field: getAdjustedYField(fieldPrefix) },
     dx: { signal: getAdvancedLabelAnchorDxExpr(options) },
     align: { value: 'left' },
     baseline: {
-      signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? 'bottom' : 'top'`,
+      signal: `${getIsTopHalfExpr(fieldPrefix)} ? 'bottom' : 'top'`,
     },
   };
 };
@@ -295,40 +387,44 @@ const getAdvancedLabelSharedEncode = (options: AdvancedLabelSpecOptions): TextEn
  * @returns ProductionRule<{ signal?: string; value?: number }>
  */
 const getAdvancedLabelFontSize = (name: string, fontSizeSignal: string) => [
+  // hide all labels when there isn't any data to display, the empty state ring is shown instead.
+  // segments below DONUT_SEGMENT_LABEL_MIN_ANGLE are already excluded from the label data source
+  // (getAdvancedLabelData) entirely, so there's no need to zero their font size here too
   { test: getDonutEmptyStateTest(name), value: 0 },
-  { test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 },
   { signal: fontSizeSignal },
 ];
 
 /**
  * Gets the swatch mark - always the leftmost element of the block, on both hemispheres. Symbol
- * marks have no radius/theta/dx encode channels (those are text-mark-only per Vega's spec), so
- * this replicates Vega's own polar-to-cartesian conversion (vega-scenegraph text.js anchorPoint:
- * x = cx + r*sin(theta), y = cy - r*cos(theta)) directly as x/y signal expressions, then nudges y
- * from the name row's own anchor to sit at that text's optical vertical center.
+ * marks have no radius/theta/dx encode channels (those are text-mark-only per Vega's spec), so its
+ * x/y read the same collision-adjusted fields (donutLabelCollisionUtils.ts) the text rows use,
+ * rather than re-deriving polar position independently - the ideal-Y-to-pixel conversion happens
+ * once, inside the shared derived data source, not per-mark. y is then nudged from the name row's
+ * own anchor to sit at that text's optical vertical center.
  * @param advancedLabelOptions
  * @returns SymbolMark
  */
 const getAdvancedLabelSwatchMark = (options: AdvancedLabelSpecOptions): SymbolMark => {
   const { donutOptions } = options;
   const { color, colorScheme, name } = donutOptions;
-  const arcThetaExpr = `datum['${name}_arcTheta']`;
-  const radiusExpr = getAdvancedLabelAnchorRadiusExpr(donutOptions);
+  const fieldPrefix = getAdvancedLabelFieldPrefix(name);
+  const hemisphereField = getHemisphereField(fieldPrefix);
+  const halfWidthField = getCollisionHalfWidthField(fieldPrefix);
   const dxExpr = getAdvancedLabelAnchorDxExpr(options);
   const rowDy = getAdvancedLabelRowDy(options);
-  const isTopHalfExpr = `${arcThetaExpr} <= 0.5 * PI || ${arcThetaExpr} >= 1.5 * PI`;
+  const isTopHalfExpr = getIsTopHalfExpr(fieldPrefix);
   const nameFontSize = `${name}_advancedLabelNameFontSize`;
 
-  const polarX = `width / 2 + (${radiusExpr}) * sin(${arcThetaExpr})`;
-  const polarY = `height / 2 - (${radiusExpr}) * cos(${arcThetaExpr})`;
-  const nameAnchorY = `(${polarY}) + (${rowDy.name})`;
+  const anchorX = `datum['${hemisphereField}'] === 'right' ? width / 2 + datum['${halfWidthField}'] : width / 2 - datum['${halfWidthField}']`;
+  const anchorY = `datum['${getAdjustedYField(fieldPrefix)}']`;
+  const nameAnchorY = `(${anchorY}) + (${rowDy.name})`;
   // shift from the name row's baseline anchor to its optical vertical center
   const nameCenterY = `(${nameAnchorY}) + (${isTopHalfExpr} ? -(${nameFontSize} * 0.5) : (${nameFontSize} * 0.5))`;
 
   return {
     type: 'symbol',
     name: `${name}_advancedLabelSwatch`,
-    from: { data: FILTERED_TABLE },
+    from: { data: getAdvancedLabelDataName(name) },
     encode: {
       enter: {
         shape: { value: getPathFromSymbolShape('rounded-square') },
@@ -337,7 +433,7 @@ const getAdvancedLabelSwatchMark = (options: AdvancedLabelSpecOptions): SymbolMa
       update: {
         // symbol marks' x is their center, unlike text's left-aligned x+dx - shift right by half
         // the swatch so its rendered left edge lines up with the value/detail rows' left edge
-        x: { signal: `(${polarX}) + (${dxExpr}) + ${DONUT_ADVANCED_LABEL_SWATCH_SIZE / 2}` },
+        x: { signal: `(${anchorX}) + (${dxExpr}) + ${DONUT_ADVANCED_LABEL_SWATCH_SIZE / 2}` },
         y: { signal: nameCenterY },
         size: getAdvancedLabelFontSize(name, `${DONUT_ADVANCED_LABEL_SWATCH_SIZE * DONUT_ADVANCED_LABEL_SWATCH_SIZE}`),
         opacity: getMarkOpacity(donutOptions),
@@ -359,15 +455,13 @@ const getAdvancedLabelNameTextMark = (options: AdvancedLabelSpecOptions): TextMa
   return {
     type: 'text',
     name: `${name}_advancedLabelName`,
-    from: { data: FILTERED_TABLE },
+    from: { data: getAdvancedLabelDataName(name) },
     encode: {
       enter: {
         text: [{ test: getDonutEmptyStateTest(name), value: '' }, { field: labelKey ?? color }],
         fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
       },
       update: {
-        x: { signal: 'width / 2' },
-        y: { signal: 'height / 2' },
         ...shared,
         // name row starts after the swatch + its gap
         dx: { signal: `${getAdvancedLabelAnchorDxExpr(options)} + ${DONUT_ADVANCED_LABEL_SWATCH_SIZE} + ${DONUT_ADVANCED_LABEL_SWATCH_GAP}` },
@@ -397,15 +491,13 @@ const getAdvancedLabelValueTextMark = (options: AdvancedLabelSpecOptions): TextM
     {
       type: 'text',
       name: `${name}_advancedLabelValue`,
-      from: { data: FILTERED_TABLE },
+      from: { data: getAdvancedLabelDataName(name) },
       encode: {
         enter: {
           text: [{ test: getDonutEmptyStateTest(name), value: '' }, ...valueTextRules],
           fontWeight: { value: DONUT_ADVANCED_LABEL_VALUE_FONT_WEIGHT },
         },
         update: {
-          x: { signal: 'width / 2' },
-          y: { signal: 'height / 2' },
           ...shared,
           dy: { signal: rowDy.value as string },
           fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelValueFontSize`),
@@ -432,15 +524,13 @@ const getAdvancedLabelDetailTextMark = (options: AdvancedLabelSpecOptions): Text
     {
       type: 'text',
       name: `${name}_advancedLabelDetail`,
-      from: { data: FILTERED_TABLE },
+      from: { data: getAdvancedLabelDataName(name) },
       encode: {
         enter: {
           text: [{ test: getDonutEmptyStateTest(name), value: '' }, getAdvancedLabelDetailText(options)],
           fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
         },
         update: {
-          x: { signal: 'width / 2' },
-          y: { signal: 'height / 2' },
           ...shared,
           dy: { signal: rowDy.detail as string },
           fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelDetailFontSize`),

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
@@ -292,10 +292,10 @@ const getAdvancedLabelWidthExprs = (
 
 /**
  * Gets the widest-row-capped pixel width shared by the whole swatch+text block - the same value
- * used both to cap the left-hemisphere pull-back (getAdvancedLabelAnchorDxExpr) and as each row's
+ * used both to cap the left-hemisphere shift (getAdvancedLabelAnchorDxExpr) and as each row's
  * truncation limit (getAdvancedLabelLimitExpr), so a row's real rendered width can never exceed the
- * distance it was pulled back by. Without both using this same capped value, a row wider than the
- * cap would undershoot its pull-back and its near-ring edge would land past the anchor, into the
+ * distance it was shifted by. Without both using this same capped value, a row wider than the
+ * cap would undershoot its shift and its near-ring edge would land past the anchor, into the
  * ring itself - confirmed live (a long detail row overlapping the ring at ~195px outer diameter).
  * @param advancedLabelOptions
  * @returns vega expression string
@@ -318,8 +318,8 @@ const getAdvancedLabelAnchorDxExpr = (options: AdvancedLabelSpecOptions): string
 };
 
 /**
- * Gets a row's truncation limit - only the left hemisphere is ever capped (its pull-back is what's
- * bounded by getAdvancedLabelCappedWidthExpr); the right hemisphere has no pull-back at all (dx is
+ * Gets a row's truncation limit - only the left hemisphere is ever capped (its shift is what's
+ * bounded by getAdvancedLabelCappedWidthExpr); the right hemisphere has no shift at all (dx is
  * always 0, growing freely away from the ring) and must not be truncated by that same cap, or every
  * row - even ones that fit comfortably - gets needlessly cut off. `0` is Vega's "no limit" value.
  *
@@ -528,7 +528,7 @@ const getAdvancedLabelNameTextMark = (options: AdvancedLabelSpecOptions): TextMa
         dx: { signal: `${getAdvancedLabelAnchorDxExpr(options)} + ${DONUT_ADVANCED_LABEL_SWATCH_SIZE} + ${DONUT_ADVANCED_LABEL_SWATCH_GAP}` },
         dy: { signal: rowDy.name },
         fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelNameFontSize`),
-        // truncates (ellipsis) if the text alone would push the row past the same cap the pull-back
+        // truncates (ellipsis) if the text alone would push the row past the same cap the shift
         // already assumed - the swatch+gap are already reserved out of the cap, so only the
         // remainder is available to the text itself
         limit: {
@@ -607,7 +607,7 @@ const getAdvancedLabelDetailTextMark = (options: AdvancedLabelSpecOptions): Text
           dy: { signal: rowDy.detail as string },
           fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelDetailFontSize`),
           // truncates (ellipsis) if this row alone is what pushed the block past its cap - fixes
-          // the observed overlap where a long "X out of Y" detail row extended past the pull-back
+          // the observed overlap where a long "X out of Y" detail row extended past the shift
           // and into the ring itself
           limit: { signal: getAdvancedLabelLimitExpr(options) },
           opacity: getMarkOpacity(donutOptions),

--- a/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/advancedLabelUtils.ts
@@ -27,6 +27,7 @@ import {
   DONUT_ADVANCED_LABEL_NAME_FONT_SIZES,
   DONUT_ADVANCED_LABEL_NAME_FONT_WEIGHT,
   DONUT_ADVANCED_LABEL_NAME_VALUE_GAP,
+  DONUT_ADVANCED_LABEL_RING_GAP,
   DONUT_ADVANCED_LABEL_SWATCH_GAP,
   DONUT_ADVANCED_LABEL_SWATCH_SIZE,
   DONUT_ADVANCED_LABEL_VALUE_DETAIL_GAP,
@@ -34,7 +35,7 @@ import {
   DONUT_ADVANCED_LABEL_VALUE_FONT_WEIGHT,
   DONUT_LABEL_COLLISION_MIN_GAP_BUFFER,
   DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
-  DONUT_LABEL_RING_GAP,
+  DONUT_RADIUS,
   DONUT_SEGMENT_LABEL_MIN_ANGLE,
   DONUT_SIZE_TIER_CUTPOINTS,
   FILTERED_TABLE,
@@ -204,7 +205,7 @@ export const getAdvancedLabelData = (donutOptions: DonutSpecOptions): SourceData
           arcThetaExpr,
           getAdvancedLabelAnchorRadiusExpr(donutOptions),
           outerRadiusExpr,
-          `${DONUT_LABEL_RING_GAP}`,
+          `${DONUT_ADVANCED_LABEL_RING_GAP}`,
           getAdvancedLabelMinGapExpr(advancedLabel)
         ),
       ],
@@ -251,16 +252,19 @@ const getAdvancedLabelDetailText = ({ donutOptions, valueFormat }: AdvancedLabel
  * @returns vega expression string
  */
 const getAdvancedLabelAnchorRadiusExpr = (donutOptions: DonutSpecOptions): string =>
-  `${getDonutOuterRadiusExpr(donutOptions)} + ${DONUT_LABEL_RING_GAP}`;
+  `${getDonutOuterRadiusExpr(donutOptions)} + ${DONUT_ADVANCED_LABEL_RING_GAP}`;
 
 /**
- * Gets the shared horizontal pixel offset for the whole swatch+text block, mirroring
- * donut-direct-labels' single-line technique but measuring the widest of all rows (swatch+name,
- * value/%, and detail) rather than just two text lines.
+ * Gets the pieces behind the widest-row-capped pixel width shared by the whole swatch+text block:
+ * the real (uncapped) widest-row width, the max horizontal reach available before hitting the
+ * container's edge, and the smaller of the two. Returned separately (not just the final capped
+ * value) so callers can tell whether the cap actually did anything - see getAdvancedLabelLimitExpr.
  * @param advancedLabelOptions
- * @returns vega expression string
+ * @returns vega expression strings for the widest real row width, the max available reach, and the capped result
  */
-const getAdvancedLabelAnchorDxExpr = (options: AdvancedLabelSpecOptions): string => {
+const getAdvancedLabelWidthExprs = (
+  options: AdvancedLabelSpecOptions
+): { widerWidthExpr: string; maxReachExpr: string; cappedWidthExpr: string } => {
   const { donutOptions, labelKey, percent, detail } = options;
   const { color, name } = donutOptions;
   const nameTextExpr = `datum['${labelKey ?? color}']`;
@@ -276,11 +280,68 @@ const getAdvancedLabelAnchorDxExpr = (options: AdvancedLabelSpecOptions): string
       )}, ${DONUT_ADVANCED_LABEL_DETAIL_FONT_WEIGHT}, ${name}_advancedLabelDetailFontSize)`
     : '0';
   const widerWidthExpr = `max(${nameWidthExpr}, max(${valueWidthExpr}, ${detailWidthExpr}))`;
-  const cappedWidthExpr = `min(${widerWidthExpr}, ${getDonutOuterRadiusExpr(
-    donutOptions
-  )} * ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO})`;
+  // the cap is per-label, not a flat outerRadius*ratio - it's however much horizontal room remains
+  // between this label's own anchor point (collisionHalfWidth, which shrinks away from the ring's
+  // equator) and the container's actual edge (DONUT_RADIUS). A flat ratio-based cap matches this
+  // exactly only at the equator (the original worst-case it was derived for); away from the equator
+  // it leaves real, visible unused space between the label and the container edge.
+  const halfWidthField = getCollisionHalfWidthField(getAdvancedLabelFieldPrefix(name));
+  const maxReachExpr = `${DONUT_RADIUS} - datum['${halfWidthField}']`;
+  return { widerWidthExpr, maxReachExpr, cappedWidthExpr: `min(${widerWidthExpr}, ${maxReachExpr})` };
+};
+
+/**
+ * Gets the widest-row-capped pixel width shared by the whole swatch+text block - the same value
+ * used both to cap the left-hemisphere pull-back (getAdvancedLabelAnchorDxExpr) and as each row's
+ * truncation limit (getAdvancedLabelLimitExpr), so a row's real rendered width can never exceed the
+ * distance it was pulled back by. Without both using this same capped value, a row wider than the
+ * cap would undershoot its pull-back and its near-ring edge would land past the anchor, into the
+ * ring itself - confirmed live (a long detail row overlapping the ring at ~195px outer diameter).
+ * @param advancedLabelOptions
+ * @returns vega expression string
+ */
+const getAdvancedLabelCappedWidthExpr = (options: AdvancedLabelSpecOptions): string =>
+  getAdvancedLabelWidthExprs(options).cappedWidthExpr;
+
+/**
+ * Gets the shared horizontal pixel offset for the whole swatch+text block, mirroring
+ * donut-direct-labels' single-line technique but measuring the widest of all rows (swatch+name,
+ * value/%, and detail) rather than just two text lines.
+ * @param advancedLabelOptions
+ * @returns vega expression string
+ */
+const getAdvancedLabelAnchorDxExpr = (options: AdvancedLabelSpecOptions): string => {
+  const { donutOptions } = options;
+  const { name } = donutOptions;
   const hemisphereField = getHemisphereField(getAdvancedLabelFieldPrefix(name));
-  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${cappedWidthExpr}))`;
+  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${getAdvancedLabelCappedWidthExpr(options)}))`;
+};
+
+/**
+ * Gets a row's truncation limit - only the left hemisphere is ever capped (its pull-back is what's
+ * bounded by getAdvancedLabelCappedWidthExpr); the right hemisphere has no pull-back at all (dx is
+ * always 0, growing freely away from the ring) and must not be truncated by that same cap, or every
+ * row - even ones that fit comfortably - gets needlessly cut off. `0` is Vega's "no limit" value.
+ *
+ * Left-hemisphere rows are ALSO only limited when their real width genuinely exceeds the available
+ * reach (widerWidth > maxReach) - when it doesn't, the cap equals the row's own exact natural width
+ * (min(widerWidth, maxReach) picks widerWidth), and setting `limit` to that exact value is a
+ * razor's-edge boundary: our own width estimate and Vega's internal text-measurement can round
+ * against each other by a fraction of a pixel, truncating a character that didn't need to go.
+ * Passing `0` (no limit) whenever nothing was actually capped avoids that boundary entirely -
+ * confirmed live (a "7,045 out of 40,365" detail row losing its last two digits despite its full,
+ * untruncated width measuring under the available margin).
+ * @param advancedLabelOptions
+ * @param extraReservedWidthExpr width already reserved outside the text itself (e.g. the name row's
+ * swatch + gap), subtracted from the cap before truncating
+ * @returns vega expression string
+ */
+const getAdvancedLabelLimitExpr = (options: AdvancedLabelSpecOptions, extraReservedWidthExpr = '0'): string => {
+  const { donutOptions } = options;
+  const { name } = donutOptions;
+  const hemisphereField = getHemisphereField(getAdvancedLabelFieldPrefix(name));
+  const { widerWidthExpr, maxReachExpr, cappedWidthExpr } = getAdvancedLabelWidthExprs(options);
+  return `datum['${hemisphereField}'] === 'right' || (${widerWidthExpr}) <= (${maxReachExpr}) ? 0 : (${cappedWidthExpr}) - (${extraReservedWidthExpr})`;
 };
 
 /**
@@ -467,6 +528,15 @@ const getAdvancedLabelNameTextMark = (options: AdvancedLabelSpecOptions): TextMa
         dx: { signal: `${getAdvancedLabelAnchorDxExpr(options)} + ${DONUT_ADVANCED_LABEL_SWATCH_SIZE} + ${DONUT_ADVANCED_LABEL_SWATCH_GAP}` },
         dy: { signal: rowDy.name },
         fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelNameFontSize`),
+        // truncates (ellipsis) if the text alone would push the row past the same cap the pull-back
+        // already assumed - the swatch+gap are already reserved out of the cap, so only the
+        // remainder is available to the text itself
+        limit: {
+          signal: getAdvancedLabelLimitExpr(
+            options,
+            `${DONUT_ADVANCED_LABEL_SWATCH_SIZE} + ${DONUT_ADVANCED_LABEL_SWATCH_GAP}`
+          ),
+        },
         opacity: getMarkOpacity(donutOptions),
       },
     },
@@ -501,6 +571,8 @@ const getAdvancedLabelValueTextMark = (options: AdvancedLabelSpecOptions): TextM
           ...shared,
           dy: { signal: rowDy.value as string },
           fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelValueFontSize`),
+          // truncates (ellipsis) if this row alone is what pushed the block past its cap
+          limit: { signal: getAdvancedLabelLimitExpr(options) },
           fill: getLabelValueFill(donutOptions, 'gray-800'),
           opacity: getMarkOpacity(donutOptions),
         },
@@ -534,6 +606,10 @@ const getAdvancedLabelDetailTextMark = (options: AdvancedLabelSpecOptions): Text
           ...shared,
           dy: { signal: rowDy.detail as string },
           fontSize: getAdvancedLabelFontSize(name, `${name}_advancedLabelDetailFontSize`),
+          // truncates (ellipsis) if this row alone is what pushed the block past its cap - fixes
+          // the observed overlap where a long "X out of Y" detail row extended past the pull-back
+          // and into the ring itself
+          limit: { signal: getAdvancedLabelLimitExpr(options) },
           opacity: getMarkOpacity(donutOptions),
         },
       },

--- a/packages/vega-spec-builder-s2/src/donut/donutLabelCollisionUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutLabelCollisionUtils.ts
@@ -57,6 +57,10 @@ export const getLabelCollisionTransforms = (
   const runningMaxField = getCollisionField(fieldPrefix, 'collisionRunningMax');
   const adjustedYField = getAdjustedYField(fieldPrefix);
   const halfWidthField = getCollisionHalfWidthField(fieldPrefix);
+  // minGapExpr is a bare additive expression (e.g. "nameFontSize + valueFontSize + 16"), not a
+  // single atomic term - parenthesize before multiplying, or operator precedence silently turns
+  // "idealY - minGapExpr * rank" into "idealY - nameFontSize + valueFontSize + (16 * rank)"
+  const safeMinGapExpr = `(${minGapExpr})`;
 
   return [
     { type: 'formula', as: hemisphereField, expr: `${arcThetaExpr} <= PI ? 'right' : 'left'` },
@@ -72,7 +76,7 @@ export const getLabelCollisionTransforms = (
     },
     // row_number is 1-indexed; the cascade formula's rank is 0-indexed
     { type: 'formula', as: rankField, expr: `datum['${rankField}'] - 1` },
-    { type: 'formula', as: helperField, expr: `datum['${idealYField}'] - ${minGapExpr} * datum['${rankField}']` },
+    { type: 'formula', as: helperField, expr: `datum['${idealYField}'] - ${safeMinGapExpr} * datum['${rankField}']` },
     {
       type: 'window',
       groupby: [hemisphereField],
@@ -85,7 +89,7 @@ export const getLabelCollisionTransforms = (
     {
       type: 'formula',
       as: adjustedYField,
-      expr: `datum['${runningMaxField}'] + ${minGapExpr} * datum['${rankField}']`,
+      expr: `datum['${runningMaxField}'] + ${safeMinGapExpr} * datum['${rankField}']`,
     },
     {
       type: 'formula',

--- a/packages/vega-spec-builder-s2/src/donut/donutLabelCollisionUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutLabelCollisionUtils.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FormulaTransform, WindowTransform } from 'vega';
+
+/**
+ * Gets the field name this util writes for a given field prefix and suffix
+ * @param fieldPrefix
+ * @param suffix
+ * @returns field name
+ */
+const getCollisionField = (fieldPrefix: string, suffix: string): string => `${fieldPrefix}_${suffix}`;
+
+/** Field holding which hemisphere ('left' | 'right') a row's label anchors in */
+export const getHemisphereField = (fieldPrefix: string): string => getCollisionField(fieldPrefix, 'hemisphere');
+
+/** Field holding a row's collision-adjusted absolute Y position */
+export const getAdjustedYField = (fieldPrefix: string): string => getCollisionField(fieldPrefix, 'adjustedY');
+
+/** Field holding the ring's horizontal half-width (plus ring gap) at a row's adjusted Y */
+export const getCollisionHalfWidthField = (fieldPrefix: string): string =>
+  getCollisionField(fieldPrefix, 'collisionHalfWidth');
+
+/**
+ * Gets the data transforms that cascade a hemisphere's labels vertically to avoid overlap (sorted by
+ * their pre-collision ideal Y, closed-form running-max shortcut - see llm/skills/s2-donut/donut-label-collision),
+ * then re-anchor each label horizontally against the ring's actual half-width at its adjusted Y, since
+ * reusing the original angle-derived anchor after a Y-shift is an observed failure mode.
+ * @param fieldPrefix unique prefix for the fields this util writes, so multiple label types can coexist
+ * @param arcThetaExpr vega expression for the row's arc center angle, e.g. `datum['name_arcTheta']`
+ * @param idealRadiusExpr vega expression for the label's pre-collision anchor radius (outer radius + ring gap)
+ * @param outerRadiusExpr vega expression for the donut's (label-reserved) outer radius alone
+ * @param ringGapExpr vega expression (or literal) for the ring gap, re-added after the horizontal re-anchor
+ * @param minGapExpr vega expression for the minimum vertical gap enforced between adjacent labels
+ * @returns transforms to append to a label-specific derived data source
+ */
+export const getLabelCollisionTransforms = (
+  fieldPrefix: string,
+  arcThetaExpr: string,
+  idealRadiusExpr: string,
+  outerRadiusExpr: string,
+  ringGapExpr: string,
+  minGapExpr: string
+): (FormulaTransform | WindowTransform)[] => {
+  const hemisphereField = getHemisphereField(fieldPrefix);
+  const idealYField = getCollisionField(fieldPrefix, 'idealY');
+  const rankField = getCollisionField(fieldPrefix, 'collisionRank');
+  const helperField = getCollisionField(fieldPrefix, 'collisionHelper');
+  const runningMaxField = getCollisionField(fieldPrefix, 'collisionRunningMax');
+  const adjustedYField = getAdjustedYField(fieldPrefix);
+  const halfWidthField = getCollisionHalfWidthField(fieldPrefix);
+
+  return [
+    { type: 'formula', as: hemisphereField, expr: `${arcThetaExpr} <= PI ? 'right' : 'left'` },
+    // matches Vega's own theta/radius-to-xy conversion (vega-scenegraph text.js anchorPoint):
+    // x = cx + r*sin(theta), y = cy - r*cos(theta) (theta=0 is top, increasing clockwise)
+    { type: 'formula', as: idealYField, expr: `height / 2 - (${idealRadiusExpr}) * cos(${arcThetaExpr})` },
+    {
+      type: 'window',
+      groupby: [hemisphereField],
+      sort: { field: idealYField, order: 'ascending' },
+      ops: ['row_number'],
+      as: [rankField],
+    },
+    // row_number is 1-indexed; the cascade formula's rank is 0-indexed
+    { type: 'formula', as: rankField, expr: `datum['${rankField}'] - 1` },
+    { type: 'formula', as: helperField, expr: `datum['${idealYField}'] - ${minGapExpr} * datum['${rankField}']` },
+    {
+      type: 'window',
+      groupby: [hemisphereField],
+      sort: { field: idealYField, order: 'ascending' },
+      ops: ['max'],
+      fields: [helperField],
+      frame: [null, 0],
+      as: [runningMaxField],
+    },
+    {
+      type: 'formula',
+      as: adjustedYField,
+      expr: `datum['${runningMaxField}'] + ${minGapExpr} * datum['${rankField}']`,
+    },
+    {
+      type: 'formula',
+      as: halfWidthField,
+      expr: `sqrt(max(0, pow(${outerRadiusExpr}, 2) - pow(datum['${adjustedYField}'] - height / 2, 2))) + (${ringGapExpr})`,
+    },
+  ];
+};

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -44,7 +44,12 @@ import {
   getSumData,
 } from './donutUtils';
 import { getAdvancedLabelMarks, getAdvancedLabelScales, getAdvancedLabelSignals } from './advancedLabelUtils';
-import { getSegmentLabelMarks, getSegmentLabelScales, getSegmentLabelSignals } from './segmentLabelUtils';
+import {
+  getSegmentLabelData,
+  getSegmentLabelMarks,
+  getSegmentLabelScales,
+  getSegmentLabelSignals,
+} from './segmentLabelUtils';
 
 export const addDonut = produce<
   ScSpec,
@@ -136,7 +141,7 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
     });
   }
   // used to detect the empty state (no data or all metric values are 0)
-  data.push(getSumData(options), ...getDonutSummaryData(options));
+  data.push(getSumData(options), ...getDonutSummaryData(options), ...getSegmentLabelData(options));
 });
 
 const getPieTransforms = ({ startAngle, metric, name }: DonutSpecOptions): (FormulaTransform | PieTransform)[] => [

--- a/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutSpecBuilder.ts
@@ -43,7 +43,12 @@ import {
   getSliceGapSignal,
   getSumData,
 } from './donutUtils';
-import { getAdvancedLabelMarks, getAdvancedLabelScales, getAdvancedLabelSignals } from './advancedLabelUtils';
+import {
+  getAdvancedLabelData,
+  getAdvancedLabelMarks,
+  getAdvancedLabelScales,
+  getAdvancedLabelSignals,
+} from './advancedLabelUtils';
 import {
   getSegmentLabelData,
   getSegmentLabelMarks,
@@ -141,7 +146,12 @@ export const addData = produce<Data[], [DonutSpecOptions]>((data, options) => {
     });
   }
   // used to detect the empty state (no data or all metric values are 0)
-  data.push(getSumData(options), ...getDonutSummaryData(options), ...getSegmentLabelData(options));
+  data.push(
+    getSumData(options),
+    ...getDonutSummaryData(options),
+    ...getSegmentLabelData(options),
+    ...getAdvancedLabelData(options)
+  );
 });
 
 const getPieTransforms = ({ startAngle, metric, name }: DonutSpecOptions): (FormulaTransform | PieTransform)[] => [

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  */
 import {
+  DONUT_ADVANCED_LABEL_RING_GAP,
+  DONUT_LABEL_RING_GAP,
+  DONUT_RADIUS,
   DONUT_RING_WIDTHS,
   DONUT_SIZE_TIER_CUTPOINTS,
   DONUT_SLICE_GAPS,
@@ -22,6 +25,7 @@ import {
   getArcMark,
   getDonutEmptyStateTest,
   getDonutInnerRadiusExpr,
+  getDonutOuterRadiusExpr,
   getEmptyStateArcMark,
   getRingWidthScale,
   getRingWidthSignal,
@@ -34,6 +38,33 @@ describe('getDonutEmptyStateTest()', () => {
   test('should test for empty data and a metric sum of 0', () => {
     const test = getDonutEmptyStateTest('testName');
     expect(test).toBe(`length(data('${FILTERED_TABLE}')) === 0 || !data('testName_sumData')[0]['sum']`);
+  });
+});
+
+describe('getDonutOuterRadiusExpr()', () => {
+  test('should return the raw donut radius when neither SegmentLabel nor AdvancedLabel is present', () => {
+    expect(getDonutOuterRadiusExpr(defaultDonutOptions)).toBe(DONUT_RADIUS);
+  });
+
+  test('should return the raw donut radius for isBoolean donuts, even with labels configured', () => {
+    expect(
+      getDonutOuterRadiusExpr({ ...defaultDonutOptions, isBoolean: true, segmentLabels: [{}], advancedLabels: [{}] })
+    ).toBe(DONUT_RADIUS);
+  });
+
+  test('should reserve room using the direct-label ring gap when only SegmentLabel is present', () => {
+    const expr = getDonutOuterRadiusExpr({ ...defaultDonutOptions, segmentLabels: [{}] });
+    expect(expr).toBe(`((${DONUT_RADIUS} - ${DONUT_LABEL_RING_GAP}) / (1 + 0.6))`);
+  });
+
+  test('should reserve room using the (larger) advanced-label ring gap when only AdvancedLabel is present', () => {
+    const expr = getDonutOuterRadiusExpr({ ...defaultDonutOptions, advancedLabels: [{}] });
+    expect(expr).toBe(`((${DONUT_RADIUS} - ${DONUT_ADVANCED_LABEL_RING_GAP}) / (1 + 0.6))`);
+  });
+
+  test('should reserve room using the advanced-label ring gap when both SegmentLabel and AdvancedLabel are present', () => {
+    const expr = getDonutOuterRadiusExpr({ ...defaultDonutOptions, segmentLabels: [{}], advancedLabels: [{}] });
+    expect(expr).toBe(`((${DONUT_RADIUS} - ${DONUT_ADVANCED_LABEL_RING_GAP}) / (1 + 0.6))`);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
@@ -13,6 +13,7 @@ import { ArcMark, ColorValueRef, NumericValueRef, ProductionRule, Signal, Source
 
 import {
   DEFAULT_HOLE_RATIO,
+  DONUT_ADVANCED_LABEL_RING_GAP,
   DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
   DONUT_LABEL_RING_GAP,
   DONUT_RADIUS,
@@ -83,7 +84,11 @@ const getArcFillEncoding = (options: DonutSpecOptions): ColorValueRef | Producti
  * AdvancedLabel's taller (swatch + up to 3 stacked rows) block also has a vertical reach (for a
  * segment anchored near the very top/bottom of the ring), but it's capped against this exact same
  * reserved margin (DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO) rather than growing the reservation itself -
- * see getAdvancedLabelRowDy - so the ring stays the same size as a direct-labels-only donut.
+ * see getAdvancedLabelRowDy. AdvancedLabel does use a larger ring-gap than direct labels
+ * (DONUT_ADVANCED_LABEL_RING_GAP, 40px vs 20px) to give its bulkier block more breathing room, so a
+ * donut with an AdvancedLabel reserves slightly more radius (a slightly smaller ring) than one with
+ * only a SegmentLabel - a deliberate tradeoff, not a bug. When both are present on the same donut,
+ * the larger (advanced) gap is reserved, since that's the actual worst-case requirement.
  * @param donutOptions
  * @returns vega expression string
  */
@@ -91,8 +96,9 @@ export const getDonutOuterRadiusExpr = ({ isBoolean, segmentLabels, advancedLabe
   // DONUT_RADIUS is already parenthesized; the reserved branch below self-parenthesizes too, so
   // callers can interpolate this result directly without adding their own wrapping parens
   if (isBoolean || (!segmentLabels.length && !advancedLabels.length)) return DONUT_RADIUS;
+  const ringGap = advancedLabels.length ? DONUT_ADVANCED_LABEL_RING_GAP : DONUT_LABEL_RING_GAP;
   // solve R such that R + ringGap + R*capRatio == DONUT_RADIUS (the worst-case label reach)
-  return `((${DONUT_RADIUS} - ${DONUT_LABEL_RING_GAP}) / (1 + ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO}))`;
+  return `((${DONUT_RADIUS} - ${ringGap}) / (1 + ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO}))`;
 };
 
 /**

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -209,13 +209,19 @@ describe('getSegmentLabelSignals()', () => {
   });
 });
 
-describe('label anchor radius/dx (hemisphere offset)', () => {
-  test('radius should always be the constant ring-gap point, regardless of hemisphere', () => {
+describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offset)', () => {
+  test('y should come from the collision-adjusted field, not a polar radius/theta anchor', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
-    // radius must never depend on hemisphere/text width - only dx does, so a label's vertical
-    // position never shifts based on label content (see the autosize-shrink regression this guards against)
-    expect(mark.encode?.update?.radius).toEqual({
-      signal: '(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) + 20',
+    expect(mark.encode?.update?.y).toEqual({ field: 'testName_segmentLabel_adjustedY' });
+    expect(mark.encode?.update?.radius).toBeUndefined();
+    expect(mark.encode?.update?.theta).toBeUndefined();
+  });
+
+  test('x should place the anchor at the collision-adjusted ring half-width, mirrored by hemisphere', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    expect(mark.encode?.update?.x).toEqual({
+      signal:
+        "datum['testName_segmentLabel_hemisphere'] === 'right' ? width / 2 + datum['testName_segmentLabel_collisionHalfWidth'] : width / 2 - datum['testName_segmentLabel_collisionHalfWidth']",
     });
   });
 
@@ -223,14 +229,14 @@ describe('label anchor radius/dx (hemisphere offset)', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toBe(
-      "(datum['testName_arcTheta'] <= PI ? 0 : -(min(max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
     );
   });
 
   test('left hemisphere dx offset should account for the wider of name/value widths when value is shown', () => {
     const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
-    // the offset branch (used when arcTheta > PI) must compare name width against the real value text's measured width
+    // the offset branch (used for the left hemisphere) must compare name width against the real value text's measured width
     expect(dxSignal).toContain(
       "max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), getLabelWidth("
     );
@@ -244,14 +250,15 @@ describe('label anchor radius/dx (hemisphere offset)', () => {
     expect(dxSignal).toContain('(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6');
   });
 
-  test('name and value marks should share the exact same radius and dx expressions', () => {
+  test('name and value marks should share the exact same x, y, and dx expressions', () => {
     const nameMark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
     const [valueMark] = getSegmentLabelValueTextMark({ ...defaultSegmentLabelOptions, value: true });
-    expect(nameMark.encode?.update?.radius).toEqual(valueMark.encode?.update?.radius);
+    expect(nameMark.encode?.update?.x).toEqual(valueMark.encode?.update?.x);
+    expect(nameMark.encode?.update?.y).toEqual(valueMark.encode?.update?.y);
     expect(nameMark.encode?.update?.dx).toEqual(valueMark.encode?.update?.dx);
   });
 
-  test('both hemispheres should use left alignment (only dx differs, not align or radius)', () => {
+  test('both hemispheres should use left alignment (only dx differs, not align or y)', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     expect(mark.encode?.update?.align).toEqual({ value: 'left' });
   });
@@ -260,7 +267,7 @@ describe('label anchor radius/dx (hemisphere offset)', () => {
     const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, labelKey: 'region' });
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toBe(
-      "(datum['testName_arcTheta'] <= PI ? 0 : -(min(max(getLabelWidth(datum['region'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['region'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
     );
   });
 });
@@ -274,18 +281,16 @@ describe('getSegmentLabelTextMark()', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     expect(mark.encode?.update?.dy).toBeUndefined();
   });
-  test('name dy should shift by the value line font size, not a fixed px amount, so the gap stays 0px at every tier', () => {
+  test('name dy should shift up when the collision-adjusted position is in the top half, not a fixed px amount, so the gap stays 0px at every tier', () => {
     const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
     expect(mark.encode?.update?.dy).toEqual({
-      signal:
-        "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? -testName_segmentLabelValueFontSize : 0",
+      signal: "datum['testName_segmentLabel_adjustedY'] <= height / 2 ? -testName_segmentLabelValueFontSize : 0",
     });
   });
   test('should hide labels when the donut is in the empty state', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     expect(mark.encode?.update?.fontSize).toEqual([
       { test: getDonutEmptyStateTest('testName'), value: 0 },
-      { test: `datum['testName_arcLength'] < 0.3`, value: 0 },
       { signal: 'testName_segmentLabelNameFontSize' },
     ]);
   });
@@ -321,11 +326,10 @@ describe('s2 styles', () => {
       ]);
     });
 
-    test('value dy should shift by the name line font size, not a fixed px amount, so the gap stays 0px at every tier', () => {
+    test('value dy should shift down when the collision-adjusted position is in the bottom half, not a fixed px amount, so the gap stays 0px at every tier', () => {
       const [mark] = getSegmentLabelValueTextMark({ ...defaultSegmentLabelOptions, value: true });
       expect(mark.encode?.update?.dy).toEqual({
-        signal:
-          "datum['testName_arcTheta'] <= 0.5 * PI || datum['testName_arcTheta'] >= 1.5 * PI ? 0 : testName_segmentLabelNameFontSize",
+        signal: "datum['testName_segmentLabel_adjustedY'] <= height / 2 ? 0 : testName_segmentLabelNameFontSize",
       });
     });
   });

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -229,7 +229,7 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toBe(
-      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['testColor'], 400, testName_segmentLabelNameFontSize), 0), (min(width, height) / 2 - 2) - datum['testName_segmentLabel_collisionHalfWidth'])))"
     );
   });
 
@@ -243,11 +243,13 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     expect(dxSignal).toContain('testName_segmentLabelValueFontSize');
   });
 
-  test('the pull-back should be capped at a fraction of the donut radius', () => {
+  test('the pull-back should be capped at however much room remains before the container edge', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toContain('min(max(getLabelWidth(');
-    expect(dxSignal).toContain('(((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6');
+    // the cap is per-label (available radius minus this label's own ring half-width at its actual
+    // Y), not a flat ratio of the ring's radius - see getWidthExprs
+    expect(dxSignal).toContain("(min(width, height) / 2 - 2) - datum['testName_segmentLabel_collisionHalfWidth']");
   });
 
   test('name and value marks should share the exact same x, y, and dx expressions', () => {
@@ -267,8 +269,33 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     const mark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, labelKey: 'region' });
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toBe(
-      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['region'], 400, testName_segmentLabelNameFontSize), 0), (((min(width, height) / 2 - 2) - 20) / (1 + 0.6)) * 0.6)))"
+      "(datum['testName_segmentLabel_hemisphere'] === 'right' ? 0 : -(min(max(getLabelWidth(datum['region'], 400, testName_segmentLabelNameFontSize), 0), (min(width, height) / 2 - 2) - datum['testName_segmentLabel_collisionHalfWidth'])))"
     );
+  });
+});
+
+describe('truncation limit', () => {
+  test('right hemisphere should never be truncated (limit 0, unlimited) regardless of content width', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    const limitSignal = (mark.encode?.update?.limit as { signal: string }).signal;
+    expect(limitSignal).toContain("datum['testName_segmentLabel_hemisphere'] === 'right' ||");
+    expect(limitSignal).toMatch(/=== 'right'.*\? 0 :/);
+  });
+
+  test('left hemisphere should only apply a real limit when content exceeds the available reach, not the line\'s own natural width', () => {
+    const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
+    const limitSignal = (mark.encode?.update?.limit as { signal: string }).signal;
+    // guards against the razor's-edge case where limit equals the line's own exact width - see
+    // getLimitExpr's doc comment. The comparison must be present so a line that already fits isn't
+    // handed a limit that's numerically identical to its own measured width.
+    expect(limitSignal).toContain('<= (');
+    expect(limitSignal).toContain('? 0 :');
+  });
+
+  test('name and value marks should share the exact same limit expression', () => {
+    const nameMark = getSegmentLabelTextMark({ ...defaultSegmentLabelOptions, value: true });
+    const [valueMark] = getSegmentLabelValueTextMark({ ...defaultSegmentLabelOptions, value: true });
+    expect(nameMark.encode?.update?.limit).toEqual(valueMark.encode?.update?.limit);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.test.tsx
@@ -243,7 +243,7 @@ describe('label anchor x/y (collision-aware positioning) and dx (hemisphere offs
     expect(dxSignal).toContain('testName_segmentLabelValueFontSize');
   });
 
-  test('the pull-back should be capped at however much room remains before the container edge', () => {
+  test('the shift should be capped at however much room remains before the container edge', () => {
     const mark = getSegmentLabelTextMark(defaultSegmentLabelOptions);
     const dxSignal = (mark.encode?.update?.dx as { signal: string }).signal;
     expect(dxSignal).toContain('min(max(getLabelWidth(');

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -28,8 +28,8 @@ import {
   DONUT_DIRECT_LABEL_VALUE_FONT_SIZES,
   DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT,
   DONUT_LABEL_COLLISION_MIN_GAP_BUFFER,
-  DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
   DONUT_LABEL_RING_GAP,
+  DONUT_RADIUS,
   DONUT_SEGMENT_LABEL_MIN_ANGLE,
   DONUT_SIZE_TIER_CUTPOINTS,
   FILTERED_TABLE,
@@ -227,14 +227,16 @@ const getLabelAnchorRadiusExpr = (donutOptions: DonutSpecOptions): string =>
   `${getDonutOuterRadiusExpr(donutOptions)} + ${DONUT_LABEL_RING_GAP}`;
 
 /**
- * Gets each label's horizontal offset (dx). Right-hemisphere labels start right at the ring - no
- * offset needed. Left-hemisphere labels move left by their own width (capped at a fraction of the
- * donut's radius - see DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO), so their far end touches the ring
- * instead of their near end.
+ * Gets the pieces behind the widest-line-capped pixel width shared by a label's name/value lines:
+ * the real (uncapped) widest-line width, the max horizontal reach available before hitting the
+ * container's edge, and the smaller of the two. Returned separately (not just the final capped
+ * value) so callers can tell whether the cap actually did anything - see getLimitExpr.
  * @param segmentLabelOptions
- * @returns vega expression string
+ * @returns vega expression strings for the widest real line width, the max available reach, and the capped result
  */
-const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
+const getWidthExprs = (
+  options: SegmentLabelSpecOptions
+): { widerWidthExpr: string; maxReachExpr: string; cappedWidthExpr: string } => {
   const { donutOptions, labelKey, percent, value } = options;
   const { color, name } = donutOptions;
   const nameTextExpr = `datum['${labelKey ?? color}']`;
@@ -246,13 +248,65 @@ const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
         )}, ${DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT}, ${name}_segmentLabelValueFontSize)`
       : '0';
   const widerWidthExpr = `max(${nameWidthExpr}, ${valueWidthExpr})`;
-  // capped at the same ratio getDonutOuterRadiusExpr already reserved room for, so the worst-case
-  // reach (ring + gap + this cap) exactly matches the space getDonutOuterRadiusExpr solved for
-  const cappedWidthExpr = `min(${widerWidthExpr}, ${getDonutOuterRadiusExpr(
-    donutOptions
-  )} * ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO})`;
+  // the cap is per-label, not a flat outerRadius*ratio - it's however much horizontal room remains
+  // between this label's own anchor point (collisionHalfWidth, which shrinks away from the ring's
+  // equator) and the container's actual edge (DONUT_RADIUS). A flat ratio-based cap matches this
+  // exactly only at the equator (the original worst-case it was derived for); away from the equator
+  // it leaves real, visible unused space between the label and the container edge.
+  const halfWidthField = getCollisionHalfWidthField(getSegmentLabelFieldPrefix(name));
+  const maxReachExpr = `${DONUT_RADIUS} - datum['${halfWidthField}']`;
+  return { widerWidthExpr, maxReachExpr, cappedWidthExpr: `min(${widerWidthExpr}, ${maxReachExpr})` };
+};
+
+/**
+ * Gets the widest-line-capped pixel width shared by a label's name/value lines - the same value used
+ * both to cap the left-hemisphere pull-back (getLabelAnchorDxExpr) and as each line's truncation
+ * limit (see getSegmentLabelTextMark/getSegmentLabelValueTextMark), so a line's real rendered width
+ * can never exceed the distance it was pulled back by. Without both using this same capped value, a
+ * line wider than the cap would undershoot its pull-back and its near-ring edge would land past the
+ * anchor, into the ring itself.
+ * @param segmentLabelOptions
+ * @returns vega expression string
+ */
+const getCappedWidthExpr = (options: SegmentLabelSpecOptions): string => getWidthExprs(options).cappedWidthExpr;
+
+/**
+ * Gets the shared horizontal pixel offset for a label's name/value lines. Right-hemisphere labels get
+ * no offset (anchor sits at the ring-gap point and grows away from the ring). Left-hemisphere labels
+ * get pulled left by the wider line's real rendered width, so that line's far (right) edge lands
+ * exactly on the ring-gap point while both lines still share the same near (left) edge. This is a pure
+ * horizontal (dx) adjustment, independent of theta, so it never distorts a label's vertical position.
+ * @param segmentLabelOptions
+ * @returns vega expression string
+ */
+const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
+  const { donutOptions } = options;
+  const { name } = donutOptions;
   const hemisphereField = getHemisphereField(getSegmentLabelFieldPrefix(name));
-  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${cappedWidthExpr}))`;
+  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${getCappedWidthExpr(options)}))`;
+};
+
+/**
+ * Gets a line's truncation limit - only the left hemisphere is ever capped (its pull-back is what's
+ * bounded by getCappedWidthExpr); the right hemisphere has no pull-back at all (dx is always 0,
+ * growing freely away from the ring) and must not be truncated by that same cap, or every line -
+ * even ones that fit comfortably - gets needlessly cut off. `0` is Vega's "no limit" value.
+ *
+ * Left-hemisphere lines are ALSO only limited when their real width genuinely exceeds the available
+ * reach (widerWidth > maxReach) - when it doesn't, the cap equals the line's own exact natural
+ * width, and setting `limit` to that exact value is a razor's-edge boundary: our own width estimate
+ * and Vega's internal text-measurement can round against each other by a fraction of a pixel,
+ * truncating a character that didn't need to go. Passing `0` (no limit) whenever nothing was
+ * actually capped avoids that boundary entirely.
+ * @param segmentLabelOptions
+ * @returns vega expression string
+ */
+const getLimitExpr = (options: SegmentLabelSpecOptions): string => {
+  const { donutOptions } = options;
+  const { name } = donutOptions;
+  const hemisphereField = getHemisphereField(getSegmentLabelFieldPrefix(name));
+  const { widerWidthExpr, maxReachExpr, cappedWidthExpr } = getWidthExprs(options);
+  return `datum['${hemisphereField}'] === 'right' || (${widerWidthExpr}) <= (${maxReachExpr}) ? 0 : ${cappedWidthExpr}`;
 };
 
 /**
@@ -378,6 +432,9 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
     y: { field: getAdjustedYField(fieldPrefix) },
     // shifts left-hemisphere labels left by the wider line's width - see getLabelAnchorDxExpr
     dx: { signal: getLabelAnchorDxExpr(options) },
+    // truncates (ellipsis) if this line alone is what pushed the pair past their shared cap, so its
+    // real rendered width can never exceed the distance the pull-back already assumed
+    limit: { signal: getLimitExpr(options) },
     fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
     // both hemispheres anchor at their near (left) edge - only the dx offset differs by hemisphere
     align: { value: 'left' },

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -260,10 +260,10 @@ const getWidthExprs = (
 
 /**
  * Gets the widest-line-capped pixel width shared by a label's name/value lines - the same value used
- * both to cap the left-hemisphere pull-back (getLabelAnchorDxExpr) and as each line's truncation
+ * both to cap the left-hemisphere shift (getLabelAnchorDxExpr) and as each line's truncation
  * limit (see getSegmentLabelTextMark/getSegmentLabelValueTextMark), so a line's real rendered width
- * can never exceed the distance it was pulled back by. Without both using this same capped value, a
- * line wider than the cap would undershoot its pull-back and its near-ring edge would land past the
+ * can never exceed the distance it was shifted by. Without both using this same capped value, a
+ * line wider than the cap would undershoot its shift and its near-ring edge would land past the
  * anchor, into the ring itself.
  * @param segmentLabelOptions
  * @returns vega expression string
@@ -273,7 +273,7 @@ const getCappedWidthExpr = (options: SegmentLabelSpecOptions): string => getWidt
 /**
  * Gets the shared horizontal pixel offset for a label's name/value lines. Right-hemisphere labels get
  * no offset (anchor sits at the ring-gap point and grows away from the ring). Left-hemisphere labels
- * get pulled left by the wider line's real rendered width, so that line's far (right) edge lands
+ * shift left by the wider line's real rendered width, so that line's far (right) edge lands
  * exactly on the ring-gap point while both lines still share the same near (left) edge. This is a pure
  * horizontal (dx) adjustment, independent of theta, so it never distorts a label's vertical position.
  * @param segmentLabelOptions
@@ -287,8 +287,8 @@ const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
 };
 
 /**
- * Gets a line's truncation limit - only the left hemisphere is ever capped (its pull-back is what's
- * bounded by getCappedWidthExpr); the right hemisphere has no pull-back at all (dx is always 0,
+ * Gets a line's truncation limit - only the left hemisphere is ever capped (its shift is what's
+ * bounded by getCappedWidthExpr); the right hemisphere has no shift at all (dx is always 0,
  * growing freely away from the ring) and must not be truncated by that same cap, or every line -
  * even ones that fit comfortably - gets needlessly cut off. `0` is Vega's "no limit" value.
  *
@@ -433,7 +433,7 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
     // shifts left-hemisphere labels left by the wider line's width - see getLabelAnchorDxExpr
     dx: { signal: getLabelAnchorDxExpr(options) },
     // truncates (ellipsis) if this line alone is what pushed the pair past their shared cap, so its
-    // real rendered width can never exceed the distance the pull-back already assumed
+    // real rendered width can never exceed the distance the shift already assumed
     limit: { signal: getLimitExpr(options) },
     fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
     // both hemispheres anchor at their near (left) edge - only the dx offset differs by hemisphere

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -15,6 +15,7 @@ import {
   NumericValueRef,
   ProductionRule,
   Signal,
+  SourceData,
   TextEncodeEntry,
   TextMark,
   TextValueRef,
@@ -26,6 +27,7 @@ import {
   DONUT_DIRECT_LABEL_NAME_FONT_WEIGHT,
   DONUT_DIRECT_LABEL_VALUE_FONT_SIZES,
   DONUT_DIRECT_LABEL_VALUE_FONT_WEIGHT,
+  DONUT_LABEL_COLLISION_MIN_GAP_BUFFER,
   DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
   DONUT_LABEL_RING_GAP,
   DONUT_SEGMENT_LABEL_MIN_ANGLE,
@@ -39,7 +41,28 @@ import { getS2ColorValue } from '@spectrum-charts/themes';
 import { getColorProductionRule, getMarkOpacity } from '../marks/markUtils';
 import { getTextNumberFormat } from '../textUtils';
 import { DonutSpecOptions, SegmentLabelOptions, SegmentLabelSpecOptions } from '../types';
+import {
+  getAdjustedYField,
+  getCollisionHalfWidthField,
+  getHemisphereField,
+  getLabelCollisionTransforms,
+} from './donutLabelCollisionUtils';
 import { getDonutEmptyStateTest, getDonutOuterRadiusExpr } from './donutUtils';
+
+/** Unique field/data-source prefix for direct labels' collision fields, distinct from advanced labels' */
+const getSegmentLabelFieldPrefix = (name: string): string => `${name}_segmentLabel`;
+
+/** Name of the derived, collision-adjusted data source direct label marks read from */
+const getSegmentLabelDataName = (name: string): string => `${name}_segmentLabelData`;
+
+/**
+ * Gets the expression testing whether a label's collision-adjusted (not original ideal) position
+ * falls in the top half of the donut - collision can push a label across the vertical midpoint, so
+ * the top/bottom split for dy/baseline must track where the label actually ends up, not its ideal angle
+ * @param fieldPrefix
+ * @returns vega expression string
+ */
+const getIsTopHalfExpr = (fieldPrefix: string): string => `datum['${getAdjustedYField(fieldPrefix)}'] <= height / 2`;
 
 /**
  * Gets the SegmentLabel component from the children if one exists
@@ -123,6 +146,50 @@ export const getSegmentLabelSignals = (donutOptions: DonutSpecOptions): Signal[]
 };
 
 /**
+ * Gets the minimum vertical gap enforced between two colliding direct labels - the rendered
+ * (name + optional value line) block height plus a stacking buffer
+ * @param segmentLabelOptions
+ * @returns vega expression string
+ */
+const getSegmentLabelMinGapExpr = ({ donutOptions, value, percent }: SegmentLabelSpecOptions): string => {
+  const { name } = donutOptions;
+  const valueLineHeight = value || percent ? ` + ${name}_segmentLabelValueFontSize` : '';
+  return `${name}_segmentLabelNameFontSize${valueLineHeight} + ${DONUT_LABEL_COLLISION_MIN_GAP_BUFFER}`;
+};
+
+/**
+ * Gets the derived, collision-adjusted data source direct label marks read from. Excludes segments
+ * below the min-angle threshold entirely (rather than rendering them at fontSize 0) so they don't
+ * consume a collision rank slot and needlessly push visible labels further apart.
+ * @param donutOptions
+ * @returns SourceData[]
+ */
+export const getSegmentLabelData = (donutOptions: DonutSpecOptions): SourceData[] => {
+  const segmentLabel = getSegmentLabel(donutOptions);
+  if (!segmentLabel) return [];
+  const { name } = donutOptions;
+  const arcThetaExpr = `datum['${name}_arcTheta']`;
+  const outerRadiusExpr = getDonutOuterRadiusExpr(donutOptions);
+  return [
+    {
+      name: getSegmentLabelDataName(name),
+      source: FILTERED_TABLE,
+      transform: [
+        { type: 'filter', expr: `datum['${name}_arcLength'] >= ${DONUT_SEGMENT_LABEL_MIN_ANGLE}` },
+        ...getLabelCollisionTransforms(
+          getSegmentLabelFieldPrefix(name),
+          arcThetaExpr,
+          getLabelAnchorRadiusExpr(donutOptions),
+          outerRadiusExpr,
+          `${DONUT_LABEL_RING_GAP}`,
+          getSegmentLabelMinGapExpr(segmentLabel)
+        ),
+      ],
+    },
+  ];
+};
+
+/**
  * Converts a text production rule into a single Vega expression string, for use inside getLabelWidth()
  * @param rule
  * @returns vega expression string
@@ -149,11 +216,10 @@ export const getTextRuleExpr = (rule: ProductionRule<TextValueRef> | undefined):
 };
 
 /**
- * Gets the anchor radius both hemispheres use for a label's name/value lines - the ring's outer
- * edge plus the ring-gap. The left-hemisphere horizontal shift is applied separately as a dx offset
- * (getLabelAnchorDxExpr), not folded into this radius, since radius+theta positioning has a
- * vertical component for any label off the 9/3 o'clock points - adjusting radius there would push
- * the anchor up/down instead of sideways.
+ * Gets a label's pre-collision ideal anchor radius (the ring-gap point) - used only to compute its
+ * ideal Y for the collision cascade (donutLabelCollisionUtils.ts), not as a mark encode field directly,
+ * since the actual rendered position re-anchors horizontally against the ring's real half-width at
+ * whatever Y the label ends up at after collision adjustment.
  * @param donutOptions
  * @returns vega expression string
  */
@@ -185,7 +251,8 @@ const getLabelAnchorDxExpr = (options: SegmentLabelSpecOptions): string => {
   const cappedWidthExpr = `min(${widerWidthExpr}, ${getDonutOuterRadiusExpr(
     donutOptions
   )} * ${DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO})`;
-  return `(datum['${name}_arcTheta'] <= PI ? 0 : -(${cappedWidthExpr}))`;
+  const hemisphereField = getHemisphereField(getSegmentLabelFieldPrefix(name));
+  return `(datum['${hemisphereField}'] === 'right' ? 0 : -(${cappedWidthExpr}))`;
 };
 
 /**
@@ -222,7 +289,7 @@ export const getSegmentLabelTextMark = (options: SegmentLabelSpecOptions): TextM
   return {
     type: 'text',
     name: `${name}_segmentLabel`,
-    from: { data: FILTERED_TABLE },
+    from: { data: getSegmentLabelDataName(name) },
     encode: {
       enter: {
         // drop all labels when there isn't any data to display, the empty state ring is shown instead
@@ -230,7 +297,6 @@ export const getSegmentLabelTextMark = (options: SegmentLabelSpecOptions): TextM
         fill: { value: getS2ColorValue('gray-700', donutOptions.colorScheme) },
       },
       update: {
-        ...positionEncodings,
         ...getSegmentLabelUpdateEncode(options, `${name}_segmentLabelNameFontSize`),
         // top half: shift up by the value line's own font size so the two lines sit flush (0px gap
         // token) regardless of size tier - a fixed px shift would leave a mismatched gap at every
@@ -238,7 +304,9 @@ export const getSegmentLabelTextMark = (options: SegmentLabelSpecOptions): TextM
         dy:
           value || percent
             ? {
-                signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? -${name}_segmentLabelValueFontSize : 0`,
+                signal: `${getIsTopHalfExpr(
+                  getSegmentLabelFieldPrefix(name)
+                )} ? -${name}_segmentLabelValueFontSize : 0`,
               }
             : undefined,
         // fades in step with the arc's own hover/controlled-highlight fade (getMarkOpacity is the
@@ -264,7 +332,7 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
     {
       type: 'text',
       name: `${donutOptions.name}_segmentLabelValue`,
-      from: { data: FILTERED_TABLE },
+      from: { data: getSegmentLabelDataName(donutOptions.name) },
       encode: {
         enter: {
           // drop all labels when there isn't any data to display, the empty state ring is shown instead
@@ -272,11 +340,12 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
           fontWeight: { value: 'bold' },
         },
         update: {
-          ...positionEncodings,
           ...getSegmentLabelUpdateEncode(options, `${donutOptions.name}_segmentLabelValueFontSize`),
           // bottom half: shift down by the name line's own font size, mirroring the top-half case
           dy: {
-            signal: `datum['${donutOptions.name}_arcTheta'] <= 0.5 * PI || datum['${donutOptions.name}_arcTheta'] >= 1.5 * PI ? 0 : ${donutOptions.name}_segmentLabelNameFontSize`,
+            signal: `${getIsTopHalfExpr(getSegmentLabelFieldPrefix(donutOptions.name))} ? 0 : ${
+              donutOptions.name
+            }_segmentLabelNameFontSize`,
           },
           fill: getLabelValueFill(donutOptions, 'gray-700'),
           opacity: getMarkOpacity(donutOptions),
@@ -289,16 +358,24 @@ export const getSegmentLabelValueTextMark = (options: SegmentLabelSpecOptions): 
 /**
  * Gets the standard position/size encodes for segment label text marks. These must live in the
  * `update` set, not `enter` - Vega only evaluates `enter` once per mark instance at creation, but
- * radius/dx/fontSize here all derive from `width`/`height`-dependent signals that change on resize.
+ * x/y/dx/fontSize here all derive from `width`/`height`-dependent signals that change on resize.
+ * Position is collision-adjusted (see donutLabelCollisionUtils.ts): x/y come from the derived
+ * data source's per-hemisphere cascade fields, not a fixed radius+theta polar anchor, since the
+ * ring's horizontal half-width must be re-measured at each label's (possibly shifted) Y.
  * @param segmentLabelOptions
  * @param fontSizeSignal - the tier-based font size signal name for this specific line (name or value)
  * @returns TextEncodeEntry
  */
 const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeSignal: string): TextEncodeEntry => {
   const { name } = options.donutOptions;
+  const fieldPrefix = getSegmentLabelFieldPrefix(name);
+  const hemisphereField = getHemisphereField(fieldPrefix);
+  const halfWidthField = getCollisionHalfWidthField(fieldPrefix);
   return {
-    radius: { signal: getLabelAnchorRadiusExpr(options.donutOptions) },
-    theta: { field: `${name}_arcTheta` },
+    x: {
+      signal: `datum['${hemisphereField}'] === 'right' ? width / 2 + datum['${halfWidthField}'] : width / 2 - datum['${halfWidthField}']`,
+    },
+    y: { field: getAdjustedYField(fieldPrefix) },
     // shifts left-hemisphere labels left by the wider line's width - see getLabelAnchorDxExpr
     dx: { signal: getLabelAnchorDxExpr(options) },
     fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
@@ -342,14 +419,6 @@ export const getLabelValueFill = (
 };
 
 /**
- * position encodings
- */
-const positionEncodings: TextEncodeEntry = {
-  x: { signal: 'width / 2' },
-  y: { signal: 'height / 2' },
-};
-
-/**
  * Gets the text value ref for the segment label values (percent and/or value)
  * @param segmentLabelOptions
  * @returns TextValueRef
@@ -388,13 +457,11 @@ export const getSegmentLabelValueText = ({
  * @returns NumericValueRef
  */
 const getSegmentLabelFontSize = (name: string, fontSizeSignal: string): ProductionRule<NumericValueRef> => {
-  // need to use radians for this. 0.3 radians is about 17 degrees
-  // if we used arc length, then showing a label could shrink the overall donut size which could make the arc to small
-  // that would hide the label which would make the arc bigger which would show the label and so on
+  // segments below DONUT_SEGMENT_LABEL_MIN_ANGLE are already excluded from the label data source
+  // (getSegmentLabelData) entirely, so there's no need to zero their font size here too
   return [
     // hide all labels when there isn't any data to display, the empty state ring is shown instead
     { test: getDonutEmptyStateTest(name), value: 0 },
-    { test: `datum['${name}_arcLength'] < ${DONUT_SEGMENT_LABEL_MIN_ANGLE}`, value: 0 },
     { signal: fontSizeSignal },
   ];
 };

--- a/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/segmentLabelUtils.ts
@@ -381,9 +381,10 @@ const getSegmentLabelUpdateEncode = (options: SegmentLabelSpecOptions, fontSizeS
     fontSize: getSegmentLabelFontSize(name, fontSizeSignal),
     // both hemispheres anchor at their near (left) edge - only the dx offset differs by hemisphere
     align: { value: 'left' },
+    // uses the collision-adjusted position, not the ideal arcTheta - collision can push a label
+    // across the vertical midpoint, and baseline must track where it actually ends up
     baseline: {
-      // if the center of the arc is in the top half of the donut, the text baseline should be bottom, else top
-      signal: `datum['${name}_arcTheta'] <= 0.5 * PI || datum['${name}_arcTheta'] >= 1.5 * PI ? 'bottom' : 'top'`,
+      signal: `${getIsTopHalfExpr(fieldPrefix)} ? 'bottom' : 'top'`,
     },
   };
 };


### PR DESCRIPTION
## Description

Fixes the donut label collision-avoidance algorithm (a parenthesization bug in the running-max cascade formula was pushing labels far below the ring), wires the same collision avoidance into AdvancedLabel (which previously had none), and adds ring-overlap protection via text truncation for both SegmentLabel and AdvancedLabel.

- Fixed `getLabelCollisionTransforms`'s min-gap expression missing parentheses, which broke the vertical push-down math for colliding direct labels.
- Wired collision avoidance into AdvancedLabel (swatch + name/value/detail block), previously unguarded against overlapping neighbors.
- Replaced the flat, equator-only-correct `outerRadius * ratio` truncation cap with a dynamic per-label cap (`DONUT_RADIUS - collisionHalfWidth`) that uses each label's own actual remaining room, freeing up unused space away from the ring's equator.
- Added a hemisphere-conditional `limit` (Vega ellipsis truncation) so labels only truncate when content would genuinely overlap the ring, guarding against a floating-point boundary mismatch that could truncate content that already fit.

## Related Issue

N/A - direct debugging/hardening of `feat/donut-advanced-labels` label positioning.

## Motivation and Context

Advanced/Direct labels could overlap each other or overrun the donut ring at certain sizes and content lengths; this makes both mark types self-consistently avoid collisions and gracefully truncate instead of visually breaking.

## How Has This Been Tested?

- Full donut unit test suite (272 suites / 4240+ tests) passing, including new coverage for the truncation `limit` expressions and collision math.
- Manually verified in Storybook (S2) across the Direct Label and Advanced Label responsive stories, sweeping container widths through all size tiers.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.