### PR TITLE
feat: bar data navigator

### DIFF
--- a/packages/constants/constants.ts
+++ b/packages/constants/constants.ts
@@ -179,6 +179,11 @@ export const DRAW_IN_ANIM_T_EASED = 'drawInAnimTEased'; // eased (quadratic in-o
 export const DRAW_IN_DOMAIN_MIN = 'drawInDomainMin'; // draw-in animation: dimension scale domain min, captured once at mount
 export const DRAW_IN_DOMAIN_MAX = 'drawInDomainMax'; // draw-in animation: dimension scale domain max, captured once at mount
 export const DRAW_IN_ANIM_CUTOFF = 'drawInAnimCutoff'; // draw-in animation: sweeping cutoff position, in domain units
+export const FOCUSED_ITEM = 'focusedItem'; // data point focused via keyboard navigation (data-navigator)
+export const FOCUSED_REGION = 'focusedRegion'; // chart region focused via keyboard navigation (data-navigator)
+export const FOCUSED_DIMENSION = 'focusedDimension'; // dimension group (e.g. a whole stack) focused via keyboard navigation
+/** Separator joining fields into a unique data-navigator node id (e.g. stacked segment = dimension + series). */
+export const NAVIGATION_ID_SEPARATOR = '__rsc__';
 
 // scale names
 export const COLOR_SCALE = 'color';

--- a/packages/docs/docs/spectrum2/bar.md
+++ b/packages/docs/docs/spectrum2/bar.md
@@ -10,6 +10,8 @@ The `Bar` component in the S2 package supports nearly all props from the [base B
 The S2 `Bar` component does not yet support `Trendline` as a child component.
 :::
 
+See [Keyboard Navigation](/docs/spectrum2/keyboard-navigation) for the `accessibleNavigation` chart prop, currently supported only for `Bar`.
+
 ```jsx
 import { Chart, Axis, Bar } from '@spectrum-charts/react-spectrum-charts-s2';
 ```

--- a/packages/docs/docs/spectrum2/keyboard-navigation.md
+++ b/packages/docs/docs/spectrum2/keyboard-navigation.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 5
+---
+
+# Keyboard Navigation (S2)
+
+:::caution Work in progress
+Keyboard navigation is an early, work-in-progress feature. It does not yet provide full chart accessibility or screen reader support — treat it as a keyboard-only enhancement, not a complete accessibility solution.
+:::
+
+:::caution Bar charts only
+Keyboard navigation is currently only supported for `Bar` charts with a plain or stacked layout. Grouped (dodged) and trellis bar configurations, other mark types (Line, Area, Donut, Scatter, etc.), and legend/axis label navigation are not yet supported.
+:::
+
+Set `accessibleNavigation` on `Chart` to let keyboard users navigate bar chart content — individual bars, stacked segments, and their tooltips and popovers — without a mouse.
+
+```jsx
+<Chart data={data} accessibleNavigation>
+  <Axis position="bottom" baseline title="Browser" />
+  <Axis position="left" grid title="Downloads" />
+  <Bar dimension="browser" color="operatingSystem">
+    <ChartInspect>
+      {(datum) => (
+        <div>
+          <div>Operating system: {datum.operatingSystem}</div>
+          <div>Downloads: {datum.value}</div>
+        </div>
+      )}
+    </ChartInspect>
+    <ChartPopover>
+      {(datum, close) => (
+        <div>
+          <div>Operating system: {datum.operatingSystem}</div>
+          <button onClick={close}>Close</button>
+        </div>
+      )}
+    </ChartPopover>
+  </Bar>
+</Chart>
+```
+
+---
+
+## Keyboard interactions
+
+| Key | Action |
+|---|---|
+| `Tab` | Focuses the "Enter navigation area" affordance, shown at the top-left of the chart |
+| `Enter` | Enters the navigation area, or drills into the focused stack |
+| `Escape` | Drills back out one layer; at the top level, exits the navigation area |
+| `Arrow Right` / `Arrow Down` | Moves to the next sibling (bar, stack, or segment) |
+| `Arrow Left` / `Arrow Up` | Moves to the previous sibling |
+| `Space` | Opens the `ChartPopover` for the focused bar, segment, or stack, if one is configured |
+
+Right and Down behave identically, as do Left and Up. Navigation does not wrap — arrowing past the last item stays there — and arrowing through a stack's segments never spills into the next stack.
+
+Bars and segments with a value of exactly `0` are excluded from navigation, since they render invisibly and a mouse could never reach them either.
+
+---
+
+## Focus and hover parity
+
+A keyboard-focused bar drives the same signals real mouse hover drives, so keyboard and mouse interactions look identical: other bars dim the same way, the real `ChartInspect` tooltip appears with the same content and positioning, and `Space` opens the real `ChartPopover` through the same trigger a click uses.
+
+---
+
+## Stacked bars
+
+For a stacked `Bar` (`color` set), navigation has an extra layer: `Enter` on the chart root drills into a stack (column), and `Enter` again drills into an individual segment. `Escape` reverses this one layer at a time.
+
+Focusing a stack — before drilling into a segment — shows the dimension-area tooltip or popover, if configured, the same one a mouse hovering the stack's exposed padding would show. See the `targets` prop on [`ChartInspect`](/docs/spectrum2/overview#chartinspect-props).

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -75,6 +75,7 @@ const sidebars: SidebarsConfig = {
         'spectrum2/bar',
         'spectrum2/legend',
         'spectrum2/chart-sizing',
+        'spectrum2/keyboard-navigation',
         'spectrum2/react-server-components',
         {
           type: 'category',

--- a/packages/react-spectrum-charts-s2/package.json
+++ b/packages/react-spectrum-charts-s2/package.json
@@ -92,6 +92,7 @@
     "@spectrum-charts/utils": "1.52.0",
     "@spectrum-charts/vega-spec-builder-s2": "0.7.0",
     "d3-format": "^3.1.0",
+    "data-navigator": "^2.4.1",
     "deepmerge": ">= 4.0.0",
     "immer": ">= 9.0.0",
     "vega-embed": ">= 7.1.0",

--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -27,7 +27,7 @@ import usePopovers, { PopoverDetail } from './hooks/usePopovers';
 import useSpec from './hooks/useSpec';
 import useSpecProps from './hooks/useSpecProps';
 import { RscChartProps } from './types';
-import { clearHoverSignals, sanitizeRscChartChildren, setSelectedSignals } from './utils';
+import { clearHoverSignals, sanitizeRscChartChildren, setSelectedSignals, shouldClearHoverSignalsOnClose } from './utils';
 
 interface ChartDialogProps {
   targetElement: RefObject<HTMLElement | null>;
@@ -225,9 +225,7 @@ const ChartDialog = ({ popover, setIsPopoverOpen, targetElement, idKey, specSign
           keyboardPopoverComponentName.current = null;
           selectedData.current = null;
           selectedDataName.current = '';
-          // A keyboard-opened popover's hover-parity is still owned by keyboard focus, which never
-          // left — clearing it here would just get reapplied moments later, causing a visible flash.
-          if (componentName && keyboardComponentName !== componentName) {
+          if (shouldClearHoverSignalsOnClose(componentName, keyboardComponentName)) {
             clearHoverSignals(chartView.current, componentName, specSignalNames);
           }
         }

--- a/packages/react-spectrum-charts-s2/src/RscChart.tsx
+++ b/packages/react-spectrum-charts-s2/src/RscChart.tsx
@@ -9,15 +9,17 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { CSSProperties, RefObject, Ref, useCallback, useEffect, useMemo, useState } from 'react';
+import { CSSProperties, RefObject, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Popover } from '@react-spectrum/s2';
 import { View as VegaView } from 'vega';
 import { COMPONENT_NAME, DEFAULT_SYMBOL_SHAPES, DEFAULT_SYMBOL_SIZES } from '@spectrum-charts/constants';
-import { ChartHandle, Datum, SymbolSize, getChartConfig } from '@spectrum-charts/vega-spec-builder-s2';
+import { ChartHandle, Datum, SimpleData, SymbolSize, getChartConfig } from '@spectrum-charts/vega-spec-builder-s2';
 
 import './Chart.css';
 import { VegaChart } from './VegaChart';
+import { Navigator } from './dataNavigator/Navigator';
+import { getNavigableChartType } from './dataNavigator/navigableMarks';
 import { useChartContext } from './context/RscChartContext';
 import useChartImperativeHandle from './hooks/useChartImperativeHandle';
 import { useChartInteractions } from './hooks/useChartInteractions';
@@ -39,6 +41,7 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
   const {
     animations,
     animationTypes,
+    accessibleNavigation,
     backgroundColor,
     data,
     chartWidth,
@@ -65,7 +68,17 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
     idKey,
   } = props;
 
-  const { chartView, chartId, popoverAnchorRef, isPopoverOpen, setIsPopoverOpen } = useChartContext();
+  const {
+    chartView,
+    chartId,
+    popoverAnchorRef,
+    isPopoverOpen,
+    setIsPopoverOpen,
+    selectedData,
+    selectedDataBounds,
+    selectedDataName,
+    keyboardPopoverComponentName,
+  } = useChartContext();
 
   const sanitizedChildren = useMemo(() => sanitizeRscChartChildren(props.children), [props.children]);
 
@@ -73,6 +86,7 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
   const spec = useSpec({
     animations,
     animationTypes,
+    accessibleNavigation,
     backgroundColor,
     children: sanitizedChildren,
     colors,
@@ -119,6 +133,19 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
     [onNewView, onVegaViewReady]
   );
 
+  const navContainerRef = useRef<HTMLDivElement>(null);
+  const navChild = sanitizedChildren.find(
+    (child) => 'displayName' in child.type && getNavigableChartType(child.type.displayName)
+  );
+  const navChartType =
+    navChild && 'displayName' in navChild.type ? getNavigableChartType(navChild.type.displayName) : undefined;
+  const navFields = navChild?.props as { dimension?: string; metric?: string; color?: unknown; name?: string } | undefined;
+  const navColor = typeof navFields?.color === 'string' ? navFields.color : undefined;
+  // The bar's own mark name, so keyboard focus can drive the same hover signals real mouse hover drives, for exact parity.
+  const markName = navFields?.name ?? 'bar0';
+
+  const getView = useCallback(() => chartView.current ?? undefined, [chartView]);
+
   return (
     <>
       <div
@@ -127,20 +154,40 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
         ref={popoverAnchorRef}
         style={targetStyle}
       />
-      <VegaChart
-        spec={spec}
-        config={chartConfig}
-        data={data}
-        debug={debug}
-        renderer={renderer}
-        width={chartWidth}
-        height={chartHeight}
-        locale={locale}
-        padding={padding}
-        signals={signals}
-        tooltip={inspectOptions} // legend show/hide relies on this
-        onNewView={handleNewView}
-      />
+      <div id={`${chartId}-dn-root`} ref={navContainerRef} style={{ position: 'relative' }}>
+        <VegaChart
+          spec={spec}
+          config={chartConfig}
+          data={data}
+          debug={debug}
+          renderer={renderer}
+          width={chartWidth}
+          height={chartHeight}
+          locale={locale}
+          padding={padding}
+          signals={signals}
+          tooltip={inspectOptions} // legend show/hide relies on this
+          onNewView={handleNewView}
+        />
+        {accessibleNavigation && navChartType && (
+          <Navigator
+            chartType={navChartType}
+            data={data as SimpleData[]}
+            dimension={navFields?.dimension}
+            color={navColor}
+            metric={navFields?.metric}
+            markName={markName}
+            title={title}
+            containerRef={navContainerRef}
+            chartId={chartId}
+            getView={getView}
+            selectedData={selectedData}
+            selectedDataBounds={selectedDataBounds}
+            selectedDataName={selectedDataName}
+            keyboardPopoverComponentName={keyboardPopoverComponentName}
+          />
+        )}
+      </div>
       {popovers.map((popover) => (
         <ChartDialog
           key={popover.key}
@@ -157,7 +204,7 @@ export const RscChart = ({ ref, ...props }: RscChartProps & { ref?: Ref<ChartHan
 RscChart.displayName = 'RscChart';
 
 const ChartDialog = ({ popover, setIsPopoverOpen, targetElement, idKey, specSignalNames }: ChartDialogProps) => {
-  const { chartView, selectedData, selectedDataName } = useChartContext();
+  const { chartView, selectedData, selectedDataName, keyboardPopoverComponentName } = useChartContext();
   const [renderDatum, setRenderDatum] = useState<Datum | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const { chartPopoverProps, name } = popover;
@@ -174,9 +221,13 @@ const ChartDialog = ({ popover, setIsPopoverOpen, targetElement, idKey, specSign
           setRenderDatum(selectedData.current);
         } else {
           const componentName = selectedDataName.current;
+          const keyboardComponentName = keyboardPopoverComponentName.current;
+          keyboardPopoverComponentName.current = null;
           selectedData.current = null;
           selectedDataName.current = '';
-          if (componentName) {
+          // A keyboard-opened popover's hover-parity is still owned by keyboard focus, which never
+          // left — clearing it here would just get reapplied moments later, causing a visible flash.
+          if (componentName && keyboardComponentName !== componentName) {
             clearHoverSignals(chartView.current, componentName, specSignalNames);
           }
         }
@@ -184,7 +235,16 @@ const ChartDialog = ({ popover, setIsPopoverOpen, targetElement, idKey, specSign
         chartView.current.run();
       }
     },
-    [chartView, idKey, onOpenChange, selectedData, selectedDataName, setIsPopoverOpen, specSignalNames]
+    [
+      chartView,
+      keyboardPopoverComponentName,
+      idKey,
+      onOpenChange,
+      selectedData,
+      selectedDataName,
+      setIsPopoverOpen,
+      specSignalNames,
+    ]
   );
 
   const close = useCallback(() => handleOpenChange(false), [handleOpenChange]);

--- a/packages/react-spectrum-charts-s2/src/context/RscChartContext.tsx
+++ b/packages/react-spectrum-charts-s2/src/context/RscChartContext.tsx
@@ -25,6 +25,9 @@ interface ChartContextValue {
   selectedDataName: RefObject<string>;
   selectedDataBounds: RefObject<MarkBounds>;
 
+  // Set when Space opens a popover, so its close handler can skip clearing hover-parity signals keyboard focus still owns.
+  keyboardPopoverComponentName: RefObject<string | null>;
+
   // Popover state
   isPopoverOpen: boolean;
   setIsPopoverOpen: (isOpen: boolean) => void;
@@ -50,6 +53,7 @@ export const ChartProvider = ({ children, chartId, chartView }: ChartProviderPro
   const selectedData = useRef<Datum | null>(null);
   const selectedDataName = useRef<string>('');
   const selectedDataBounds = useRef<MarkBounds>({ x1: 0, x2: 0, y1: 0, y2: 0 });
+  const keyboardPopoverComponentName = useRef<string | null>(null);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
@@ -60,6 +64,7 @@ export const ChartProvider = ({ children, chartId, chartView }: ChartProviderPro
       selectedData,
       selectedDataName,
       selectedDataBounds,
+      keyboardPopoverComponentName,
       controlledHoveredIdSignal,
       controlledHoveredGroupSignal,
       isPopoverOpen,

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/Navigator.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/Navigator.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement, useRef } from 'react';
+
+import { render } from '@testing-library/react';
+import { View } from 'vega';
+
+import { SimpleData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { Navigator } from './Navigator';
+
+const data: SimpleData[] = [
+  { browser: 'Chrome', downloads: 27000 },
+  { browser: 'Firefox', downloads: 8000 },
+];
+
+const getView = () => ({ signal: jest.fn(), runAsync: jest.fn() }) as unknown as View;
+
+const Harness = ({ chartData }: { chartData: SimpleData[] }): ReactElement => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={ref} data-testid="dn-container" style={{ position: 'relative' }}>
+      <Navigator
+        chartType="bar"
+        data={chartData}
+        dimension="browser"
+        chartId="navigator-test"
+        containerRef={ref}
+        getView={getView}
+      />
+    </div>
+  );
+};
+
+describe('Navigator', () => {
+  test('renders no DOM of its own', () => {
+    const { container } = render(<Navigator chartType="bar" data={data} dimension="browser" chartId="t" containerRef={{ current: null }} getView={getView} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('attaches the data-navigator entry button into the container', () => {
+    const { getByTestId } = render(<Harness chartData={data} />);
+    expect(getByTestId('dn-container').querySelector('button')).toBeTruthy();
+  });
+
+  test('does not attach navigation when there is no data', () => {
+    const { getByTestId } = render(<Harness chartData={[]} />);
+    expect(getByTestId('dn-container').querySelector('button')).toBeFalsy();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/Navigator.tsx
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/Navigator.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { RefObject, useEffect } from 'react';
+
+import { View } from 'vega';
+
+import { Datum, MarkBounds, SimpleData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { NavigableChartType } from './buildChartStructure';
+import { attachDataNavigator } from './dataNavigatorAdapter';
+
+export interface NavigatorProps {
+  /** The chart type to build navigation for. */
+  chartType: NavigableChartType;
+  /** The chart data (plain objects). */
+  data: SimpleData[];
+  /** Primary categorical / x-axis field. */
+  dimension?: string;
+  /** Series / color field (set for stacked bars). */
+  color?: string;
+  /** Primary metric / y-axis field. */
+  metric?: string;
+  /** The mark's own name (e.g. `bar0`) — drives its real hover signals and focus ring, so keyboard focus matches mouse hover exactly. */
+  markName?: string;
+  /** Optional chart title for the accessible description. */
+  title?: string;
+  /** Ref to the positioned container that wraps the chart. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Stable id used to namespace the rendered nav elements. */
+  chartId: string;
+  /** Accessor for the live Vega view. */
+  getView: () => View | undefined;
+  /** Same context refs `handleMarkClick` uses — Space opens a focused bar/segment's popover through the exact same trigger. */
+  selectedData?: RefObject<Datum | null>;
+  selectedDataBounds?: RefObject<MarkBounds>;
+  selectedDataName?: RefObject<string>;
+  /** Lets the popover's own close handler know it doesn't need to clear hover-parity signals — keyboard focus still owns them. */
+  keyboardPopoverComponentName?: RefObject<string | null>;
+}
+
+export const Navigator = ({
+  chartType,
+  data,
+  dimension,
+  color,
+  metric,
+  markName,
+  title,
+  containerRef,
+  chartId,
+  getView,
+  selectedData,
+  selectedDataBounds,
+  selectedDataName,
+  keyboardPopoverComponentName,
+}: NavigatorProps): null => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || data.length === 0) {
+      return;
+    }
+    const attach = () =>
+      attachDataNavigator({
+        container,
+        chartType,
+        data,
+        dimension,
+        color,
+        metric,
+        markName,
+        title,
+        chartId,
+        getView,
+        selectedData,
+        selectedDataBounds,
+        selectedDataName,
+        keyboardPopoverComponentName,
+      });
+    attach();
+    // Re-attach on the next frame so a fresh render reads a laid-out scenegraph (the first effect
+    // tick can run before Vega's async layout settles). attachDataNavigator rebuilds cleanly.
+    const raf = requestAnimationFrame(attach);
+    return () => cancelAnimationFrame(raf);
+  }, [
+    chartType,
+    data,
+    dimension,
+    color,
+    metric,
+    markName,
+    title,
+    chartId,
+    containerRef,
+    getView,
+    selectedData,
+    selectedDataBounds,
+    selectedDataName,
+    keyboardPopoverComponentName,
+  ]);
+
+  return null;
+};
+Navigator.displayName = 'Navigator';

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/barHoverParity.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/barHoverParity.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { NodeObject } from 'data-navigator';
+import { View } from 'vega';
+
+import { applyHoverParitySignals, findFocusedStackRow } from './barHoverParity';
+
+const rows = [
+  { browser: 'Chrome', os: 'Windows', value: 18000, rscMarkId: 0 },
+  { browser: 'Chrome', os: 'Mac', value: 9000, rscMarkId: 1 },
+  { browser: 'Firefox', os: 'Windows', value: 5000, rscMarkId: 2 },
+];
+
+const mockView = () => {
+  const signal = jest.fn();
+  return { view: { signal, data: jest.fn().mockReturnValue(rows) } as unknown as View, signal };
+};
+
+describe('applyHoverParitySignals()', () => {
+  test('a leaf node sets both hoveredItem and dimensionHoverArea_hoveredItem to the matching row', () => {
+    const { view, signal } = mockView();
+    const node = { id: 'Chrome__rsc__Windows', data: { browser: 'Chrome', os: 'Windows', value: 18000 } } as unknown as NodeObject;
+
+    applyHoverParitySignals(view, { markName: 'bar0', dimension: 'browser', color: 'os' }, node);
+
+    expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', rows[0]);
+    expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', rows[0]);
+  });
+
+  test('a division (stack) node sets only dimensionHoverArea_hoveredItem, not hoveredItem', () => {
+    const { view, signal } = mockView();
+    const node = { id: 'Chrome', dimensionLevel: 2, derivedNode: 'browser', data: { browser: 'Chrome' } } as unknown as NodeObject;
+
+    applyHoverParitySignals(view, { markName: 'bar0', dimension: 'browser', color: 'os' }, node);
+
+    expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', null);
+    expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', rows[0]);
+  });
+
+  test('clears both signals when node is null (focus left the chart)', () => {
+    const { view, signal } = mockView();
+    applyHoverParitySignals(view, { markName: 'bar0', dimension: 'browser', color: 'os' }, null);
+
+    expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', null);
+    expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', null);
+  });
+
+  test('clears both signals for the chart-root (overview) node — no dimension value to match', () => {
+    const { view, signal } = mockView();
+    const node = { id: '_browser', dimensionLevel: 1, data: { dimensionKey: 'browser', divisions: {} } } as unknown as NodeObject;
+
+    applyHoverParitySignals(view, { markName: 'bar0', dimension: 'browser', color: 'os' }, node);
+
+    expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', null);
+    expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', null);
+  });
+
+  test('works for a basic (non-stacked) bar with no color field', () => {
+    const { view, signal } = mockView();
+    const basicRows = [{ browser: 'Firefox', value: 5000 }];
+    (view.data as jest.Mock).mockReturnValue(basicRows);
+    const node = { id: 'Firefox', data: { browser: 'Firefox', value: 5000 } } as unknown as NodeObject;
+
+    applyHoverParitySignals(view, { markName: 'bar0', dimension: 'browser' }, node);
+
+    expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', basicRows[0]);
+    expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', basicRows[0]);
+  });
+});
+
+describe('findFocusedStackRow()', () => {
+  const stackRows = [
+    { browser: 'Chrome', min_value1: 0, max_value1: 27000 },
+    { browser: 'Firefox', min_value1: 0, max_value1: 8000 },
+  ];
+
+  const mockStackView = () => ({ data: jest.fn().mockReturnValue(stackRows) }) as unknown as View;
+
+  test('finds the stack aggregate row matching a division node\'s dimension value', () => {
+    const view = mockStackView();
+    const node = { id: 'Chrome', dimensionLevel: 2, derivedNode: 'browser', data: { browser: 'Chrome' } } as unknown as NodeObject;
+
+    expect(findFocusedStackRow(view, node, 'browser', 'bar0')).toBe(stackRows[0]);
+    expect(view.data).toHaveBeenCalledWith('bar0_stacks');
+  });
+
+  test('returns undefined when the node has no resolvable dimension value', () => {
+    const view = mockStackView();
+    const node = { id: '_browser', dimensionLevel: 1, data: {} } as unknown as NodeObject;
+
+    expect(findFocusedStackRow(view, node, 'browser', 'bar0')).toBeUndefined();
+  });
+
+  test('returns undefined when no stack row matches', () => {
+    const view = mockStackView();
+    const node = { id: 'Safari', dimensionLevel: 2, derivedNode: 'browser', data: { browser: 'Safari' } } as unknown as NodeObject;
+
+    expect(findFocusedStackRow(view, node, 'browser', 'bar0')).toBeUndefined();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/barHoverParity.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/barHoverParity.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { NodeObject } from 'data-navigator';
+import { View } from 'vega';
+
+import { DIMENSION_HOVER_AREA, FILTERED_TABLE, HOVERED_ITEM } from '@spectrum-charts/constants';
+
+export interface BarHoverParityOptions {
+  /** The bar mark's own name (e.g. `bar0`) — signals are namespaced off of it, same as mouse hover. */
+  markName: string;
+  /** The bar's category field. */
+  dimension: string;
+  /** The bar's series/color field (stacked bars only). */
+  color?: string;
+}
+
+export type Row = Record<string, unknown>;
+
+/** The raw dimension/color value(s) a focused node represents: a leaf's `node.data`, or a division's dimension value via `derivedNode`. */
+const getNodeFieldValues = (node: NodeObject, dimension: string, color?: string): { dimensionValue: unknown; colorValue?: unknown } => {
+  const data = node.data as Row | undefined;
+  if (node.dimensionLevel == null) {
+    return { dimensionValue: data?.[dimension], colorValue: color ? data?.[color] : undefined };
+  }
+  return { dimensionValue: node.derivedNode ? data?.[node.derivedNode] : undefined };
+};
+
+/** Finds the live post-`identifier`-transform row matching a focused node, since `node.data` predates that transform. `undefined` for a division — no single row represents a whole stack. */
+export const findFocusedRow = (view: View, node: NodeObject, dimension: string, color?: string): Row | undefined => {
+  const { dimensionValue, colorValue } = getNodeFieldValues(node, dimension, color);
+  if (dimensionValue == null) return undefined;
+  const rows = (view.data(FILTERED_TABLE) ?? []) as Row[];
+  // A division (whole stack) has no series of its own, so any row for that dimension value matches.
+  return rows.find((row) => row[dimension] === dimensionValue && (colorValue === undefined || (color && row[color] === colorValue)));
+};
+
+/** The `${markName}_stacks` aggregate row for a focused division node — only meaningful for a division; a leaf's own row already has everything `formatTooltip` needs. */
+export const findFocusedStackRow = (view: View, node: NodeObject, dimension: string, markName: string): Row | undefined => {
+  const { dimensionValue } = getNodeFieldValues(node, dimension);
+  if (dimensionValue == null) return undefined;
+  const rows = (view.data(`${markName}_stacks`) ?? []) as Row[];
+  return rows.find((row) => row[dimension] === dimensionValue);
+};
+
+/** Drives the same hover signals real mouse hover drives (see `addHoveredItemSignal`), so every existing hover rule gives keyboard focus exact parity for free. */
+export const applyHoverParitySignals = (view: View, options: BarHoverParityOptions, node: NodeObject | null): void => {
+  const { markName, dimension, color } = options;
+  const itemSignal = `${markName}_${HOVERED_ITEM}`;
+  const dimensionSignal = `${markName}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`;
+
+  const row = node ? findFocusedRow(view, node, dimension, color) ?? null : null;
+  if (!row) {
+    view.signal(itemSignal, null);
+    view.signal(dimensionSignal, null);
+    return;
+  }
+
+  const isLeaf = node?.dimensionLevel == null;
+  // A division (whole stack) only matches the dimension-wide target — no single bar is hovered.
+  view.signal(itemSignal, isLeaf ? row : null);
+  view.signal(dimensionSignal, row);
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/buildBarStructure.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/buildBarStructure.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { NodeObject, Structure } from 'data-navigator';
+
+import { buildBarStructure, buildNodeLabel, segmentId } from './buildBarStructure';
+
+const hasEdgeBetween = (structure: Structure, a: string, b: string): boolean =>
+  Object.values(structure.edges).some((edge) => (edge.source === a && edge.target === b) || (edge.source === b && edge.target === a));
+
+const data = [
+  { browser: 'Chrome', downloads: 27000 },
+  { browser: 'Firefox', downloads: 8000 },
+  { browser: 'Safari', downloads: 4000 },
+];
+
+const stackedData = [
+  { browser: 'Chrome', os: 'Windows', downloads: 18000 },
+  { browser: 'Chrome', os: 'Mac', downloads: 9000 },
+  { browser: 'Firefox', os: 'Windows', downloads: 5000 },
+  { browser: 'Firefox', os: 'Mac', downloads: 3000 },
+];
+
+describe('buildBarStructure()', () => {
+  test('keys leaf nodes by the dimension value', () => {
+    const { structure } = buildBarStructure({ data, dimension: 'browser' });
+    expect(structure.nodes.Chrome).toBeDefined();
+    expect(structure.nodes.Chrome.data).toHaveProperty('browser', 'Chrome');
+    expect(structure.nodes.Firefox).toBeDefined();
+    expect(structure.nodes.Safari).toBeDefined();
+  });
+
+  test('returns the dimension root as the entry point', () => {
+    const { structure, entryPoint } = buildBarStructure({ data, dimension: 'browser' });
+    expect(entryPoint).toBeDefined();
+    expect(structure.nodes[entryPoint as string]).toBeDefined();
+    // dimension root nodes carry a dimensionLevel; leaf nodes do not
+    expect(structure.nodes[entryPoint as string].dimensionLevel).not.toBeUndefined();
+  });
+
+  test('uses the consumer-supplied title verbatim as the entry point label (no synthesized narration)', () => {
+    const { structure, entryPoint } = buildBarStructure({ data, dimension: 'browser', title: 'Browser downloads' });
+    expect(structure.nodes[entryPoint as string].semantics?.label).toBe('Browser downloads');
+  });
+
+  test('falls back to the node id (no synthesized narration) when no title is supplied', () => {
+    const { structure, entryPoint } = buildBarStructure({ data, dimension: 'browser' });
+    expect(structure.nodes[entryPoint as string].semantics?.label).toBe(entryPoint);
+  });
+
+  test('ensures every node has a semantics label', () => {
+    const { structure } = buildBarStructure({ data, dimension: 'browser' });
+    Object.values(structure.nodes).forEach((node) => {
+      expect(node.semantics?.label).toBeTruthy();
+    });
+  });
+
+  describe('zero-value rows (invisible to mouse, so excluded from navigation too)', () => {
+    test('excludes a basic bar leaf whose metric is exactly 0', () => {
+      const zeroData = [...data, { browser: 'Edge', downloads: 0 }];
+      const { structure } = buildBarStructure({ data: zeroData, dimension: 'browser', metric: 'downloads' });
+      expect(structure.nodes.Edge).toBeUndefined();
+      expect(structure.nodes.Chrome).toBeDefined();
+    });
+
+    test('keeps a negative-value leaf (only exactly-0 renders as invisible)', () => {
+      const negativeData = [...data, { browser: 'Edge', downloads: -100 }];
+      const { structure } = buildBarStructure({ data: negativeData, dimension: 'browser', metric: 'downloads' });
+      expect(structure.nodes.Edge).toBeDefined();
+    });
+
+    test('excludes a zero-value segment from a stack, keeping its non-zero siblings', () => {
+      const zeroSegmentData = [...stackedData, { browser: 'Chrome', os: 'Edge', downloads: 0 }];
+      const { structure } = buildBarStructure({ data: zeroSegmentData, dimension: 'browser', color: 'os', metric: 'downloads' });
+      expect(structure.nodes[segmentId('Chrome', 'Edge')]).toBeUndefined();
+      expect(structure.nodes[segmentId('Chrome', 'Windows')]).toBeDefined();
+    });
+
+    test('excludes a whole stack when every one of its segments is zero-value', () => {
+      const allZeroData = [
+        ...stackedData,
+        { browser: 'Safari', os: 'Mac', downloads: 0 },
+        { browser: 'Safari', os: 'Windows', downloads: 0 },
+      ];
+      const { structure } = buildBarStructure({ data: allZeroData, dimension: 'browser', color: 'os', metric: 'downloads' });
+      const divisions = Object.values(structure.nodes).filter((node) => node.dimensionLevel === 2);
+      expect(divisions.map((node) => node.id)).not.toContain('Safari');
+      expect(structure.nodes[segmentId('Safari', 'Mac')]).toBeUndefined();
+    });
+  });
+
+  describe('stacked (color series present)', () => {
+    test('keys leaf segments by the dimension + series composite', () => {
+      const { structure } = buildBarStructure({ data: stackedData, dimension: 'browser', color: 'os' });
+      expect(structure.nodes[segmentId('Chrome', 'Windows')]).toBeDefined();
+      expect(structure.nodes[segmentId('Chrome', 'Mac')]).toBeDefined();
+      expect(structure.nodes[segmentId('Firefox', 'Mac')]).toBeDefined();
+    });
+
+    test('keeps one division per column (not compressed), each with multiple segments', () => {
+      const { structure } = buildBarStructure({ data: stackedData, dimension: 'browser', color: 'os' });
+      // dimensionLevel === 2 are division (per-stack) nodes; basic bars compress these away
+      const divisions = Object.values(structure.nodes).filter((node) => node.dimensionLevel === 2);
+      expect(divisions).toHaveLength(2); // Chrome, Firefox
+    });
+  });
+
+  describe('no wraparound (matches real mouse hover: navigation stays within its own level)', () => {
+    test('does not wrap the last basic bar back to the first', () => {
+      const { structure } = buildBarStructure({ data, dimension: 'browser' });
+      expect(hasEdgeBetween(structure, 'Safari', 'Chrome')).toBe(false);
+    });
+
+    test('does not wrap the last stack back to the first stack', () => {
+      const { structure } = buildBarStructure({ data: stackedData, dimension: 'browser', color: 'os' });
+      expect(hasEdgeBetween(structure, 'Firefox', 'Chrome')).toBe(false);
+    });
+
+    test('does not bridge the last segment of a stack into the next stack\'s first segment', () => {
+      const { structure } = buildBarStructure({ data: stackedData, dimension: 'browser', color: 'os' });
+      expect(hasEdgeBetween(structure, segmentId('Chrome', 'Mac'), segmentId('Firefox', 'Windows'))).toBe(false);
+    });
+  });
+});
+
+describe('buildNodeLabel()', () => {
+  test('falls back to the node id when there is no data', () => {
+    expect(buildNodeLabel({ id: 'lonely' } as NodeObject)).toBe('lonely');
+  });
+
+  test('falls back to the node id for a dimension (root) node — no synthesized narration', () => {
+    const node = {
+      id: '_browser',
+      dimensionLevel: 1,
+      data: { dimensionKey: 'browser', divisions: { a: {}, b: {} } },
+    } as unknown as NodeObject;
+    expect(buildNodeLabel(node)).toBe('_browser');
+  });
+
+  test('falls back to the node id for a division (stack) node — no synthesized narration', () => {
+    const node = { id: 'Chrome', dimensionLevel: 2, data: { values: { x: {}, y: {}, z: {} } } } as unknown as NodeObject;
+    expect(buildNodeLabel(node)).toBe('Chrome');
+  });
+
+  test('describes a leaf node by its own scalar fields (consumer-owned field names, not translatable prose)', () => {
+    const node = { id: 'Chrome', data: { browser: 'Chrome', downloads: 27000, _dnId: 'skip-me' } } as unknown as NodeObject;
+    const label = buildNodeLabel(node);
+    expect(label).toContain('browser: Chrome');
+    expect(label).toContain('downloads: 27000');
+    expect(label).not.toContain('_dnId');
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/buildBarStructure.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/buildBarStructure.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import dataNavigator, { NodeObject, Structure, StructureOptions } from 'data-navigator';
+
+import { DEFAULT_CATEGORICAL_DIMENSION, DEFAULT_METRIC, NAVIGATION_ID_SEPARATOR } from '@spectrum-charts/constants';
+import { SimpleData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { addSiblingKeySynonyms, baseNavigationRules } from './navigationRules';
+
+export interface BuildBarStructureOptions {
+  /** The chart data (plain objects). */
+  data: SimpleData[];
+  /** The bar's category field (the stack/column for a stacked bar). Defaults to the standard categorical dimension. */
+  dimension?: string;
+  /** The series/color field. When set, the bar is multi-series (each column holds multiple segments). */
+  color?: string;
+  /** The bar's metric field. Rows with a value of exactly 0 are excluded from navigation — they render invisibly, so a mouse could never reach them either. */
+  metric?: string;
+  /** Already-localized label for the chart-root node, read verbatim from the consumer's `Chart.title` — this module never constructs narration strings itself. */
+  title?: string;
+}
+
+/** Data field that carries the composite leaf id for multi-series (stacked/dodged) bars. */
+const SEGMENT_ID_KEY = '_dnId';
+
+export const segmentId = (dimensionValue: unknown, seriesValue: unknown): string =>
+  `${dimensionValue}${NAVIGATION_ID_SEPARATOR}${seriesValue}`;
+
+export interface BarStructure {
+  structure: Structure;
+  entryPoint: string | undefined;
+}
+
+export const buildBarStructure = ({
+  data,
+  dimension = DEFAULT_CATEGORICAL_DIMENSION,
+  color,
+  metric = DEFAULT_METRIC,
+  title,
+}: BuildBarStructureOptions): BarStructure => {
+  const isMultiSeries = color !== undefined;
+  const idKey = isMultiSeries ? SEGMENT_ID_KEY : dimension;
+  // Excluded so a zero-value row never gets a leaf node here — it's invisible, so a mouse can't reach it either.
+  const visibleData = data.filter((d) => Number(d[metric]) !== 0);
+  const structureData = color
+    ? visibleData.map((d) => ({ ...d, [SEGMENT_ID_KEY]: segmentId(d[dimension], d[color]) }))
+    : visibleData;
+
+  const structureOptions: StructureOptions = {
+    data: structureData,
+    idKey,
+    navigationRules: baseNavigationRules,
+    dimensions: {
+      values: [
+        {
+          dimensionKey: dimension,
+          type: 'categorical',
+          // 'terminal': no wraparound at the first/last stack, and segments stay within their own stack.
+          behavior: { extents: 'terminal' },
+          operations: { compressSparseDivisions: !isMultiSeries },
+          navigationRules: {
+            sibling_sibling: ['left', 'right'],
+            parent_child: ['parent', 'child'],
+          },
+        },
+      ],
+    },
+  };
+
+  const structure = dataNavigator.structure(structureOptions);
+  addSiblingKeySynonyms(structure);
+
+  let entryPoint: string | undefined;
+  if (structure.dimensions) {
+    const firstKey = Object.keys(structure.dimensions)[0];
+    const rootNodeId = structure.dimensions[firstKey]?.nodeId;
+    entryPoint = rootNodeId;
+    const rootNode = rootNodeId ? structure.nodes[rootNodeId] : undefined;
+    if (rootNode && title) {
+      rootNode.semantics = { label: title };
+    }
+  }
+
+  // Every node rendered in keyboard mode needs an aria-label.
+  prepareNodeSemantics(structure);
+
+  return { structure, entryPoint };
+};
+
+/** Fallback label for a node with no consumer-supplied semantics: a leaf's own `field: value` pairs, or the bare node id for a structural (dimension/division) node. */
+export const buildNodeLabel = (node: NodeObject): string => {
+  if (node.dimensionLevel != null) return String(node.id);
+
+  const data = node.data as Record<string, unknown> | undefined;
+  if (!data) return String(node.id);
+
+  const parts = Object.entries(data)
+    .filter(([key, value]) => !key.startsWith('_') && value != null && typeof value !== 'object' && typeof value !== 'function')
+    .map(([key, value]) => `${key}: ${value}`);
+  return parts.length > 0 ? `${parts.join('. ')}.` : String(node.id);
+};
+
+export const prepareNodeSemantics = (structure: Structure): void => {
+  for (const node of Object.values(structure.nodes)) {
+    if (!node.semantics?.label) {
+      node.semantics = { ...node.semantics, label: buildNodeLabel(node) };
+    }
+  }
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/buildChartStructure.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/buildChartStructure.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { buildBarStructure } from './buildBarStructure';
+import { buildChartStructure } from './buildChartStructure';
+import { getNavigableChartType } from './navigableMarks';
+
+const data = [
+  { browser: 'Chrome', downloads: 27000 },
+  { browser: 'Firefox', downloads: 8000 },
+  { browser: 'Safari', downloads: 4000 },
+];
+
+describe('getNavigableChartType()', () => {
+  test('resolves the Bar mark to the bar chart type', () => {
+    expect(getNavigableChartType('Bar')).toBe('bar');
+  });
+  test('returns undefined for non-navigable marks', () => {
+    expect(getNavigableChartType('Axis')).toBeUndefined();
+    expect(getNavigableChartType('Line')).toBeUndefined();
+  });
+  test('returns undefined when there is no displayName', () => {
+    expect(getNavigableChartType(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildChartStructure()', () => {
+  test('delegates the bar chart type to buildBarStructure', () => {
+    const viaDispatch = buildChartStructure({ chartType: 'bar', data, dimension: 'browser' });
+    const direct = buildBarStructure({ data, dimension: 'browser' });
+
+    expect(viaDispatch).toBeDefined();
+    expect(viaDispatch?.entryPoint).toBe(direct.entryPoint);
+    expect(Object.keys(viaDispatch?.structure.nodes ?? {}).sort()).toEqual(
+      Object.keys(direct.structure.nodes).sort()
+    );
+  });
+
+  test('returns undefined for an unsupported chart type', () => {
+    expect(buildChartStructure({ chartType: 'pie' as never, data, dimension: 'browser' })).toBeUndefined();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/buildChartStructure.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/buildChartStructure.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { Structure } from 'data-navigator';
+
+import { SimpleData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { buildBarStructure } from './buildBarStructure';
+
+export type NavigableChartType = 'bar';
+
+export interface ChartStructureOptions {
+  /** The chart type to build a navigation structure for. */
+  chartType: NavigableChartType;
+  /** Chart data (plain objects). */
+  data: SimpleData[];
+  /** Primary categorical / x-axis field (e.g. bar category). */
+  dimension?: string;
+  /** Series / color field. When set on a bar, the chart is stacked. */
+  color?: string;
+  /** Primary metric / y-axis field. */
+  metric?: string;
+  /** Optional chart title for the accessible description. */
+  title?: string;
+}
+
+export interface ChartStructure {
+  structure: Structure;
+  entryPoint: string | undefined;
+}
+
+const contentStructureBuilders: Record<NavigableChartType, (options: ChartStructureOptions) => ChartStructure> = {
+  bar: buildBarStructure,
+};
+
+export const buildChartStructure = (options: ChartStructureOptions): ChartStructure | undefined => {
+  const buildContent = contentStructureBuilders[options.chartType];
+  if (!buildContent) return undefined;
+  return buildContent(options);
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigator.css
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigator.css
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+  data-navigator keyboard navigation elements.
+  The visible focus indicator is drawn on the Vega canvas (focus-ring marks), so these DOM
+  elements are invisible overlays that exist only for keyboard focus and assistive technology.
+*/
+.dn-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* All children are position: absolute, so without this the wrapper collapses to 0px tall,
+     making every .dn-node (height: 100%) unfocusable in a real browser (jsdom skips layout). */
+  height: 100%;
+  /* The overlay is for keyboard focus / AT only. Without this it captures the mouse across the whole
+     chart, blocking Vega hover/click (e.g. legend highlight). Focus is unaffected by pointer-events. */
+  pointer-events: none;
+}
+.dn-node {
+  position: absolute;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+.dn-node:focus,
+.dn-node:focus-visible {
+  outline: none;
+}
+/* Off-screen until focused (standard skip-link pattern), then shown as a visible affordance
+   INSIDE the chart's top-left so a keyboard user can see where "Enter navigation area" is. */
+.dn-entry-button {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+  /* Re-enable pointer events on the button (the wrapper disables them) so it stays clickable. */
+  pointer-events: auto;
+}
+.dn-entry-button:focus,
+.dn-entry-button:focus-visible {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 10;
+  width: auto;
+  height: auto;
+  padding: 4px 8px;
+  overflow: visible;
+  clip: auto;
+  background: var(--spectrum-blue-800, #4b75ff);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.test.ts
@@ -1,0 +1,627 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { RefObject } from 'react';
+
+import { fireEvent } from '@testing-library/react';
+import { View } from 'vega';
+
+import {
+  COMPONENT_NAME,
+  DIMENSION_HOVER_AREA,
+  FOCUSED_DIMENSION,
+  FOCUSED_ITEM,
+  FOCUSED_REGION,
+  MARK_ID,
+} from '@spectrum-charts/constants';
+import { Datum, MarkBounds } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { getItemBounds, triggerPopover } from '../utils/markClickUtils';
+import { NavigableChartType } from './buildChartStructure';
+import { attachDataNavigator } from './dataNavigatorAdapter';
+
+jest.mock('../utils/markClickUtils', () => ({
+  ...jest.requireActual('../utils/markClickUtils'),
+  // Defaults to a real button existing (matches a chart with a ChartPopover configured); override
+  // per-test with mockReturnValueOnce(false) to simulate no popover being configured.
+  triggerPopover: jest.fn(() => true),
+  getItemBounds: jest.fn(() => ({ x1: 1, y1: 2, x2: 3, y2: 4 })),
+}));
+
+const data = [
+  { browser: 'Chrome', downloads: 27000 },
+  { browser: 'Firefox', downloads: 8000 },
+  { browser: 'Safari', downloads: 4000 },
+];
+
+const stackedData = [
+  { browser: 'Chrome', os: 'Windows', downloads: 18000 },
+  { browser: 'Chrome', os: 'Mac', downloads: 9000 },
+  { browser: 'Firefox', os: 'Windows', downloads: 5000 },
+  { browser: 'Firefox', os: 'Mac', downloads: 3000 },
+];
+
+let container: HTMLElement;
+let signal: jest.Mock;
+let view: View;
+let tooltipCallback: jest.Mock;
+// The one rendered `bar0_focusRing`/`bar0_stackFocusRing` instance; tests flip opacity/bounds to simulate it becoming visible.
+let ringItem: { opacity: number; bounds?: { x1: number; y1: number; x2: number; y2: number } };
+let stackRingItem: { opacity: number; bounds?: { x1: number; y1: number; x2: number; y2: number } };
+// The rendered `bar0` rect items themselves (not their focus ring) — Space-triggered popovers
+// anchor to these, matched by MARK_ID, the same as a real click would.
+let barItems: { datum: Record<string, unknown> }[];
+
+const mockView = () => {
+  const values: Record<string, unknown> = {};
+  signal = jest.fn((name: string, ...rest: unknown[]) => {
+    if (rest.length === 0) return values[name];
+    values[name] = rest[0];
+  });
+  ringItem = { opacity: 0 };
+  stackRingItem = { opacity: 0 };
+  barItems = [];
+  tooltipCallback = jest.fn();
+  return {
+    signal,
+    runAsync: jest.fn().mockResolvedValue(undefined),
+    origin: jest.fn().mockReturnValue([0, 0]),
+    data: jest.fn().mockReturnValue([]),
+    // Real vega-view's tooltip() is a getter when called with no args — see focusedItemTooltip.ts.
+    tooltip: jest.fn().mockReturnValue(tooltipCallback),
+    scenegraph: () => ({
+      root: {
+        items: [
+          { marktype: 'rect', name: 'bar0_focusRing', items: [ringItem] },
+          { marktype: 'rect', name: 'bar0_stackFocusRing', items: [stackRingItem] },
+          { marktype: 'rect', name: 'bar0', items: barItems },
+        ],
+      },
+    }),
+  } as unknown as View;
+};
+
+/** Populates the fake `bar0` rect mark's rendered items for `findFocusedBarSceneItem` to match against. */
+const setBarItems = (rows: Record<string, unknown>[]): void => {
+  barItems.length = 0;
+  barItems.push(...rows.map((datum) => ({ datum })));
+};
+
+/** The last non-null value the fake tooltip callback was triggered with, if any. */
+const lastTooltipValue = (): unknown => {
+  const call = [...tooltipCallback.mock.calls].reverse().find(([, , , value]) => value != null);
+  return call?.[3];
+};
+
+const setRingBounds = (bounds: { x1: number; y1: number; x2: number; y2: number }): void => {
+  ringItem.opacity = 1;
+  ringItem.bounds = bounds;
+};
+
+const setStackRingBounds = (bounds: { x1: number; y1: number; x2: number; y2: number }): void => {
+  stackRingItem.opacity = 1;
+  stackRingItem.bounds = bounds;
+};
+
+const signaledWith = (name: string, value: unknown): boolean =>
+  signal.mock.calls.some(([n, v]) => n === name && v === value);
+
+const entryButton = (): HTMLButtonElement => container.querySelector('button') as HTMLButtonElement;
+// data-navigator renders exactly one node element (class `dn-node`) at a time; it carries the
+// keydown listener. jsdom does not reliably track activeElement for it, so target it directly.
+const focused = (): HTMLElement => container.querySelector('.dn-node') as HTMLElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  view = mockView();
+  (triggerPopover as jest.Mock).mockClear();
+  (getItemBounds as jest.Mock).mockClear();
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe('attachDataNavigator()', () => {
+  const attach = (overrides = {}) =>
+    attachDataNavigator({
+      container,
+      chartType: 'bar',
+      data,
+      dimension: 'browser',
+      chartId: 'test-chart',
+      getView: () => view,
+      ...overrides,
+    });
+
+  test('renders an entry button into the container', () => {
+    attach();
+    expect(entryButton()).toBeTruthy();
+  });
+
+  test('does nothing for an unsupported chart type', () => {
+    attach({ chartType: 'pie' as unknown as NavigableChartType });
+    expect(entryButton()).toBeFalsy();
+    expect(signal).not.toHaveBeenCalled();
+  });
+
+  test('namespaces the container id when one is not already set', () => {
+    attach();
+    expect(container.id).toBe('dn-root-test-chart');
+  });
+
+  test('leaves an existing container id untouched', () => {
+    container.id = 'preset-id';
+    attach();
+    expect(container.id).toBe('preset-id');
+  });
+
+  test('entering the navigation focuses the chart region', () => {
+    attach();
+    entryButton().click();
+    expect(signaledWith(FOCUSED_REGION, 'chart')).toBe(true);
+  });
+
+  test('does not throw when there is no live view to signal', () => {
+    attach({ getView: () => undefined });
+    expect(() => entryButton().click()).not.toThrow();
+  });
+
+  test('drilling in and arrowing focuses individual bars', () => {
+    attach();
+    entryButton().click();
+
+    // data-navigator's keydownValidator matches on event.code, not event.key.
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+    const itemCall = signal.mock.calls.find(([n, v]) => n === FOCUSED_ITEM && v !== null);
+    expect(itemCall).toBeDefined();
+
+    signal.mockClear();
+    fireEvent.keyDown(focused(), { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(signal.mock.calls.some(([n, v]) => n === FOCUSED_ITEM && v !== null)).toBe(true);
+  });
+
+  test('drilling into a bar triggers the real tooltip callback with a non-null value', async () => {
+    (view.data as jest.Mock).mockReturnValue(data);
+    attach({ markName: 'bar0' });
+    setRingBounds({ x1: 10, y1: 20, x2: 30, y2: 40 });
+    entryButton().click();
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+    await Promise.resolve(); // flush the .then() chained after view.runAsync()
+
+    expect(lastTooltipValue()).not.toBeUndefined();
+  });
+
+  test('does not trigger the tooltip while focused on the chart root (not a leaf)', async () => {
+    attach();
+    setRingBounds({ x1: 10, y1: 20, x2: 30, y2: 40 });
+    entryButton().click();
+    await Promise.resolve();
+
+    expect(lastTooltipValue()).toBeUndefined();
+  });
+
+  test('Escape hides the tooltip (calls it with null) along with clearing focus', async () => {
+    (view.data as jest.Mock).mockReturnValue(data);
+    attach({ markName: 'bar0' });
+    setRingBounds({ x1: 10, y1: 20, x2: 30, y2: 40 });
+    entryButton().click();
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+    await Promise.resolve();
+    expect(lastTooltipValue()).not.toBeUndefined();
+
+    tooltipCallback.mockClear();
+    fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' });
+    expect(tooltipCallback).toHaveBeenCalledWith(undefined, undefined, undefined, null);
+  });
+
+  test('ArrowDown moves to the next bar, the same as ArrowRight', () => {
+    attach();
+    entryButton().click();
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+    const firstItem = signal.mock.calls.find(([n, v]) => n === FOCUSED_ITEM && v !== null)?.[1];
+
+    signal.mockClear();
+    fireEvent.keyDown(focused(), { key: 'ArrowDown', code: 'ArrowDown' });
+    const nextItem = signal.mock.calls.find(([n, v]) => n === FOCUSED_ITEM && v !== null)?.[1];
+    expect(nextItem).toBeDefined();
+    expect(nextItem).not.toBe(firstItem);
+  });
+
+  test('ArrowUp moves to the previous bar, the same as ArrowLeft', () => {
+    attach();
+    entryButton().click();
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+    signal.mockClear();
+    fireEvent.keyDown(focused(), { key: 'ArrowRight', code: 'ArrowRight' });
+    const secondItem = signal.mock.calls.find(([n, v]) => n === FOCUSED_ITEM && v !== null)?.[1];
+
+    signal.mockClear();
+    fireEvent.keyDown(focused(), { key: 'ArrowUp', code: 'ArrowUp' });
+    const previousItem = signal.mock.calls.find(([n, v]) => n === FOCUSED_ITEM && v !== null)?.[1];
+    expect(previousItem).toBeDefined();
+    expect(previousItem).not.toBe(secondItem);
+  });
+
+  test('Escape at the chart root drills out and clears focus', () => {
+    attach();
+    entryButton().click();
+    // entry focuses the chart root, which is also the entry point, so Escape exits.
+    expect(focused()).toBeTruthy();
+
+    signal.mockClear();
+    fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' });
+
+    // the focused node is removed on drill-out and every focus signal is cleared
+    expect(focused()).toBeNull();
+    expect(signaledWith(FOCUSED_REGION, null)).toBe(true);
+    expect(signaledWith(FOCUSED_ITEM, null)).toBe(true);
+  });
+
+  test('focus leaving the widget (tab/click away) clears focus and removes the node', () => {
+    attach();
+    entryButton().click();
+    expect(focused()).toBeTruthy();
+
+    signal.mockClear();
+    // relatedTarget outside the container === focus left the navigator entirely.
+    fireEvent.focusOut(focused(), { relatedTarget: document.body });
+
+    expect(focused()).toBeNull();
+    expect(signaledWith(FOCUSED_REGION, null)).toBe(true);
+  });
+
+  test('focus moving within the widget does not clear (relatedTarget stays inside)', () => {
+    attach();
+    entryButton().click();
+    fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill to a bar
+
+    signal.mockClear();
+    // A focusout whose relatedTarget is still inside the container is an internal move, not a leave.
+    const insideTarget = focused();
+    fireEvent.focusOut(focused(), { relatedTarget: insideTarget });
+    expect(focused()).not.toBeNull();
+    expect(signaledWith(FOCUSED_REGION, null)).toBe(false);
+    expect(signaledWith(FOCUSED_ITEM, null)).toBe(false);
+  });
+
+  describe('entry button tab order (Shift+Tab should leave the widget, not land back on it)', () => {
+    test('removes the entry button from tab order once a bar is focused', () => {
+      attach();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill to a bar
+
+      expect(entryButton().tabIndex).toBe(-1);
+    });
+
+    test('restores the entry button to tab order once focus leaves the widget', () => {
+      attach();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      // relatedTarget outside the container === focus left the navigator entirely (e.g. Shift+Tab).
+      fireEvent.focusOut(focused(), { relatedTarget: document.body });
+
+      expect(entryButton().tabIndex).toBe(0);
+    });
+
+    test('leaves the entry button tabbable while focus stays inside (an internal move)', () => {
+      attach();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      const insideTarget = focused();
+      fireEvent.focusOut(focused(), { relatedTarget: insideTarget });
+
+      expect(entryButton().tabIndex).toBe(-1);
+    });
+  });
+
+  describe('stacked bars (series present)', () => {
+    const attachStacked = () =>
+      attachDataNavigator({
+        container,
+        chartType: 'bar',
+        data: stackedData,
+        dimension: 'browser',
+        color: 'os',
+        chartId: 'stacked-chart',
+        getView: () => view,
+      });
+
+    test('drilling into a stack focuses the dimension group, then a segment', () => {
+      attachStacked();
+      entryButton().click();
+      expect(signaledWith(FOCUSED_REGION, 'chart')).toBe(true);
+
+      // Enter the chart root → a per-column stack (dimension group).
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      const dimensionCall = signal.mock.calls.find(([n, v]) => n === FOCUSED_DIMENSION && v !== null);
+      expect(dimensionCall).toBeDefined();
+
+      // Enter the stack → an individual segment.
+      signal.mockClear();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      expect(signal.mock.calls.some(([n, v]) => n === FOCUSED_ITEM && v !== null)).toBe(true);
+    });
+
+    test('drilling into a stack (not yet a segment) triggers the dimension-area tooltip', async () => {
+      const stackRows = [
+        { browser: 'Chrome', min_value1: 0, max_value1: 27000 },
+        { browser: 'Firefox', min_value1: 0, max_value1: 13000 },
+      ];
+      (view.data as jest.Mock).mockImplementation((name: string) => (name === 'bar0_stacks' ? stackRows : []));
+      setStackRingBounds({ x1: 0, y1: 0, x2: 10, y2: 10 });
+
+      attachDataNavigator({
+        container,
+        chartType: 'bar',
+        data: stackedData,
+        dimension: 'browser',
+        color: 'os',
+        markName: 'bar0',
+        chartId: 'stacked-tooltip-chart',
+        getView: () => view,
+      });
+
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill into the first stack
+      await Promise.resolve();
+
+      expect(lastTooltipValue()).toMatchObject({
+        browser: 'Chrome',
+        [COMPONENT_NAME]: `bar0_${DIMENSION_HOVER_AREA}`,
+        dimension: 'browser',
+      });
+    });
+  });
+
+  describe('mouse-hover parity (markName provided)', () => {
+    const rows = [
+      { browser: 'Chrome', downloads: 27000 },
+      { browser: 'Firefox', downloads: 8000 },
+      { browser: 'Safari', downloads: 4000 },
+    ];
+
+    const attachWithMarkName = () => {
+      (view.data as jest.Mock).mockReturnValue(rows);
+      return attachDataNavigator({
+        container,
+        chartType: 'bar',
+        data,
+        dimension: 'browser',
+        markName: 'bar0',
+        chartId: 'hover-parity-chart',
+        getView: () => view,
+      });
+    };
+
+    test('focusing a bar sets the same bar0_hoveredItem signal real mouse hover sets', () => {
+      attachWithMarkName();
+      entryButton().click();
+      signal.mockClear();
+
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', rows[0]);
+      expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', rows[0]);
+    });
+
+    test('does not touch hover signals when markName is not provided', () => {
+      attach();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      expect(signal.mock.calls.some(([n]) => n === 'bar0_hoveredItem')).toBe(false);
+    });
+
+    test('clearing focus clears the hover signals too', () => {
+      attachWithMarkName();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      signal.mockClear();
+      fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' });
+      fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' });
+
+      expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', null);
+      expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', null);
+    });
+  });
+
+  describe('Space opens a popover on a focused leaf bar', () => {
+    const rows = [
+      { browser: 'Chrome', downloads: 27000, [MARK_ID]: 0 },
+      { browser: 'Firefox', downloads: 8000, [MARK_ID]: 1 },
+    ];
+
+    let selectedData: RefObject<Datum | null>;
+    let selectedDataBounds: RefObject<MarkBounds>;
+    let selectedDataName: RefObject<string>;
+
+    const attachWithPopoverRefs = (overrides = {}) => {
+      (view.data as jest.Mock).mockReturnValue(rows);
+      setBarItems(rows);
+      selectedData = { current: null };
+      selectedDataBounds = { current: { x1: 0, y1: 0, x2: 0, y2: 0 } };
+      selectedDataName = { current: '' };
+      return attachDataNavigator({
+        container,
+        chartType: 'bar',
+        data,
+        dimension: 'browser',
+        markName: 'bar0',
+        chartId: 'popover-chart',
+        getView: () => view,
+        selectedData,
+        selectedDataBounds,
+        selectedDataName,
+        ...overrides,
+      });
+    };
+
+    test('sets the same context refs a real click sets, anchored to the bar (not its focus ring)', () => {
+      attachWithPopoverRefs();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill to the first bar (a leaf)
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(selectedData.current).toMatchObject({ browser: 'Chrome', [COMPONENT_NAME]: 'bar0' });
+      expect(selectedDataName.current).toBe('bar0');
+    });
+
+    test('triggers the same popover-button click a real click uses', () => {
+      attachWithPopoverRefs();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(triggerPopover).toHaveBeenCalledWith('popover-chart', 'bar0', 'click');
+    });
+
+    test('hides the keyboard focus ring so it does not double up with the popover selection ring', () => {
+      attachWithPopoverRefs();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      signal.mockClear();
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(signaledWith(FOCUSED_ITEM, null)).toBe(true);
+    });
+
+    test('leaves the hover-parity dimming signal active (mirrors a real click happening mid-hover)', () => {
+      attachWithPopoverRefs();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      signal.mockClear();
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(signal.mock.calls.some(([n, v]) => n === 'bar0_hoveredItem' && v === null)).toBe(false);
+    });
+
+    test('anchors to the real bar mark bounds via getItemBounds, not the focus ring', () => {
+      attachWithPopoverRefs();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(getItemBounds).toHaveBeenCalledWith(barItems[0]);
+      expect(selectedDataBounds.current).toEqual({ x1: 1, y1: 2, x2: 3, y2: 4 });
+    });
+
+    test('does not open a popover while focused on the chart root (not a leaf)', () => {
+      attachWithPopoverRefs();
+      entryButton().click(); // focus lands on the chart root, not a leaf
+
+      fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+      expect(triggerPopover).not.toHaveBeenCalled();
+    });
+
+    test('does not throw when selectedData refs are not provided', () => {
+      attachWithPopoverRefs({ selectedData: undefined, selectedDataBounds: undefined, selectedDataName: undefined });
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+      expect(() => fireEvent.keyDown(focused(), { key: ' ', code: 'Space' })).not.toThrow();
+      expect(triggerPopover).not.toHaveBeenCalled();
+    });
+
+    describe('focus retention while the popover is open (so Escape can return to it)', () => {
+      // Opening the popover moves DOM focus into its own dialog, which fires a focusout on the
+      // navigated node whose relatedTarget (the popover) is outside `container` — simulated here
+      // the same way the real popover's portal would look to the wrapper's focusout listener.
+      const focusOutToPopover = () => fireEvent.focusOut(focused(), { relatedTarget: document.body });
+
+      test('does not clear focus/remove the node for the focusout caused by opening the popover', () => {
+        attachWithPopoverRefs();
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+        fireEvent.keyDown(focused(), { key: ' ', code: 'Space' }); // opens the popover
+        signal.mockClear();
+        focusOutToPopover();
+
+        expect(focused()).not.toBeNull();
+        expect(signaledWith(FOCUSED_REGION, null)).toBe(false);
+        expect(signaledWith(FOCUSED_ITEM, null)).toBe(false);
+      });
+
+      test('clears focus normally the next time focus actually leaves the widget', () => {
+        attachWithPopoverRefs();
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+        fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+        focusOutToPopover(); // suppressed (opening the popover)
+
+        signal.mockClear();
+        focusOutToPopover(); // a second, genuine leave — not suppressed this time
+
+        expect(focused()).toBeNull();
+        expect(signaledWith(FOCUSED_REGION, null)).toBe(true);
+      });
+
+      test('does not suppress the next focusout when there was no popover button to click', () => {
+        (triggerPopover as jest.Mock).mockReturnValueOnce(false);
+        attachWithPopoverRefs();
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+
+        fireEvent.keyDown(focused(), { key: ' ', code: 'Space' }); // no button found, nothing opened
+        signal.mockClear();
+        focusOutToPopover();
+
+        expect(focused()).toBeNull();
+        expect(signaledWith(FOCUSED_REGION, null)).toBe(true);
+      });
+    });
+
+    describe('stacked bars', () => {
+      const stackRows = [
+        { browser: 'Chrome', os: 'Windows', downloads: 18000, [MARK_ID]: 0 },
+        { browser: 'Chrome', os: 'Mac', downloads: 9000, [MARK_ID]: 1 },
+      ];
+
+      test('does not open a popover while focused on a whole stack (not yet a segment)', () => {
+        (view.data as jest.Mock).mockReturnValue(stackRows);
+        setBarItems(stackRows);
+        const selectedData: RefObject<Datum | null> = { current: null };
+        attachDataNavigator({
+          container,
+          chartType: 'bar',
+          data: stackedData,
+          dimension: 'browser',
+          color: 'os',
+          markName: 'bar0',
+          chartId: 'stacked-popover-chart',
+          getView: () => view,
+          selectedData,
+          selectedDataBounds: { current: { x1: 0, y1: 0, x2: 0, y2: 0 } },
+          selectedDataName: { current: '' },
+        });
+
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill into the first stack (not a segment)
+
+        fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+        expect(triggerPopover).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.test.ts
@@ -59,6 +59,11 @@ let stackRingItem: { opacity: number; bounds?: { x1: number; y1: number; x2: num
 // The rendered `bar0` rect items themselves (not their focus ring) — Space-triggered popovers
 // anchor to these, matched by MARK_ID, the same as a real click would.
 let barItems: { datum: Record<string, unknown> }[];
+// The rendered `bar0_dimensionHoverArea` rect items — Space-triggered stack popovers anchor to these, matched by dimension value.
+let dimensionAreaItems: { datum: Record<string, unknown> }[];
+// Handlers registered via addSignalListener, keyed by signal name — lets tests simulate a real
+// mouseout (which drives these signals directly, bypassing `signal()`) by invoking them directly.
+let signalListeners: Record<string, ((name: string, value: unknown) => void)[]>;
 
 const mockView = () => {
   const values: Record<string, unknown> = {};
@@ -69,10 +74,19 @@ const mockView = () => {
   ringItem = { opacity: 0 };
   stackRingItem = { opacity: 0 };
   barItems = [];
+  dimensionAreaItems = [];
+  signalListeners = {};
   tooltipCallback = jest.fn();
-  return {
+  const viewMock = {
     signal,
     runAsync: jest.fn().mockResolvedValue(undefined),
+    runAfter: jest.fn((callback: (v: View) => void) => callback(viewMock)),
+    addSignalListener: jest.fn((name: string, handler: (name: string, value: unknown) => void) => {
+      (signalListeners[name] ??= []).push(handler);
+    }),
+    removeSignalListener: jest.fn((name: string, handler: (name: string, value: unknown) => void) => {
+      signalListeners[name] = (signalListeners[name] ?? []).filter((h) => h !== handler);
+    }),
     origin: jest.fn().mockReturnValue([0, 0]),
     data: jest.fn().mockReturnValue([]),
     // Real vega-view's tooltip() is a getter when called with no args — see focusedItemTooltip.ts.
@@ -83,16 +97,29 @@ const mockView = () => {
           { marktype: 'rect', name: 'bar0_focusRing', items: [ringItem] },
           { marktype: 'rect', name: 'bar0_stackFocusRing', items: [stackRingItem] },
           { marktype: 'rect', name: 'bar0', items: barItems },
+          { marktype: 'rect', name: 'bar0_dimensionHoverArea', items: dimensionAreaItems },
         ],
       },
     }),
   } as unknown as View;
+  return viewMock;
+};
+
+/** Simulates real mouse mouseout nulling a hover signal directly (bypassing `signal()`, same as Vega's own `on:` trigger would). */
+const simulateMouseoutClear = (signalName: string): void => {
+  signalListeners[signalName]?.forEach((handler) => handler(signalName, null));
 };
 
 /** Populates the fake `bar0` rect mark's rendered items for `findFocusedBarSceneItem` to match against. */
 const setBarItems = (rows: Record<string, unknown>[]): void => {
   barItems.length = 0;
   barItems.push(...rows.map((datum) => ({ datum })));
+};
+
+/** Populates the fake `bar0_dimensionHoverArea` rect mark's rendered items for `findFocusedDimensionAreaSceneItem` to match against. */
+const setDimensionAreaItems = (rows: Record<string, unknown>[]): void => {
+  dimensionAreaItems.length = 0;
+  dimensionAreaItems.push(...rows.map((datum) => ({ datum })));
 };
 
 /** The last non-null value the fake tooltip callback was triggered with, if any. */
@@ -383,6 +410,59 @@ describe('attachDataNavigator()', () => {
         dimension: 'browser',
       });
     });
+
+    describe('drilling from a segment back to its stack via Escape', () => {
+      const segmentRows = [
+        { browser: 'Chrome', os: 'Windows', downloads: 18000 },
+        { browser: 'Chrome', os: 'Mac', downloads: 9000 },
+      ];
+      const stackAggregateRows = [{ browser: 'Chrome', min_value1: 0, max_value1: 27000 }];
+
+      const attachAndDrillToSegment = async () => {
+        (view.data as jest.Mock).mockImplementation((name: string) => (name === 'bar0_stacks' ? stackAggregateRows : segmentRows));
+        setStackRingBounds({ x1: 0, y1: 0, x2: 10, y2: 10 });
+        attachDataNavigator({
+          container,
+          chartType: 'bar',
+          data: stackedData,
+          dimension: 'browser',
+          color: 'os',
+          markName: 'bar0',
+          chartId: 'stacked-escape-chart',
+          getView: () => view,
+        });
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // root -> stack
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // stack -> segment
+        await Promise.resolve();
+      };
+
+      // Regression: the mouse-hover guard used to reapply the segment's own (stale) hover-parity
+      // right after Escape correctly nulled it, because `current` wasn't updated until after the
+      // synchronous focus event that triggers the guard's signal listener.
+      test('does not revert bar0_hoveredItem back to the segment it left', async () => {
+        await attachAndDrillToSegment();
+
+        fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' }); // segment -> back to the stack
+        await Promise.resolve();
+
+        const lastItemCall = [...signal.mock.calls].reverse().find(([n]) => n === 'bar0_hoveredItem');
+        expect(lastItemCall).toEqual(['bar0_hoveredItem', null]);
+      });
+
+      test('shows the stack tooltip, not the segment it left', async () => {
+        await attachAndDrillToSegment();
+        tooltipCallback.mockClear();
+
+        fireEvent.keyDown(focused(), { key: 'Escape', code: 'Escape' });
+        await Promise.resolve();
+
+        expect(lastTooltipValue()).toMatchObject({
+          browser: 'Chrome',
+          [COMPONENT_NAME]: `bar0_${DIMENSION_HOVER_AREA}`,
+        });
+      });
+    });
   });
 
   describe('mouse-hover parity (markName provided)', () => {
@@ -435,6 +515,69 @@ describe('attachDataNavigator()', () => {
 
       expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', null);
       expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', null);
+    });
+  });
+
+  describe('guarding hover-parity against real mouse mouseout clobbering keyboard focus', () => {
+    const rows = [
+      { browser: 'Chrome', downloads: 27000 },
+      { browser: 'Firefox', downloads: 8000 },
+    ];
+
+    const attachWithMarkName = () => {
+      (view.data as jest.Mock).mockReturnValue(rows);
+      return attachDataNavigator({
+        container,
+        chartType: 'bar',
+        data,
+        dimension: 'browser',
+        markName: 'bar0',
+        chartId: 'hover-guard-chart',
+        getView: () => view,
+      });
+    };
+
+    test('reapplies the keyboard-focused row when a real mouseout nulls the shared hover signal', () => {
+      attachWithMarkName();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // focuses the first bar
+      signal.mockClear();
+
+      simulateMouseoutClear('bar0_hoveredItem');
+
+      expect(signal).toHaveBeenCalledWith('bar0_hoveredItem', rows[0]);
+      expect(signal).toHaveBeenCalledWith('bar0_dimensionHoverArea_hoveredItem', rows[0]);
+    });
+
+    test('re-shows the tooltip when reapplying after a mouseout clear', () => {
+      attachWithMarkName();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      setRingBounds({ x1: 10, y1: 20, x2: 30, y2: 40 });
+      tooltipCallback.mockClear();
+
+      simulateMouseoutClear('bar0_dimensionHoverArea_hoveredItem');
+
+      expect(lastTooltipValue()).not.toBeUndefined();
+    });
+
+    test('does nothing when no node is keyboard-focused', () => {
+      attachWithMarkName();
+      signal.mockClear();
+
+      expect(() => simulateMouseoutClear('bar0_hoveredItem')).not.toThrow();
+      expect(signal.mock.calls.some(([n]) => n === 'bar0_hoveredItem')).toBe(false);
+    });
+
+    test('ignores a real (non-null) hover value — only reapplies on a clobbering clear', () => {
+      attachWithMarkName();
+      entryButton().click();
+      fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
+      signal.mockClear();
+
+      signalListeners['bar0_hoveredItem']?.forEach((handler) => handler('bar0_hoveredItem', rows[1]));
+
+      expect(signal.mock.calls.some(([n]) => n === 'bar0_hoveredItem')).toBe(false);
     });
   });
 
@@ -591,16 +734,17 @@ describe('attachDataNavigator()', () => {
       });
     });
 
-    describe('stacked bars', () => {
-      const stackRows = [
-        { browser: 'Chrome', os: 'Windows', downloads: 18000, [MARK_ID]: 0 },
-        { browser: 'Chrome', os: 'Mac', downloads: 9000, [MARK_ID]: 1 },
+    describe('Space on a whole stack (dimension area)', () => {
+      const stackAggregateRows = [
+        { browser: 'Chrome', min_value1: 0, max_value1: 27000 },
+        { browser: 'Firefox', min_value1: 0, max_value1: 13000 },
       ];
 
-      test('does not open a popover while focused on a whole stack (not yet a segment)', () => {
-        (view.data as jest.Mock).mockReturnValue(stackRows);
-        setBarItems(stackRows);
+      const attachStackedWithPopoverRefs = (chartId = 'stacked-popover-chart') => {
+        (view.data as jest.Mock).mockImplementation((name: string) => (name === 'bar0_stacks' ? stackAggregateRows : []));
         const selectedData: RefObject<Datum | null> = { current: null };
+        const selectedDataBounds: RefObject<MarkBounds> = { current: { x1: 0, y1: 0, x2: 0, y2: 0 } };
+        const selectedDataName: RefObject<string> = { current: '' };
         attachDataNavigator({
           container,
           chartType: 'bar',
@@ -608,15 +752,34 @@ describe('attachDataNavigator()', () => {
           dimension: 'browser',
           color: 'os',
           markName: 'bar0',
-          chartId: 'stacked-popover-chart',
+          chartId,
           getView: () => view,
           selectedData,
-          selectedDataBounds: { current: { x1: 0, y1: 0, x2: 0, y2: 0 } },
-          selectedDataName: { current: '' },
+          selectedDataBounds,
+          selectedDataName,
         });
+        return { selectedData, selectedDataBounds, selectedDataName };
+      };
 
+      test('opens a popover with the stack\'s aggregate row, anchored to the dimension-hover-area bounds', () => {
+        setDimensionAreaItems(stackAggregateRows);
+        const { selectedData, selectedDataName } = attachStackedWithPopoverRefs();
         entryButton().click();
         fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' }); // drill into the first stack (not a segment)
+
+        fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
+
+        expect(selectedData.current).toMatchObject({ browser: 'Chrome', [COMPONENT_NAME]: 'bar0' });
+        expect(selectedDataName.current).toBe('bar0');
+        expect(triggerPopover).toHaveBeenCalledWith('stacked-popover-chart', 'bar0', 'click');
+        expect(getItemBounds).toHaveBeenCalledWith(dimensionAreaItems[0]);
+      });
+
+      test('does not open a popover when the dimension-hover-area mark has no rendered item for the focused stack', () => {
+        // dimensionAreaItems left empty — no rendered item to anchor to.
+        attachStackedWithPopoverRefs('stacked-popover-chart-empty');
+        entryButton().click();
+        fireEvent.keyDown(focused(), { key: 'Enter', code: 'Enter' });
 
         fireEvent.keyDown(focused(), { key: ' ', code: 'Space' });
 

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.ts
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { RefObject } from 'react';
+
+import dataNavigator, { NodeObject } from 'data-navigator';
+import { SignalListenerHandler, View } from 'vega';
+
+import {
+  COMPONENT_NAME,
+  DIMENSION_HOVER_AREA,
+  FOCUSED_DIMENSION,
+  FOCUSED_ITEM,
+  FOCUSED_REGION,
+  HOVERED_ITEM,
+  MARK_ID,
+} from '@spectrum-charts/constants';
+import { Datum, MarkBounds, SimpleData } from '@spectrum-charts/vega-spec-builder-s2';
+
+import { ActionItem, getItemBounds, triggerPopover } from '../utils/markClickUtils';
+import { applyHoverParitySignals, findFocusedRow, findFocusedStackRow, Row } from './barHoverParity';
+import { NavigableChartType, buildChartStructure } from './buildChartStructure';
+import {
+  findFocusedBarSceneItem,
+  findFocusedDimensionAreaSceneItem,
+  hideFocusedItemTooltip,
+  showFocusedItemTooltip,
+} from './focusedItemTooltip';
+import './dataNavigator.css';
+
+/*
+ * data-navigator's `rendering()` and `input()` factories are typed as `() => any`.
+ */
+interface DataNavigatorRenderer {
+  initialize: () => void;
+  render: (node: { renderId: string; datum: NodeObject }) => HTMLElement | undefined;
+  remove: (renderId: string) => void;
+  wrapper?: HTMLElement;
+  exitElement?: HTMLElement;
+  entryButton?: HTMLElement;
+}
+
+interface DataNavigatorInput {
+  enter: () => NodeObject | undefined;
+  move: (current: string | null, direction: string) => NodeObject | undefined;
+  keydownValidator: (event: KeyboardEvent) => string | undefined;
+  focus: (renderId: string) => void;
+}
+
+export interface AttachDataNavigatorOptions {
+  /** Positioned element the navigation overlay is rendered into. */
+  container: HTMLElement;
+  /** The chart type to build navigation for. */
+  chartType: NavigableChartType;
+  /** Chart data (plain objects). */
+  data: SimpleData[];
+  /** Primary categorical / x-axis field. */
+  dimension?: string;
+  /** Series / color field (set for stacked bars). */
+  color?: string;
+  /** Primary metric / y-axis field. */
+  metric?: string;
+  /** The mark's own name (e.g. `bar0`) — drives its real hover signals for mouse-hover parity. */
+  markName?: string;
+  /** Optional chart title for the accessible description. */
+  title?: string;
+  /** Stable id used to namespace the rendered nav elements. */
+  chartId: string;
+  /** Accessor for the live Vega view; focus signals are set on it as the user navigates. */
+  getView: () => View | undefined;
+  /** Same context refs `handleMarkClick` uses — Space opens a focused bar/segment's popover through the exact same trigger. */
+  selectedData?: RefObject<Datum | null>;
+  selectedDataBounds?: RefObject<MarkBounds>;
+  selectedDataName?: RefObject<string>;
+  /** Lets the popover's own close handler know it doesn't need to clear hover-parity signals — keyboard focus still owns them. */
+  keyboardPopoverComponentName?: RefObject<string | null>;
+}
+
+interface FocusSignals {
+  item: string | null; // a single bar / stacked segment
+  region: string | null; // the whole chart (entry/root)
+  dimension: string | null; // a dimension group, e.g. a whole stack
+}
+
+const CLEARED_FOCUS: FocusSignals = { item: null, region: null, dimension: null };
+
+/**
+ * Maps the focused node to the chart's focus signals:
+ *  - leaf (no dimensionLevel)   → a single bar/segment (`item` = node id)
+ *  - dimension root (level 1)   → the chart overview (`region` = 'chart')
+ *  - division (level 2)         → a dimension group / stack (`dimension` = the column value)
+ */
+const nodeFocusSignals = (node: NodeObject): FocusSignals => {
+  if (node.dimensionLevel == null) {
+    return { ...CLEARED_FOCUS, item: node.id };
+  }
+  if (node.dimensionLevel === 1) {
+    return { ...CLEARED_FOCUS, region: 'chart' };
+  }
+  const dimensionValue = node.derivedNode ? node.data?.[node.derivedNode] : undefined;
+  const dimension = dimensionValue == null ? null : String(dimensionValue);
+  return { ...CLEARED_FOCUS, dimension };
+};
+
+const applyFocusSignals = (view: View | undefined, { item, region, dimension }: FocusSignals): Promise<unknown> | undefined => {
+  if (!view) return undefined;
+
+  view.signal(FOCUSED_ITEM, item);
+  view.signal(FOCUSED_REGION, region);
+  view.signal(FOCUSED_DIMENSION, dimension);
+  return view.runAsync();
+};
+
+/** Shows the tooltip matching a focused node (leaf, stack, or none) — shared by the `focus` handler and the mouse-hover guard below. */
+const showTooltipForFocusedNode = (
+  container: HTMLElement,
+  view: View,
+  node: NodeObject,
+  markName: string,
+  dimension: string,
+  color: string | undefined
+): void => {
+  const signals = nodeFocusSignals(node);
+  if (signals.item != null) {
+    // Leaf: same value shape its own tooltip encoding produces.
+    const row = findFocusedRow(view, node, dimension, color);
+    const value = row ? { ...row, [COMPONENT_NAME]: markName } : null;
+    showFocusedItemTooltip(container, view, `${markName}_focusRing`, value);
+  } else if (signals.dimension != null) {
+    // Division (whole stack): empty unless a dimensionArea-targeted ChartInspect exists, matching real hover.
+    const stackRow = findFocusedStackRow(view, node, dimension, markName);
+    const value = stackRow ? { ...stackRow, [COMPONENT_NAME]: `${markName}_${DIMENSION_HOVER_AREA}`, dimension } : null;
+    showFocusedItemTooltip(container, view, `${markName}_stackFocusRing`, value);
+  } else {
+    showFocusedItemTooltip(container, view, `${markName}_focusRing`, null);
+  }
+};
+
+/** One guard handler per view (re-registering on every attach would leak stale closures/duplicate listeners). */
+const hoverGuardHandlers = new WeakMap<View, SignalListenerHandler>();
+
+/**
+ * Real mouse mouseout unconditionally nulls the shared `${markName}_hoveredItem` signals (see
+ * `addHoveredItemSignal`), clobbering whatever the keyboard-focused item set. Reapplies that
+ * item's value (and its tooltip) whenever this happens while a node is still keyboard-focused.
+ */
+const guardHoverParityAgainstMouseClear = (
+  container: HTMLElement,
+  view: View,
+  markName: string,
+  dimension: string,
+  color: string | undefined,
+  getFocusedNode: () => NodeObject | undefined
+): void => {
+  const itemSignal = `${markName}_${HOVERED_ITEM}`;
+  const dimensionSignal = `${markName}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`;
+  const previous = hoverGuardHandlers.get(view);
+  if (previous) {
+    view.removeSignalListener(itemSignal, previous);
+    view.removeSignalListener(dimensionSignal, previous);
+  }
+  const handler: SignalListenerHandler = (_name, value) => {
+    if (value != null) return;
+    const node = getFocusedNode();
+    if (!node) return;
+    applyHoverParitySignals(view, { markName, dimension, color }, node);
+    view.runAfter((v) => {
+      v.runAsync().then(() => showTooltipForFocusedNode(container, v, node, markName, dimension, color));
+    });
+  };
+  view.addSignalListener(itemSignal, handler);
+  view.addSignalListener(dimensionSignal, handler);
+  hoverGuardHandlers.set(view, handler);
+};
+
+/**
+ * Builds the navigation structure and drives data-navigator's rendering +
+ * input modules. The visible focus indicator is drawn on the Vega canvas (focus-ring marks); the
+ * elements created here are invisible overlays used only for keyboard focus and assistive tech.
+ */
+export const attachDataNavigator = ({
+  container,
+  chartType,
+  data,
+  dimension,
+  color,
+  metric,
+  markName,
+  title,
+  chartId,
+  getView,
+  selectedData,
+  selectedDataBounds,
+  selectedDataName,
+  keyboardPopoverComponentName,
+}: AttachDataNavigatorOptions): void => {
+  const built = buildChartStructure({ chartType, data, dimension, color, metric, title });
+  if (!built) return;
+  const { structure, entryPoint } = built;
+
+  if (!container.id) {
+    container.id = `dn-root-${chartId}`;
+  }
+
+  container.querySelectorAll('.dn-wrapper, .dn-exit-position, .dn-exit').forEach((node) => node.remove());
+
+  let current: string | null = null;
+  // Set when Space opens a popover: moving focus into it fires a focusout that looks identical to
+  // leaving the widget. Consumed by the next focusout so the node survives for focus-restore on close.
+  let suppressNextLeave = false;
+  const width = container.clientWidth || 400;
+  const height = container.clientHeight || 300;
+
+  const view = getView();
+  if (view && markName && dimension) {
+    guardHoverParityAgainstMouseClear(container, view, markName, dimension, color, () => (current ? structure.nodes[current] : undefined));
+  }
+
+  const rendering: DataNavigatorRenderer = dataNavigator.rendering({
+    elementData: structure.nodes,
+    defaults: {
+      cssClass: 'dn-node',
+      spatialProperties: { x: 0, y: 0, width, height },
+    },
+    suffixId: chartId,
+    root: {
+      id: container.id,
+      description: 'Accessible chart navigation',
+      width: '100%',
+      // A falsy height here is a no-op in the library's own `root.height && (...)` check, so this
+      // must stay a truthy value or .dn-wrapper (and every .dn-node under it) collapses to 0px tall.
+      height: '100%',
+    },
+    entryButton: { include: true, callbacks: { click: enter } },
+    exitElement: { include: true },
+  });
+
+  rendering.initialize();
+
+  const input: DataNavigatorInput = dataNavigator.input({
+    structure,
+    navigationRules: structure.navigationRules ?? {},
+    entryPoint,
+    exitPoint: rendering.exitElement?.id,
+  });
+
+  function enter() {
+    const node = input.enter();
+    if (node) {
+      navigate(node);
+    }
+  }
+
+  /** Sets the shared context refs and triggers the popover through the same DOM-button-click a real click uses. */
+  function triggerBarPopover(row: Row, sceneItem: unknown) {
+    if (!markName || !selectedData || !selectedDataBounds || !selectedDataName) return;
+    selectedData.current = { ...row, [COMPONENT_NAME]: markName } as unknown as Datum;
+    selectedDataBounds.current = getItemBounds(sceneItem as ActionItem);
+    selectedDataName.current = markName;
+    if (triggerPopover(chartId, markName, 'click')) {
+      suppressNextLeave = true;
+      // FOCUSED_ITEM stays untouched — getBarFocusRing already hides the ring when SELECTED_ITEM
+      // matches. Tells the popover's close handler this component's hover-parity is still owned by
+      // keyboard focus (see keyboardPopoverComponentName's doc).
+      if (keyboardPopoverComponentName) keyboardPopoverComponentName.current = markName;
+    }
+  }
+
+  /** Opens the focused leaf bar/segment's popover — same mechanism `handleMarkClick` uses on a real click. */
+  function openBarPopover(node: NodeObject) {
+    const view = getView();
+    if (!view || !markName || !dimension) return;
+    const row = findFocusedRow(view, node, dimension, color);
+    if (!row) return;
+    const sceneItem = findFocusedBarSceneItem(view, markName, row[MARK_ID]);
+    if (!sceneItem) return;
+    triggerBarPopover(row, sceneItem);
+  }
+
+  /** Opens the focused whole-stack (dimension area) popover — same one a real click on the stack's exposed padding already opens. */
+  function openStackPopover(node: NodeObject) {
+    const view = getView();
+    if (!view || !markName || !dimension) return;
+    const stackRow = findFocusedStackRow(view, node, dimension, markName);
+    if (!stackRow) return;
+    const sceneItem = findFocusedDimensionAreaSceneItem(view, markName, dimension, stackRow[dimension]);
+    if (!sceneItem) return;
+    triggerBarPopover(stackRow, sceneItem);
+  }
+
+  function navigate(node: NodeObject) {
+    const renderId = node.renderId || node.id;
+    node.renderId = renderId;
+
+    // Take the entry button out of Tab order once inside, or Shift+Tab lands back on it (a real,
+    // always-tabbable <button>) instead of leaving the widget — restored in clearFocusState().
+    if (rendering.entryButton) {
+      (rendering.entryButton as HTMLButtonElement).tabIndex = -1;
+    }
+
+    const previous = current;
+    // Hide synchronously so a stale tooltip never lingers while the new focus's bounds resolve.
+    hideFocusedItemTooltip(getView());
+
+    const el = rendering.render({ renderId, datum: node });
+    if (!el) return;
+
+    // Visual focus comes from the Vega ring, so overlay the element across the whole container.
+    el.style.width = '100%';
+    el.style.height = '100%';
+    el.style.top = '0';
+    el.style.left = '0';
+
+    el.addEventListener('keydown', (event) => {
+      // Space opens a popover, mirroring a real click on the bar/segment or the stack's padding —
+      // no equivalent at the chart-root level.
+      if (event.code === 'Space') {
+        event.preventDefault();
+        if (node.dimensionLevel == null) {
+          openBarPopover(node);
+        } else if (node.dimensionLevel === 2) {
+          openStackPopover(node);
+        }
+        return;
+      }
+      const direction = input.keydownValidator(event);
+      if (!direction) return;
+      event.preventDefault();
+      const next = input.move(current, direction);
+      if (next) {
+        navigate(next);
+        return;
+      }
+      // No edge supports this move (e.g. Escape at a top-level region root): drill out of the widget.
+      if (direction === 'parent' && rendering.exitElement) {
+        rendering.exitElement.style.display = 'block';
+        input.focus(rendering.exitElement.id);
+      }
+    });
+
+    el.addEventListener('focus', () => {
+      const view = getView();
+      // Set before applyFocusSignals's runAsync() so both flush together in one dataflow pulse.
+      if (view && markName && dimension) {
+        applyHoverParitySignals(view, { markName, dimension, color }, node);
+      }
+      const signals = nodeFocusSignals(node);
+      applyFocusSignals(view, signals)
+        ?.then(() => {
+          if (!view) return;
+          if (!markName || !dimension) {
+            showFocusedItemTooltip(container, view, `${markName ?? 'bar0'}_focusRing`, null);
+            return;
+          }
+          showTooltipForFocusedNode(container, view, node, markName, dimension, color);
+        });
+    });
+
+    input.focus(renderId);
+    current = node.id;
+
+    // Remove the previous node AFTER moving focus, so its focusout carries the new node as
+    // relatedTarget — keeping the focusout handler below from treating this as leaving the widget.
+    if (previous && previous !== node.id) rendering.remove(previous);
+  }
+
+  const clearFocusState = () => {
+    if (current) rendering.remove(current);
+    current = null;
+    if (rendering.entryButton) {
+      (rendering.entryButton as HTMLButtonElement).tabIndex = 0;
+    }
+    const view = getView();
+    hideFocusedItemTooltip(view);
+    if (view && markName && dimension) {
+      applyHoverParitySignals(view, { markName, dimension, color }, null);
+    }
+    applyFocusSignals(view, CLEARED_FOCUS);
+  };
+
+  // Clear focus state when it leaves the navigator entirely. Moves within the widget (node→node,
+  // node→exit) keep a relatedTarget inside the container and are ignored.
+  rendering.wrapper?.addEventListener('focusout', (event) => {
+    if (suppressNextLeave) {
+      suppressNextLeave = false;
+      return;
+    }
+    const next = event.relatedTarget;
+    if (next instanceof Node && container.contains(next)) return;
+    clearFocusState();
+  });
+
+  if (rendering.exitElement) {
+    rendering.exitElement.addEventListener('focus', clearFocusState);
+  }
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/dataNavigatorAdapter.ts
@@ -365,8 +365,11 @@ export const attachDataNavigator = ({
         });
     });
 
-    input.focus(renderId);
+    // Set before input.focus(): it synchronously fires the 'focus' listener above, which can
+    // synchronously flush signal listeners (e.g. the mouse-hover guard) — current must already
+    // reflect this node or a listener firing mid-transition reapplies the previous node's values.
     current = node.id;
+    input.focus(renderId);
 
     // Remove the previous node AFTER moving focus, so its focusout carries the new node as
     // relatedTarget — keeping the focusout handler below from treating this as leaving the widget.

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.test.ts
@@ -13,7 +13,12 @@ import { View } from 'vega';
 
 import { MARK_ID } from '@spectrum-charts/constants';
 
-import { findFocusedBarSceneItem, hideFocusedItemTooltip, showFocusedItemTooltip } from './focusedItemTooltip';
+import {
+  findFocusedBarSceneItem,
+  findFocusedDimensionAreaSceneItem,
+  hideFocusedItemTooltip,
+  showFocusedItemTooltip,
+} from './focusedItemTooltip';
 
 const MARK_NAME = 'bar0';
 const RING_NAME = `${MARK_NAME}_focusRing`;
@@ -128,5 +133,27 @@ describe('findFocusedBarSceneItem()', () => {
     const view = mockBarView([{ datum: { browser: 'Chrome', [MARK_ID]: 0 } }]);
 
     expect(findFocusedBarSceneItem(view, MARK_NAME, 99)).toBeUndefined();
+  });
+});
+
+describe('findFocusedDimensionAreaSceneItem()', () => {
+  const DIMENSION_AREA_NAME = `${MARK_NAME}_dimensionHoverArea`;
+
+  const mockDimensionAreaView = (items: { datum: Record<string, unknown> }[]) =>
+    ({
+      scenegraph: () => ({ root: { items: [{ marktype: 'rect', name: DIMENSION_AREA_NAME, items }] } }),
+    }) as unknown as View;
+
+  test('finds the rendered dimension-area item whose datum carries the given dimension value', () => {
+    const match = { datum: { browser: 'Chrome' } };
+    const view = mockDimensionAreaView([{ datum: { browser: 'Firefox' } }, match]);
+
+    expect(findFocusedDimensionAreaSceneItem(view, MARK_NAME, 'browser', 'Chrome')).toBe(match);
+  });
+
+  test('returns undefined when no rendered item matches the given dimension value', () => {
+    const view = mockDimensionAreaView([{ datum: { browser: 'Firefox' } }]);
+
+    expect(findFocusedDimensionAreaSceneItem(view, MARK_NAME, 'browser', 'Chrome')).toBeUndefined();
   });
 });

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { View } from 'vega';
+
+import { MARK_ID } from '@spectrum-charts/constants';
+
+import { findFocusedBarSceneItem, hideFocusedItemTooltip, showFocusedItemTooltip } from './focusedItemTooltip';
+
+const MARK_NAME = 'bar0';
+const RING_NAME = `${MARK_NAME}_focusRing`;
+
+let tooltipCallback: jest.Mock;
+let container: HTMLElement;
+
+/** Builds a fake View exposing `tooltip()` as a getter (real vega-view behavior) and a scenegraph
+ *  containing one `${markName}_focusRing` rect mark with the given rendered items. */
+const mockView = (ringItems: object[] = [], origin: [number, number] = [0, 0]) => {
+  tooltipCallback = jest.fn();
+  return {
+    tooltip: jest.fn().mockReturnValue(tooltipCallback),
+    scenegraph: () => ({
+      root: { items: [{ marktype: 'rect', name: RING_NAME, items: ringItems }] },
+    }),
+    origin: jest.fn().mockReturnValue(origin),
+  } as unknown as View;
+};
+
+beforeEach(() => {
+  container = document.createElement('div');
+  jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({ left: 0, top: 0 } as DOMRect);
+});
+
+describe('showFocusedItemTooltip()', () => {
+  test('does nothing when the view has no registered tooltip callback', () => {
+    const view = { tooltip: jest.fn().mockReturnValue(undefined) } as unknown as View;
+    expect(() => showFocusedItemTooltip(container, view, MARK_NAME, { value: 1 })).not.toThrow();
+  });
+
+  test('hides (calls with a null value) when the given value is null', () => {
+    const view = mockView([{ opacity: 1, bounds: { x1: 0, y1: 0, x2: 10, y2: 10 } }]);
+    showFocusedItemTooltip(container, view, MARK_NAME, null);
+    expect(tooltipCallback).toHaveBeenCalledWith(undefined, undefined, undefined, null);
+  });
+
+  test('hides when no ring item is currently visible, even with a real value', () => {
+    const view = mockView([]);
+    showFocusedItemTooltip(container, view, MARK_NAME, { value: 1 });
+    expect(tooltipCallback).toHaveBeenCalledWith(undefined, undefined, undefined, null);
+  });
+
+  test('hides when every ring item has zero opacity', () => {
+    const view = mockView([{ opacity: 0, bounds: { x1: 0, y1: 0, x2: 10, y2: 10 } }]);
+    showFocusedItemTooltip(container, view, MARK_NAME, { value: 1 });
+    expect(tooltipCallback).toHaveBeenCalledWith(undefined, undefined, undefined, null);
+  });
+
+  test('triggers the real callback with the visible ring item and the given value', () => {
+    const ringItem = { opacity: 1, bounds: { x1: 10, y1: 20, x2: 30, y2: 40 } };
+    const view = mockView([ringItem]);
+    const value = { browser: 'Chrome', rscComponentName: MARK_NAME };
+    showFocusedItemTooltip(container, view, MARK_NAME, value);
+
+    expect(tooltipCallback).toHaveBeenCalledTimes(1);
+    const [handler, event, item, calledValue] = tooltipCallback.mock.calls[0];
+    expect(calledValue).toBe(value);
+    expect(item).toBe(ringItem);
+    expect(handler).toMatchObject({ _el: container, _origin: [0, 0] });
+    expect(event).toMatchObject({ clientX: 20, clientY: 20 });
+  });
+
+  test('adds the view origin and the container\'s page offset to the synthetic event position', () => {
+    const ringItem = { opacity: 1, bounds: { x1: 10, y1: 20, x2: 30, y2: 40 } };
+    const view = mockView([ringItem], [5, 6]);
+    jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({ left: 100, top: 200 } as DOMRect);
+    showFocusedItemTooltip(container, view, MARK_NAME, { value: 1 });
+
+    const [, event] = tooltipCallback.mock.calls[0];
+    expect(event).toMatchObject({ clientX: 100 + 5 + 20, clientY: 200 + 6 + 20 });
+  });
+
+  test('adds the owning group\'s offset to the ring item\'s own (group-relative) bounds', () => {
+    const ringItem = { opacity: 1, bounds: { x1: 10, y1: 20, x2: 30, y2: 40 }, mark: { group: { x: 100, y: 200 } } };
+    const view = mockView([ringItem]);
+    showFocusedItemTooltip(container, view, MARK_NAME, { value: 1 });
+
+    // group-relative bounds {x1:10,y1:20,x2:30,y2:40} + group offset {x:100,y:200} = {x1:110,y1:220,x2:130,y2:240};
+    // containerRect/origin are both zero in this test, so clientX/clientY are just those bounds.
+    const [, event] = tooltipCallback.mock.calls[0];
+    expect(event).toMatchObject({ clientX: 120, clientY: 220 });
+  });
+});
+
+describe('hideFocusedItemTooltip()', () => {
+  test('does nothing when there is no view', () => {
+    expect(() => hideFocusedItemTooltip(undefined)).not.toThrow();
+  });
+
+  test('calls the registered callback with a null value', () => {
+    const view = mockView();
+    hideFocusedItemTooltip(view);
+    expect(tooltipCallback).toHaveBeenCalledWith(undefined, undefined, undefined, null);
+  });
+});
+
+describe('findFocusedBarSceneItem()', () => {
+  const mockBarView = (items: { datum: Record<string, unknown> }[]) =>
+    ({
+      scenegraph: () => ({ root: { items: [{ marktype: 'rect', name: MARK_NAME, items }] } }),
+    }) as unknown as View;
+
+  test('finds the rendered bar item whose datum carries the given MARK_ID', () => {
+    const match = { datum: { browser: 'Chrome', [MARK_ID]: 1 } };
+    const view = mockBarView([{ datum: { browser: 'Firefox', [MARK_ID]: 0 } }, match]);
+
+    expect(findFocusedBarSceneItem(view, MARK_NAME, 1)).toBe(match);
+  });
+
+  test('returns undefined when no rendered item matches the given MARK_ID', () => {
+    const view = mockBarView([{ datum: { browser: 'Chrome', [MARK_ID]: 0 } }]);
+
+    expect(findFocusedBarSceneItem(view, MARK_NAME, 99)).toBeUndefined();
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/focusedItemTooltip.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { View } from 'vega';
+
+import { DIMENSION_HOVER_AREA, MARK_ID } from '@spectrum-charts/constants';
+
+import { Row } from './barHoverParity';
+
+interface Bounds {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/*
+ * Vega scenegraph nodes are loosely typed; narrow the few fields read here. A plain signal's
+ * `data(name)` reference isn't reliably re-evaluated on data changes (unlike a mark's own encode),
+ * so the focused item is read directly off the rendered scenegraph instead of a derived signal.
+ */
+interface SceneNode {
+  marktype?: string;
+  name?: string;
+  items?: SceneNode[];
+  bounds?: Bounds;
+  opacity?: number;
+  x?: number;
+  y?: number;
+  mark?: { group?: SceneNode };
+  datum?: Row;
+}
+
+/** Every rendered instance of a named mark, wherever it's nested in the scenegraph. */
+const findSceneItems = (view: View, marktype: string, name: string): SceneNode[] => {
+  const results: SceneNode[] = [];
+  const walk = (node: SceneNode | undefined): void => {
+    if (!node || typeof node !== 'object') return;
+    if (node.marktype === marktype && node.name === name && Array.isArray(node.items)) {
+      results.push(...node.items);
+      return;
+    }
+    node.items?.forEach(walk);
+  };
+  walk((view as unknown as { scenegraph: () => { root: SceneNode } }).scenegraph().root);
+  return results;
+};
+
+/*
+ * vega-tooltip's registered callback (set via `view.tooltip((handler, event, item, value) => ...)`
+ * in useNewChartView.tsx). Calling it ourselves reuses ChartInspect's real DOM element, styling,
+ * and positioning instead of a parallel tooltip implementation.
+ */
+type TooltipCallback = (handler: unknown, event: unknown, item: unknown, value: unknown) => void;
+
+/** `view.tooltip()` with no args is an untyped getter for the callback above (vega-view: `if (!arguments.length) return this._tooltip`). */
+const getRegisteredTooltipCallback = (view: View): TooltipCallback | undefined =>
+  (view.tooltip as unknown as () => TooltipCallback | undefined)();
+
+/** Finds the currently-visible (`opacity > 0`) rendered instance of a named rect mark, if any. */
+export const findVisibleRingItem = (view: View, ringMarkName: string): SceneNode | undefined =>
+  findSceneItems(view, 'rect', ringMarkName).find((item) => (item.opacity ?? 0) > 0);
+
+/** Finds the real rendered bar/segment rect (not its focus ring) by `MARK_ID`, so a Space-triggered popover can anchor to the actual mark's bounds, as a real click does. */
+export const findFocusedBarSceneItem = (view: View, markName: string, markId: unknown): SceneNode | undefined =>
+  findSceneItems(view, 'rect', markName).find((item) => item.datum?.[MARK_ID] === markId);
+
+/** Same as `findFocusedBarSceneItem`, but for the `${markName}_dimensionHoverArea` mark (a whole stack), matched by dimension value since its rows have no `MARK_ID`. */
+export const findFocusedDimensionAreaSceneItem = (
+  view: View,
+  markName: string,
+  dimension: string,
+  dimensionValue: unknown
+): SceneNode | undefined =>
+  findSceneItems(view, 'rect', `${markName}_${DIMENSION_HOVER_AREA}`).find((item) => item.datum?.[dimension] === dimensionValue);
+
+/** Bounds are group-relative; walk up the mark's owning groups to make them view-relative. */
+const absoluteBounds = (item: SceneNode): Bounds | undefined => {
+  const b = item.bounds;
+  if (!b) return undefined;
+  let dx = 0;
+  let dy = 0;
+  let group = item.mark?.group;
+  while (group) {
+    dx += group.x ?? 0;
+    dy += group.y ?? 0;
+    group = group.mark?.group;
+  }
+  return { x1: b.x1 + dx, y1: b.y1 + dy, x2: b.x2 + dx, y2: b.y2 + dy };
+};
+
+export const hideFocusedItemTooltip = (view: View | undefined): void => {
+  const tooltipCallback = view && getRegisteredTooltipCallback(view);
+  tooltipCallback?.(undefined, undefined, undefined, null);
+};
+
+/**
+ * Triggers the real ChartInspect tooltip by calling the same callback Vega calls on mouseover, so
+ * keyboard focus gets identical content and positioning. `value` must match the mark's own
+ * `tooltip` encoding shape (see `dataNavigatorAdapter.ts`); `null` hides it. `ringMarkName` is
+ * whichever ring is visible for the node, used to read its bounds for positioning — call only
+ * after `view.runAsync()` resolves so those bounds reflect the new focus.
+ */
+export const showFocusedItemTooltip = (container: HTMLElement, view: View, ringMarkName: string, value: unknown): void => {
+  const tooltipCallback = getRegisteredTooltipCallback(view);
+  if (!tooltipCallback) return;
+
+  if (value == null) {
+    tooltipCallback(undefined, undefined, undefined, null);
+    return;
+  }
+
+  const ringItem = findVisibleRingItem(view, ringMarkName);
+  const bounds = ringItem ? absoluteBounds(ringItem) : undefined;
+  if (!ringItem || !bounds) {
+    tooltipCallback(undefined, undefined, undefined, null);
+    return;
+  }
+
+  const [originX, originY] = view.origin();
+  const containerRect = container.getBoundingClientRect();
+  // Duck-typed stand-in for Vega's private interaction handler — vega-tooltip's mark-relative
+  // positioning (calculatePositionRelativeToMark) only reads these two fields off it.
+  const fakeHandler = { _el: container, _origin: [originX, originY] };
+  const syntheticEvent = {
+    type: 'focus',
+    clientX: containerRect.left + originX + (bounds.x1 + bounds.x2) / 2,
+    clientY: containerRect.top + originY + bounds.y1,
+  };
+
+  tooltipCallback(fakeHandler, syntheticEvent, ringItem, value);
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/navigableMarks.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/navigableMarks.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Bar } from '../components/Bar';
+import { NavigableChartType } from './buildChartStructure';
+
+export const getNavigableChartType = (displayName: unknown): NavigableChartType | undefined => {
+  if (displayName === Bar.displayName) return 'bar';
+  return undefined;
+};

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/navigationRules.test.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/navigationRules.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { Structure } from 'data-navigator';
+
+import { addSiblingKeySynonyms } from './navigationRules';
+
+const structureWith = (edges: Structure['edges']): Structure => ({ nodes: {}, edges });
+
+describe('addSiblingKeySynonyms()', () => {
+  test('adds up alongside left and down alongside right', () => {
+    const structure = structureWith({
+      e1: { source: 'a', target: 'b', navigationRules: ['left', 'right'] },
+    });
+    addSiblingKeySynonyms(structure);
+    expect(structure.edges.e1.navigationRules).toEqual(['left', 'right', 'up', 'down']);
+  });
+
+  test('leaves edges with no left/right rules untouched', () => {
+    const structure = structureWith({
+      e1: { source: 'a', target: 'b', navigationRules: ['parent', 'child'] },
+    });
+    addSiblingKeySynonyms(structure);
+    expect(structure.edges.e1.navigationRules).toEqual(['parent', 'child']);
+  });
+
+  test('is idempotent — running twice does not duplicate synonyms', () => {
+    const structure = structureWith({
+      e1: { source: 'a', target: 'b', navigationRules: ['left', 'right'] },
+    });
+    addSiblingKeySynonyms(structure);
+    addSiblingKeySynonyms(structure);
+    expect(structure.edges.e1.navigationRules).toEqual(['left', 'right', 'up', 'down']);
+  });
+});

--- a/packages/react-spectrum-charts-s2/src/dataNavigator/navigationRules.ts
+++ b/packages/react-spectrum-charts-s2/src/dataNavigator/navigationRules.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { NavigationRules, Structure } from 'data-navigator';
+
+/** Shared keyboard navigation rules: Left/Right (and Up/Down synonyms, see {@link addSiblingKeySynonyms}) move between siblings, Enter drills in, Escape drills out. */
+export const baseNavigationRules: NavigationRules = {
+  left: { key: 'ArrowLeft', direction: 'source' },
+  right: { key: 'ArrowRight', direction: 'target' },
+  up: { key: 'ArrowUp', direction: 'source' },
+  down: { key: 'ArrowDown', direction: 'target' },
+  child: { key: 'Enter', direction: 'target' },
+  parent: { key: 'Escape', direction: 'source' },
+};
+
+/** `sibling_sibling` is typed as an exact `['left', 'right']` 2-tuple, so Up/Down can't be registered at structure-build time — copy each sibling edge's left/right rule onto its up/down synonym after the fact. */
+export const addSiblingKeySynonyms = (structure: Structure): void => {
+  for (const edge of Object.values(structure.edges)) {
+    if (edge.navigationRules.includes('left') && !edge.navigationRules.includes('up')) {
+      edge.navigationRules.push('up');
+    }
+    if (edge.navigationRules.includes('right') && !edge.navigationRules.includes('down')) {
+      edge.navigationRules.push('down');
+    }
+  }
+};

--- a/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
+++ b/packages/react-spectrum-charts-s2/src/hooks/useSpec.tsx
@@ -22,6 +22,7 @@ import { SanitizedSpecProps } from '../types';
 export default function useSpec({
   animations,
   animationTypes,
+  accessibleNavigation,
   backgroundColor,
   children,
   colors,
@@ -55,6 +56,7 @@ export default function useSpec({
     const chartOptions = rscPropsToSpecBuilderOptions({
       animations,
       animationTypes,
+      accessibleNavigation,
       backgroundColor,
       children,
       colors,
@@ -78,6 +80,7 @@ export default function useSpec({
     UNSAFE_vegaSpec,
     animations,
     animationTypes,
+    accessibleNavigation,
     backgroundColor,
     children,
     colors,

--- a/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
+++ b/packages/react-spectrum-charts-s2/src/rscToSbAdapter/chartAdapter.test.ts
@@ -55,6 +55,17 @@ describe('rscPropsToSpecBuilderOptions()', () => {
     });
   });
 
+  describe('accessibleNavigation', () => {
+    test('should pass accessibleNavigation through to the spec builder options', () => {
+      const options = rscPropsToSpecBuilderOptions({ ...chartProps, accessibleNavigation: true });
+      expect(options).toHaveProperty('accessibleNavigation', true);
+    });
+    test('should be omitted when not provided', () => {
+      const options = rscPropsToSpecBuilderOptions(chartProps);
+      expect(options.accessibleNavigation).toBeUndefined();
+    });
+  });
+
   describe('marks', () => {
     test('should return provided marks in the marks array', () => {
       const options = rscPropsToSpecBuilderOptions({

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/Bar.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/Bar.story.tsx
@@ -92,6 +92,17 @@ const BarStory: StoryFn<typeof Bar> = (args): ReactElement => {
   );
 };
 
+const AccessibleNavigationStory: StoryFn<typeof Bar> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: barData, width: 600, height: 600, accessibleNavigation: true });
+  return (
+    <Chart {...chartProps}>
+      <Axis position={args.orientation === 'horizontal' ? 'left' : 'bottom'} baseline title="Browser" />
+      <Axis position={args.orientation === 'horizontal' ? 'bottom' : 'left'} baseline grid title="Downloads" />
+      <Bar {...args} color="browser" />
+    </Chart>
+  );
+};
+
 const BarWithInspectStory: StoryFn<typeof Bar> = (args): ReactElement => {
   const chartProps = useChartProps({ data: barData, width: 600, height: 600 });
   return (
@@ -216,7 +227,13 @@ AxisLabelHighlight.args = {
   ...defaultProps,
 };
 
+const AccessibleNavigation = bindWithProps(AccessibleNavigationStory);
+AccessibleNavigation.args = {
+  ...defaultProps,
+};
+
 export {
+  AccessibleNavigation,
   BarWithUTCDatetimeFormat,
   Basic,
   HasSquareCorners,

--- a/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/Bar/StackedBar.story.tsx
@@ -100,6 +100,18 @@ const StackedBarPopoverStory: StoryFn<typeof Bar> = (args): ReactElement => {
   );
 };
 
+const AccessibleNavigationStory: StoryFn<typeof Bar> = (args): ReactElement => {
+  const chartProps = useChartProps({ data: barSeriesData, colors, width: 800, height: 600, accessibleNavigation: true });
+  return (
+    <Chart {...chartProps}>
+      <Axis position={args.orientation === 'horizontal' ? 'left' : 'bottom'} baseline title="Browser" />
+      <Axis position={args.orientation === 'horizontal' ? 'bottom' : 'left'} grid title="Downloads" />
+      <Bar {...args} />
+      <Legend title="Operating system" color="operatingSystem" />
+    </Chart>
+  );
+};
+
 const defaultProps: BarProps = {
   dimension: 'browser',
   order: 'order',
@@ -156,7 +168,13 @@ AxisLabelHighlight.args = {
   ...defaultProps,
 };
 
+const AccessibleNavigation = bindWithProps(AccessibleNavigationStory);
+AccessibleNavigation.args = {
+  ...defaultProps,
+};
+
 export {
+  AccessibleNavigation,
   Basic,
   NegativeStack,
   OnClick,

--- a/packages/react-spectrum-charts-s2/src/stories/components/NavigationPrototype/BarNavigation.story.tsx
+++ b/packages/react-spectrum-charts-s2/src/stories/components/NavigationPrototype/BarNavigation.story.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ReactElement } from 'react';
+
+import { StoryFn } from '@storybook/react';
+
+import { GROUP_DATA, MARK_ID } from '@spectrum-charts/constants';
+
+import { Chart } from '../../../Chart';
+import { Axis, Bar, ChartInspect, ChartPopover, Legend } from '../../../components';
+import useChartProps from '../../../hooks/useChartProps';
+import { barSeriesData } from '../Bar/data';
+
+export default {
+  title: 'React Spectrum Charts 2/NavigationPrototype/Features/Bar Navigation',
+};
+
+/** Stacked bar keyboard navigation: Tab to "Enter navigation area", then arrow keys move between bars/segments. */
+const BarNavigationStory: StoryFn = (): ReactElement => {
+  const chartProps = useChartProps({
+    data: barSeriesData,
+    width: 800,
+    height: 600,
+    accessibleNavigation: true,
+  });
+  return (
+    <>
+      {/* Real page elements before/after the chart, so Tab/Shift+Tab in and out of the widget is observable. */}
+      <button type="button">Prev element</button>
+      <Chart {...chartProps}>
+        <Axis position="bottom" baseline title="Browser" />
+        <Axis position="left" grid title="Downloads" />
+        <Bar dimension="browser" order="order" color="operatingSystem">
+          <ChartInspect>
+            {(datum) => (
+              <div>
+                Operating system: {datum.operatingSystem}
+                <br />
+                Browser: {datum.browser}
+                <br />
+                Downloads: {datum.value}
+              </div>
+            )}
+          </ChartInspect>
+          {/* Focusing a stack (not a segment) shows this, same as hovering the stack's padding area with a mouse. */}
+          <ChartInspect targets={['dimensionArea']}>
+            {(datum) => (
+              <div>
+                <div style={{ fontWeight: 'bold' }}>{datum.browser}</div>
+                {datum[GROUP_DATA]?.map((d) => (
+                  <div key={d[MARK_ID]}>
+                    {d.operatingSystem}: {d.value}
+                  </div>
+                ))}
+              </div>
+            )}
+          </ChartInspect>
+          {/* Real buttons so focus entering the popover is testable — Safari's popover has none, for contrast. */}
+          <ChartPopover width={200}>
+            {(datum, close) => (
+              <div>
+                Operating system: {datum.operatingSystem}
+                <br />
+                Browser: {datum.browser}
+                <br />
+                Downloads: {datum.value}
+                {datum.browser !== 'Safari' && (
+                  <>
+                    <br />
+                    <button type="button">Action one</button>
+                    <button type="button">Action two</button>
+                    {close && (
+                      <button type="button" onClick={close}>
+                        Close
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+          </ChartPopover>
+        </Bar>
+        <Legend title="Operating system" color="operatingSystem" highlight />
+      </Chart>
+      <button type="button">Next element</button>
+    </>
+  );
+};
+
+export const BarNavigation = BarNavigationStory.bind({});

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.test.ts
@@ -25,6 +25,7 @@ import {
   getOnMarkClickCallback,
   handleLegendItemClick,
   handleLegendItemMouseInput,
+  triggerPopover,
 } from './markClickUtils';
 
 const defaultMarkClickArgs: GetOnMarkClickCallbackArgs = {
@@ -43,6 +44,30 @@ describe('getItemBounds()', () => {
   test('should return default bounds if null or undefined', () => {
     expect(getItemBounds(null)).toStrictEqual({ x1: 0, x2: 0, y1: 0, y2: 0 });
     expect(getItemBounds(undefined)).toStrictEqual({ x1: 0, x2: 0, y1: 0, y2: 0 });
+  });
+});
+
+describe('triggerPopover()', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('clicks the matching button and returns true when one exists', () => {
+    document.body.innerHTML = '<div id="test-chart"><div><button id="bar0-popover-button"></button></div></div>';
+    const button = document.getElementById('bar0-popover-button') as HTMLButtonElement;
+    const onClick = jest.fn();
+    button.addEventListener('click', onClick);
+
+    expect(triggerPopover('test-chart', 'bar0', 'click')).toBe(true);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns false without clicking anything when no matching button exists', () => {
+    expect(triggerPopover('test-chart', 'bar0', 'click')).toBe(false);
+  });
+
+  test('returns false when itemName is undefined', () => {
+    expect(triggerPopover('test-chart', undefined, 'click')).toBe(false);
   });
 });
 

--- a/packages/react-spectrum-charts-s2/src/utils/markClickUtils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/markClickUtils.ts
@@ -85,13 +85,14 @@ const handleMarkClick = (
   triggerPopover(chartId, itemName, trigger);
 };
 
-const triggerPopover = (chartId: string, itemName: string | undefined, trigger: 'click' | 'contextmenu') => {
-  if (!itemName) return;
-  (
-    document.querySelector(
-      `#${chartId} > div > #${itemName}-${trigger === 'contextmenu' ? 'contextmenu' : 'popover'}-button`
-    ) as HTMLButtonElement
-  )?.click();
+/** @returns whether a matching popover button was actually found and clicked. */
+export const triggerPopover = (chartId: string, itemName: string | undefined, trigger: 'click' | 'contextmenu'): boolean => {
+  if (!itemName) return false;
+  const button = document.querySelector(
+    `#${chartId} > div > #${itemName}-${trigger === 'contextmenu' ? 'contextmenu' : 'popover'}-button`
+  ) as HTMLButtonElement | null;
+  button?.click();
+  return button != null;
 };
 
 /**

--- a/packages/react-spectrum-charts-s2/src/utils/utils.test.tsx
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.test.tsx
@@ -18,10 +18,29 @@ import {
   debugLog,
   getAllElements,
   getComponentName,
+  shouldClearHoverSignalsOnClose,
   toggleStringArrayValue,
 } from './utils';
 
 describe('utils', () => {
+  describe('shouldClearHoverSignalsOnClose()', () => {
+    test('true for a real (mouse-opened) popover close', () => {
+      expect(shouldClearHoverSignalsOnClose('bar0', null)).toBe(true);
+    });
+
+    test('false when this exact component is still owned by an active keyboard focus', () => {
+      expect(shouldClearHoverSignalsOnClose('bar0', 'bar0')).toBe(false);
+    });
+
+    test('true when the keyboard-focused component is a different one', () => {
+      expect(shouldClearHoverSignalsOnClose('bar0', 'line0')).toBe(true);
+    });
+
+    test('false when there is no component to clear', () => {
+      expect(shouldClearHoverSignalsOnClose('', null)).toBe(false);
+    });
+  });
+
   describe('toggleStringArrayValue()', () => {
     test('should add value to target if it does not exist', () => {
       expect(toggleStringArrayValue(['a', 'b'], 'c')).toStrictEqual(['a', 'b', 'c']);

--- a/packages/react-spectrum-charts-s2/src/utils/utils.ts
+++ b/packages/react-spectrum-charts-s2/src/utils/utils.ts
@@ -473,6 +473,10 @@ export const clearHoverSignals = (
   safeClear(`${componentName}_${DIMENSION_HOVER_AREA}_${HOVERED_ITEM}`);
 };
 
+/** False when a closing popover's hover-parity is still owned by an active keyboard focus on the same component — clearing it would just get reapplied moments later, causing a visible flash. */
+export const shouldClearHoverSignalsOnClose = (componentName: string, keyboardComponentName: string | null): boolean =>
+  !!componentName && keyboardComponentName !== componentName;
+
 /**
  * Return true if chart has a child with the corresponding displayName
  * @param0

--- a/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { FOCUSED_DIMENSION, FOCUSED_REGION, NAVIGATION_ID_SEPARATOR } from '@spectrum-charts/constants';
+
+import { defaultBarOptions, defaultBarOptionsWithSecondayColor } from './barTestUtils';
+import { getBarFocusRing, getChartFocusRing, getStackFocusRing } from './barFocusRingUtils';
+
+const { dimension, metric } = defaultBarOptions;
+
+describe('getBarFocusRing()', () => {
+  test('sources the ring from the bar mark', () => {
+    const ring = getBarFocusRing(defaultBarOptions);
+    expect(ring).toHaveProperty('name', 'bar0_focusRing');
+    expect(ring.from).toEqual({ data: 'bar0' });
+    expect(ring.interactive).toBe(false);
+  });
+
+  test('keys a single-color (string) bar on the dimension + series composite', () => {
+    // defaultBarOptions.color is a string series field → composite leaf id
+    const opacity = JSON.stringify(getBarFocusRing(defaultBarOptions).encode?.update?.opacity);
+    expect(opacity).toContain(NAVIGATION_ID_SEPARATOR);
+  });
+
+  test('keys a multi-color (array) bar on the dimension value only', () => {
+    const opacity = JSON.stringify(getBarFocusRing(defaultBarOptionsWithSecondayColor).encode?.update?.opacity);
+    expect(opacity).not.toContain(NAVIGATION_ID_SEPARATOR);
+    expect(opacity).toContain(`datum.datum.${dimension}`);
+  });
+
+  test('uses metric-sign corner tests for dodged (non-stacked) bars', () => {
+    const corners = JSON.stringify(getBarFocusRing({ ...defaultBarOptions, type: 'dodged' }).encode?.enter);
+    expect(corners).toContain(`datum.datum.${metric} > 0`);
+  });
+
+  test('uses stack-extent corner tests for stacked bars', () => {
+    const corners = JSON.stringify(getBarFocusRing(defaultBarOptions).encode?.enter);
+    expect(corners).toContain('_stacks');
+  });
+
+  test('flattens the rounded corner radius when square corners are requested', () => {
+    const ring = getBarFocusRing({ ...defaultBarOptions, hasSquareCorners: true });
+    // the "rounded" arm of each corner rule collapses to the flat radius (2)
+    expect(ring.encode?.enter?.cornerRadiusTopLeft).toEqual([{ test: expect.any(String), value: 2 }, { value: 2 }]);
+  });
+});
+
+describe('getChartFocusRing()', () => {
+  test('covers the full plot area and keys opacity on the chart region', () => {
+    const ring = getChartFocusRing(defaultBarOptions);
+    expect(ring).toHaveProperty('name', 'chartFocusRing');
+    expect(ring.encode?.update?.x).toEqual({ value: 0 });
+    expect(ring.encode?.update?.x2).toEqual({ signal: 'width' });
+    expect(ring.encode?.update?.opacity).toEqual([
+      { test: `${FOCUSED_REGION} === 'chart'`, value: 1 },
+      { value: 0 },
+    ]);
+  });
+});
+
+describe('getStackFocusRing()', () => {
+  test('sources from the per-stack data and keys opacity on the focused dimension', () => {
+    const ring = getStackFocusRing(defaultBarOptions);
+    expect(ring).toHaveProperty('name', 'bar0_stackFocusRing');
+    expect(ring.from).toEqual({ data: 'bar0_stacks' });
+    expect(ring.encode?.update?.opacity).toEqual([
+      { test: `${FOCUSED_DIMENSION} === datum.${dimension}`, value: 1 },
+      { value: 0 },
+    ]);
+  });
+
+  test('positions a vertical stack ring along the y axis', () => {
+    const ring = getStackFocusRing(defaultBarOptions);
+    // vertical: top edge follows the stack-top metric scale
+    expect(JSON.stringify(ring.encode?.update?.y)).toContain(`max_${metric}1`);
+  });
+
+  test('positions a horizontal stack ring along the x axis', () => {
+    const ring = getStackFocusRing({ ...defaultBarOptions, orientation: 'horizontal' });
+    expect(JSON.stringify(ring.encode?.update?.x2)).toContain(`max_${metric}1`);
+  });
+
+  test('rounds the metric-end corners unless square corners are requested', () => {
+    expect(getStackFocusRing(defaultBarOptions).encode?.enter?.cornerRadiusTopLeft).toEqual({ value: 6 });
+    expect(getStackFocusRing({ ...defaultBarOptions, hasSquareCorners: true }).encode?.enter?.cornerRadiusTopLeft).toEqual({
+      value: 2,
+    });
+  });
+
+  test('rounds the trailing corner for a horizontal stack', () => {
+    const ring = getStackFocusRing({ ...defaultBarOptions, orientation: 'horizontal' });
+    expect(ring.encode?.enter?.cornerRadiusTopRight).toEqual({ value: 6 });
+  });
+});

--- a/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.test.ts
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { FOCUSED_DIMENSION, FOCUSED_REGION, NAVIGATION_ID_SEPARATOR } from '@spectrum-charts/constants';
+import { FOCUSED_DIMENSION, FOCUSED_REGION, NAVIGATION_ID_SEPARATOR, SELECTED_ITEM } from '@spectrum-charts/constants';
 
 import { defaultBarOptions, defaultBarOptionsWithSecondayColor } from './barTestUtils';
 import { getBarFocusRing, getChartFocusRing, getStackFocusRing } from './barFocusRingUtils';
@@ -50,6 +50,11 @@ describe('getBarFocusRing()', () => {
     const ring = getBarFocusRing({ ...defaultBarOptions, hasSquareCorners: true });
     // the "rounded" arm of each corner rule collapses to the flat radius (2)
     expect(ring.encode?.enter?.cornerRadiusTopLeft).toEqual([{ test: expect.any(String), value: 2 }, { value: 2 }]);
+  });
+
+  test('suppresses opacity when this item is also the selected/popover-open one', () => {
+    const opacity = JSON.stringify(getBarFocusRing(defaultBarOptions).encode?.update?.opacity);
+    expect(opacity).toContain(`${SELECTED_ITEM} === datum.datum.${defaultBarOptions.idKey}`);
   });
 });
 

--- a/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barFocusRingUtils.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { RectEncodeEntry, RectMark } from 'vega';
+
+import {
+  FOCUSED_DIMENSION,
+  FOCUSED_ITEM,
+  FOCUSED_REGION,
+  NAVIGATION_ID_SEPARATOR,
+  SELECTED_ITEM,
+  STACK_ID,
+} from '@spectrum-charts/constants';
+import { getS2ColorValue } from '@spectrum-charts/themes';
+
+import { BarSpecOptions } from '../types';
+import { getOrientationProperties, isDodgedAndStacked, rotateRectClockwiseIfNeeded } from './barUtils';
+
+const FOCUS_RING_STROKE_WIDTH = 2;
+const FOCUS_RING_ROUNDED_RADIUS = 6;
+const FOCUS_RING_FLAT_RADIUS = 2;
+const FOCUS_RING_OFFSET = 3;
+
+/** Ring corners for a single bar or whole stack treated as one shape: rounded metric end, flat base. */
+const getStaticFocusRingCorners = ({ hasSquareCorners, orientation }: BarSpecOptions): RectEncodeEntry => {
+  const rounded = hasSquareCorners ? FOCUS_RING_FLAT_RADIUS : FOCUS_RING_ROUNDED_RADIUS;
+  const flat = FOCUS_RING_FLAT_RADIUS;
+  return orientation === 'vertical'
+    ? {
+        cornerRadiusTopLeft: { value: rounded },
+        cornerRadiusTopRight: { value: rounded },
+        cornerRadiusBottomRight: { value: flat },
+        cornerRadiusBottomLeft: { value: flat },
+      }
+    : {
+        cornerRadiusTopLeft: { value: flat },
+        cornerRadiusTopRight: { value: rounded },
+        cornerRadiusBottomRight: { value: rounded },
+        cornerRadiusBottomLeft: { value: flat },
+      };
+};
+
+/** Handle square corners for the inner stacked bar segments. */
+const getDynamicFocusRingCorners = (options: BarSpecOptions): RectEncodeEntry => {
+  const { hasSquareCorners, metric, name, type } = options;
+  const rounded = hasSquareCorners ? FOCUS_RING_FLAT_RADIUS : FOCUS_RING_ROUNDED_RADIUS;
+  const flat = FOCUS_RING_FLAT_RADIUS;
+  let topTest: string;
+  let bottomTest: string;
+  if (type === 'dodged' && !isDodgedAndStacked(options)) {
+    topTest = `datum.datum.${metric} > 0`;
+    bottomTest = `datum.datum.${metric} < 0`;
+  } else {
+    const stacks = `data('${name}_stacks')`;
+    const stackIndex = `indexof(pluck(${stacks}, '${STACK_ID}'), datum.datum.${STACK_ID})`;
+    topTest = `datum.datum.${metric}1 > 0 && ${stacks}[${stackIndex}].max_${metric}1 === datum.datum.${metric}1`;
+    bottomTest = `datum.datum.${metric}1 < 0 && ${stacks}[${stackIndex}].min_${metric}1 === datum.datum.${metric}1`;
+  }
+  const rect: RectEncodeEntry = {
+    cornerRadiusTopLeft: [{ test: topTest, value: rounded }, { value: flat }],
+    cornerRadiusTopRight: [{ test: topTest, value: rounded }, { value: flat }],
+    cornerRadiusBottomLeft: [{ test: bottomTest, value: rounded }, { value: flat }],
+    cornerRadiusBottomRight: [{ test: bottomTest, value: rounded }, { value: flat }],
+  };
+  return rotateRectClockwiseIfNeeded(rect, options);
+};
+
+export const getBarFocusRing = (options: BarSpecOptions): RectMark => {
+  const { color, colorScheme, dimension, idKey, name } = options;
+  const focusedItemId =
+    typeof color === 'string'
+      ? `datum.datum.${dimension} + "${NAVIGATION_ID_SEPARATOR}" + datum.datum.${color}`
+      : `datum.datum.${dimension}`;
+  // Suppressed when a popover is open on this same item, so it doesn't double up with the selection ring.
+  const isSelected = `isValid(${SELECTED_ITEM}) && ${SELECTED_ITEM} === datum.datum.${idKey}`;
+  return {
+    name: `${name}_focusRing`,
+    type: 'rect',
+    from: { data: name },
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { value: 'transparent' },
+        strokeWidth: { value: FOCUS_RING_STROKE_WIDTH },
+        stroke: { value: getS2ColorValue('blue-800', colorScheme) },
+        // Mirror the segment's own corners so stacked middle segments stay square.
+        ...getDynamicFocusRingCorners(options),
+      },
+      update: {
+        x: { signal: `datum.bounds.x1 - ${FOCUS_RING_OFFSET}` },
+        x2: { signal: `datum.bounds.x2 + ${FOCUS_RING_OFFSET}` },
+        y: { signal: `datum.bounds.y1 - ${FOCUS_RING_OFFSET}` },
+        y2: { signal: `datum.bounds.y2 + ${FOCUS_RING_OFFSET}` },
+        opacity: [{ test: `${FOCUSED_ITEM} === ${focusedItemId} && !(${isSelected})`, value: 1 }, { value: 0 }],
+      },
+    },
+  };
+};
+
+export const getChartFocusRing = (options: BarSpecOptions): RectMark => {
+  const { colorScheme } = options;
+  return {
+    name: 'chartFocusRing',
+    type: 'rect',
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { value: 'transparent' },
+        strokeWidth: { value: FOCUS_RING_STROKE_WIDTH },
+        stroke: { value: getS2ColorValue('blue-800', colorScheme) },
+        cornerRadius: { value: FOCUS_RING_ROUNDED_RADIUS },
+      },
+      update: {
+        x: { value: 0 },
+        x2: { signal: 'width' },
+        y: { value: 0 },
+        y2: { signal: 'height' },
+        opacity: [{ test: `${FOCUSED_REGION} === 'chart'`, value: 1 }, { value: 0 }],
+      },
+    },
+  };
+};
+
+/** Focus ring around a whole stack (column) when that stack is focused. */
+export const getStackFocusRing = (options: BarSpecOptions): RectMark => {
+  const { colorScheme, dimension, metric, name, orientation } = options;
+  const { dimensionScaleKey, metricScaleKey } = getOrientationProperties(orientation);
+  const dimStart = `scale('${dimensionScaleKey}', datum.${dimension}) - ${FOCUS_RING_OFFSET}`;
+  const dimEnd = `scale('${dimensionScaleKey}', datum.${dimension}) + bandwidth('${dimensionScaleKey}') + ${FOCUS_RING_OFFSET}`;
+  const stackTop = `scale('${metricScaleKey}', datum.max_${metric}1)`;
+  const baseline = `scale('${metricScaleKey}', 0)`;
+  const update: RectEncodeEntry =
+    orientation === 'vertical'
+      ? 
+        {
+          x: { signal: dimStart },
+          x2: { signal: dimEnd },
+          y: { signal: `${stackTop} - ${FOCUS_RING_OFFSET}` },
+          y2: { signal: `${baseline} + ${FOCUS_RING_OFFSET}` },
+        }
+      : 
+        {
+          y: { signal: dimStart },
+          y2: { signal: dimEnd },
+          x: { signal: `${baseline} - ${FOCUS_RING_OFFSET}` },
+          x2: { signal: `${stackTop} + ${FOCUS_RING_OFFSET}` },
+        };
+  return {
+    name: `${name}_stackFocusRing`,
+    type: 'rect',
+    from: { data: `${name}_stacks` },
+    interactive: false,
+    encode: {
+      enter: {
+        fill: { value: 'transparent' },
+        strokeWidth: { value: FOCUS_RING_STROKE_WIDTH },
+        stroke: { value: getS2ColorValue('blue-800', colorScheme) },
+        ...getStaticFocusRingCorners(options),
+      },
+      update: {
+        ...update,
+        opacity: [{ test: `${FOCUSED_DIMENSION} === datum.${dimension}`, value: 1 }, { value: 0 }],
+      },
+    },
+  };
+};

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.test.ts
@@ -33,6 +33,9 @@ import {
   DEFAULT_SECONDARY_COLOR,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
+  FOCUSED_DIMENSION,
+  FOCUSED_ITEM,
+  FOCUSED_REGION,
   GROUP_ID,
   HOVERED_ITEM,
   LINE_TYPE_SCALE,
@@ -546,6 +549,17 @@ describe('barSpecBuilder', () => {
       const signals = addSignals(defaultSignals, defaultBarOptions);
       expect(signals).toHaveLength(defaultSignals.length + 1);
       expect(signals.at(-1)).toHaveProperty('name', 'paddingInner');
+    });
+    test('should add focus signals when accessibleNavigation is enabled', () => {
+      const signals = addSignals(defaultSignals, { ...defaultBarOptions, accessibleNavigation: true });
+      expect(signals.find((signal) => signal.name === FOCUSED_ITEM)).toBeDefined();
+      expect(signals.find((signal) => signal.name === FOCUSED_REGION)).toBeDefined();
+      expect(signals.find((signal) => signal.name === FOCUSED_DIMENSION)).toBeDefined();
+    });
+    test('should not add focus signals by default', () => {
+      const signals = addSignals(defaultSignals, defaultBarOptions);
+      expect(signals.find((signal) => signal.name === FOCUSED_ITEM)).toBeUndefined();
+      expect(signals.find((signal) => signal.name === FOCUSED_REGION)).toBeUndefined();
     });
     test('should add hover events if inspect is present', () => {
       const signals = addSignals(defaultSignals, { ...defaultBarOptions, chartInspects: [{}] });
@@ -1071,6 +1085,33 @@ describe('barSpecBuilder', () => {
       });
       test('default options + type = "dodged", should add default dodged bar', () => {
         expect(addMarks([], { ...defaultBarOptions, type: 'dodged' })).toStrictEqual([defaultDodgedMark]);
+      });
+    });
+
+    describe('accessibleNavigation', () => {
+      test('should add chart and bar focus rings when enabled (stacked/basic bar)', () => {
+        const marks = addMarks([], { ...defaultBarOptions, accessibleNavigation: true });
+        expect(marks.find((mark) => mark.name === 'chartFocusRing')).toBeDefined();
+        expect(marks.find((mark) => mark.name === 'bar0_focusRing')).toBeDefined();
+      });
+      test('should add the bar focus ring inside the dodge group when enabled (dodged bar)', () => {
+        const marks = addMarks([], { ...defaultBarOptions, type: 'dodged', accessibleNavigation: true });
+        const group = marks.find((mark) => mark.name === 'bar0_group') as GroupMark;
+        expect(group.marks?.find((mark) => mark.name === 'bar0_focusRing')).toBeDefined();
+      });
+      test('should not add focus rings by default', () => {
+        const marks = addMarks([], defaultBarOptions);
+        expect(marks.find((mark) => mark.name === 'chartFocusRing')).toBeUndefined();
+        expect(marks.find((mark) => mark.name === 'bar0_focusRing')).toBeUndefined();
+      });
+      test('should add the per-stack group focus ring when enabled on a stacked bar', () => {
+        const marks = addMarks([], { ...defaultBarOptions, type: 'stacked', accessibleNavigation: true, color: 'series' });
+        expect(marks.find((mark) => mark.name === 'bar0_stackFocusRing')).toBeDefined();
+      });
+      test('should not add the stack group focus ring on a basic (single-series) bar', () => {
+        // a static {value} color (no series field) → basic bar, so no per-stack group ring
+        const marks = addMarks([], { ...defaultBarOptions, accessibleNavigation: true, color: { value: 'categorical-100' } });
+        expect(marks.find((mark) => mark.name === 'bar0_stackFocusRing')).toBeUndefined();
       });
     });
 

--- a/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/bar/barSpecBuilder.ts
@@ -21,6 +21,9 @@ import {
   DEFAULT_METRIC,
   DIMENSION_HOVER_AREA,
   FILTERED_TABLE,
+  FOCUSED_DIMENSION,
+  FOCUSED_ITEM,
+  FOCUSED_REGION,
   GROUP_ID,
   LAST_RSC_SERIES_ID,
   LINE_TYPE_SCALE,
@@ -67,10 +70,16 @@ import {
   getGenericValueSignal,
   getLastRscSeriesIdSignal,
 } from '../signal/signalSpecBuilder';
-import { addUserMetaAnimatedMark, addUserMetaDivergingBarMark, addUserMetaInteractiveMark, getFacetsFromOptions } from '../specUtils';
+import {
+  addUserMetaAnimatedMark,
+  addUserMetaDivergingBarMark,
+  addUserMetaInteractiveMark,
+  getFacetsFromOptions,
+} from '../specUtils';
 import { getBarDirectLabelMarks, getBarDirectLabelSpecOptions } from '../barDirectLabel/barDirectLabelUtils';
 import { addTrendlineData, getTrendlineMarks, setTrendlineSignals } from '../trendline';
 import { BarOptions, BarSpecOptions, ChartData, ColorScheme, HighlightedItem, ScSpec } from '../types';
+import { getChartFocusRing } from './barFocusRingUtils';
 import {
   getBarAnimIdField,
   getBarHoverRules,
@@ -92,6 +101,7 @@ export const addBar = produce<
     BarOptions & {
       animations?: boolean;
       animationTypes?: AnimationType[];
+      accessibleNavigation?: boolean;
       colorScheme?: ColorScheme;
       data?: ChartData[];
       highlightedItem?: HighlightedItem;
@@ -255,6 +265,10 @@ export const addSignals = produce<Signal[], [BarSpecOptions]>((signals, options)
   // We use this value to calculate ReferenceLine positions.
   const { paddingInner } = getBarPadding(paddingRatio, barPaddingOuter);
   signals.push(getGenericValueSignal('paddingInner', paddingInner));
+
+  if (options.accessibleNavigation) {
+    signals.push(getGenericValueSignal(FOCUSED_ITEM), getGenericValueSignal(FOCUSED_REGION), getGenericValueSignal(FOCUSED_DIMENSION));
+  }
 
   if (isDualMetricAxis(options)) {
     signals.push(getFirstRscSeriesIdSignal(), getLastRscSeriesIdSignal());
@@ -553,6 +567,10 @@ export const addMarks = produce<Mark[], [BarSpecOptions]>((marks, options) => {
 
   for (const [i, label] of options.barDirectLabels.entries()) {
     marks.push(...getBarDirectLabelMarks(getBarDirectLabelSpecOptions(label, i, options), options));
+  }
+
+  if (options.accessibleNavigation) {
+    marks.push(getChartFocusRing(options));
   }
 });
 

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.test.ts
@@ -68,7 +68,6 @@ const defaultDodgedStackedEnterEncodings: RectEncodeEntry = {
 
 const defaultBackgroundMark: Mark = {
   name: 'bar0_background',
-  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -84,7 +83,6 @@ const defaultBackgroundMark: Mark = {
 
 const defaultMark: Mark = {
   name: 'bar0',
-  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -107,7 +105,6 @@ const defaultMark: Mark = {
 
 const defaultMarkWithInspect: Mark = {
   name: 'bar0',
-  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: true,
@@ -144,7 +141,6 @@ const defaultMarkWithInspect: Mark = {
 
 const defaultDodgedStackedBackgroundMark: Mark = {
   name: 'bar0_background',
-  description: 'bar0_background',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,
@@ -159,7 +155,6 @@ const defaultDodgedStackedBackgroundMark: Mark = {
 
 const defaultDodgedStackedMark: Mark = {
   name: 'bar0',
-  description: 'bar0',
   type: 'rect',
   from: { data: 'bar0_facet' },
   interactive: false,

--- a/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/dodgedBarUtils.ts
@@ -15,6 +15,7 @@ import { BACKGROUND_COLOR } from '@spectrum-charts/constants';
 
 import { isInteractive } from '../marks/markUtils';
 import { BarSpecOptions } from '../types';
+import { getBarFocusRing } from './barFocusRingUtils';
 import { getAnnotationMarks } from './barAnnotationUtils';
 import {
   getBarDimensionHoverArea,
@@ -44,7 +45,6 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         // background bars
         {
           name: `${name}_background`,
-          description: `${name}_background`,
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: false,
@@ -61,7 +61,6 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         // bars
         {
           name,
-          description: name,
           from: { data: `${name}_facet` },
           type: 'rect',
           interactive: isInteractive(options),
@@ -78,7 +77,11 @@ export const getDodgedMarks = (options: BarSpecOptions): (GroupMark | RectMark)[
         },
         ...getAnnotationMarks(options, `${name}_facet`, `${name}_position`, `${name}_dodgeGroup`),
         // visible outline drawn on top of the bars so it is never occluded by adjacent marks
-        ...(showItemSelectionRing ? [getBarItemSelectionRing(options, `${name}_facet`, ringDimensionEncodings)] : []),
+        ...(showItemSelectionRing
+          ? [getBarItemSelectionRing(options, `${name}_facet`, ringDimensionEncodings)]
+          : []),
+        // focus ring for keyboard navigation (experimental); inside the group so it can read the bar mark bounds
+        ...(options.accessibleNavigation ? [getBarFocusRing(options)] : []),
       ],
     },
   ];

--- a/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.ts
+++ b/packages/vega-spec-builder-s2/src/bar/stackedBarUtils.ts
@@ -16,6 +16,7 @@ import { BACKGROUND_COLOR, FILTERED_TABLE } from '@spectrum-charts/constants';
 import { isInteractive } from '../marks/markUtils';
 import { BarSpecOptions } from '../types';
 import { getAnnotationMarks } from './barAnnotationUtils';
+import { getBarFocusRing, getStackFocusRing } from './barFocusRingUtils';
 import {
   getBarDimensionHoverArea,
   getBarEnterEncodings,
@@ -65,6 +66,14 @@ export const getStackedBarMarks = (options: BarSpecOptions): Mark[] => {
   // visible outline drawn on top of the bars so it is never occluded (e.g. by adjacent stack segments)
   if (showItemSelectionRing) {
     marks.push(getBarItemSelectionRing(options, ringDataSource, ringDimensionEncodings));
+  }
+
+  // Per-segment ring always, plus a per-stack ring when actually stacked (a color field is present).
+  if (options.accessibleNavigation) {
+    marks.push(getBarFocusRing(options));
+    if (typeof options.color === 'string') {
+      marks.push(getStackFocusRing(options));
+    }
   }
 
   return marks;

--- a/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
+++ b/packages/vega-spec-builder-s2/src/chartSpecBuilder.ts
@@ -102,6 +102,7 @@ const isDivergingAxis = (axis: Axis): boolean => {
 export function buildSpec({
   animations,
   animationTypes,
+  accessibleNavigation = false,
   axes = [],
   backgroundColor = DEFAULT_BACKGROUND_COLOR,
   chartHeight,
@@ -157,6 +158,7 @@ export function buildSpec({
   const specOptions = {
     animations,
     animationTypes,
+    accessibleNavigation,
     backgroundColor,
     colorScheme,
     idKey,

--- a/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/chartSpec.types.ts
@@ -108,6 +108,8 @@ export interface ChartOptions {
   idKey?: string;
   /** Width of chart */
   chartWidth?: number;
+  /** Enables experimental keyboard navigation via data-navigator. Only basic bar charts are currently supported. Defaults to `false`. */
+  accessibleNavigation?: boolean;
 
   // children
   marks: MarkOptions[];

--- a/packages/vega-spec-builder-s2/src/types/marks/barSpec.types.ts
+++ b/packages/vega-spec-builder-s2/src/types/marks/barSpec.types.ts
@@ -107,6 +107,8 @@ type BarOptionsWithDefaults =
 export interface BarSpecOptions extends PartiallyRequired<BarOptions, BarOptionsWithDefaults> {
   /** Unique composite hover-animation identity per rendered bar, computed from the real data (not `rscMarkId`). */
   barIds?: string[];
+  /** Experimental: keyboard navigation focus rings/signals are emitted when true. @see ChartOptions.accessibleNavigation */
+  accessibleNavigation?: boolean;
   colorScheme: ColorScheme;
   comboSiblingNames?: string[];
   dimensionScaleType: 'band';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9371,6 +9371,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+data-navigator@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/data-navigator/-/data-navigator-2.4.1.tgz#46ee7c17e35fcd7a54bf998fc77101a802d224c1"
+  integrity sha512-JYoSq2Wt1PTNuFRj+eUuUVfGTOOpc/XgJYiDMri+c35NRuCDDY/H+WeFr+SxZYmP6HlgV40VWXjBTVr1TFM0ww==
+
 data-urls@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Refined data navigator implementation targeting stacked bars. The core behaviors are:

- TAB to chart "Enter navigation area" button is focused (to change later with l10n)
- ENTER to reach top nodes (currently Chart with Axes and Legend in progress)
- RIGHT/DOWN for next node
- LEFT/UP for previous node
- ENTER on Chart to focus bar dimensions (the stack)
- SPACE to activate dimension level popover. TAB to navigate within the popover
- ENTER to drill into individual bars
- SPACE to activate individual bar popovers
- At nodes, if there's a tooltip available, focusing the node displays. 
- ESC to go up one level
- TAB or SHIFT+TAB from within the navigation tree focuses the next element in the dom (exits focus from the chart/navigation tree)

Screen reader output is not included in this change. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Accessible keyboard navigation for Canvas and SVG rendered charts. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Thorough manual review and automated testing.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
