### PR TITLE
fix(s2-donut): create slice gaps with a border

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -253,14 +253,7 @@ export const DONUT_SIZE_TIER_CUTPOINTS = [120, 160, 200, 400];
 /** S2 donut fixed ring (hole) width per named size tier (XS/S/M/L/XL), used only when holeRatio is left at DEFAULT_HOLE_RATIO */
 export const DONUT_RING_WIDTHS = [16, 18, 20, 22, 24];
 /** S2 donut gap between adjacent segments per named size tier (XS/S/M/L/XL), per chart.donut.size.slice-gap */
-export const DONUT_SLICE_GAPS = [1, 2, 2, 2, 4];
-/**
- * Max fraction of a donut's average segment angular width the slice gap (padAngle) may consume.
- * Without this, a donut with many segments (some much smaller than the average) can have its
- * smallest segments' entire angular width eaten by the fixed per-tier gap, collapsing them to
- * nothing. The gap degrades gracefully instead by shrinking below the fixed size when needed.
- */
-export const DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION = 1 / 3;
+export const DONUT_SLICE_GAPS = [1, 2, 2, 2, 2];
 /**
  * S2 min inner radius to display the summary metric, recalibrated against the corrected per-tier ring width
  * (DONUT_SUMMARY_MIN_RADIUS is s1's, kept unchanged since it's paired with s1's proportional ring geometry).

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.test.ts
@@ -119,14 +119,17 @@ describe('getArcMark()', () => {
     expect(arcMark.encode?.update?.innerRadius).toEqual({ signal: '0.5 * (min(width, height) / 2 - 2)' });
   });
 
-  test('should convert the per-tier fixed slice gap to an angle at the outer radius, capped to a fraction of this segment\'s own angular width', () => {
+  test('should use the per-tier fixed slice gap as the segment border width', () => {
     const arcMark = getArcMark(defaultDonutOptions);
-    // capping against this segment's own arcLength (not an average across all segments) is what
-    // actually prevents collapse for a donut whose segment sizes are highly skewed
-    expect(arcMark.encode?.update?.padAngle).toEqual({
-      signal:
-        "min(testName_sliceGap / (min(width, height) / 2 - 2), datum['testName_arcLength'] * 0.3333333333333333)",
-    });
+    expect(arcMark.encode?.update).not.toHaveProperty('padAngle');
+    expect(arcMark.encode?.update?.stroke).toEqual([
+      { test: 'selectedItem === datum.rscMarkId', value: 'static-blue' },
+      { signal: 'chartBackgroundColor' },
+    ]);
+    expect(arcMark.encode?.update?.strokeWidth).toEqual([
+      { test: 'selectedItem === datum.rscMarkId', value: 2 },
+      { signal: 'testName_sliceGap' },
+    ]);
   });
 
   test('should fade segments that do not match a hovered Legend entry', () => {

--- a/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
+++ b/packages/vega-spec-builder-s2/src/donut/donutUtils.ts
@@ -12,6 +12,7 @@
 import { ArcMark, ColorValueRef, NumericValueRef, ProductionRule, Signal, SourceData, ThresholdScale } from 'vega';
 
 import {
+  BACKGROUND_COLOR,
   DEFAULT_HOLE_RATIO,
   DONUT_ADVANCED_LABEL_RING_GAP,
   DONUT_LABEL_MAX_ANCHOR_OFFSET_RATIO,
@@ -19,7 +20,6 @@ import {
   DONUT_RADIUS,
   DONUT_RING_WIDTHS,
   DONUT_SIZE_TIER_CUTPOINTS,
-  DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION,
   DONUT_SLICE_GAPS,
   FADE_FACTOR,
   FILTERED_TABLE,
@@ -161,21 +161,6 @@ export const getDonutInnerRadiusExpr = (options: DonutSpecOptions): string => {
 };
 
 /**
- * Gets the arc mark's padAngle - the fixed per-tier px slice gap converted to radians, capped to a
- * fraction of each segment's own angular width so a tiny segment can't collapse under a gap sized
- * for a larger one.
- * @param donutOptions
- * @returns vega expression string
- */
-const getPadAngleExpr = (options: DonutSpecOptions): string => {
-  const { name } = options;
-  const outerRadius = getDonutOuterRadiusExpr(options);
-  const fixedGapAngle = `${name}_sliceGap / ${outerRadius}`;
-  const segmentAngle = `datum['${name}_arcLength']`;
-  return `min(${fixedGapAngle}, ${segmentAngle} * ${DONUT_SLICE_GAP_MAX_SEGMENT_FRACTION})`;
-};
-
-/**
  * Gets opacity rules that fade a segment when a paired Legend's hovered entry doesn't match it -
  * the reverse direction of the arc's own hover fading the legend (legendUtils.ts). Each signal
  * fades non-matching segments and falls through (to getMarkOpacity's own rules) otherwise, mirroring
@@ -228,14 +213,16 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
         x: { signal: 'width / 2' },
         y: { signal: 'height / 2' },
         tooltip: getInspectEncoding(chartInspects, name),
-        stroke: { value: getS2ColorValue('static-blue', colorScheme) },
       },
       update: {
         startAngle: { field: `${name}_startAngle` },
         endAngle: { field: `${name}_endAngle` },
-        padAngle: { signal: getPadAngleExpr(options) },
         innerRadius: { signal: getDonutInnerRadiusExpr(options) },
         outerRadius: { signal: outerRadius },
+        stroke: [
+          { test: `${SELECTED_ITEM} === datum.${idKey}`, value: getS2ColorValue('static-blue', colorScheme) },
+          { signal: BACKGROUND_COLOR },
+        ],
         // hide the segments when there isn't any data to display, the empty state ring is shown instead
         opacity: [
           { test: getDonutEmptyStateTest(name), value: 0 },
@@ -243,7 +230,7 @@ export const getArcMark = (options: DonutSpecOptions): ArcMark => {
           ...getMarkOpacity(options),
         ],
         cursor: getCursor(chartPopovers),
-        strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${idKey}`, value: 2 }, { value: 0 }],
+        strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${idKey}`, value: 2 }, { signal: `${name}_sliceGap` }],
       },
     },
   };


### PR DESCRIPTION
## Description

To create space between each donut segment, create a white border (background halo) around each slice, rather than using an actual pixel gap. 

## Related Issue

## Motivation and Context

Cleaner way to create gaps.

## How Has This Been Tested?

Visually in storybook, unit tests. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
