### PR TITLE
feat: AN-456588 Add axis label hover tooltip to Bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tmp/
 
 .agents/
 .scout/
+.claude/rules/

--- a/packages/docs/docs/spectrum2/axis.md
+++ b/packages/docs/docs/spectrum2/axis.md
@@ -1,0 +1,345 @@
+---
+sidebar_position: 4
+---
+
+# Axis (S2)
+
+The `Axis` component in the S2 package supports nearly all props from the [base Axis component](/docs/api/components/Axis) plus S2-exclusive features: axis label hover tooltips and axis label click callbacks.
+
+:::note
+The S2 `Axis` component does not yet support:
+- `chartTooltips` (rich per-tooltip JSX content via a `ChartTooltip` child) — use `hasTooltip`/`tooltipText` instead, which show plain text.
+- `hasPopover` (triggering a `ChartPopover` from an `AxisThumbnail` click).
+- `AxisAnnotation` as a child component.
+:::
+
+```jsx
+import { Chart, Axis } from '@spectrum-charts/react-spectrum-charts-s2';
+```
+
+---
+
+## Axis label hover tooltips
+
+Set `hasTooltip` to show a Spectrum 2 tooltip when hovering an axis label. By default the tooltip shows the label's full, untruncated value — useful when combined with `truncateLabels` or `labelLimit`.
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" truncateLabels hasTooltip title="Browser" />
+  <Bar dimension="browser" metric="downloads" />
+</Chart>
+```
+
+### Custom tooltip text (`tooltipText`)
+
+Pass `tooltipText` to override the tooltip content for specific values. Values not listed keep the default (full label value). Set `text: null` to suppress the tooltip entirely for one value.
+
+```jsx
+<Chart data={data}>
+  <Axis
+    position="bottom"
+    truncateLabels
+    hasTooltip
+    title="Browser"
+    tooltipText={[
+      { value: 'Other', text: 'Clicking Other may expand the chart' },
+      { value: 'Mac Safari', text: null },
+    ]}
+  />
+  <Bar dimension="browser" metric="downloads" />
+</Chart>
+```
+
+---
+
+## Axis label click
+
+Set `onClick` to run a callback when an axis label is clicked. The callback receives the native mouse event, the label's value, and its tick index.
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" title="Browser" onClick={(event, value, index) => console.log(value, index)} />
+  <Bar dimension="browser" metric="downloads" />
+</Chart>
+```
+
+---
+
+## AxisThumbnail
+
+`AxisThumbnail` is a child of `Axis` that replaces each tick label with a thumbnail image, read from a key in the data.
+
+```jsx
+<Chart data={data}>
+  <Axis position="bottom" title="Browser">
+    <AxisThumbnail urlKey="thumbnail" />
+  </Axis>
+  <Bar dimension="browser" metric="downloads" />
+</Chart>
+```
+
+### AxisThumbnail props
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>urlKey</td>
+            <td>string</td>
+            <td>'thumbnail'</td>
+            <td>The data field key that contains the URL of the thumbnail image.</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+## ReferenceLine
+
+`ReferenceLine` is a child of `Axis` that draws a labeled line at a specific value.
+
+```jsx
+<Chart data={data}>
+  <Axis position="left" title="Users">
+    <ReferenceLine value={50} label="Target" />
+  </Axis>
+  <Line dimension="datetime" metric="users" />
+</Chart>
+```
+
+### ReferenceLine props
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>value*</td>
+            <td>number | string</td>
+            <td>–</td>
+            <td>The value on the axis where the reference line should be drawn.</td>
+        </tr>
+        <tr>
+            <td>position</td>
+            <td>'before' | 'after' | 'center'</td>
+            <td>–</td>
+            <td>Position the line on the value, or between the previous/next value. Only supported in Bar visualizations.</td>
+        </tr>
+        <tr>
+            <td>label</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Axis text label for the reference line.</td>
+        </tr>
+        <tr>
+            <td>size</td>
+            <td>'S' | 'M' | 'L'</td>
+            <td>–</td>
+            <td>Size variant controlling stroke weight and caret triangle dimensions. When omitted, stroke width reacts to chart size automatically.</td>
+        </tr>
+        <tr>
+            <td>secondary</td>
+            <td>boolean</td>
+            <td>–</td>
+            <td>When true, renders a lighter secondary style: no caret caps, and a lighter stroke color for size 'S'.</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+## Axis props (S2)
+
+<table>
+    <thead>
+        <tr>
+            <th>name</th>
+            <th>type</th>
+            <th>default</th>
+            <th>description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>position*</td>
+            <td>'left' | 'bottom' | 'top' | 'right'</td>
+            <td>–</td>
+            <td>Sets where the axis will be displayed.</td>
+        </tr>
+        <tr>
+            <td>children</td>
+            <td>AxisThumbnail | ReferenceLine</td>
+            <td>–</td>
+            <td>Optional child components for tick thumbnails and reference lines.</td>
+        </tr>
+        <tr>
+            <td>name</td>
+            <td>string</td>
+            <td>–</td>
+            <td>Sets the name of the component.</td>
+        </tr>
+        <tr>
+            <td>baseline</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Adds a baseline rule for this axis.</td>
+        </tr>
+        <tr>
+            <td>baselineOffset</td>
+            <td>number</td>
+            <td>0</td>
+            <td>Adds an offset to the baseline. Ignored if <code>baseline</code> is false, or if the baseline is drawn relative to a categorical axis.</td>
+        </tr>
+        <tr>
+            <td>granularity</td>
+            <td>'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'</td>
+            <td>–</td>
+            <td>Sets the granularity of the primary axis labels for a time axis. Ignored if this axis is not a time axis.</td>
+        </tr>
+        <tr>
+            <td>grid</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Displays gridlines at each tick location.</td>
+        </tr>
+        <tr>
+            <td>hasTooltip</td>
+            <td>boolean</td>
+            <td>–</td>
+            <td>Enables a Spectrum 2 hover tooltip on axis labels. See <a href="#axis-label-hover-tooltips">Axis label hover tooltips</a>.</td>
+        </tr>
+        <tr>
+            <td>hideDefaultLabels</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Hides the axis labels. If labels have been explicitly added using the <code>labels</code> prop, those remain visible.</td>
+        </tr>
+        <tr>
+            <td>labelAlign</td>
+            <td>'center' | 'start' | 'end'</td>
+            <td>'center'</td>
+            <td>Sets the alignment of axis labels.</td>
+        </tr>
+        <tr>
+            <td>labelFontWeight</td>
+            <td>FontWeight</td>
+            <td>–</td>
+            <td>Sets the font weight of axis labels.</td>
+        </tr>
+        <tr>
+            <td>labelFormat</td>
+            <td>'duration' | 'linear' | 'percentage' | 'time'</td>
+            <td>–</td>
+            <td>Sets the format of the axis labels.</td>
+        </tr>
+        <tr>
+            <td>labelLimit</td>
+            <td>number</td>
+            <td>180</td>
+            <td>Sets the maximum allowed length, in pixels, of axis tick labels. Combine with <code>truncateLabels</code> to keep the limit within the tick bandwidth.</td>
+        </tr>
+        <tr>
+            <td>labelOrientation</td>
+            <td>'horizontal' | 'vertical'</td>
+            <td>'horizontal'</td>
+            <td>Sets the orientation of the label.</td>
+        </tr>
+        <tr>
+            <td>labels</td>
+            <td>(Label | string | number)[]</td>
+            <td>–</td>
+            <td>Explicitly sets the axis labels (controlled). Providing a <code>Label</code> object allows control over the display value, alignment, and font weight per label.</td>
+        </tr>
+        <tr>
+            <td>numberFormat</td>
+            <td>string</td>
+            <td>–</td>
+            <td>d3 number format specifier. Only valid if <code>labelFormat</code> is <code>'linear'</code> or unset.</td>
+        </tr>
+        <tr>
+            <td>onClick</td>
+            <td>(event: MouseEvent, value: string | number | Date, index: number) =&gt; void</td>
+            <td>–</td>
+            <td>Callback fired when an axis label is clicked. See <a href="#axis-label-click">Axis label click</a>.</td>
+        </tr>
+        <tr>
+            <td>range</td>
+            <td>[number, number]</td>
+            <td>–</td>
+            <td>The minimum and maximum values for the axis. Only supported for axes with <code>linear</code> or <code>time</code> scale types.</td>
+        </tr>
+        <tr>
+            <td>subLabels</td>
+            <td>SubLabel[]</td>
+            <td>–</td>
+            <td>Adds sublabels below the axis labels.</td>
+        </tr>
+        <tr>
+            <td>tickCountMinimum</td>
+            <td>number</td>
+            <td>2</td>
+            <td>Sets the minimum number of axis ticks. Smaller charts may want a minimum of 3 for a more accurate representation of the data.</td>
+        </tr>
+        <tr>
+            <td>tickCountLimit</td>
+            <td>number</td>
+            <td>–</td>
+            <td>Sets the upper limit on the number of axis ticks. On time-based axes, setting this overrides the automatic granularity-based tick interval and can produce duplicate labels — you are responsible for aligning it with the data granularity.</td>
+        </tr>
+        <tr>
+            <td>tickMinStep</td>
+            <td>number</td>
+            <td>–</td>
+            <td>The minimum desired step between axis ticks, in scale domain values. Only supported for linear axes.</td>
+        </tr>
+        <tr>
+            <td>ticks</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>Displays ticks at each label location.</td>
+        </tr>
+        <tr>
+            <td>title</td>
+            <td>string | string[]</td>
+            <td>–</td>
+            <td>Sets the axis title. Pass an array for a multi-line title.</td>
+        </tr>
+        <tr>
+            <td>tooltipText</td>
+            <td>&#123;value: string | number, text: string | null&#125;[]</td>
+            <td>–</td>
+            <td>Per-value tooltip text overrides. See <a href="#custom-tooltip-text-tooltiptext">Custom tooltip text</a>.</td>
+        </tr>
+        <tr>
+            <td>truncateLabels</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>If the text is wider than the tick's bandwidth, truncates it so it stays within that bandwidth.</td>
+        </tr>
+        <tr>
+            <td>currencyLocale</td>
+            <td>string</td>
+            <td>–</td>
+            <td>⚠️ Limited support. Sets the locale for currency formatting (affects symbol position and spacing). Requires <code>currencyCode</code> to take effect.</td>
+        </tr>
+        <tr>
+            <td>currencyCode</td>
+            <td>string</td>
+            <td>–</td>
+            <td>⚠️ Limited support. Overrides the currency symbol from the chart locale. Requires <code>currencyLocale</code> to take effect.</td>
+        </tr>
+    </tbody>
+</table>

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -73,6 +73,7 @@ const sidebars: SidebarsConfig = {
         'spectrum2/overview',
         'spectrum2/line',
         'spectrum2/bar',
+        'spectrum2/axis',
         'spectrum2/legend',
         'spectrum2/chart-sizing',
         'spectrum2/react-server-components',

--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -146,6 +146,7 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
             data-testid="rsc-axis-label-tooltip-anchor"
             ref={axisLabelTooltipAnchorRef}
             style={axisLabelTooltipAnchorStyle}
+            tabIndex={-1}
           />
         </Focusable>
         <Tooltip>{hoveredAxisLabel?.content ?? lastAxisLabelContentRef.current}</Tooltip>

--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -9,9 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { CSSProperties, RefObject, Ref, useCallback, useEffect, useMemo, useState } from 'react';
+import { CSSProperties, RefObject, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { Popover } from '@react-spectrum/s2';
+import { Popover, Tooltip, TooltipTrigger } from '@react-spectrum/s2';
+import { Focusable } from 'react-aria-components';
 import { View as VegaView } from 'vega';
 import { COMPONENT_NAME, DEFAULT_SYMBOL_SHAPES, DEFAULT_SYMBOL_SIZES } from '@spectrum-charts/constants';
 import { ChartHandle, Datum, SymbolSize, getChartConfig } from '@spectrum-charts/vega-spec-builder-s2';
@@ -65,7 +66,14 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
     idKey,
   } = props;
 
-  const { chartView, chartId, popoverAnchorRef, isPopoverOpen, setIsPopoverOpen } = useChartContext();
+  const { chartView, chartId, popoverAnchorRef, isPopoverOpen, setIsPopoverOpen, hoveredAxisLabel } =
+    useChartContext();
+  const axisLabelTooltipAnchorRef = useRef<HTMLDivElement>(null);
+  // Retained through the Tooltip's exit animation so it doesn't fade out empty.
+  const lastAxisLabelContentRef = useRef<string | undefined>(undefined);
+  if (hoveredAxisLabel) {
+    lastAxisLabelContentRef.current = hoveredAxisLabel.content;
+  }
 
   const sanitizedChildren = useMemo(() => sanitizeRscChartChildren(props.children), [props.children]);
 
@@ -96,7 +104,10 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
 
   useSpecProps(spec);
 
-  const { signals, targetStyle, inspectOptions, onNewView } = useChartInteractions(props, sanitizedChildren);
+  const { signals, targetStyle, axisLabelTooltipAnchorStyle, inspectOptions, onNewView } = useChartInteractions(
+    props,
+    sanitizedChildren
+  );
   const chartConfig = useMemo(() => getChartConfig(config, colorScheme), [config, colorScheme]);
   const specSignalNames = useMemo(() => new Set(spec.signals?.map((s) => s.name) ?? []), [spec.signals]);
 
@@ -127,6 +138,18 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
         ref={popoverAnchorRef}
         style={targetStyle}
       />
+      <TooltipTrigger isOpen={Boolean(hoveredAxisLabel)}>
+        {/* Focusable forwards TooltipTrigger's FocusableContext ref onto our plain div. */}
+        <Focusable>
+          <div
+            id={`${chartId}-axis-label-tooltip-anchor`}
+            data-testid="rsc-axis-label-tooltip-anchor"
+            ref={axisLabelTooltipAnchorRef}
+            style={axisLabelTooltipAnchorStyle}
+          />
+        </Focusable>
+        <Tooltip>{hoveredAxisLabel?.content ?? lastAxisLabelContentRef.current}</Tooltip>
+      </TooltipTrigger>
       <VegaChart
         spec={spec}
         config={chartConfig}

--- a/packages/react-spectrum-charts-s2/src/components/Axis/Axis.tsx
+++ b/packages/react-spectrum-charts-s2/src/components/Axis/Axis.tsx
@@ -28,6 +28,7 @@ const Axis: FC<AxisProps> = ({
   baselineOffset = 0,
   granularity = DEFAULT_GRANULARITY,
   grid = false,
+  hasTooltip = false,
   hideDefaultLabels = false,
   labelAlign = DEFAULT_LABEL_ALIGN,
   labelFontWeight = DEFAULT_LABEL_FONT_WEIGHT,
@@ -43,6 +44,7 @@ const Axis: FC<AxisProps> = ({
   tickCountMinimum = undefined,
   tickMinStep = undefined,
   title = undefined,
+  tooltipText = undefined,
 }) => {
   return null;
 };

--- a/packages/react-spectrum-charts-s2/src/context/RscChartContext.tsx
+++ b/packages/react-spectrum-charts-s2/src/context/RscChartContext.tsx
@@ -15,6 +15,11 @@ import { Signal, View } from 'vega';
 
 import { Datum, MarkBounds } from '@spectrum-charts/vega-spec-builder-s2';
 
+interface HoveredAxisLabel {
+  bounds: MarkBounds;
+  content: string;
+}
+
 interface ChartContextValue {
   // Chart view state
   chartView: RefObject<View | undefined>;
@@ -29,6 +34,10 @@ interface ChartContextValue {
   isPopoverOpen: boolean;
   setIsPopoverOpen: (isOpen: boolean) => void;
   popoverAnchorRef: RefObject<HTMLDivElement | null>;
+
+  // Axis label tooltip state
+  hoveredAxisLabel: HoveredAxisLabel | null;
+  setHoveredAxisLabel: (hoveredAxisLabel: HoveredAxisLabel | null) => void;
 
   // Spec state
   controlledHoveredIdSignal: RefObject<Signal | undefined>;
@@ -52,6 +61,7 @@ export const ChartProvider = ({ children, chartId, chartView }: ChartProviderPro
   const selectedDataBounds = useRef<MarkBounds>({ x1: 0, x2: 0, y1: 0, y2: 0 });
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [hoveredAxisLabel, setHoveredAxisLabel] = useState<HoveredAxisLabel | null>(null);
 
   const value: ChartContextValue = useMemo(
     () => ({
@@ -65,8 +75,10 @@ export const ChartProvider = ({ children, chartId, chartView }: ChartProviderPro
       isPopoverOpen,
       setIsPopoverOpen,
       popoverAnchorRef,
+      hoveredAxisLabel,
+      setHoveredAxisLabel,
     }),
-    [chartId, chartView, isPopoverOpen]
+    [chartId, chartView, isPopoverOpen, hoveredAxisLabel]
   );
 
   return <ChartContext.Provider value={value}>{children}</ChartContext.Provider>;

--- a/packages/react-spectrum-charts-s2/src/hooks/useAxisLabelTooltipAnchorStyle.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useAxisLabelTooltipAnchorStyle.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+
+import { useChartContext } from '../context/RscChartContext';
+import useAxisLabelTooltipAnchorStyle from './useAxisLabelTooltipAnchorStyle';
+
+jest.mock('../context/RscChartContext', () => ({
+  useChartContext: jest.fn(),
+}));
+
+const mockUseChartContext = jest.mocked(useChartContext);
+
+const mockView = { origin: jest.fn(() => [1, 0]) };
+
+describe('useAxisLabelTooltipAnchorStyle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns display: none when no axis label is hovered', () => {
+    mockUseChartContext.mockReturnValue({
+      chartView: { current: mockView },
+      hoveredAxisLabel: null,
+    } as unknown as ReturnType<typeof useChartContext>);
+
+    const { result } = renderHook(() => useAxisLabelTooltipAnchorStyle(10));
+    expect(result.current).toStrictEqual({ display: 'none' });
+  });
+
+  test('returns display: none when the view is not yet ready', () => {
+    mockUseChartContext.mockReturnValue({
+      chartView: { current: undefined },
+      hoveredAxisLabel: { bounds: { x1: 0, x2: 10, y1: 0, y2: 20 }, content: 'Category A' },
+    } as unknown as ReturnType<typeof useChartContext>);
+
+    const { result } = renderHook(() => useAxisLabelTooltipAnchorStyle(10));
+    expect(result.current).toStrictEqual({ display: 'none' });
+  });
+
+  test('positions the anchor from the hovered label bounds, padding, and view origin', () => {
+    mockUseChartContext.mockReturnValue({
+      chartView: { current: mockView },
+      hoveredAxisLabel: { bounds: { x1: 5, x2: 25, y1: 100, y2: 114 }, content: 'Category A' },
+    } as unknown as ReturnType<typeof useChartContext>);
+
+    const { result } = renderHook(() => useAxisLabelTooltipAnchorStyle(10));
+    expect(result.current).toStrictEqual({
+      position: 'absolute',
+      width: 20,
+      height: 14,
+      left: 16, // x1(5) + leftPadding(10) + origin[0](1)
+      top: 110, // y1(100) + topPadding(10) + origin[1](0)
+    });
+  });
+
+  test('supports a per-side padding object', () => {
+    mockUseChartContext.mockReturnValue({
+      chartView: { current: mockView },
+      hoveredAxisLabel: { bounds: { x1: 5, x2: 25, y1: 100, y2: 114 }, content: 'Category A' },
+    } as unknown as ReturnType<typeof useChartContext>);
+
+    const { result } = renderHook(() => useAxisLabelTooltipAnchorStyle({ top: 4, left: 8, right: 0, bottom: 0 }));
+    expect(result.current).toMatchObject({ left: 14, top: 104 });
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/hooks/useAxisLabelTooltipAnchorStyle.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useAxisLabelTooltipAnchorStyle.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { CSSProperties, useMemo } from 'react';
+
+import { Padding } from 'vega';
+
+import { useChartContext } from '../context/RscChartContext';
+
+export default function useAxisLabelTooltipAnchorStyle(padding: Padding): CSSProperties {
+  const { chartView, hoveredAxisLabel } = useChartContext();
+
+  const view = chartView.current;
+
+  return useMemo((): CSSProperties => {
+    if (hoveredAxisLabel && view) {
+      const { x1, x2, y1, y2 } = hoveredAxisLabel.bounds;
+      const leftPadding = (typeof padding === 'number' ? padding : padding.left) ?? 0;
+      const topPadding = (typeof padding === 'number' ? padding : padding.top) ?? 0;
+      return {
+        position: 'absolute',
+        width: x2 - x1,
+        height: y2 - y1,
+        left: x1 + leftPadding + view.origin()[0],
+        top: y1 + topPadding + view.origin()[1],
+      };
+    }
+    return { display: 'none' };
+  }, [hoveredAxisLabel, view, padding]);
+}

--- a/packages/react-spectrum-charts-s2/src/hooks/useChartInspectInteractions.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useChartInspectInteractions.test.tsx
@@ -64,6 +64,15 @@ function makeContext(
 ) {
   return {
     chartView: { current: { signal: mockSignal, data: mockData } },
+    chartId: 'test-chart',
+    selectedData: { current: null },
+    selectedDataName: { current: '' },
+    selectedDataBounds: { current: { x1: 0, x2: 0, y1: 0, y2: 0 } },
+    isPopoverOpen: false,
+    setIsPopoverOpen: jest.fn(),
+    popoverAnchorRef: { current: null },
+    hoveredAxisLabel: null,
+    setHoveredAxisLabel: jest.fn(),
     controlledHoveredIdSignal: { current: idSignal },
     controlledHoveredGroupSignal: { current: groupSignal },
   };
@@ -81,21 +90,21 @@ describe('useChartInspectInteractions - controlledHoveredIdSignal', () => {
   });
 
   test('calls signal with the idKey value when controlledHoveredIdSignal is set', () => {
-    mockUseChartContext.mockReturnValue(makeContext({ name: 'line0_controlledHoveredId' }) as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext({ name: 'line0_controlledHoveredId' }) as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ ...baseValue });
     expect(mockSignal).toHaveBeenCalledWith('line0_controlledHoveredId', 'item-1');
   });
 
   test('calls signal with null when idKey is absent from value', () => {
-    mockUseChartContext.mockReturnValue(makeContext({ name: 'line0_controlledHoveredId' }) as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext({ name: 'line0_controlledHoveredId' }) as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ [COMPONENT_NAME]: 'line0' });
     expect(mockSignal).toHaveBeenCalledWith('line0_controlledHoveredId', null);
   });
 
   test('does not call signal when controlledHoveredIdSignal is not set', () => {
-    mockUseChartContext.mockReturnValue(makeContext() as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext() as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ ...baseValue });
     expect(mockSignal).not.toHaveBeenCalled();
@@ -111,21 +120,21 @@ describe('useChartInspectInteractions - controlledHoveredGroupSignal', () => {
   });
 
   test('calls group signal when value contains a key ending in GROUP_ID', () => {
-    mockUseChartContext.mockReturnValue(makeContext(undefined, { name: 'line0_controlledHoveredGroup' }) as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext(undefined, { name: 'line0_controlledHoveredGroup' }) as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ ...baseValue, [groupKey]: 'group-a' });
     expect(mockSignal).toHaveBeenCalledWith('line0_controlledHoveredGroup', 'group-a');
   });
 
   test('does not call group signal when no GROUP_ID key exists in value', () => {
-    mockUseChartContext.mockReturnValue(makeContext(undefined, { name: 'line0_controlledHoveredGroup' }) as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext(undefined, { name: 'line0_controlledHoveredGroup' }) as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ ...baseValue }); // no key ending in GROUP_ID
     expect(mockSignal).not.toHaveBeenCalled();
   });
 
   test('does not call group signal when controlledHoveredGroupSignal is not set', () => {
-    mockUseChartContext.mockReturnValue(makeContext() as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext() as unknown as ReturnType<typeof useChartContext>);
     const formatTooltip = getFormatTooltip();
     formatTooltip?.({ ...baseValue, [groupKey]: 'group-a' });
     expect(mockSignal).not.toHaveBeenCalled();
@@ -142,7 +151,7 @@ describe('useChartInspectInteractions - highlightBy GROUP_DATA population', () =
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseChartContext.mockReturnValue(makeContext() as ReturnType<typeof useChartContext>);
+    mockUseChartContext.mockReturnValue(makeContext() as unknown as ReturnType<typeof useChartContext>);
     mockData.mockReturnValue(tableData);
   });
 

--- a/packages/react-spectrum-charts-s2/src/hooks/useChartInteractions.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useChartInteractions.tsx
@@ -16,6 +16,7 @@ import { getColorValue } from '@spectrum-charts/themes';
 
 import { useChartContext } from '../context/RscChartContext';
 import { ChartChildElement, RscChartProps } from '../types';
+import useAxisLabelTooltipAnchorStyle from './useAxisLabelTooltipAnchorStyle';
 import useLegend from './useLegend';
 import useNewChartView from './useNewChartView';
 import usePopoverAnchorStyle from './usePopoverAnchorStyle';
@@ -27,6 +28,7 @@ export const useChartInteractions = (props: RscChartProps, sanitizedChildren: Ch
   const legendProps = useLegend(sanitizedChildren);
   const { legendHiddenSeries, isToggleable: legendIsToggleable } = legendProps;
   const targetStyle = usePopoverAnchorStyle(props.padding);
+  const axisLabelTooltipAnchorStyle = useAxisLabelTooltipAnchorStyle(props.padding);
 
   const signals = useMemo(() => {
     const signals: Record<string, unknown> = {
@@ -43,5 +45,5 @@ export const useChartInteractions = (props: RscChartProps, sanitizedChildren: Ch
 
   const onNewView = useNewChartView(props, sanitizedChildren, inspectOptions, legendProps);
 
-  return { signals, targetStyle, inspectOptions, onNewView };
+  return { signals, targetStyle, axisLabelTooltipAnchorStyle, inspectOptions, onNewView };
 };

--- a/packages/react-spectrum-charts-s2/src/hooks/useNewChartView.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useNewChartView.test.tsx
@@ -67,6 +67,8 @@ const makeFakeView = () =>
     addEventListener: jest.fn(),
   } as unknown as View);
 
+const mockSetHoveredAxisLabel = jest.fn();
+
 describe('useNewChartView - axis label click wiring', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -76,6 +78,7 @@ describe('useNewChartView - axis label click wiring', () => {
       selectedDataBounds: { current: undefined },
       selectedDataName: { current: undefined },
       chartId: 'test-chart',
+      setHoveredAxisLabel: mockSetHoveredAxisLabel,
     } as unknown as ReturnType<typeof useChartContext>);
     mockUsePopovers.mockReturnValue([]);
     mockUseMarkOnClickDetails.mockReturnValue([]);
@@ -100,5 +103,53 @@ describe('useNewChartView - axis label click wiring', () => {
       ([eventName]) => eventName === 'click'
     ).length;
     expect(clickListenerCount).toBe(1);
+  });
+});
+
+describe('useNewChartView - axis label tooltip wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseChartContext.mockReturnValue({
+      chartView: { current: undefined },
+      selectedData: { current: null },
+      selectedDataBounds: { current: undefined },
+      selectedDataName: { current: undefined },
+      chartId: 'test-chart',
+      setHoveredAxisLabel: mockSetHoveredAxisLabel,
+    } as unknown as ReturnType<typeof useChartContext>);
+    mockUsePopovers.mockReturnValue([]);
+    mockUseMarkOnClickDetails.mockReturnValue([]);
+    mockUseMarkMouseInputDetails.mockReturnValue([]);
+    mockUseAxisLabelOnClickDetails.mockReturnValue([]);
+  });
+
+  const axisLabelItem = {
+    mark: { role: 'axis-label', group: {} },
+    bounds: { x1: 0, x2: 10, y1: 0, y2: 20 },
+    datum: {},
+  };
+
+  test('hovering an axis label sets hoveredAxisLabel with the item bounds and tooltip content', () => {
+    const view = makeFakeView();
+    getOnNewView()(view);
+    const tooltipCallback = (view.tooltip as jest.Mock).mock.calls[0][0];
+
+    tooltipCallback(view, { type: 'pointermove' }, axisLabelItem, 'Category A');
+
+    expect(mockSetHoveredAxisLabel).toHaveBeenCalledWith({
+      bounds: { x1: 0, x2: 10, y1: 0, y2: 20 },
+      content: 'Category A',
+    });
+  });
+
+  test('hovering a non-axis-label item clears hoveredAxisLabel', () => {
+    const view = makeFakeView();
+    getOnNewView()(view);
+    const tooltipCallback = (view.tooltip as jest.Mock).mock.calls[0][0];
+    const barItem = { mark: { name: 'bar0' }, bounds: { x1: 0, x2: 0, y1: 0, y2: 0 }, datum: {} };
+
+    tooltipCallback(view, { type: 'mouseout' }, barItem, 'value');
+
+    expect(mockSetHoveredAxisLabel).toHaveBeenCalledWith(null);
   });
 });

--- a/packages/react-spectrum-charts-s2/src/hooks/useNewChartView.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useNewChartView.tsx
@@ -20,6 +20,7 @@ import { Legend } from '../components';
 import { useChartContext } from '../context/RscChartContext';
 import { ChartChildElement, RscChartProps } from '../types';
 import {
+  getItemBounds,
   getOnAxisLabelClickCallback,
   getOnChartMarkClickCallback,
   getOnChartMarkContextMenuCallback,
@@ -39,7 +40,8 @@ const useNewChartView = (
   inspectOptions: TooltipOptions,
   legendProps: UseLegendProps
 ) => {
-  const { chartView, selectedData, selectedDataBounds, selectedDataName, chartId } = useChartContext();
+  const { chartView, selectedData, selectedDataBounds, selectedDataName, chartId, setHoveredAxisLabel } =
+    useChartContext();
   const popovers = usePopovers(sanitizedChildren);
   const {
     legendHiddenSeries,
@@ -78,7 +80,13 @@ const useNewChartView = (
           clearTimeout(inspectTimeout);
           inspectTimeout = undefined;
         }
-        if (event?.type === 'pointermove' && (itemIsLegendItem(item) || itemIsAxisLabel(item)) && 'tooltip' in item) {
+        // Axis labels use a real Tooltip, not vega-tooltip's popup.
+        if (item && itemIsAxisLabel(item) && value !== undefined && value !== null) {
+          setHoveredAxisLabel({ bounds: getItemBounds(item), content: String(value) });
+          return;
+        }
+        setHoveredAxisLabel(null);
+        if (event?.type === 'pointermove' && itemIsLegendItem(item) && 'tooltip' in item) {
           inspectTimeout = setTimeout(() => {
             inspectHandler.call(viewRef, event, item, value);
             inspectTimeout = undefined;
@@ -170,6 +178,7 @@ const useNewChartView = (
       selectedData,
       selectedDataBounds,
       selectedDataName,
+      setHoveredAxisLabel,
       setLegendHiddenSeries,
       inspectOptions,
     ]

--- a/packages/react-spectrum-charts-s2/src/stories/components/Axis/AxisLabels.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Axis/AxisLabels.story.tsx
@@ -19,6 +19,7 @@ import { Axis, Bar } from '../../../components';
 import useChartProps from '../../../hooks/useChartProps';
 import { Chart } from '../../../index';
 import { bindWithProps } from '../../../test-utils';
+import { barDataLongLabels } from '../Bar/data';
 
 export default {
   title: 'React Spectrum Charts 2/Axis/Features/Labels',
@@ -87,6 +88,41 @@ LabelWithTooltip.args = {
   hasTooltip: true,
 };
 
+const TruncatedLabelStory: StoryFn<typeof Axis> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: barDataLongLabels, width: 450 });
+  return (
+    <Chart {...chartProps}>
+      <Axis {...args} />
+      <Bar dimension="browser" metric="downloads" />
+    </Chart>
+  );
+};
+
+// Truncated so the tooltip's full text differs visibly from what's shown.
+const TruncatedLabelWithTooltip = bindWithProps(TruncatedLabelStory);
+TruncatedLabelWithTooltip.args = {
+  truncateLabels: true,
+  position: 'bottom',
+  baseline: true,
+  title: 'Browser',
+  hasTooltip: true,
+};
+
+// Per-value overrides: custom text, suppressed, and default.
+const CustomTooltipText = bindWithProps(TruncatedLabelStory);
+CustomTooltipText.args = {
+  truncateLabels: true,
+  position: 'bottom',
+  baseline: true,
+  title: 'Browser',
+  hasTooltip: true,
+  tooltipText: [
+    { value: 'Microsoft Explorer', text: 'Microsoft Explorer is the most widely used browser' },
+    { value: 'Mozilla Firefox', text: null },
+    { value: 'Google Chrome', text: 'Chrome is the most popular browser' },
+  ],
+};
+
 const LabelLimitStory: StoryFn<typeof Axis> = (args): ReactElement => {
   const longLabelData = [
     { browser: 'Chrome with Very Long Browser Name That Exceeds Normal Limits', downloads: 100 },
@@ -111,4 +147,12 @@ LabelLimit.args = {
   labelLimit: 60,
 };
 
-export { Basic, LabelAlign, LabelOrientation, LabelLimit, LabelWithTooltip };
+export {
+  Basic,
+  LabelAlign,
+  LabelOrientation,
+  LabelLimit,
+  LabelWithTooltip,
+  TruncatedLabelWithTooltip,
+  CustomTooltipText,
+};

--- a/packages/react-spectrum-charts-s2/src/stories/components/Axis/AxisLabels.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Axis/AxisLabels.test.tsx
@@ -9,8 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { findChart, render, screen } from '../../../test-utils';
-import { LabelAlign, LabelOrientation } from './AxisLabels.story';
+import { findChart, getAllAxisLabels, hoverNthElement, render, screen, unhoverNthElement } from '../../../test-utils';
+import { CustomTooltipText, LabelAlign, LabelOrientation, TruncatedLabelWithTooltip } from './AxisLabels.story';
 
 describe('LabelAlign', () => {
   test('anchor should be on the left side of text for labelAlign="start" and labelOrientation="horizontal"', async () => {
@@ -40,5 +40,62 @@ describe('LabelOrientation', () => {
     expect(chart).toBeInTheDocument();
 
     expect(screen.getByText('0').getAttribute('transform')?.includes('rotate(270')).toBeTruthy();
+  });
+});
+
+describe('axis label tooltip', () => {
+  test('hovering a truncated label shows its full, untruncated value', async () => {
+    render(<TruncatedLabelWithTooltip {...TruncatedLabelWithTooltip.args} />);
+    const chart = await findChart();
+    const axisLabels = getAllAxisLabels(chart);
+
+    await hoverNthElement(axisLabels, 0); // Google Chrome
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Google Chrome');
+  });
+
+  test('a per-value override shows custom text instead of the label value', async () => {
+    render(<CustomTooltipText {...CustomTooltipText.args} />);
+    const chart = await findChart();
+    const axisLabels = getAllAxisLabels(chart);
+
+    await hoverNthElement(axisLabels, 4); // Microsoft Explorer
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Microsoft Explorer is the most widely used browser');
+  });
+
+  test('an unlisted value still falls back to its default full label value', async () => {
+    render(<CustomTooltipText {...CustomTooltipText.args} />);
+    const chart = await findChart();
+    const axisLabels = getAllAxisLabels(chart);
+
+    await hoverNthElement(axisLabels, 2); // Mac Safari - not in tooltipText
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Mac Safari');
+  });
+
+  test('text: null suppresses the tooltip for that value', async () => {
+    render(<CustomTooltipText {...CustomTooltipText.args} />);
+    const chart = await findChart();
+    const axisLabels = getAllAxisLabels(chart);
+
+    await hoverNthElement(axisLabels, 1); // Mozilla Firefox - text: null
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  test('unhovering closes the tooltip', async () => {
+    render(<TruncatedLabelWithTooltip {...TruncatedLabelWithTooltip.args} />);
+    const chart = await findChart();
+    const axisLabels = getAllAxisLabels(chart);
+
+    await hoverNthElement(axisLabels, 0);
+    await screen.findByRole('tooltip');
+
+    await unhoverNthElement(axisLabels, 0);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 });

--- a/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisLabelUtils.ts
@@ -17,6 +17,7 @@ import {
   GuideEncodeEntry,
   NumberValue,
   ProductionRule,
+  StringValueRef,
   TextEncodeEntry,
   TextValueRef,
   TickCount,
@@ -261,6 +262,21 @@ export const getLabelFormat = (
     ...(truncateLabels && scaleName.includes('Band') && labelIsParallelToAxis(position, labelOrientation)
       ? [{ signal: 'truncateText(datum.value, bandwidth("xBand")/(1- paddingInner), "normal", 14)' }]
       : [{ signal: 'datum.value' }]),
+  ];
+};
+
+/**
+ * Tooltip production rule: per-value override, suppress, or the label's raw value.
+ * @param name axis name
+ * @returns tooltip production rule
+ */
+export const getAxisLabelTooltipRule = (name: string): ProductionRule<StringValueRef> => {
+  const signalName = `${name}_tooltipText`;
+  const matchIndex = `indexof(pluck(${signalName}, 'value'), datum.value)`;
+  return [
+    { test: `${matchIndex} > -1 && ${signalName}[${matchIndex}].text === null`, signal: 'null' },
+    { test: `${matchIndex} > -1`, signal: `${signalName}[${matchIndex}].text` },
+    { signal: 'datum.value' },
   ];
 };
 

--- a/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.test.ts
@@ -614,6 +614,22 @@ describe('Spec builder, Axis', () => {
         })[0];
         expect(axis.encode?.labels).toHaveProperty('interactive', true);
       });
+
+      test('tooltip is a lookup production rule over the axis0_tooltipText signal', () => {
+        const axis = addAxes([], {
+          ...defaultAxisOptions,
+          hasTooltip: true,
+          scaleName: 'xBand',
+          scaleField: 'category',
+          usermeta: {},
+        })[0];
+        const matchIndex = "indexof(pluck(axis0_tooltipText, 'value'), datum.value)";
+        expect(axis.encode?.labels?.update?.tooltip).toStrictEqual([
+          { test: `${matchIndex} > -1 && axis0_tooltipText[${matchIndex}].text === null`, signal: 'null' },
+          { test: `${matchIndex} > -1`, signal: `axis0_tooltipText[${matchIndex}].text` },
+          { signal: 'datum.value' },
+        ]);
+      });
     });
 
     describe('onClick wiring', () => {
@@ -1136,6 +1152,43 @@ describe('Spec builder, Axis', () => {
       expect(signals[0]).toHaveProperty('value', [
         { value: 1, subLabel: 'one', align: 'left', baseline: 'top' },
         { value: 2, subLabel: 'two', align: 'right', baseline: 'top' },
+      ]);
+    });
+
+    test('should add an empty tooltipText signal when hasTooltip is true with no overrides', () => {
+      const signals = addAxisSignals([], { ...defaultAxisOptions, hasTooltip: true }, 'xLinear');
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toHaveProperty('name', 'axis0_tooltipText');
+      expect(signals[0]).toHaveProperty('value', []);
+    });
+
+    test('should not add a tooltipText signal when hasTooltip is false', () => {
+      const signals = addAxisSignals(
+        [],
+        { ...defaultAxisOptions, tooltipText: [{ value: 'Mac Safari', text: null }] },
+        'xLinear'
+      );
+      expect(signals).toHaveLength(0);
+    });
+
+    test('should add tooltipText signal with per-value overrides, including suppression', () => {
+      const signals = addAxisSignals(
+        [],
+        {
+          ...defaultAxisOptions,
+          hasTooltip: true,
+          tooltipText: [
+            { value: 'Microsoft Explorer', text: 'Clicking Other may expand the chart' },
+            { value: 'Mac Safari', text: null },
+          ],
+        },
+        'xLinear'
+      );
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).toHaveProperty('name', 'axis0_tooltipText');
+      expect(signals[0]).toHaveProperty('value', [
+        { value: 'Microsoft Explorer', text: 'Clicking Other may expand the chart' },
+        { value: 'Mac Safari', text: null },
       ]);
     });
 

--- a/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisSpecBuilder.ts
@@ -56,7 +56,12 @@ import {
   getAxisLabelMarkName,
   getMatchingInteractiveBarDimensionFields,
 } from './axisLabelHoverUtils';
-import { getAxisLabelsEncoding, getControlledLabelAnchorValues, getLabelValue } from './axisLabelUtils';
+import {
+  getAxisLabelsEncoding,
+  getAxisLabelTooltipRule,
+  getControlledLabelAnchorValues,
+  getLabelValue,
+} from './axisLabelUtils';
 import { getReferenceLineMarks, scaleTypeSupportsReferenceLines } from './axisReferenceLineUtils';
 import {
   addAxisThumbnailSignals,
@@ -243,10 +248,14 @@ export const addAxisData = produce<Data[], [AxisSpecOptions & { scaleType: Scale
 });
 
 export const addAxisSignals = produce<Signal[], [AxisSpecOptions, string]>((signals, options, scaleName) => {
-  const { name, labels, position, subLabels, labelOrientation } = options;
+  const { name, hasTooltip, labels, position, subLabels, labelOrientation, tooltipText } = options;
   if (labels?.length) {
     // add all the label properties to a signal so that the axis encoding can use it to style each label correctly
     signals.push(getGenericValueSignal(`${name}_labels`, getLabelSignalValue(labels, position, labelOrientation)));
+  }
+  if (hasTooltip) {
+    // signal must exist since the rule always references it
+    signals.push(getGenericValueSignal(`${name}_tooltipText`, tooltipText ?? []));
   }
   if (hasSubLabels(options)) {
     // add all the sublabel properties to a signal so that the axis encoding can use it to style each sublabel correctly
@@ -583,7 +592,7 @@ function applyAxisLabelEncodings(
   axis.values = labels.map((label) => getLabelValue(label));
   const baseEncoding = getAxisLabelsEncoding(labelAlign, labelFontWeight, 'label', labelOrientation, position, signalName);
   const encodingWithOptionalTooltip = hasTooltip
-    ? { ...baseEncoding, update: { ...baseEncoding.update, tooltip: { signal: 'datum.value' } } }
+    ? { ...baseEncoding, update: { ...baseEncoding.update, tooltip: getAxisLabelTooltipRule(name) } }
     : baseEncoding;
 
   axis.encode = {

--- a/packages/vega-spec-builder-s2/src/axis/axisUtils.ts
+++ b/packages/vega-spec-builder-s2/src/axis/axisUtils.ts
@@ -16,6 +16,7 @@ import { FILTERED_TABLE } from '@spectrum-charts/constants';
 import { AxisSpecOptions, DivergingBarMark, Granularity, Orientation, Position } from '../types';
 import {
   getAxisLabelsEncoding,
+  getAxisLabelTooltipRule,
   getLabelAnchorValues,
   getLabelAngle,
   getLabelFormat,
@@ -37,6 +38,7 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
     labelFontWeight,
     labelLimit,
     labelOrientation,
+    name,
     tickCountLimit,
     tickCountMinimum,
     position,
@@ -70,7 +72,7 @@ export const getDefaultAxis = (axisOptions: AxisSpecOptions, scaleName: string):
         interactive: Boolean(hasTooltip),
         update: {
           text: getLabelFormat(axisOptions, scaleName),
-          ...(hasTooltip ? { tooltip: { signal: 'datum.value' } } : {}),
+          ...(hasTooltip ? { tooltip: getAxisLabelTooltipRule(name) } : {}),
         },
       },
     },

--- a/packages/vega-spec-builder-s2/src/types/axis/axisSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/axis/axisSpec.types.ts
@@ -51,6 +51,13 @@ export type SubLabel = {
   fontWeight?: FontWeight;
 };
 
+export type AxisTooltip = {
+  /** The axis value that this tooltip is anchored to */
+  value: string | number;
+  /** Custom tooltip text; `null` suppresses it. */
+  text: string | null;
+};
+
 export interface AxisOptions {
   /** Sets the name of the component. */
   name?: string;
@@ -118,6 +125,8 @@ export interface AxisOptions {
   ticks?: boolean;
   /** Enables hover tooltips on axis labels for this axis. */
   hasTooltip?: boolean;
+  /** Per-value tooltip text overrides. Unlisted values use the default; `text: null` suppresses. */
+  tooltipText?: AxisTooltip[];
   /** Whether the axis has an onClick callback set. */
   hasOnClick?: boolean;
   /**


### PR DESCRIPTION
AN-456588 Add axis label hover tooltip to Bar

## Description

Adds a Spectrum 2 tooltip that appears when hovering an axis label, plus a way to customize its text per value.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests: added/updated coverage in axisSpecBuilder.test.ts (tooltip production-rule shape, per-value override + suppression, signal registration with/without hasTooltip) and useNewChartView.test.tsx (hover sets/clears the tooltip state). Full targeted suite passing (395+ tests across the touched area).
Manual verification in Storybook (Axis/Features/Labels, stories TruncatedLabelWithTooltip and CustomTooltipText): confirmed correct positioning, correct default/custom/suppressed content per bar, and correct fade-out behavior on hover-out.

## Screenshots (if appropriate):
<img width="522" height="338" alt="Screenshot 2026-09-09 at 11 17 00 AM" src="https://github.com/user-attachments/assets/b004ad51-46ee-4123-bcf9-d997362292be" />
<img width="851" height="470" alt="Screenshot 2026-09-09 at 11 17 11 AM" src="https://github.com/user-attachments/assets/ee4f46fb-6096-4ca1-8f01-b198bc8b5838" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
