### PR TITLE
docs: remove unplanned feature note from S2 axis docs

### DIFF
--- a/packages/docs/docs/spectrum2/axis.md
+++ b/packages/docs/docs/spectrum2/axis.md
@@ -6,13 +6,6 @@ sidebar_position: 4
 
 The `Axis` component in the S2 package supports nearly all props from the [base Axis component](/docs/api/components/Axis) plus S2-exclusive features: axis label hover tooltips and axis label click callbacks.
 
-:::note
-The S2 `Axis` component does not yet support:
-- `chartTooltips` (rich per-tooltip JSX content via a `ChartTooltip` child) — use `hasTooltip`/`tooltipText` instead, which show plain text.
-- `hasPopover` (triggering a `ChartPopover` from an `AxisThumbnail` click).
-- `AxisAnnotation` as a child component.
-:::
-
 ```jsx
 import { Chart, Axis } from '@spectrum-charts/react-spectrum-charts-s2';
 ```


### PR DESCRIPTION
chartTooltips, hasPopover, and AxisAnnotation aren't currently planned for the S2 Axis component, so listing them as "not yet supported" wrongly implied they're on a roadmap.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
